### PR TITLE
Update base32 to our fork; use HEAD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "base32"]
 	path = submodules/base32
-	url = https://github.com/e10s/d-base32.git
+	url = https://github.com/bpfkorea/d-base32.git
 [submodule "bitblob"]
 	path = submodules/bitblob
 	url = https://github.com/Geod24/bitblob.git


### PR DESCRIPTION
Since upstream is not responsive, this allows us to move forward.
It is just a gitignore update but it is midly annoying,
and since base32 is not under active development, there's no cost to us.
Remember to run `git submodules sync; git submodule update` after
pulling this.