### PR TITLE
Improve signature code to use detached mode & document it

### DIFF
--- a/source/agora/common/Data.d
+++ b/source/agora/common/Data.d
@@ -26,4 +26,12 @@ public alias Hash = BitBlob!256;
 public alias Address = string;
 
 /// The type of a signature
-public alias Signature = BitBlob!256;
+public alias Signature = BitBlob!512;
+
+unittest
+{
+    // Check that our type match libsodium's definition
+    import libsodium;
+
+    static assert(Signature.sizeof == crypto_sign_ed25519_BYTES);
+}

--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -16,9 +16,7 @@ module agora.common.crypto.Key;
 import agora.common.crypto.Crc16;
 
 import geod24.bitblob;
-
 import base32;
-
 import libsodium;
 
 import std.exception;


### PR DESCRIPTION
```
- Make it less of a Stellar interfacing module
- Use 'detached' mode signing to make it `@nogc` when possible
- Move attributes to the RHS
- Add `pure`, `nothrow`, `@safe`, `@nogc` where applicable
- Expand documentation & add documented tests
- Add more unittests
```

Pretty straightforward. Also fixes the definition of `Signature`, as it is 64 bytes not 32 (that error did cost me 3 hours 🤦‍♂ )