### PR TITLE
Simplify creation of metadata in the unittests

### DIFF
--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -49,6 +49,9 @@ private enum MaxBatchBlocksSent = 1000;
 *******************************************************************************/
 public class Node (Network) : API
 {
+    /// Metadata instance
+    protected Metadata metadata;
+
     /// Config instance
     private const Config config;
 
@@ -68,10 +71,12 @@ public class Node (Network) : API
     /// Ctor
     public this (const Config config)
     {
+        this.metadata = this.getMetadata(config.node.data_dir);
+
         this.config = config;
         this.network = new Network(config.node, config.network,
             config.dns_seeds,
-            this.getMetadata(config.node.data_dir));
+            this.metadata);
         this.ledger = new Ledger();
         this.gossip = new GossipProtocol(this.network, this.ledger);
         this.exception = new RestException(

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -180,13 +180,9 @@ public interface TestAPI : API
 /// Ditto
 public final class TestNode (Net) : Node!Net, TestAPI
 {
-    /// The metadata used for the tests
-    MemMetadata mem_metadata;
-
     ///
     public this (Config config)
     {
-        this.mem_metadata = new MemMetadata;
         super(config);
     }
 
@@ -199,13 +195,13 @@ public final class TestNode (Net) : Node!Net, TestAPI
     /// Used by the node
     public override Metadata getMetadata (string _unused) @system
     {
-        return this.mem_metadata;
+        return new MemMetadata();
     }
 
     /// Used by unittests
     public override void metaAddPeer (Address peer)
     {
-        this.mem_metadata.peers.put(peer);
+        this.metadata.peers.put(peer);
     }
 }
 


### PR DESCRIPTION
Thanks to @Geod24 for catching the weirdness in https://github.com/bpfkorea/agora/pull/80, it made me realize this metadata code can be simplified.