### PR TITLE
Move transaction verification into the Ledger

### DIFF
--- a/source/agora/node/GossipProtocol.d
+++ b/source/agora/node/GossipProtocol.d
@@ -65,20 +65,9 @@ public class GossipProtocol
         if (this.hasTransactionHash(tx_hash))
             return;
 
-        // delegate for finding `Output`
-        auto findOutput = (Hash hash, size_t index)
-            {
-                if (auto txn = this.ledger.findTransaction(hash))
-                    if (index < txn.outputs.length)
-                        return &txn.outputs[index];
-
-                    return null;
-            };
-
-        if (tx.verifyData(findOutput) && tx.verifySignature(findOutput))
+        if (this.ledger.acceptTransaction(tx))
         {
             this.tx_cache[tx_hash] = tx;
-            this.ledger.receiveTransaction(tx);
             this.network.sendTransaction(tx);
         }
     }


### PR DESCRIPTION
I've named it `acceptTransaction` rather than `acceptsTransaction` because it's a verb (it has side-effects), and not just a question (do you accept this transaction). 

I wanted to avoid having two separate methods `isTransactionAccepted` and `putTransaction`, because then you could circumvent the check outside the `Ledger` class.