### PR TITLE
Fix error message in tests

### DIFF
--- a/source/agora/test/Network.d
+++ b/source/agora/test/Network.d
@@ -92,7 +92,7 @@ class TestNodeRegistry : TestRegistry
             format("Got %s/%s discovered nodes. Missing nodes: %s",
                 fully_discovered.length,
                 this.registry.length,
-                this.registry.byKey.filter!(a => !!(a in fully_discovered))));
+                this.registry.byKey.filter!(a => !(a in fully_discovered))));
     }
 }
 


### PR DESCRIPTION
The message actually only printed those in fully_discovered, not missing in it.