### PR TITLE
Fix naming of unittest classes and file names

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -86,6 +86,20 @@ public class TestNetwork : Network
 
     /***************************************************************************
 
+        Start each of the nodes
+
+        Params:
+            count = Expected number of nodes
+
+    ***************************************************************************/
+
+    public void start ()
+    {
+        this.apis.each!(a => a.start());
+    }
+
+    /***************************************************************************
+
         Wait until the nodes have reached discovery.
         If after 10 query attempts they haven't connected
         to each other, throw an exception.
@@ -260,7 +274,6 @@ public NetworkT makeTestNetwork (NetworkT : TestNetwork)
             net.apis[address] = base_net.createNewNode(address.toString(), conf);
         }
 
-        net.apis.each!(a => a.start());
         return net;
 
     case NetworkTopology.Balanced:

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -104,12 +104,9 @@ public class TestNetwork : Network
         If after 10 query attempts they haven't connected
         to each other, throw an exception.
 
-        Params:
-            count = Expected number of nodes
-
     ***************************************************************************/
 
-    public void waitUntilConnected (size_t count)
+    public void waitUntilConnected ()
     {
         import core.thread;
         import std.stdio;
@@ -132,19 +129,19 @@ public class TestNetwork : Network
             }
 
             // we're done
-            if (fully_discovered.length == count)
+            if (fully_discovered.length == this.apis.length)
                 return;
 
             // try again
             auto sleep_time = 1.seconds;  // should be enough time
             writefln("Sleeping for %s. Discovered %s/%s nodes", sleep_time,
-                fully_discovered.length, count);
+                fully_discovered.length, this.apis.length);
             Thread.sleep(sleep_time);
         }
 
         assert(fully_discovered.length == count,
                format("Got %s/%s discovered nodes. Missing nodes: %s",
-                   fully_discovered.length, count, this.todo_addresses));
+                   fully_discovered.length, this.apis.length, this.todo_addresses));
     }
 }
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -100,13 +100,15 @@ public class TestNetwork : Network
 
     /***************************************************************************
 
-        Wait until the nodes have reached discovery.
-        If after 10 query attempts they haven't connected
-        to each other, throw an exception.
+        Keep polling and waiting for nodes to all reach discovery,
+        up to 10 attempts and a sleep time between each attempt;
+
+        Returns:
+            the public keys of the nodes which reached discovery
 
     ***************************************************************************/
 
-    public void waitUntilConnected ()
+    public PublicKey[] getDiscoveredNodes ()
     {
         import core.thread;
         import std.stdio;
@@ -130,7 +132,7 @@ public class TestNetwork : Network
 
             // we're done
             if (fully_discovered.length == this.apis.length)
-                return;
+                break;
 
             // try again
             auto sleep_time = 1.seconds;  // should be enough time
@@ -139,9 +141,7 @@ public class TestNetwork : Network
             Thread.sleep(sleep_time);
         }
 
-        assert(fully_discovered.length == count,
-               format("Got %s/%s discovered nodes. Missing nodes: %s",
-                   fully_discovered.length, this.apis.length, this.todo_addresses));
+        return fully_discovered.byKey.array;
     }
 }
 

--- a/source/agora/test/Network.d
+++ b/source/agora/test/Network.d
@@ -20,7 +20,8 @@ import agora.test.Base;
 ///
 unittest
 {
-    auto network = makeTestNetwork!TestNetwork(NetworkTopology.Simple, 4);
+    const NodeCount = 4;
+    auto network = makeTestNetwork!TestNetwork(NetworkTopology.Simple, NodeCount);
     network.start();
-    network.waitUntilConnected();
+    assert(network.getDiscoveredNodes().length == NodeCount);
 }

--- a/source/agora/test/Network.d
+++ b/source/agora/test/Network.d
@@ -15,74 +15,11 @@ module agora.test.Network;
 
 version (unittest):
 
-import agora.common.API;
-import agora.common.Config;
-import agora.common.Data;
-import agora.common.crypto.Key;
-import agora.node.Network;
-import agora.node.Node;
 import agora.test.Base;
-
-import std.algorithm.iteration;
-import std.exception;
-import std.format;
-
-
-///
-private final class Network : TestNetwork
-{
-    /// Ctor
-    public this (NodeConfig config, in string[] peers)
-    {
-        super(config, peers);
-    }
-
-    /// Wait a certain time until the nodes have reached discovery
-    /// If after 10 query attempts they still all haven't discovered => assert
-    /// Params:
-    ///   count = Expected number of nodes
-    public void waitUntilConnected (size_t count)
-    {
-        import core.thread;
-        import std.stdio;
-
-        const attempts = 10;
-
-        bool[PublicKey] fully_discovered;
-
-        foreach (_; 0 .. attempts)
-        {
-            foreach (key, api; this.apis)
-            try
-            {
-                if (api.getNetworkInfo().state == NetworkState.Complete)
-                    fully_discovered[key] = true;
-            }
-            catch (Exception ex)
-            {
-                // just continue
-            }
-
-            // we're done
-            if (fully_discovered.length == count)
-                return;
-
-            // try again
-            auto sleep_time = 1.seconds;  // should be enough time
-            writefln("Sleeping for %s. Discovered %s/%s nodes", sleep_time,
-                fully_discovered.length, count);
-            Thread.sleep(sleep_time);
-        }
-
-        assert(fully_discovered.length == count,
-               format("Got %s/%s discovered nodes. Missing nodes: %s",
-                   fully_discovered.length, count, this.todo_addresses));
-    }
-}
 
 ///
 unittest
 {
-    auto network = makeTestNetwork!Network(NetworkTopology.Simple, 4);
+    auto network = makeTestNetwork!TestNetwork(NetworkTopology.Simple, 4);
     network.waitUntilConnected(4);
 }

--- a/source/agora/test/Network.d
+++ b/source/agora/test/Network.d
@@ -22,5 +22,5 @@ unittest
 {
     auto network = makeTestNetwork!TestNetwork(NetworkTopology.Simple, 4);
     network.start();
-    network.waitUntilConnected(4);
+    network.waitUntilConnected();
 }

--- a/source/agora/test/Network.d
+++ b/source/agora/test/Network.d
@@ -21,5 +21,6 @@ import agora.test.Base;
 unittest
 {
     auto network = makeTestNetwork!TestNetwork(NetworkTopology.Simple, 4);
+    network.start();
     network.waitUntilConnected(4);
 }


### PR DESCRIPTION
I often find myself looking at the wrong module when trying to find the Network class. I think this naming convention is easier for humans to distinguish between test modules and core modules, even if it's a little bit repetitive.