### PR TITLE
Fix check in the Ledger unittest

### DIFF
--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -187,4 +187,6 @@ unittest
         // let them do catch-up after boot
         Thread.sleep(100.msecs);
     }
+
+    assert(0, "Nodes do not contain the same blocks");
 }


### PR DESCRIPTION
I've just noticed this part missing, as we periodically poll for the node height until the desired height is reached and then exit early. But if the same height isn't reached, we should assert.