### PR TITLE
Fix visibility issue with calling a protected method

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -201,10 +201,14 @@ public NetworkT makeTestNetwork (NetworkT : TestNetwork)
 
         auto net = new NetworkT(NodeConfig.init, node_configs.map!(
             c => c.key_pair.address.toString()).array);
+
+        // Workaround https://issues.dlang.org/show_bug.cgi?id=20002
+        TestNetwork base_net = net;
+
         foreach (idx, ref conf; configs)
         {
             const address = node_configs[idx].key_pair.address;
-            net.apis[address] = net.createNewNode(address.toString(), conf);
+            net.apis[address] = base_net.createNewNode(address.toString(), conf);
         }
 
         net.apis.each!(a => a.start());


### PR DESCRIPTION
`createNewNode` might be overriden in a subclass, but if it is we can't directly call it because it might be defined in another module.

Perhaps it should be made public instead? Or this could even be a drawback in the visibility rules in D / a bug.