### PR TITLE
Optimize Serialization & Merkle Tree creation

### DIFF
--- a/source/agora/common/API.d
+++ b/source/agora/common/API.d
@@ -24,7 +24,7 @@ import vibe.web.rest;
 import vibe.http.common;
 
 /// The network state (completed when sufficient validators are connected to)
-enum NetworkState
+public enum NetworkState
 {
     Incomplete,
     Complete

--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -175,11 +175,17 @@ public struct Block
     public void deserialize (scope DeserializeDg dg) nothrow @safe
     {
         deserializePart(this.header, dg);
+
         size_t size;
         deserializePart(size, dg);
         this.txs.length = size;
         foreach (ref tx; this.txs)
             deserializePart(tx, dg);
+
+        deserializePart(size, dg);
+        this.merkle_tree.length = size;
+        foreach (ref h; this.merkle_tree)
+            deserializePart(h, dg);
     }
 
     /***************************************************************************

--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -349,7 +349,7 @@ unittest
 
 *******************************************************************************/
 
-public Block makeNewBlock (Block prev_block, Transaction[] txs) @safe
+public Block makeNewBlock (const ref Block prev_block, Transaction[] txs) @safe
 {
     Block block;
 

--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -192,9 +192,9 @@ public struct Block
 
     public Hash buildMerkleTree() nothrow @safe
     {
-        this.merkle_tree.reserve(this.txs.length);
-        foreach (ref tx; this.txs)
-            this.merkle_tree ~= hashFull(tx);
+        this.merkle_tree.length = this.txs.length;
+        foreach (size_t idx, ref hash; this.merkle_tree)
+            hash = hashFull(this.txs[idx]);
 
         // transactions are ordered lexicographically by hash in the Merkle tree
         this.merkle_tree.sort!("a < b");

--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -192,12 +192,19 @@ public struct Block
 
     public Hash buildMerkleTree() nothrow @safe
     {
+        this.merkle_tree.length = (this.txs.length * 2) - 1;
+        return this.buildMerkleTreeImpl();
+    }
+
+    /// Ditto
+    public Hash buildMerkleTreeImpl () nothrow @safe @nogc
+    {
         import core.bitop;
         const log2 = bsf(this.txs.length);
         assert((1 << log2) == this.txs.length,
                "Transactions for a block should be a strict power of 2");
+        assert(this.merkle_tree.length == (this.txs.length * 2) - 1);
 
-        this.merkle_tree.length = (this.txs.length * 2) - 1;
         foreach (size_t idx, ref hash; this.merkle_tree[0 .. this.txs.length])
             hash = hashFull(this.txs[idx]);
 

--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -21,6 +21,7 @@ import agora.common.Deserializer;
 import agora.common.Hash;
 import agora.common.Serializer;
 import agora.common.Transaction;
+import agora.consensus.Genesis;
 
 import std.algorithm.comparison;
 import std.algorithm.iteration;
@@ -306,36 +307,6 @@ public struct Block
                 return idx;
         return this.txs.length;
     }
-}
-
-/*******************************************************************************
-
-    Creates the genesis block.
-    The output address is currently hardcoded to a randomly generated value,
-    it will be replaced later with the proper address.
-
-    Returns:
-        the genesis block
-
-*******************************************************************************/
-
-public Block getGenesisBlock ()
-{
-    import agora.common.crypto.Key;
-
-    auto gen_tx = newCoinbaseTX(getGenesisKeyPair().address, 40_000_000);
-    auto header = BlockHeader(
-        Hash.init, 0,
-        mergeHash(hashFull(gen_tx),hashFull(gen_tx)));
-
-    return Block(header, [gen_tx]);
-}
-
-///
-unittest
-{
-    // ensure the genesis block is always the same
-    assert(getGenesisBlock() == getGenesisBlock());
 }
 
 /*******************************************************************************

--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -175,10 +175,8 @@ public struct Block
         size_t size;
         deserializePart(size, dg);
         this.txs.length = size;
-        foreach (idx; 0 .. size)
-        {
-            deserializePart(this.txs[idx], dg);
-        }
+        foreach (ref tx; this.txs)
+            deserializePart(tx, dg);
     }
 
     /***************************************************************************

--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -190,6 +190,10 @@ public struct Block
 
     public Hash buildMerkleTree() nothrow @safe
     {
+        import core.bitop;
+        assert((1 << bsf(this.txs.length)) == this.txs.length,
+               "Transactions for a block should be a strict power of 2");
+
         this.merkle_tree.length = this.txs.length;
         foreach (size_t idx, ref hash; this.merkle_tree)
             hash = hashFull(this.txs[idx]);
@@ -210,7 +214,7 @@ public struct Block
             j += length;
         }
 
-        return this.merkle_tree.length == 0 ? Hash.init : this.merkle_tree[$ - 1];
+        return this.merkle_tree[$ - 1];
     }
 
     /***************************************************************************

--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -215,7 +215,7 @@ public struct Block
         return this.merkle_tree.length == 0 ? Hash.init : this.merkle_tree[$ - 1];
     }
 
-    /*******************************************************************************
+    /***************************************************************************
 
         Get merkle path
 
@@ -225,7 +225,7 @@ public struct Block
         Returns:
             Return merkle path
 
-    *******************************************************************************/
+    ***************************************************************************/
 
     public Hash[] getMerklePath (size_t index) @safe
     {
@@ -244,19 +244,19 @@ public struct Block
         return merkle_path;
     }
 
-    /*******************************************************************************
+    /***************************************************************************
 
         Calculate the merkle root using the merkle path.
 
         Params:
             hash = `Hash` of `Transaction`
             merkle_path  = `Hash` of merkle path
-            index = Index of the hash in the array of transactions. It starts at zero.
+            index = Index of the hash in the array of transactions.
 
         Returns:
             Return `Hash` of merkle root.
 
-    *******************************************************************************/
+    ***************************************************************************/
 
     public static Hash checkMerklePath (Hash hash, Hash[] merkle_path, size_t index) @safe
     {
@@ -273,7 +273,7 @@ public struct Block
         return hash;
     }
 
-    /*******************************************************************************
+    /***************************************************************************
 
         Find the sequence of transactions for the hash.
 
@@ -284,7 +284,7 @@ public struct Block
             Return sequence if found hash, otherwise Retrun the number of
             transactions.
 
-    *******************************************************************************/
+    ***************************************************************************/
 
     public size_t findHashIndex (Hash hash) @safe
     {

--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -190,7 +190,7 @@ public struct Block
 
     ***************************************************************************/
 
-    public Hash buildMerkleTree() nothrow @safe
+    public Hash buildMerkleTree () nothrow @safe
     {
         this.merkle_tree.length = (this.txs.length * 2) - 1;
         return this.buildMerkleTreeImpl();

--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -428,20 +428,20 @@ unittest
 
     const Hash habcdefgh = mergeHash(habcd, hefgh);
 
-    assert(block.header.merkle_root == habcdefgh, "Error in MerkleTree.");
+    assert(block.header.merkle_root == habcdefgh);
 
     // Merkle Proof
     merkle_path = block.getMerklePath(2);
     assert(merkle_path.length == 3);
-    assert(merkle_path[0] == hd, "Error in the merkle path.");
-    assert(merkle_path[1] == hab, "Error in the merkle path.");
-    assert(merkle_path[2] == hefgh, "Error in the merkle path.");
-    assert(block.header.merkle_root == Block.checkMerklePath(hc, merkle_path, 2), "Error in the merkle proof.");
+    assert(merkle_path[0] == hd);
+    assert(merkle_path[1] == hab);
+    assert(merkle_path[2] == hefgh);
+    assert(block.header.merkle_root == Block.checkMerklePath(hc, merkle_path, 2));
 
     merkle_path = block.getMerklePath(4);
     assert(merkle_path.length == 3);
-    assert(merkle_path[0] == hf, "Error in the merkle path.");
-    assert(merkle_path[1] == hgh, "Error in the merkle path.");
-    assert(merkle_path[2] == habcd, "Error in the merkle path.");
-    assert(block.header.merkle_root == Block.checkMerklePath(he, merkle_path, 4), "Error in the merkle proof.");
+    assert(merkle_path[0] == hf);
+    assert(merkle_path[1] == hgh);
+    assert(merkle_path[2] == habcd);
+    assert(block.header.merkle_root == Block.checkMerklePath(he, merkle_path, 4));
 }

--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -72,7 +72,7 @@ public struct BlockHeader
 
     ***************************************************************************/
 
-    public void serialize (scope SerializeDg dg) pure const nothrow @safe
+    public void serialize (scope SerializeDg dg) const nothrow @safe
     {
         dg(this.prev_block[]);
         serializePart(this.height, dg);
@@ -150,7 +150,7 @@ public struct Block
 
     ***************************************************************************/
 
-    public void serialize (scope SerializeDg dg) pure const nothrow @safe
+    public void serialize (scope SerializeDg dg) const nothrow @safe
     {
         serializePart(this.header, dg);
 

--- a/source/agora/common/Deserializer.d
+++ b/source/agora/common/Deserializer.d
@@ -110,7 +110,7 @@ unittest
     import agora.common.Hash;
     import agora.common.Serializer;
 
-    scope Block block = getGenesisBlock();
+    const block = getGenesisBlock();
 
     // Block Testing serialization & deserialization
     // Compare the serialization data with the origin Ledger data.

--- a/source/agora/common/Deserializer.d
+++ b/source/agora/common/Deserializer.d
@@ -109,6 +109,7 @@ unittest
 {
     import agora.common.Hash;
     import agora.common.Serializer;
+    import agora.consensus.Genesis;
 
     const block = getGenesisBlock();
 

--- a/source/agora/common/Deserializer.d
+++ b/source/agora/common/Deserializer.d
@@ -39,12 +39,11 @@ public Block deserializeBlock (scope ubyte[] data)
     nothrow @safe
 {
     Block block;
-    size_t offset = 0;
 
     scope DeserializeDg dg = (size) nothrow @safe
     {
-        ubyte[] res = data[offset .. offset + size];
-        offset += size;
+        ubyte[] res = data[0 .. size];
+        data = data[size .. $];
         return res;
     };
 

--- a/source/agora/common/Deserializer.d
+++ b/source/agora/common/Deserializer.d
@@ -117,4 +117,24 @@ unittest
     // Compare the serialization data with the origin Ledger data.
     ubyte[] serializedData = serializeFull(block);
     assert(block == deserializeBlock(serializedData));
+
+    // Check that there is no trailing data
+    ubyte[] arrayData = serializeFull(block) ~ serializeFull(block);
+
+    void deserializeArrayEntry () nothrow @safe
+    {
+        scope DeserializeDg dg = (size) nothrow @safe
+        {
+            ubyte[] res = arrayData[0 .. size];
+            arrayData = arrayData[size .. $];
+            return res;
+        };
+
+        Block newblock;
+        newblock.deserialize(dg);
+        assert(newblock == block);
+    }
+
+    deserializeArrayEntry();
+    deserializeArrayEntry();
 }

--- a/source/agora/common/Hash.d
+++ b/source/agora/common/Hash.d
@@ -170,7 +170,7 @@ public void hashPart (scope cstring record, scope HashDg state) /*pure*/ nothrow
 
 *******************************************************************************/
 
-public Hash mergeHash (Hash h1, Hash h2) nothrow @nogc @trusted
+public Hash mergeHash (Hash h1, Hash h2) nothrow @nogc @safe
 {
     static struct MergeHash
     {

--- a/source/agora/common/Serializer.d
+++ b/source/agora/common/Serializer.d
@@ -16,7 +16,7 @@ module agora.common.Serializer;
 import agora.common.Data;
 
 /// Type of delegate SerializeDg
-public alias SerializeDg = void delegate(scope const(ubyte)[]) pure nothrow @safe;
+public alias SerializeDg = void delegate(scope const(ubyte)[]) nothrow @safe;
 
 /*******************************************************************************
 
@@ -33,7 +33,7 @@ public alias SerializeDg = void delegate(scope const(ubyte)[]) pure nothrow @saf
 *******************************************************************************/
 
 public ubyte[] serializeFull (T) (scope const auto ref T record)
-    pure nothrow @safe
+    nothrow @safe
     if (is(T == struct))
 {
     ubyte[] res;
@@ -48,7 +48,7 @@ public ubyte[] serializeFull (T) (scope const auto ref T record)
 
 /// Ditto
 public void serializePart (T) (scope const auto ref T record, scope SerializeDg dg)
-    pure nothrow @safe
+    nothrow @safe
     if (is(T == struct))
 {
     static assert(is(typeof(T.init.serialize(SerializeDg.init))),
@@ -59,49 +59,49 @@ public void serializePart (T) (scope const auto ref T record, scope SerializeDg 
 
 /// Ditto
 public void serializePart () (scope const auto ref Hash record, scope SerializeDg dg)
-    pure nothrow @safe
+    nothrow @safe
 {
     dg(record[]);
 }
 
 /// Ditto
 public void serializePart (scope const Signature record, scope SerializeDg dg)
-    pure nothrow @trusted
+    nothrow @trusted
 {
    dg(record[]);
 }
 
 /// Ditto
 public void serializePart (ubyte record, scope SerializeDg dg)
-    pure nothrow @trusted
+    nothrow @trusted
 {
     dg((cast(ubyte*)&record)[0 .. ubyte.sizeof]);
 }
 
 /// Ditto
 public void serializePart (ushort record, scope SerializeDg dg)
-    pure nothrow @trusted
+    nothrow @trusted
 {
     dg((cast(ubyte*)&record)[0 .. ushort.sizeof]);
 }
 
 /// Ditto
 public void serializePart (uint record, scope SerializeDg dg)
-    pure nothrow @trusted
+    nothrow @trusted
 {
     dg((cast(ubyte*)&record)[0 .. uint.sizeof]);
 }
 
 /// Ditto
 public void serializePart (ulong record, scope SerializeDg dg)
-    pure nothrow @trusted
+    nothrow @trusted
 {
     dg((cast(ubyte*)&record)[0 .. ulong.sizeof]);
 }
 
 /// Ditto
 public void serializePart (scope cstring record, scope SerializeDg dg)
-    pure nothrow @trusted
+    nothrow @trusted
 {
     dg(cast(const ubyte[])record);
 }

--- a/source/agora/common/Transaction.d
+++ b/source/agora/common/Transaction.d
@@ -116,24 +116,16 @@ public struct Transaction
         this.inputs.length = input_size;
 
         // deserialize and generate inputs
-        foreach (idx; 0 .. input_size)
-        {
-            Input input;
+        foreach (ref input; this.inputs)
             deserializePart(input , dg);
-            this.inputs[idx] = input;
-        }
 
         size_t output_size;
         deserializePart(output_size, dg);
         this.outputs.length = output_size;
 
         // deserialize and generate outputs
-        foreach (idx; 0 .. output_size)
-        {
-            Output output;
+        foreach (ref output; this.outputs)
             deserializePart(output, dg);
-            this.outputs[idx] = output;
-        }
     }
 }
 

--- a/source/agora/common/Transaction.d
+++ b/source/agora/common/Transaction.d
@@ -89,7 +89,7 @@ public struct Transaction
 
     ***************************************************************************/
 
-    public void serialize (scope SerializeDg dg) pure const nothrow @safe
+    public void serialize (scope SerializeDg dg) const nothrow @safe
     {
         serializePart(this.inputs.length, dg);
         foreach (const ref input; this.inputs)
@@ -183,7 +183,7 @@ public struct Output
 
     ***************************************************************************/
 
-    public void serialize (scope SerializeDg dg) pure const nothrow @safe
+    public void serialize (scope SerializeDg dg) const nothrow @safe
     {
         serializePart(this.value, dg);
         serializePart(this.address, dg);
@@ -242,7 +242,7 @@ public struct Input
 
     ***************************************************************************/
 
-    public void serialize (scope SerializeDg dg) pure const nothrow @safe
+    public void serialize (scope SerializeDg dg) const nothrow @safe
     {
         serializePart(this.previous, dg);
         serializePart(this.index, dg);

--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -99,23 +99,6 @@ public struct KeyPair
     }
 }
 
-/*******************************************************************************
-
-    Get the key-pair which can spend the UTXO in the genesis transaction.
-    Used for unittests, will be removed later.
-
-    Returns:
-        the key pair which can spend the UTXO in the genesis transaction
-
-*******************************************************************************/
-
-public KeyPair getGenesisKeyPair ()
-{
-    return KeyPair.fromSeed(
-        Seed.fromString(
-            "SCT4KKJNYLTQO4TVDPVJQZEONTVVW66YLRWAINWI3FZDY7U4JS4JJEI4"));
-}
-
 /// Represent a public key / address
 public struct PublicKey
 {

--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -185,7 +185,7 @@ public struct PublicKey
 
     ***************************************************************************/
 
-    public void serialize (scope SerializeDg dg) pure const nothrow @safe
+    public void serialize (scope SerializeDg dg) const nothrow @safe
     {
         dg(this.data[]);
     }

--- a/source/agora/consensus/Genesis.d
+++ b/source/agora/consensus/Genesis.d
@@ -50,7 +50,10 @@ unittest
 /*******************************************************************************
 
     Get the key-pair which can spend the UTXO in the genesis transaction.
+
     Used for unittests, will be removed later.
+    The associated address is :
+    GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ
 
     Returns:
         the key pair which can spend the UTXO in the genesis transaction

--- a/source/agora/consensus/Genesis.d
+++ b/source/agora/consensus/Genesis.d
@@ -1,0 +1,65 @@
+/*******************************************************************************
+
+    Contains primitives related to the genesis block
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.consensus.Genesis;
+
+import agora.common.Block;
+import agora.common.Data;
+import agora.common.Hash;
+import agora.common.Transaction;
+import agora.common.crypto.Key;
+
+/*******************************************************************************
+
+    Creates the genesis block.
+    The output address is currently hardcoded to a randomly generated value,
+    it will be replaced later with the proper address.
+
+    Returns:
+        the genesis block
+
+*******************************************************************************/
+
+public Block getGenesisBlock ()
+{
+    auto gen_tx = newCoinbaseTX(getGenesisKeyPair().address, 40_000_000);
+    auto header = BlockHeader(
+        Hash.init, 0,
+        mergeHash(hashFull(gen_tx),hashFull(gen_tx)));
+
+    return Block(header, [gen_tx]);
+}
+
+///
+unittest
+{
+    // ensure the genesis block is always the same
+    assert(getGenesisBlock() == getGenesisBlock());
+}
+
+/*******************************************************************************
+
+    Get the key-pair which can spend the UTXO in the genesis transaction.
+    Used for unittests, will be removed later.
+
+    Returns:
+        the key pair which can spend the UTXO in the genesis transaction
+
+*******************************************************************************/
+
+public KeyPair getGenesisKeyPair ()
+{
+    return KeyPair.fromSeed(
+        Seed.fromString(
+            "SCT4KKJNYLTQO4TVDPVJQZEONTVVW66YLRWAINWI3FZDY7U4JS4JJEI4"));
+}

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -18,6 +18,7 @@ import agora.common.Block;
 import agora.common.Data;
 import agora.common.Hash;
 import agora.common.Transaction;
+import agora.consensus.Genesis;
 
 import vibe.core.log;
 

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -398,19 +398,19 @@ unittest
     Hash[] merkle_path;
     merkle_path = ledger.getMerklePath(1, hc);
     assert(merkle_path.length == 3);
-    assert(merkle_path[0] == hd, "Error in the merkle path.");
-    assert(merkle_path[1] == hab, "Error in the merkle path.");
-    assert(merkle_path[2] == hefgh, "Error in the merkle path.");
-    assert(habcdefgh == Block.checkMerklePath(hc, merkle_path, 2), "Error in the merkle proof.");
-    assert(habcdefgh != Block.checkMerklePath(hd, merkle_path, 2), "Error in the merkle proof.");
+    assert(merkle_path[0] == hd);
+    assert(merkle_path[1] == hab);
+    assert(merkle_path[2] == hefgh);
+    assert(habcdefgh == Block.checkMerklePath(hc, merkle_path, 2));
+    assert(habcdefgh != Block.checkMerklePath(hd, merkle_path, 2));
 
     merkle_path = ledger.getMerklePath(1, he);
     assert(merkle_path.length == 3);
-    assert(merkle_path[0] == hf, "Error in the merkle path.");
-    assert(merkle_path[1] == hgh, "Error in the merkle path.");
-    assert(merkle_path[2] == habcd, "Error in the merkle path.");
-    assert(habcdefgh == Block.checkMerklePath(he, merkle_path, 4), "Error in the merkle proof.");
-    assert(habcdefgh != Block.checkMerklePath(hf, merkle_path, 4), "Error in the merkle proof.");
+    assert(merkle_path[0] == hf);
+    assert(merkle_path[1] == hgh);
+    assert(merkle_path[2] == habcd);
+    assert(habcdefgh == Block.checkMerklePath(he, merkle_path, 4));
+    assert(habcdefgh != Block.checkMerklePath(hf, merkle_path, 4));
 
     merkle_path = ledger.getMerklePath(1, Hash.init);
     assert(merkle_path.length == 0);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -221,7 +221,7 @@ public class Ledger
         if (block_height >= this.ledger.length)
             return null;
 
-        Block * block = &this.ledger[block_height];
+        Block* block = &this.ledger[block_height];
 
         size_t index = block.findHashIndex(hash);
         if (index < block.txs.length)
@@ -341,7 +341,10 @@ unittest
 {
     import agora.common.crypto.Key;
 
-    KeyPair[] key_pairs = [KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random];
+    KeyPair[] key_pairs = [
+        KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random,
+        KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random
+    ];
 
     scope ledger = new Ledger;
     assert(ledger.getLastBlock() == getGenesisBlock());

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -32,7 +32,7 @@ public class Ledger
     private Block[] ledger;
 
     /// pointer to the latest block
-    private Block* last_block;
+    private const(Block)* last_block;
 
     /// Temporary storage where transactions are stored until blocks are created.
     private Transaction[] storage;
@@ -94,9 +94,9 @@ public class Ledger
 
     ***************************************************************************/
 
-    public Block getLastBlock () @safe nothrow @nogc
+    public const(Block)* getLastBlock () @safe nothrow @nogc
     {
-        return *this.last_block;
+        return this.last_block;
     }
 
     /***************************************************************************
@@ -237,7 +237,7 @@ unittest
     import agora.common.crypto.Key;
 
     scope ledger = new Ledger;
-    assert(ledger.getLastBlock() == getGenesisBlock());
+    assert(*ledger.getLastBlock() == getGenesisBlock());
 
     // same key-pair as in getGenesisBlock()
     const genesis_key_pair = KeyPair.fromSeed(
@@ -265,7 +265,7 @@ unittest
     import agora.common.crypto.Key;
 
     scope ledger = new Ledger;
-    assert(ledger.getLastBlock() == getGenesisBlock());
+    assert(*ledger.getLastBlock() == getGenesisBlock());
     assert(ledger.ledger.length == 1);
 
     auto gen_key_pair = getGenesisKeyPair();
@@ -347,7 +347,7 @@ unittest
     ];
 
     scope ledger = new Ledger;
-    assert(ledger.getLastBlock() == getGenesisBlock());
+    assert(*ledger.getLastBlock() == getGenesisBlock());
     assert(ledger.ledger.length == 1);
 
     auto gen_key_pair = getGenesisKeyPair();

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -20,6 +20,7 @@ import agora.common.Block;
 import agora.common.Data;
 import agora.common.Hash;
 import agora.common.Transaction;
+import agora.consensus.Genesis;
 import agora.test.Base;
 
 ///

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -21,6 +21,7 @@ import agora.common.Block;
 import agora.common.Data;
 import agora.common.Hash;
 import agora.common.Transaction;
+import agora.consensus.Genesis;
 import agora.test.Base;
 
 /// Returns: the entire ledger from the provided node


### PR DESCRIPTION
This is a collection of fixes. Each commit is fairly simple and does one thing.
Most commits are trivial, however:
- There's a refactoring for Merkle paths code to reduce allocations
- There's a bug fix for deserialization
- There's a removal of `pure` on serialization function (as @TrustHenry needs it)
- There's a small reorganization of the code to better isolate `getGenesis*`