### PR TITLE
Move the serialization code into common package and rename the module

### DIFF
--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -18,8 +18,8 @@ module agora.common.Block;
 import agora.common.crypto.Key;
 import agora.common.Data;
 import agora.common.Hash;
+import agora.common.Serializer;
 import agora.common.Transaction;
-import agora.node.BlockSerialize;
 
 import std.algorithm.comparison;
 

--- a/source/agora/common/Serializer.d
+++ b/source/agora/common/Serializer.d
@@ -20,20 +20,21 @@ public alias SerializeDg = void delegate(scope const(ubyte)[]) pure nothrow @saf
 
 /*******************************************************************************
 
-    Serialize the block struct and return as a ubyte[].
+    Serialize a struct and return it as a ubyte[].
 
     Params:
-      T = Type of struct to serialize
-      record = Instance of `T` to serialize
-      dg  = Serialize delegate, when this struct is nested in another.
+        T = Type of struct to serialize
+        record = Instance of `T` to serialize
+        dg  = Serialization delegate, when this struct is a nested struct
 
     Returns:
-      The serialized `ubyte[]`
+        The serialized `ubyte[]`
 
 *******************************************************************************/
 
 public ubyte[] serializeFull (T) (scope const auto ref T record)
     pure nothrow @safe
+    if (is(T == struct))
 {
     ubyte[] res;
     scope SerializeDg dg = (scope const(ubyte[]) data) nothrow @safe

--- a/source/agora/common/Serializer.d
+++ b/source/agora/common/Serializer.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-module agora.node.BlockSerialize;
+module agora.common.Serializer;
 
 import agora.common.Data;
 

--- a/source/agora/common/Transaction.d
+++ b/source/agora/common/Transaction.d
@@ -20,8 +20,8 @@ module agora.common.Transaction;
 
 import agora.common.Data;
 import agora.common.Hash;
+import agora.common.Serializer;
 import agora.common.crypto.Key;
-import agora.node.BlockSerialize;
 
 import std.algorithm;
 

--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -16,7 +16,7 @@ module agora.common.crypto.Key;
 import agora.common.Data;
 import agora.common.crypto.Crc16;
 import agora.common.Hash;
-import agora.node.BlockSerialize;
+import agora.common.Serializer;
 
 import geod24.bitblob;
 import base32;

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -17,8 +17,8 @@ import agora.common.API;
 import agora.common.Block;
 import agora.common.Data;
 import agora.common.Hash;
+import agora.common.Serializer;
 import agora.common.Transaction;
-import agora.node.BlockSerialize;
 
 import vibe.core.log;
 


### PR DESCRIPTION
This code is generic and not specific to blocks, and it has no code dealing with the node's business logic.