### PR TITLE
Add basic block height verification

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -19,6 +19,8 @@ import agora.common.Data;
 import agora.common.Hash;
 import agora.common.Transaction;
 
+import vibe.core.log;
+
 import std.algorithm;
 
 /// Ditto
@@ -106,7 +108,9 @@ public class Ledger
 
     /***************************************************************************
 
-        Add a block to the ledger
+        Add a block to the ledger.
+
+        If the block fails verification, it is not added to the ledger.
 
         Params:
             block = the block to add
@@ -117,10 +121,39 @@ public class Ledger
     {
         // force nothrow, an exception will never be thrown here
         scope (failure) assert(0);
+
+        if (!this.isValidBlock(block))
+        {
+            logDebug("Rejected block. %s", block);
+            return;
+        }
+
         this.ledger ~= block;
         this.last_block = &this.ledger[$ - 1];
     }
 
+    /***************************************************************************
+
+        Check the validity of a block.
+        Currently only the height of the block is
+        checked against the last block in the ledger.
+
+        Params:
+            block = the block to check
+
+        Returns:
+            true if the block is considered valid
+
+    ***************************************************************************/
+
+    private bool isValidBlock (Block block)
+    {
+        const expected_height = this.last_block !is null
+            ? (this.last_block.header.height + 1)
+            : 0;
+
+        return block.header.height == expected_height;
+    }
 
     /***************************************************************************
 

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -26,6 +26,7 @@ import agora.test.Base;
 /// Returns: the entire ledger from the provided node
 private Block[] getAllBlocks (TestAPI node)
 {
+    import std.range;
     Block[] blocks;
 
     // note: may return less than asked for, hence the loop
@@ -36,8 +37,11 @@ private Block[] getAllBlocks (TestAPI node)
         if (new_blocks.length == 0)  // no blocks left
             break;
 
+        // ensure sequential consistency
+        foreach (block; new_blocks)
+            assert(block.header.height == starting_block++);
+
         blocks ~= new_blocks;
-        starting_block = blocks[$ - 1].header.height + 1;
     }
 
     return blocks;


### PR DESCRIPTION
This must be done before asynchronous putTransaction requests are implemented, otherwise a node can end up building blocks indefinitely as it accepts any blocks it receives from a call to `getBlocksFrom`.