### PR TITLE
Fix the Set() implementation to not use arrays

### DIFF
--- a/source/agora/common/Set.d
+++ b/source/agora/common/Set.d
@@ -26,13 +26,13 @@ import core.stdc.string;
 struct Set (T)
 {
     ///
-    bool[][T] _set;
+    bool[T] _set;
     alias _set this;
 
     /// Put an element in the set
     public void put ( T key )
     {
-        this._set[key] = [];
+        this._set[key] = true;
     }
 
     /// Remove an element from the set


### PR DESCRIPTION
The value of the hashmap should just be a simple type like bool,
not bool[].

We use the "bool[Type]" hashmap as a Set,
where we ignore the value (the bool).

Thanks to @MukeunKim for finding the bug.