### PR TITLE
Make unittests communicate via `localrest`, not local network

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: d
 
 d:
   - dmd
-#  - ldc
+  - ldc
 
 os:
   - linux

--- a/source/agora/app.d
+++ b/source/agora/app.d
@@ -23,6 +23,10 @@ import agora.node.Network;
 import agora.node.Node;
 
 import vibe.core.core;
+import vibe.core.log;
+import vibe.http.router;
+import vibe.http.server;
+import vibe.web.rest;
 
 import std.getopt;
 import std.stdio;
@@ -49,6 +53,19 @@ private int main (string[] args)
         return 0;
     }
 
+    setLogLevel(config.logging.log_level);
+    logTrace("Config is: %s", config);
+
+    auto settings = new HTTPServerSettings(config.node.address);
+    settings.port = config.node.port;
+    auto router = new URLRouter();
+
     auto node = new Node!Network(config);
+    router.registerRestInterface(node);
+    runTask( { node.start(); });
+
+    logInfo("About to listen to HTTP: %s", settings.port);
+    listenHTTP(settings, router);
+
     return runEventLoop();
 }

--- a/source/agora/node/Network.d
+++ b/source/agora/node/Network.d
@@ -44,22 +44,22 @@ class Network
     private const NodeConfig node_config;
 
     /// The connected nodes
-    private RemoteNode[PublicKey] peers;
+    protected RemoteNode[PublicKey] peers;
 
     /// The addresses currently establishing connections to.
     /// The number of connecting addresses should not
     /// exceed MaxConnectingAddresses too much.
-    private Set!Address connecting_addresses;
+    protected Set!Address connecting_addresses;
 
     /// Addresses we won't connect to anymore
-    private Set!Address banned_addresses;
+    protected Set!Address banned_addresses;
 
     /// All known addresses so far
-    private Set!Address known_addresses;
+    protected Set!Address known_addresses;
 
     /// Addresses are added and removed here,
     /// but never added again if they're already in known_addresses
-    private Set!Address todo_addresses;
+    protected Set!Address todo_addresses;
 
 
     /// Ctor

--- a/source/agora/node/Network.d
+++ b/source/agora/node/Network.d
@@ -79,7 +79,7 @@ class Network
     /// all the validator nodes from our quorum set.
     public void discover ()
     {
-        logInfo("Discovering from %s", this.known_addresses.byKey());
+        logInfo("Discovering from %s", this.todo_addresses.byKey());
 
         while (!this.allPeersConnected())
         {

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -17,7 +17,9 @@ import agora.common.API;
 import agora.common.Config;
 import agora.common.crypto.Key;
 
-import vibe.d;
+import vibe.core.log;
+import vibe.data.json;
+import vibe.web.rest;
 
 
 /*******************************************************************************
@@ -53,21 +55,6 @@ public class Node (Network) : API
         this.network = new Network(config.node, config.network);
         this.exception = new RestException(
             400, Json("The query was incorrect"), string.init, int.init);
-
-        setLogLevel(config.logging.log_level);
-        logTrace("Config is: %s", config);
-
-        auto router = new URLRouter();
-        router.registerRestInterface(this);
-
-        // initial task
-        runTask( { this.start(); });
-
-        auto settings = new HTTPServerSettings(config.node.address);
-        settings.port = config.node.port;
-
-        logInfo("About to listen to HTTP: %s", settings.port);
-        listenHTTP(settings, router);
     }
 
     /// The first task method, loading from disk, node discovery, etc

--- a/source/agora/node/RemoteNode.d
+++ b/source/agora/node/RemoteNode.d
@@ -137,9 +137,9 @@ class RemoteNode
     {
         try
         {
+            this.net_info = this.api.getNetworkInfo();
             logInfo("IP %s: Received network info %s", this.address,
                 net_info);
-            this.net_info = this.api.getNetworkInfo();
             return true;
         }
         catch (Exception ex)


### PR DESCRIPTION
This stream of change, better reviewed commit-by-commit, changes ~network~ communication in unittests to be thread based RPC instead of actual network call (which messes up with Vibe.d).
It also fixes the LDC failure.
I removed `Registry` and `NodeSet` as they serve the very same purpose as `Network`. We might want to re-introduce that level of abstraction in the future, but for the moment it works ™️ .