### PR TITLE
Don't emit stack traces when command-line / config file parsing fails

### DIFF
--- a/source/agora/app.d
+++ b/source/agora/app.d
@@ -39,11 +39,20 @@ version (unittest) void main () { } else:
 private int main (string[] args)
 {
     CommandLine cmdln;
-    auto help = parseCommandLine(cmdln, args);
-    if (help.helpWanted)
+
+    try
     {
-        defaultGetoptPrinter("The Agora node", help.options);
-        return 0;
+        auto help = parseCommandLine(cmdln, args);
+        if (help.helpWanted)
+        {
+            defaultGetoptPrinter("The Agora node", help.options);
+            return 0;
+        }
+    }
+    catch (Exception ex)
+    {
+        writefln("Error parsing command-line arguments '%(%s %)': %s", args,
+            ex.message);
     }
 
     try

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -147,8 +147,46 @@ public GetoptResult parseCommandLine (ref CommandLine cmdline, string[] args)
             &cmdline.config_check);
 }
 
-/// Parse the config file
+/// Thrown when parsing the config fails
+class ConfigException : Exception
+{
+    ///
+    @nogc @safe pure nothrow public this ( string msg, string file = __FILE__,
+        size_t line = __LINE__ )
+    {
+        super(msg, file, line);
+    }
+}
+
+/*******************************************************************************
+
+    Parses the config file and returns a Config instance.
+
+    Params:
+        cmdlnd = command-line arguments (containing the path to the config)
+
+    Throws:
+        ConfigException if parsing the config file failed.
+
+    Returns:
+        Config instance
+
+*******************************************************************************/
+
 public Config parseConfigFile (CommandLine cmdln)
+{
+    try
+    {
+        return parseConfigFileImpl(cmdln);
+    }
+    catch (Exception ex)
+    {
+        throw new ConfigException(ex.msg, ex.file, ex.line);
+    }
+}
+
+/// ditto
+private Config parseConfigFileImpl (CommandLine cmdln)
 {
     import std.conv;
     import dyaml;


### PR DESCRIPTION
I used the `ConfigException` workaround because I can't do this:

```D
    Config config;
    try
    {
        config = parseConfigFile(cmdln); /// <= Error: reassigning const/immutable fields
        if (cmdln.config_check)
        {
            writefln("Config file '%s' succesfully parsed.", cmdln.config_path);
            return 0;
        }
    }
    catch (Exception ex)
    {
        writefln("Failed to parse config file '%s'. Error: %s",
            cmdln.config_path, ex.msg);
        return 1;
    }

    auto node = new Node(config);
    return runEventLoop();
}
```