### PR TITLE
Remove enforce on network argument from Node

### DIFF
--- a/source/agora/node/Network.d
+++ b/source/agora/node/Network.d
@@ -70,7 +70,8 @@ class Network
 
     /// Ctor
     public this (in NodeConfig node_config, in string[] peers)
-    {
+    in { assert(peers.length > 0, "No network option found"); }
+    do {
         this.node_config = node_config;
         this.addAddresses(Set!Address.from(peers));
 

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -50,7 +50,6 @@ public class Node (Network) : API
     public this (const Config config)
     {
         this.config = config;
-        enforce(this.config.network.length > 0, "No network option found");
         this.network = new Network(config.node, config.network);
         this.exception = new RestException(
             400, Json("The query was incorrect"), string.init, int.init);


### PR DESCRIPTION
Node should not care what is a valid argument for Network,
it should just pass it along.
In addition, since this enforcement is done at the config parsing level,
we can make it an assert in Network's constructor.