### PR TITLE
Add Homebrew repository to the cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ os:
 cache:
   directories:
     - $HOME/Library/Caches/Homebrew
+    - /usr/local/Homebrew
 
 # We need a fairly recent compiler for SCP
 # Namely one with N4387 fixed


### PR DESCRIPTION
It means our cache gets invalidated much more frequently,
but fetching those commits is actually what takes time.