### PR TITLE
Network: Remove dependencies and clean up "validators"

### DIFF
--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -30,28 +30,6 @@ import std.getopt;
 import std.range;
 import std.traits;
 
-/// Verifies the config is in a valid state.
-/// This function should be called both after parsing a config file,
-/// or after manually constructing a config file.
-public void verifyConfigFile ( Config config )
-{
-    // ensure a quorum doesn't contain a public key of this node (self-reference)
-    Set!PublicKey all_validators;
-    getAllValidators(config.quorums, all_validators);
-    enforce(config.node.key_pair.address !in all_validators,
-        format("Cannot have our own key as a validator node: %s", config.node.key_pair.address));
-}
-
-// extract the set of all validators as configured in the quorum config
-public void getAllValidators ( in QuorumConfig[] quorums,
-    ref Set!PublicKey result )
-{
-    foreach (quorum; quorums)
-    {
-        result.fill(quorum.nodes);
-        getAllValidators(quorum.quorums, result);
-    }
-}
 
 /// Command-line arguments
 public struct CommandLine
@@ -211,8 +189,6 @@ public Config parseConfigFile (CommandLine cmdln)
 
     enforce(conf.quorums.length != 0);
     logInfo("Quorum set: %s", conf.quorums);
-
-    verifyConfigFile(conf);
 
     return conf;
 }

--- a/source/agora/node/Network.d
+++ b/source/agora/node/Network.d
@@ -77,8 +77,6 @@ class Network
         // the node communicating with itself
         this.banned_addresses.put(
             format("http://%s:%s", this.config.node.address, this.config.node.port));
-
-        getAllValidators(this.config.quorums, this.expected_validators);
     }
 
     /// try to discover the network until we found

--- a/source/agora/node/Network.d
+++ b/source/agora/node/Network.d
@@ -79,7 +79,6 @@ class Network
             format("http://%s:%s", this.config.node.address, this.config.node.port));
 
         getAllValidators(this.config.quorums, this.expected_validators);
-        enforce(this.expected_validators.length != 0);
     }
 
     /// try to discover the network until we found

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -40,7 +40,7 @@ public class Node : API
     {
         this.config = config;
         enforce(this.config.network.length > 0, "No network option found");
-        this.network = new Network(config);
+        this.network = new Network(config.node, config.network);
         this.exception = new RestException(
             400, Json("The query was incorrect"), string.init, int.init);
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -223,8 +223,6 @@ public const(PublicKey)[] makeTestNetwork (
                 logging : LoggingConfig(LogLevel.none)
             };
 
-            verifyConfigFile(conf);
-
             configs ~= conf;
         }
 


### PR DESCRIPTION
The epic we're working on is the Full Node, thus there shouldn't be any notion of "validators".
At the moment those two functions stood out as being out of place.
The quorum config was left in place as it does not hurt.