### PR TITLE
Fix tests so they're reliable against block size changes

### DIFF
--- a/source/agora/consensus/Genesis.d
+++ b/source/agora/consensus/Genesis.d
@@ -32,12 +32,11 @@ import agora.common.crypto.Key;
 
 public Block getGenesisBlock ()
 {
-    auto gen_tx = newCoinbaseTX(getGenesisKeyPair().address, 40_000_000);
-    auto header = BlockHeader(
-        Hash.init, 0,
-        mergeHash(hashFull(gen_tx),hashFull(gen_tx)));
-
-    return Block(header, [gen_tx]);
+    Block block;
+    block.header.height = 0;
+    block.txs ~= getGenesisTx();
+    block.header.merkle_root = block.buildMerkleTree();
+    return block;
 }
 
 ///
@@ -45,6 +44,29 @@ unittest
 {
     // ensure the genesis block is always the same
     assert(getGenesisBlock() == getGenesisBlock());
+}
+
+/*******************************************************************************
+
+    Returns:
+        the genesis transaction
+
+*******************************************************************************/
+
+public Transaction getGenesisTx ()
+{
+    import agora.common.Block;
+    import std.algorithm;
+    import std.range;
+    import std.format;
+
+    Output[] outputs = iota(Block.TxsInBlock).map!(_ =>
+        Output(40_000_000 / Block.TxsInBlock, getGenesisKeyPair().address)).array;
+
+    return Transaction(
+        [Input(Hash.init, 0)],
+        outputs
+    );
 }
 
 /*******************************************************************************

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -26,155 +26,39 @@ import agora.test.Base;
 ///
 unittest
 {
+    import core.thread;
+    import std.algorithm;
     import std.conv;
+    import std.format;
+    import std.range;
+
     const NodeCount = 4;
     auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
     network.start();
     assert(network.getDiscoveredNodes().length == NodeCount);
-    auto node_1 = network.apis.values[0];
 
-    KeyPair[] key_pairs = [
-        KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random,
-        KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random,
-        KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random,
-        ];
+    auto nodes = network.apis.values;
+    auto node_1 = nodes[0];
 
-    KeyPair gen_key_pair = getGenesisKeyPair();
-    const gen_block = getGenesisBlock();
+    nodes.each!(node => assert(node.getBlockHeight() == 0));
 
-    // last transaction in the ledger
-    Hash gen_tx_hash = hashFull(gen_block.txs[$-1]);
-    Hash last_tx_hash;
-    Transaction[] txs;
-
-    // check block height
-    foreach (key, ref node; network.apis)
+    Transaction[] last_txs;
+    foreach (block_idx; 0 .. 10)  // create 10 blocks
     {
-        auto block_height = node.getBlockHeight();
-        assert(block_height == 0, block_height.to!string);
-    }
+        // create enough tx's for a single block
+        auto txs = makeChainedTransactions(getGenesisKeyPair(), last_txs, 1);
 
-    // It is validated. (the sum of `Output` < the sum of `Input`)
-    // The Genesis block has 40,000,000
+        // send it to one node
+        txs.each!(tx => node_1.putTransaction(tx));
 
-    // Creates the first transaction.
-    foreach (idx; 0 .. 8)
-    {
-        Transaction tx1 = Transaction(
-            [
-                Input(gen_tx_hash, 0)
-            ],
-            [
-                Output(1_000_000, key_pairs[idx].address)
-            ]
-        );
-        last_tx_hash = hashFull(tx1);
+        Thread.sleep(50.msecs);  // await gossip
 
-        // Sign a transaction and assign it to the input
-        tx1.inputs[0].signature = gen_key_pair.secret.sign(last_tx_hash[]);
-        node_1.putTransaction(tx1);
+        // gossip was complete
+        nodes.each!(node =>
+            txs.each!(tx =>
+                assert(node.hasTransactionHash(hashFull(tx)))
+        ));
 
-        txs ~= tx1;
-    }
-
-    // Check hasTransactionHash
-    foreach (key, ref node; network.apis)
-    {
-        //  every nodes received tx
-        assert(node.hasTransactionHash(last_tx_hash));
-
-        auto block_height = node.getBlockHeight();
-        assert(block_height == 1, block_height.to!string);
-    }
-
-    // It is validated. (the sum of `Output` == the sum of `Input`)
-
-    // Creates the second transaction.
-    foreach (idx; 0 .. 8)
-    {
-        Transaction tx2 = Transaction(
-            [
-                Input(hashFull(txs[idx]), 0)
-            ],
-            [
-                Output(1_000_000, key_pairs[idx+8].address)
-            ]
-        );
-        last_tx_hash = hashFull(tx2);
-
-        // Sign a transaction and assign it to the input
-        tx2.inputs[0].signature = key_pairs[idx].secret.sign(last_tx_hash[]);
-        node_1.putTransaction(tx2);
-        txs ~= tx2;
-    }
-
-    // Check hasTransactionHash
-    foreach (key, ref node; network.apis)
-    {
-        //  every nodes received tx
-        assert(node.hasTransactionHash(last_tx_hash));
-
-        auto block_height = node.getBlockHeight();
-        assert(block_height == 2, block_height.to!string);
-    }
-
-
-    // It isn't validated. (the sum of `Output` > the sum of `Input`)
-
-    // Creates the third transaction.
-    foreach (idx; 0 .. 8)
-    {
-        Transaction tx3 = Transaction(
-            [
-                Input(hashFull(txs[idx+8]), 0)
-            ],
-            [
-                Output(2_000_000, key_pairs[idx].address)
-            ]
-        );
-        last_tx_hash = hashFull(tx3);
-
-        // Sign a transaction and assign it to the input
-        tx3.inputs[0].signature = key_pairs[idx+8].secret.sign(last_tx_hash[]);
-        node_1.putTransaction(tx3);
-        txs ~= tx3;
-    }
-
-    // Check hasTransactionHash
-    foreach (key, ref node; network.apis)
-    {
-        assert(!node.hasTransactionHash(last_tx_hash));
-
-        auto block_height = node.getBlockHeight();
-        assert(block_height == 2, block_height.to!string);
-    }
-
-    // Creates the fourth transaction.
-    foreach (idx; 0 .. 8)
-    {
-        Transaction tx4 = Transaction(
-            [
-                Input(hashFull(txs[idx+8]), 0)
-            ],
-            [
-                Output(1_000_000, key_pairs[idx].address)
-            ]
-        );
-        last_tx_hash = hashFull(tx4);
-
-        // Sign a transaction and assign it to the input,  the exact `KeyPair` is `key_pairs[idx+8]
-
-        tx4.inputs[0].signature = gen_key_pair.secret.sign(last_tx_hash[]);
-        node_1.putTransaction(tx4);
-        txs ~= tx4;
-    }
-
-    // Check hasTransactionHash
-    foreach (key, ref node; network.apis)
-    {
-        assert(!node.hasTransactionHash(last_tx_hash));
-
-        auto block_height = node.getBlockHeight();
-        assert(block_height == 2, block_height.to!string);
+        last_txs = txs;
     }
 }

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -68,53 +68,62 @@ private bool containSameBlocks (API)(API[] nodes, size_t height)
 ///
 unittest
 {
+    import core.thread;
     import std.algorithm;
     import std.conv;
     import std.format;
-
-    import std.array;
+    import std.range;
 
     const NodeCount = 4;
     auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
     network.start();
     assert(network.getDiscoveredNodes().length == NodeCount);
 
-    auto node_1 = network.apis.values[0];
-    KeyPair[] key_pairs;
+    auto nodes = network.apis.values;
+    auto node_1 = nodes[0];
 
-    auto gen_key_pair = getGenesisKeyPair();
-    auto gen_block = getGenesisBlock();
-
-    int period = 8;
-    auto txes = getChainedTransactions(gen_block.txs[$-1], period*10, gen_key_pair, 8);
-    txes.each!(tx => node_1.putTransaction(tx));
-
-    // ensure block height is the same everywhere
-    foreach (key, ref node; network.apis)
+    Transaction[][] block_txes; /// per-block array of transactions (genesis not included)
+    Transaction[] last_txs;
+    foreach (block_idx; 0 .. 100)  // create 100 blocks
     {
-        auto block_height = node.getBlockHeight();
-        assert(block_height == 10, block_height.to!string);
+        // create enough tx's for a single block
+        auto txs = makeChainedTransactions(getGenesisKeyPair(), last_txs, 1);
+
+        // send it to one node
+        txs.each!(tx => node_1.putTransaction(tx));
+
+        Thread.sleep(50.msecs);  // await gossip and block creation
+
+        nodes.enumerate.each!((idx, node) =>
+            assert(node.getBlockHeight() == block_idx + 1,
+                format("Node %s has block height %s. Expected: %s",
+                    idx, node.getBlockHeight().to!string, block_idx + 1)));
+
+        block_txes ~= txs;
+        last_txs = txs;
     }
 
     // get all the blocks (including genesis block)
-    auto blocks = node_1.getBlocksFrom(0, 11);
+    auto blocks = node_1.getBlocksFrom(0, 101);
 
     assert(blocks[0] == getGenesisBlock());
 
     // exclude genesis block
-    assert(join(blocks[1 .. $].map!(block => block.txs.map!(tx => tx))).equal(txes[]));
+    assert(blocks[1 .. $].enumerate.each!((idx, block) =>
+        assert(block.txs == block_txes[idx])
+    ));
 
     blocks = node_1.getBlocksFrom(0, 1);
     assert(blocks.length == 1 && blocks[0] == getGenesisBlock());
 
-    blocks = node_1.getBlocksFrom(10, 1);
-    assert(blocks.length == 1 && blocks[0].txs[0..$].equal(txes[$-period..$]));
+    blocks = node_1.getBlocksFrom(100, 1);
+    assert(blocks.length == 1 && blocks[0].txs == block_txes[99]);  // -1 as genesis block not included
 
     // over the limit => return up to the highest block
-    assert(node_1.getBlocksFrom(0, 100).length == 11);
+    assert(node_1.getBlocksFrom(0, 1000).length == 101);
 
     // higher index than available => return nothing
-    assert(node_1.getBlocksFrom(100, 10).length == 0);
+    assert(node_1.getBlocksFrom(1000, 10).length == 0);
 }
 
 /// test catch-up phase during booting
@@ -122,20 +131,35 @@ unittest
 {
     import core.thread;
     import std.algorithm;
+    import std.conv;
+    import std.format;
+    import std.range;
 
     const NodeCount = 4;
     auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
 
     auto nodes = network.apis.values;
     auto node_1 = nodes[0];
-    auto gen_key_pair = getGenesisKeyPair();
-    auto gen_block = getGenesisBlock();
 
-    int period = 8;
-    auto txes = getChainedTransactions(gen_block.txs[$-1], period*10, gen_key_pair, 8);
-    txes.each!(tx => node_1.putTransaction(tx));
+    Transaction[] last_txs;
+    foreach (block_idx; 0 .. 100)  // create 100 blocks
+    {
+        // create enough tx's for a single block
+        auto txs = makeChainedTransactions(getGenesisKeyPair(), last_txs, 1);
 
-    assert(node_1.getBlockHeight() == 10);
+        // send it to one node
+        txs.each!(tx => node_1.putTransaction(tx));
+
+        assert(node_1.getBlockHeight() == block_idx + 1,
+            format("Node 1 has block height %s. Expected: %s",
+                node_1.getBlockHeight().to!string, block_idx + 1));
+
+        last_txs = txs;
+    }
+
+    Thread.sleep(50.msecs);  // await block creation
+
+    assert(node_1.getBlockHeight() == 100);
 
     foreach (empty_node; nodes[1 .. $])
     {
@@ -149,7 +173,7 @@ unittest
     auto attempts = 80;  // wait up to 80*100 msecs (8 seconds)
     while (attempts--)
     {
-        if (containSameBlocks(nodes, 10))
+        if (containSameBlocks(nodes, 100))
             return;
 
         // let them do catch-up after boot
@@ -162,6 +186,7 @@ unittest
 {
     import core.thread;
     import std.algorithm;
+    import std.range;
 
     const NodeCount = 4;
     auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
@@ -169,20 +194,17 @@ unittest
 
     auto nodes = network.apis.values;
     auto node_1 = nodes[0];
-    auto gen_key_pair = getGenesisKeyPair();
-    auto gen_block = getGenesisBlock();
 
     // ignore transaction propagation and periodically retrieve blocks via getBlocksFrom
     nodes[1 .. $].each!(node => node.filter!(node.putTransaction));
 
-    int period = 8;
-    auto txes = getChainedTransactions(gen_block.txs[$-1], period*10, gen_key_pair, 8);
-    txes.each!(tx => node_1.putTransaction(tx));
+    auto txs = makeChainedTransactions(getGenesisKeyPair(), null, 100);
+    txs.each!(tx => node_1.putTransaction(tx));
 
     auto attempts = 80;  // wait up to 80*100 msecs (8 seconds)
     while (attempts--)
     {
-        if (containSameBlocks(nodes, 10))
+        if (containSameBlocks(nodes, 100))
             return;
 
         // let them do catch-up after boot


### PR DESCRIPTION
This should be merged after ~https://github.com/bpfkorea/agora/pull/113~ https://github.com/bpfkorea/agora/pull/112, so I can fix up the unittests in that code as well.

It's hard to split up the second commit into multiple commits, because the change in `getChainedTransactions` affects most unittests (and it was broken before, referencing the same Input multiple times, and hardcoded to 8 transactions per block).