### PR TITLE
Implement size & layout checks for the glue layer

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -37,6 +37,16 @@
     ],
     "lflags": [ "-lsodium", "-lstdc++" ],
 
+    "configurations": [
+        {
+            "name": "unittest",
+            "sourceFiles": [
+                "source/scpp/build/DSizeChecks.o",
+                "source/scpp/build/DLayoutChecks.o"
+            ]
+        }
+    ],
+
     "dependencies": {
         "bitblob": "~>1.1.1",
         "dyaml": "~>0.7.1",

--- a/source/scpd/Util.d
+++ b/source/scpd/Util.d
@@ -1,0 +1,96 @@
+/*******************************************************************************
+
+    Contains magic code that auto-generates constructors,
+    for use with subtyping via alias this.
+
+    Code adapted from https://gist.github.com/AndrejMitrovic/72a08aa2c078767ea4c35eb1b0560c8d
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module scpd.Util;
+
+import std.exception;
+import std.string;
+import std.traits;
+import std.typecons;
+
+/// Auto-implement constructors which forward to the provided symbol's constructors
+public mixin template ForwardCtors (alias symbol)
+{
+    mixin(ForwardCtorsImpl!(typeof(symbol), symbol.stringof));
+}
+
+/// ditto
+public string ForwardCtorsImpl (T, string name)()
+{
+    string result;
+
+    foreach (Ctor; __traits(getOverloads, T, "__ctor"))
+    {
+        string[] attributes = [__traits(getFunctionAttributes, Ctor)];
+        string[] clean;
+
+        // for some reason this fails:
+        // attributes.filter!(a => a == "ref")
+        foreach (attr; attributes)
+        {
+            if (attr != "ref")
+                clean ~= attr;
+        }
+
+        auto res = getParams!Ctor;
+        result ~= format("extern(D) %s this(%s) { this.%s = typeof(this.%s)(%s); }\n",
+            clean.join(" "),
+            res[0], name, name, res[1]);
+    }
+
+    return result;
+}
+
+///
+private string stcToString (uint stc)  // bug: can't use ParameterStorageClass type
+{
+    string[] result;
+
+    if (stc & ParameterStorageClass.scope_)
+        result ~= "scope";
+    if (stc & ParameterStorageClass.out_)
+        result ~= "out";
+    if (stc & ParameterStorageClass.ref_)
+        result ~= "ref";
+    if (stc & ParameterStorageClass.lazy_)
+        result ~= "lazy";
+    if (stc & ParameterStorageClass.return_)
+        result ~= "return";
+
+    return result.join(" ");
+}
+
+///
+private Tuple!(string, string) getParams (alias func)()
+{
+    string[] params;
+    string[] args;
+
+    alias ParameterStorageClassTuple!func STCFunc;
+
+    foreach (idx, param; ParameterTypeTuple!func)
+    {
+        string default_value;
+        static if (!is(ParameterDefaults!func[idx] == void))
+            default_value = format(" = %s", ParameterDefaults!func[idx].stringof);
+
+        string arg = format("_arg%s", idx);
+        params ~= format("%s %s %s%s", stcToString(STCFunc[idx]), param.stringof, arg, default_value);
+        args ~= arg;
+    }
+
+    return tuple(params.join(", "), args.join(", "));
+}

--- a/source/scpd/tests/GlueTypes.d
+++ b/source/scpd/tests/GlueTypes.d
@@ -1,0 +1,67 @@
+/*******************************************************************************
+
+    Contains types used for size & ABI object layout checks.
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module scpd.tests.GlueTypes;
+
+import core.stdc.stdint;
+import std.meta;
+
+import scpd.types.Stellar_SCP;
+import scpd.types.Stellar_types;
+import scpd.types.Utils;
+import scpd.types.XDRBase;
+
+// todo: replace with __allMembers tricks in the future
+alias TypesWithLayout = AliasSeq!
+(
+    /// scpd.types.Stellar_SCP
+    SCPBallot,
+    SCPNomination,
+    SCPStatement._pledges_t._prepare_t,
+    SCPStatement._pledges_t._confirm_t,
+    SCPStatement._pledges_t._externalize_t,
+    SCPStatement._pledges_t,
+    SCPStatement,
+    SCPEnvelope,
+    SCPQuorumSet,
+
+    /// scpd.types.Stellar_types
+    PublicKey,
+    Hash,
+
+    /// scpd.types.Utils
+    ByteSlice,
+);
+
+/// For these types we cannot do layout checks as we require
+/// access to private std::array fields to get the offset.
+/// However we can still do sizeof() checks.
+alias TypesNoLayout = AliasSeq!
+(
+    /// scpd.types.Stellar_SCP
+    Value,
+    SCPStatementType,
+    CryptoKeyType,
+    PublicKeyType,
+    SignerKeyType,
+    Signature,
+    SignatureHint,
+
+    /// scpd.types.XDRBase
+    xvector!Value,
+    xvector!PublicKey,
+    xvector!SCPQuorumSet,
+);
+
+/// All the glue types have sizeof(), but some may not have accessible layout information
+alias GlueTypes = AliasSeq!(TypesWithLayout, TypesNoLayout);

--- a/source/scpd/tests/LayoutTest.d
+++ b/source/scpd/tests/LayoutTest.d
@@ -1,0 +1,70 @@
+/*******************************************************************************
+
+    Contains runtime field size & ABI object layout checks.
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module scpd.tests.LayoutTest;
+
+import scpd.tests.GlueTypes;
+import scpd.types.Stellar_SCP;
+import scpd.types.Stellar_types;
+
+import std.digest.sha;
+import std.random;
+import std.stdio;
+import std.string;
+import std.traits;
+
+/// Contains the size and offset of a field within a struct
+extern(C++) struct FieldInfo
+{
+    long size;
+    long offset;
+    //const(char)* mangleof;  // todo: could this work?
+}
+
+static foreach (Type; GlueTypes)
+{
+    extern(C++) FieldInfo cppFieldInfo (ref Type, const(char)*);
+}
+
+/// Special-case as we implement our own Hash type that is binary-compatible with SCP's Hash
+extern(C++) bool isHashTypeCompatible (ref Hash, const(char*));
+
+/// size & layout checks for C++ structs / objects
+unittest
+{
+    foreach (Type; TypesWithLayout)
+    {
+        foreach (idx, field; Type.init.tupleof)
+        {
+            auto object = Type.init;
+            auto field_info = cppFieldInfo(object,
+                Type.tupleof[idx].stringof.toStringz);
+
+            assert(typeof(field).sizeof == field_info.size,
+                format("Field '%s' of '%s' size mismatch: %s (D) != %s (C++)",
+                    Type.tupleof[idx].stringof, Type.stringof,
+                    typeof(field).sizeof, field_info.size));
+
+            assert(Type.tupleof[idx].offsetof == field_info.offset,
+                format("Field '%s' of '%s' offset mismatch: %s (D) != %s (C++)",
+                    Type.tupleof[idx].stringof, Type.stringof,
+                    Type.tupleof[idx].offsetof, field_info.offset));
+        }
+    }
+
+    foreach (name; ["bob", "alice", "carol"])
+    {
+        Hash hash = sha256Of(name);
+        assert(isHashTypeCompatible(hash, name.toStringz));
+    }
+}

--- a/source/scpd/tests/SizeTest.d
+++ b/source/scpd/tests/SizeTest.d
@@ -1,0 +1,35 @@
+/*******************************************************************************
+
+    Contains runtime size checks for the structs.
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module scpd.tests.SizeTest;
+
+import scpd.tests.GlueTypes;
+
+import std.string;
+
+static foreach (Type; GlueTypes)
+{
+    extern(C++) ulong cppSizeOf (ref Type);
+}
+
+/// size checks
+unittest
+{
+    foreach (Type; GlueTypes)
+    {
+        Type object;
+        assert(Type.sizeof == cppSizeOf(object),
+            format("Type '%s' size mismatch: %s (D) != %s (C++)",
+                Type.stringof, Type.sizeof, cppSizeOf(object)));
+    }
+}

--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -26,10 +26,14 @@ extern(C++, `stellar`):
 
 alias Value = opaque_vec!();
 
+static assert(Value.sizeof == 24);
+
 struct SCPBallot {
   uint32_t counter;
   Value value;
 }
+
+static assert(SCPBallot.sizeof == 32);
 
 enum SCPStatementType : int32_t {
   SCP_ST_PREPARE = 0,
@@ -43,6 +47,8 @@ struct SCPNomination {
     xvector!(Value) votes;
     xvector!(Value) accepted;
 }
+
+static assert(SCPNomination.sizeof == 80);
 
 struct SCPStatement {
 
@@ -63,6 +69,9 @@ struct SCPStatement {
             uint32_t nC;
             uint32_t nH;
         }
+
+        static assert(_prepare_t.sizeof == 88);
+
         static struct _confirm_t {
             SCPBallot ballot;
             uint32_t nPrepared;
@@ -70,11 +79,16 @@ struct SCPStatement {
             uint32_t nH;
             Hash quorumSetHash;
         }
+
+        static assert(_confirm_t.sizeof == 80);
+
         static struct _externalize_t {
             SCPBallot commit;
             uint32_t nH;
             Hash commitQuorumSetHash;
         }
+
+        static assert(_externalize_t.sizeof == 72);
 
         //using _xdr_case_type = xdr::xdr_traits<SCPStatementType>::case_type;
         //private:
@@ -140,16 +154,22 @@ struct SCPStatement {
     _pledges_t pledges;
 }
 
+static assert(SCPStatement.sizeof == 144);
+
 struct SCPEnvelope {
   SCPStatement statement;
   Signature signature;
 }
+
+static assert(SCPEnvelope.sizeof == 168);
 
 struct SCPQuorumSet {
     uint32_t threshold;
     xvector!(PublicKey) validators;
     xvector!(SCPQuorumSet) innerSets;
 }
+
+static assert(SCPQuorumSet.sizeof == 56);
 
 /// From SCPDriver, here for convenience
 public alias SCPQuorumSetPtr = shared_ptr!SCPQuorumSet;

--- a/source/scpd/types/Stellar_types.d
+++ b/source/scpd/types/Stellar_types.d
@@ -28,8 +28,7 @@ extern(C++, `stellar`):
 // Since BitBlob has the same memory layout,
 // we can just swap it, and get a much more D-friendly interface.
 
-/// alias Hash = opaque_array!32;
-alias Hash = BitBlob!256;
+alias Hash = opaque_array!32;
 /// alias uint256 = opaque_array!32;
 alias uint256 = Hash;
 

--- a/source/scpd/types/Utils.d
+++ b/source/scpd/types/Utils.d
@@ -63,7 +63,7 @@ public opaque_vec!() XDRToOpaque (const ref SCPQuorumSet arg);
 //public opaque_vec!() xdr_to_opaque(T...)(const ref T arg);
 
 extern(C++, `stellar`)
- {
+{
     public uint256 sha256(const ref ByteSlice bin);
 
     public struct ByteSlice

--- a/source/scpd/types/XDRBase.d
+++ b/source/scpd/types/XDRBase.d
@@ -25,6 +25,9 @@ import std.meta;
 import vibe.data.json;
 
 import scpd.Cpp;
+import scpd.Util;
+
+import geod24.bitblob;
 
 
 extern(C++, xdr):
@@ -88,34 +91,14 @@ class xdr_wrong_union : logic_error
 
 extern(D) static immutable XDR_MAX_LEN = 0xffff_fffc;
 
-//struct xarray(T, uint32_t N) { public array!(T, N) data; alias data this; }
-struct xarray(T, uint32_t N)
+///
+struct opaque_array(uint32_t N = XDR_MAX_LEN)
 {
-    array!(T, N) base;
+    BitBlob!(N * 8) base;
     alias base this;
-
-extern(D):
-    string toString() const @trusted
-    {
-        string ret = "[ ";
-        foreach (idx, ref entry; base)
-        {
-            ret ~= entry.serializeToJsonString();
-            if ((idx + 1) != base.length)
-                ret ~= ", ";
-        }
-        ret ~= " ]";
-        return ret;
-    }
-
-    static typeof(this) fromString(string src) @safe
-    {
-        auto array = src.deserializeJson!(T[N]);
-        return cast(typeof(this))(array);
-    }
+    mixin ForwardCtors!base;
 }
-alias opaque_array(uint32_t N = XDR_MAX_LEN) = xarray!(uint8_t, N);
-//class opaque_array(uint32_t N = XDR_MAX_LEN) : xarray!(uint8_t, N) {}
+
 
 ///alias xvector(T, uint32_t N = XDR_MAX_LEN) = vector!(T);
 alias opaque_vec(uint32_t N = XDR_MAX_LEN) = xvector!(uint8_t, N);

--- a/source/scpp/extra/DLayoutChecks.cpp
+++ b/source/scpp/extra/DLayoutChecks.cpp
@@ -1,0 +1,157 @@
+/*******************************************************************************
+
+    Contains unittest functions used for layout checks of the D glue layer.
+
+    Note: This is not part of Stellar SCP code.
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+#include <vector>
+#include "xdrpp/marshal.h"
+#include "xdrpp/types.h"
+#include "xdr/Stellar-SCP.h"
+#include "xdr/Stellar-types.h"
+#include "scp/Slot.h"
+#include "crypto/ByteSlice.h"
+#include "crypto/SHA.h"
+
+#include <stdio.h>
+#include <string.h>
+
+using namespace xdr;
+using namespace stellar;
+
+struct FieldInfo
+{
+    long long _size;
+    long long _offset;
+    //const(char)* mangleof;  // todo: could this work for type checks?
+
+    FieldInfo(unsigned long long size,
+              unsigned long long offset) : _size(size), _offset(offset) { };
+};
+
+/// Special-case as we implement our own Hash type that is binary-compatible with SCP's Hash
+bool isHashTypeCompatible (Hash &d_object, const char *string)
+{
+    ByteSlice slice(string);
+    uint256 cpp_obj = sha256(slice);
+    return memcmp(&d_object, &cpp_obj, sizeof(cpp_obj)) == 0;
+}
+
+#define HANDLE(FIELD) \
+    if (strcmp(field_name, #FIELD) == 0) \
+        return FieldInfo(sizeof(object.FIELD), (char*)&object.FIELD - (char*)&object);
+
+/// scpd.types.Stellar_SCP
+FieldInfo cppFieldInfo ( Hash &object, const char *field_name )
+{
+    // special-case: on the D side Hash just stores an internal 'base' field
+    if (strcmp(field_name, "base") == 0) \
+        return FieldInfo(sizeof(object), 0);
+
+    return FieldInfo(-1, -1);  // assert on the D side for better error messages
+}
+
+FieldInfo cppFieldInfo ( SCPBallot &object, const char *field_name )
+{
+    /// todo: is there a way to automatically expand
+    /// "MACRO(T1, T2)" to "HANDLE(T1) \n HANDLE(T2)" ?
+    HANDLE(counter)
+    HANDLE(value)
+
+    return FieldInfo(-1, -1);  // assert on the D side for better error messages
+}
+
+FieldInfo cppFieldInfo ( SCPNomination &object, const char *field_name )
+{
+    HANDLE(quorumSetHash)
+    HANDLE(votes)
+    HANDLE(accepted)
+    return FieldInfo(-1, -1);  // assert on the D side for better error messages
+}
+
+FieldInfo cppFieldInfo ( SCPStatement::_pledges_t::_prepare_t &object, const char *field_name )
+{
+    HANDLE(quorumSetHash)
+    HANDLE(ballot)
+    HANDLE(prepared)
+    HANDLE(preparedPrime)
+    HANDLE(nC)
+    HANDLE(nH)
+    return FieldInfo(-1, -1);  // assert on the D side for better error messages
+}
+
+FieldInfo cppFieldInfo ( SCPStatement::_pledges_t::_confirm_t &object, const char *field_name )
+{
+    HANDLE(ballot)
+    HANDLE(nPrepared)
+    HANDLE(nCommit)
+    HANDLE(nH)
+    HANDLE(quorumSetHash)
+    return FieldInfo(-1, -1);  // assert on the D side for better error messages
+}
+
+FieldInfo cppFieldInfo ( SCPStatement::_pledges_t::_externalize_t &object, const char *field_name )
+{
+    HANDLE(commit)
+    HANDLE(nH)
+    HANDLE(commitQuorumSetHash)
+    return FieldInfo(-1, -1);  // assert on the D side for better error messages
+}
+
+FieldInfo cppFieldInfo ( SCPStatement::_pledges_t &object, const char *field_name )
+{
+    HANDLE(type_)
+    HANDLE(prepare_)
+    HANDLE(confirm_)
+    HANDLE(externalize_)
+    HANDLE(nominate_)
+    return FieldInfo(-1, -1);  // assert on the D side for better error messages
+}
+
+FieldInfo cppFieldInfo ( SCPStatement &object, const char *field_name )
+{
+    HANDLE(nodeID)
+    HANDLE(slotIndex)
+    HANDLE(pledges)
+    return FieldInfo(-1, -1);  // assert on the D side for better error messages
+}
+
+FieldInfo cppFieldInfo ( SCPEnvelope &object, const char *field_name )
+{
+    HANDLE(statement)
+    HANDLE(signature)
+    return FieldInfo(-1, -1);  // assert on the D side for better error messages
+}
+
+FieldInfo cppFieldInfo ( SCPQuorumSet &object, const char *field_name )
+{
+    HANDLE(threshold)
+    HANDLE(validators)
+    HANDLE(innerSets)
+    return FieldInfo(-1, -1);  // assert on the D side for better error messages
+}
+
+/// scpd.types.Stellar_types
+
+FieldInfo cppFieldInfo ( PublicKey &object, const char *field_name )
+{
+    HANDLE(type_)
+    HANDLE(ed25519_)
+    return FieldInfo(-1, -1);  // assert on the D side for better error messages
+}
+
+FieldInfo cppFieldInfo ( ByteSlice &object, const char *field_name )
+{
+    HANDLE(mData)
+    HANDLE(mSize)
+    return FieldInfo(-1, -1);  // assert on the D side for better error messages
+}

--- a/source/scpp/extra/DSizeChecks.cpp
+++ b/source/scpp/extra/DSizeChecks.cpp
@@ -1,0 +1,60 @@
+/*******************************************************************************
+
+    Contains unittest functions used for size checks of the D glue layer.
+
+    Note: This is not part of Stellar SCP code.
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+#include <vector>
+#include "xdrpp/marshal.h"
+#include "xdrpp/types.h"
+#include "xdr/Stellar-SCP.h"
+#include "xdr/Stellar-types.h"
+#include "scp/Slot.h"
+#include "crypto/ByteSlice.h"
+
+using namespace xdr;
+using namespace stellar;
+
+/// note: can't use templates due to 'unsigned long long' mangling bug
+#define CPPSIZEOF(T) unsigned long long cppSizeOf ( T &value ) { return sizeof(value); }
+
+/// scpd.types.Stellar_SCP
+CPPSIZEOF(Value)
+CPPSIZEOF(SCPBallot)
+CPPSIZEOF(SCPStatementType)
+CPPSIZEOF(SCPNomination)
+CPPSIZEOF(SCPStatement::_pledges_t::_prepare_t)
+CPPSIZEOF(SCPStatement::_pledges_t::_confirm_t)
+CPPSIZEOF(SCPStatement::_pledges_t::_externalize_t)
+CPPSIZEOF(SCPStatement::_pledges_t)
+CPPSIZEOF(SCPStatement)
+CPPSIZEOF(SCPEnvelope)
+CPPSIZEOF(SCPQuorumSet)
+
+/// scpd.types.Stellar_types
+CPPSIZEOF(Hash)
+CPPSIZEOF(CryptoKeyType)
+CPPSIZEOF(PublicKeyType)
+CPPSIZEOF(SignerKeyType)
+CPPSIZEOF(PublicKey)
+CPPSIZEOF(Signature)
+CPPSIZEOF(SignatureHint)
+CPPSIZEOF(ByteSlice)
+
+// macros suck
+#define COMMA ,
+
+/// scpd.types.XDRBase
+CPPSIZEOF(xarray<std::uint8_t COMMA 4>)
+CPPSIZEOF(xvector<Value>)
+CPPSIZEOF(xvector<PublicKey>)
+CPPSIZEOF(xvector<SCPQuorumSet>)

--- a/source/scpp/extra/DUtils.cpp
+++ b/source/scpp/extra/DUtils.cpp
@@ -39,7 +39,6 @@ opaque_vec<> XDRToOpaque(const stellar::SCPQuorumSet& param)
     return xdr::xdr_to_opaque(param);
 }
 
-
 #define PUSHBACKINST1(T) template void push_back<T, xvector<T>>(xvector<T>&, T&);
 #define PUSHBACKINST2(T, VT) template void push_back<T, VT>(VT&, T&);
 #define PUSHBACKINST3(T, V) template void push_back<T, V<T>>(V<T>&, T&);

--- a/source/scpp/src/crypto/ByteSlice.h
+++ b/source/scpp/src/crypto/ByteSlice.h
@@ -18,6 +18,7 @@ namespace stellar
  */
 class ByteSlice
 {
+  public: // BPFK note: cannot be private as we require runtime layout checks
     void const* mData;
     size_t const mSize;
 

--- a/source/scpp/src/xdr/Stellar-SCP.h
+++ b/source/scpp/src/xdr/Stellar-SCP.h
@@ -229,7 +229,7 @@ struct SCPStatement {
     };
 
     using _xdr_case_type = xdr::xdr_traits<SCPStatementType>::case_type;
-  private:
+/*  private:*/  // BPFK note: cannot be private as we require runtime layout checks
     _xdr_case_type type_;
     union {
       _prepare_t prepare_;

--- a/source/scpp/src/xdr/Stellar-types.h
+++ b/source/scpp/src/xdr/Stellar-types.h
@@ -112,7 +112,7 @@ template<> struct xdr_traits<::stellar::SignerKeyType>
 
 struct PublicKey {
   using _xdr_case_type = xdr::xdr_traits<PublicKeyType>::case_type;
-private:
+/*private:*/  // BPFK note: cannot be private as we require runtime layout checks
   _xdr_case_type type_;
   union {
     uint256 ed25519_;


### PR DESCRIPTION
As noted in the commit comment, I've tried to use friend declarations, but it's problematic due to circular #include's which end up breaking compilation in subtle ways (if only C++ had modules..).

Fixes #4