### PR TITLE
Improve RemoteNode encapsulation

### DIFF
--- a/source/agora/node/Network.d
+++ b/source/agora/node/Network.d
@@ -124,7 +124,7 @@ class Network
 
         logInfo("IP %s: Establishing connection..", address);
         auto node = new RemoteNode(address, new RestInterfaceClient!API(address),
-            this.config);
+            this.config.node.retry_delay.msecs);
 
         node.getReady(
             (net_info) { this.addAddresses(net_info.addresses); },

--- a/source/agora/node/RemoteNode.d
+++ b/source/agora/node/RemoteNode.d
@@ -35,8 +35,10 @@ class RemoteNode
     /// Address of the node we're interacting with (for logging)
     private const Address address;
 
-    /// Config instance
-    private const Config config;
+    /// Caller's retry delay
+    /// TODO: This should be done at the client object level,
+    /// so whatever implements `API` should be handling this
+    private const Duration retry_delay;
 
     /// API client to the node
     private API api;
@@ -50,13 +52,12 @@ class RemoteNode
     /// Current network info state as retrieved by getNetworkInfo()
     public NetworkInfo net_info;
 
-
     /// Constructor
-    public this ( Address address, API api, const Config config )
+    public this ( Address address, API api, Duration retry_delay )
     {
         this.address = address;
         this.api = api;
-        this.config = config;
+        this.retry_delay = retry_delay;
     }
 
     /// Try connecting to the node, call onReceivedNetworkInfoDg() whenever
@@ -68,19 +69,16 @@ class RemoteNode
         while (!this.getPublicKey())
         {
             logInfo("IP %s: Couldn't retrieve public key. Will retry in %s..",
-                this.address,
-                this.config.node.retry_delay.msecs);
-            sleep(this.config.node.retry_delay.msecs);
+                this.address, this.retry_delay);
+            sleep(this.retry_delay);
         }
 
         while (!this.getPublicConfig())
         {
             logInfo("IP %s (Key: %s): Couldn't retrieve configuration. " ~
                 "Will retry in %s..",
-                this.address,
-                this.key,
-                this.config.node.retry_delay.msecs);
-            sleep(this.config.node.retry_delay.msecs);
+                this.address, this.key, this.retry_delay);
+            sleep(this.retry_delay);
         }
 
         onClientConnectedDg(this);
@@ -98,10 +96,8 @@ class RemoteNode
                 break;
 
             logInfo("IP %s (Key: %s): Peer info is incomplete. Retrying in %s..",
-                this.address,
-                this.key,
-                this.config.node.retry_delay.msecs);
-            sleep(this.config.node.retry_delay.msecs);
+                this.address, this.key, this.retry_delay);
+            sleep(this.retry_delay);
         }
     }
 

--- a/source/agora/node/RemoteNode.d
+++ b/source/agora/node/RemoteNode.d
@@ -21,7 +21,6 @@ import agora.common.Set;
 
 import vibe.core.core;
 import vibe.core.log;
-import vibe.web.rest;
 
 import core.time;
 
@@ -40,7 +39,7 @@ class RemoteNode
     private const Config config;
 
     /// API client to the node
-    private RestInterfaceClient!API api;
+    private API api;
 
     /// The public configuration as retrieved by getPublicConfig()
     public PublicConfig pub_conf;
@@ -53,8 +52,7 @@ class RemoteNode
 
 
     /// Constructor
-    public this ( Address address, RestInterfaceClient!API api,
-        const Config config )
+    public this ( Address address, API api, const Config config )
     {
         this.address = address;
         this.api = api;


### PR DESCRIPTION
In order to fix the unittests and remove IO from the unittests, I need to improve RemoteNode encapsulation so that only `API` knows about the network code.