### PR TITLE
Implement request timeouts in unittests

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -35,6 +35,8 @@ node:
   retry_delay: 1.5
   # Maximum number of retries to issue before a request is considered failed
   max_retries: 5
+  # Timeout for each request in milliseconds
+  timeout: 50
   # This is a randomly generated keypair
   # If this node is not a validator, this will be ignored
   #

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -101,6 +101,9 @@ public struct NodeConfig
     /// Maximum number of retries to issue before a request is considered failed
     public size_t max_retries = 5;
 
+    /// Timeout of each request (in milliseconds)
+    public long timeout = 500;
+
     /// Path to the data directory to store metadata and blockchain data
     public string data_dir;
 }
@@ -270,6 +273,7 @@ private NodeConfig parseNodeConfig (Node node)
         retry_delay = cast(long)(delay.as!float * 1000);
 
     size_t max_retries = node["max_retries"].as!size_t;
+    size_t timeout = node["timeout"].as!size_t;
 
     string data_dir = node["data_dir"].as!string;
     auto port = node["port"].as!ushort;
@@ -287,6 +291,7 @@ private NodeConfig parseNodeConfig (Node node)
         key_pair : key_pair,
         retry_delay : retry_delay,
         max_retries : max_retries,
+        timeout : timeout,
         data_dir : data_dir,
     };
 

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -241,7 +241,8 @@ public class NetworkManager
 
         logInfo("Establishing connection with %s...", address);
         auto node = new NetworkClient(this.taskman, address,
-            this.getClient(address), this.node_config.retry_delay.msecs,
+            this.getClient(address, this.node_config.timeout.msecs),
+            this.node_config.retry_delay.msecs,
             this.node_config.max_retries);
 
         while (1)
@@ -369,15 +370,16 @@ public class NetworkManager
 
         Params:
           address = The address (IPv4, IPv6, hostname) of this node
+          timeout = the timeout duration to use for requests
 
         Returns:
           An object to communicate with the node at `address`
 
     ***************************************************************************/
 
-    protected API getClient (Address address)
+    protected API getClient (Address address, Duration timeout)
     {
-        return new RestInterfaceClient!API(address);
+        return new RestInterfaceClient!API(address/*, timeout*/);
     }
 
     /***************************************************************************

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -124,10 +124,10 @@ public class TestNetworkManager : NetworkManager
     }
 
     ///
-    protected final override API getClient (Address address)
+    protected final override API getClient (Address address, Duration timeout)
     {
         if (auto ptr = address in tbn)
-            return new RemoteAPI!API(*ptr);
+            return new RemoteAPI!API(*ptr, timeout);
         assert(0, "Trying to access node at address '" ~ address ~
                "' without first creating it");
     }


### PR DESCRIPTION
Blocked by dependencies. The support code in the node is pretty simple though. And a unittest is included (which passes with all dependencies).

Requires:

- https://github.com/bpfkorea/agora/pull/106

The vibe.d support has not been implemented yet.