### PR TITLE
Rename Network to NetworkManager

### DIFF
--- a/source/agora/app.d
+++ b/source/agora/app.d
@@ -71,7 +71,7 @@ private int main (string[] args)
         settings.port = config.node.port;
         auto router = new URLRouter();
 
-        auto node = new Node!Network(config);
+        auto node = new Node!NetworkManager(config);
         router.registerRestInterface(node);
         runTask( { node.start(); });
 

--- a/source/agora/node/Network.d
+++ b/source/agora/node/Network.d
@@ -1,6 +1,15 @@
 /*******************************************************************************
 
-    Contains the code used for peer-to-peer network discovery.
+    Expose facilities used by the `Node` to communicate with the network
+
+    The `NetworkManager` is responsible for managing the view of the network
+    that a `Node` has.
+    Things such as peer blacklisting, prioritization (which peer is contacted
+    first when a message has to be sent), etc... are handled here.
+
+    In unittests, one can replace a `NetworkManager` with a `TestNetworkManager`
+    which provides a different client type (see `getClient`) in order to enable
+    in-memory network communication.
 
     Copyright:
         Copyright (c) 2019 BOS Platform Foundation Korea
@@ -32,13 +41,9 @@ import std.exception;
 import std.format;
 import std.random;
 
-// check up to 10 addresses at once
-private immutable MaxConnectingAddresses = 10;
 
-/// Note: cases which need to be handled:
-/// - node disconnnects during discovery => we should re-try it later (if we need more IPs)
-/// - new node connects at a random time during discovery => we should ask for its peers
-class Network
+/// Ditto
+public class NetworkManager
 {
     /// Config instance
     private const NodeConfig node_config;
@@ -234,3 +239,6 @@ class Network
         return new RestInterfaceClient!API(address);
     }
 }
+
+// check up to 10 addresses at once
+private immutable MaxConnectingAddresses = 10;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -37,9 +37,9 @@ import std.format;
 
 /*******************************************************************************
 
-    Base class for `Network` used in unittests
+    Base class for `NetworkManager` used in unittests
 
-    The `Network` class is the mean used to communicate with other nodes.
+    The `NetworkManager` class is the mean used to communicate with other nodes.
     In regular build, it does network communication, but in unittests it should
     not do IO (or appear not to).
 
@@ -48,7 +48,7 @@ import std.format;
 
 *******************************************************************************/
 
-public class TestNetwork : Network
+public class TestNetworkManager : NetworkManager
 {
     static import std.concurrency;
     import geod24.LocalRest;
@@ -79,7 +79,7 @@ public class TestNetwork : Network
     /// Initialize a new node
     protected TestAPI createNewNode (Address address, Config conf)
     {
-        auto api = RemoteAPI!TestAPI.spawn!(TestNode!TestNetwork)(conf);
+        auto api = RemoteAPI!TestAPI.spawn!(TestNode!TestNetworkManager)(conf);
         std.concurrency.register(address, api.tid());
         return api;
     }
@@ -193,10 +193,10 @@ public enum NetworkTopology
 
     This function's only usage is to create the network topology.
     The actual behavior of the nodes that are part of the network is decided
-    by the `TestNetwork` implementation.
+    by the `TestNetworkManager` implementation.
 
     Params:
-        NetworkT = Type of `Network` to instantiate
+        NetworkT = Type of `NetworkManager` to instantiate
         topology = Network topology to adopt
         nodes    = Number of nodes to instantiated
 
@@ -205,7 +205,7 @@ public enum NetworkTopology
 
 *******************************************************************************/
 
-public NetworkT makeTestNetwork (NetworkT : TestNetwork)
+public NetworkT makeTestNetwork (NetworkT : TestNetworkManager)
     (NetworkTopology topology, size_t nodes)
 {
     import std.algorithm;
@@ -263,7 +263,7 @@ public NetworkT makeTestNetwork (NetworkT : TestNetwork)
             c => c.key_pair.address.toString()).array);
 
         // Workaround https://issues.dlang.org/show_bug.cgi?id=20002
-        TestNetwork base_net = net;
+        TestNetworkManager base_net = net;
 
         foreach (idx, ref conf; configs)
         {

--- a/source/agora/test/Network.d
+++ b/source/agora/test/Network.d
@@ -21,7 +21,7 @@ import agora.test.Base;
 unittest
 {
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestNetwork(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
     network.start();
     assert(network.getDiscoveredNodes().length == NodeCount);
 }


### PR DESCRIPTION
While more verbose, it makes its intent more obvious.
Also add documentation.