### PR TITLE
Add agora.common.Amount to handle monetary operations

### DIFF
--- a/source/agora/common/Amount.d
+++ b/source/agora/common/Amount.d
@@ -1,0 +1,243 @@
+/*******************************************************************************
+
+   Defines a monetary type used in the blockchain
+
+   This struct can hold an amount between 0 and 500_000_000 * 10^7,
+   as there is an absolute maximum supply of 500M and each coin can be divided
+   in up to 10^7 units.
+
+   This struct does not expose operation overloading on purpose.
+   Having operator overloading would mean that any error should be reported
+   as either an `assert` being triggered or an `Exception` being thrown.
+   The convenience of using `a + b` would likely mean some places wouldn't
+   be properly bound checked, which would in turn open a DoS.
+   Instead, we provide two kind of functions for operations:
+   `bool OPNAME(ref Amount res, Type)` and `Amount mustOPNAME(Type)`
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.common.Amount;
+
+/// Ditto
+public struct Amount
+{
+    import agora.common.Deserializer;
+    import agora.common.Hash;
+    import agora.common.Serializer;
+
+    import core.checkedint;
+
+    /// Number of units ('cents') per coins
+    public static immutable Amount UnitPerCoin   = Amount(10_000_000, true);
+    /// Maximum number of BOA coins that can ever be in circulation
+    public static immutable ulong  MaxCoinSupply = 500_000_000;
+    /// Maximum amount of money that can ever be in circulation
+    public static immutable Amount MaxUnitSupply =
+        Amount(UnitPerCoin.value * MaxCoinSupply, true);
+
+    /// Helper type for `toString`
+    private alias SinkT = void delegate(scope const(char)[] v) @safe;
+
+    /// Internal data storage
+    private ulong value;
+
+    /***************************************************************************
+
+        Construct an instance of an `Amount`
+
+        Params:
+            units = The monetary amount this new instance represent.
+                    The unit is the smaller unit of currency (see `UnitPerCoin`)
+
+    ***************************************************************************/
+
+    public this (ulong units) nothrow pure @nogc @safe
+    {
+        assert(Amount.isInRange(units));
+        this.value = units;
+    }
+
+    /// Support for hashing
+    public void computeHash (scope HashDg dg) const nothrow @nogc @safe
+    {
+        hashPart(this.value, dg);
+    }
+
+    /// Support for serialization
+    public void serialize (scope SerializeDg dg) const nothrow @safe
+    {
+        serializePart(this.value, dg);
+    }
+
+    /// Support for deserialization
+    public void deserialize (scope DeserializeDg dg) nothrow @safe
+    {
+        deserializePart(this.value, dg);
+    }
+
+    /// Pretty-print this value
+    public void toString (SinkT dg) const @safe
+    {
+        import std.format;
+        formattedWrite(dg, "%d", this.value);
+    }
+
+    /// Also support for Vibe.d serialization to JSON
+    public string toString () const @safe
+    {
+        string ret;
+        scope SinkT dg = (scope v) { ret ~= v; };
+        this.toString(dg);
+        return ret;
+    }
+
+    /// Support for Vibe.d deserialization
+    public static Amount fromString (scope const(char)[] str) pure @safe
+    {
+        import std.conv : to;
+        immutable ul = str.to!ulong;
+        if (!Amount.isInRange(ul))
+            throw new Exception("Invalid input value to Amount");
+        return Amount(ul, true);
+    }
+
+    nothrow pure @nogc @safe:
+
+    /***************************************************************************
+
+        Returns:
+            `true` if `value` is in the range `[0; Amount.MaxUnitSupply]`
+            and can be safely used to make an `Amount`
+
+    ***************************************************************************/
+
+    pragma(inline, true)
+    public static bool isInRange (ulong value)
+    {
+        return value <= MaxUnitSupply.value;
+    }
+
+    /// `isInRange` but as member function
+    pragma(inline, true)
+    public bool isValid () const
+    {
+        return isInRange(this.value);
+    }
+
+    /***************************************************************************
+
+        Add another value to `this` `Amount`
+
+        Params:
+            other = Another `Amount` value. If the value is invalid,
+                    `false` will be returned.
+        Returns:
+            `true` if the addition returned a number within bounds.
+            `false` if the number is out of the [0; MaxUnitSupply] bound.
+
+    ***************************************************************************/
+
+    pragma(inline, true)
+    public bool add (Amount other)
+    {
+        bool overflow;
+        this.value = addu(this.value, other.value, overflow);
+        if (overflow || !this.isValid())
+        {
+            // If we overflow, make sure to poison the return value
+            this.value = ulong.max;
+            return false;
+        }
+        return true;
+    }
+
+    /***************************************************************************
+
+        Substract another value from `this` `Amount`
+
+        Params:
+            other = Another `Amount` value. If the value is invalid,
+                    `false` will be returned.
+        Returns:
+            `true` if the addition returned a number within bounds.
+            `false` if the number is out of the [0; MaxUnitSupply] bound.
+
+    ***************************************************************************/
+
+    pragma(inline, true)
+    public bool sub (Amount other)
+    {
+        // Check for validity before calling `addu`,
+        // because the value could be invalid and the substraction
+        // would make it valid - but `underflow` is sticky
+        bool underflow = !this.isValid();
+        this.value = subu(this.value, other.value, underflow);
+        if (underflow || !this.isValid())
+        {
+            // If we underflow, make sure to poison the return value
+            this.value = ulong.max;
+            return false;
+        }
+        return true;
+    }
+
+    /// Convenience version of `add` which asserts in case of overflow
+    /// Prefer using this only in `unittest`s
+    public ref Amount mustAdd (Amount other)
+    {
+        if (!this.add(other))
+            assert(0);
+        return this;
+    }
+
+    /// Convenience version of `sub` which asserts in case of underflow
+    /// Prefer using this only in `unittest`s
+    public ref Amount mustSub (Amount other)
+    {
+        if (!this.sub(other))
+            assert(0);
+        return this;
+    }
+
+    /// Make a value without checking bounds
+    /// Used to initialize the bounds themselves, and to make invalid values
+    /// in unittests
+    private this (ulong units, bool dummy) { this.value = units; }
+    /// Ditto
+    version (unittest)
+    public static Amount invalid (ulong units) { return Amount(units, true); }
+}
+
+///
+ nothrow pure @nogc @safe unittest
+ {
+     // Typical use case is to do `if (!op) error_handling;`
+     Amount two = Amount.UnitPerCoin;
+     if (!two.add(two))
+         assert(0);
+     if (!two.sub(two))
+         assert(0);
+
+     // The value is still valid
+     assert(two.isValid());
+
+     // This should error
+     if (two.sub(Amount(1)))
+         assert(0);
+
+     // The value was poisoned
+     assert(!two.isValid());
+     // Even substracting it to itself (which should yield 0) doesn't work
+     assert(!two.sub(two));
+     // But can be reset to a sane value if needed
+     two = Amount(1);
+     if (!two.sub(Amount(1)))
+         assert(0);
+}

--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -15,6 +15,7 @@
 
 module agora.common.Block;
 
+import agora.common.Amount;
 import agora.common.crypto.Key;
 import agora.common.Data;
 import agora.common.Deserializer;

--- a/source/agora/common/Block.d
+++ b/source/agora/common/Block.d
@@ -106,7 +106,7 @@ unittest
     // above parts not @safe/@nogc yet
     () @safe @nogc nothrow
     {
-        Output[1] outputs = [ Output(100, pubkey) ];
+        Output[1] outputs = [ Output(Amount(100), pubkey) ];
         Transaction tx = { outputs: outputs[] };
         BlockHeader header = { merkle_root : tx.hashFull() };
 
@@ -373,7 +373,7 @@ unittest
     Hash last_hash = Hash.init;
     for (int idx = 0; idx < 8; idx++)
     {
-        tx = Transaction([Input(last_hash, 0)],[Output(100_000, key_pairs[idx+1].address)]);
+        tx = Transaction([Input(last_hash, 0)],[Output(Amount(100_000), key_pairs[idx+1].address)]);
         last_hash = hashFull(tx);
         tx.inputs[0].signature = key_pairs[idx].secret.sign(last_hash[]);
         txs ~= tx;

--- a/source/agora/common/Transaction.d
+++ b/source/agora/common/Transaction.d
@@ -400,29 +400,6 @@ unittest
 
 /*******************************************************************************
 
-    Get sum of `Input`
-
-    Params:
-        tx = `Transaction`
-        findOutput = delegate for finding `Output`
-
-    Return:
-        Sum of `Input` in the `Transaction`
-
-*******************************************************************************/
-
-public Amount getSumInput (Transaction tx,
-    scope Output* delegate (Hash hash, size_t index) @safe findOutput) @safe
-{
-    return tx.inputs
-        .map!(a => findOutput(a.previous, a.index))
-        .filter!(a => a !is null)
-        .map!(a => a.value)
-        .reduce!((a, b) => a.mustAdd(b));
-}
-
-/*******************************************************************************
-
     Get sum of `Output`
 
     Params:

--- a/source/agora/common/Transaction.d
+++ b/source/agora/common/Transaction.d
@@ -352,7 +352,7 @@ public Transaction[] makeChainedTransactions (KeyPair key_pair,
     Transaction[] transactions;
 
     // always use the same amount, for simplicity
-    const AmountPerTx = 40_000_000 / Block.TxsInBlock;
+    const Amount AmountPerTx = 40_000_000 / Block.TxsInBlock;
 
     foreach (idx; 0 .. TxCount)
     {
@@ -479,7 +479,7 @@ public bool verify (Transaction tx,
         if (output.value < 0)
             return false;
 
-    long sum_unspent;
+    Amount sum_unspent;
 
     const tx_hash = hashFull(tx);
     foreach (input; tx.inputs)
@@ -507,7 +507,7 @@ unittest
     KeyPair[] key_pairs = [KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random];
 
     // Creates the first transaction.
-    Transaction previousTx = newCoinbaseTX(key_pairs[0].address, 100);
+    Transaction previousTx = newCoinbaseTX(key_pairs[0].address, Amount(100));
 
     // Save
     Hash previousHash = hashFull(previousTx);
@@ -519,7 +519,7 @@ unittest
             Input(previousHash, 0)
         ],
         [
-            Output(50, key_pairs[1].address)
+            Output(Amount(50), key_pairs[1].address)
         ]
     );
 
@@ -538,13 +538,13 @@ unittest
     // It is validated. (the sum of `Output` < the sum of `Input`)
     assert(secondTx.verify(findOutput), format("Transaction data is not validated %s", secondTx));
 
-    secondTx.outputs ~= Output(50, key_pairs[2].address);
+    secondTx.outputs ~= Output(Amount(50), key_pairs[2].address);
     secondTx.inputs[0].signature = key_pairs[0].secret.sign(hashFull(secondTx)[]);
 
     // It is validated. (the sum of `Output` == the sum of `Input`)
     assert(secondTx.verify(findOutput), format("Transaction data is not validated %s", secondTx));
 
-    secondTx.outputs ~= Output(50, key_pairs[3].address);
+    secondTx.outputs ~= Output(Amount(50), key_pairs[3].address);
     secondTx.inputs[0].signature = key_pairs[0].secret.sign(hashFull(secondTx)[]);
 
     // It isn't validated. (the sum of `Output` > the sum of `Input`)
@@ -555,7 +555,7 @@ unittest
 unittest
 {
     KeyPair[] key_pairs = [KeyPair.random(), KeyPair.random()];
-    Transaction tx_1 = newCoinbaseTX(key_pairs[0].address, 1000);
+    Transaction tx_1 = newCoinbaseTX(key_pairs[0].address, Amount(1000));
     Hash tx_1_hash = hashFull(tx_1);
 
     Transaction[Hash] storage;
@@ -574,7 +574,7 @@ unittest
     Transaction tx_2 =
     {
         inputs  : [Input(tx_1_hash, 0)],
-        outputs : [Output(-400_000, key_pairs[1].address)]  // oops
+        outputs : [Output(Amount(-400_000), key_pairs[1].address)]  // oops
     };
 
     tx_2.inputs[0].signature = key_pairs[0].secret.sign(hashFull(tx_2)[]);
@@ -606,7 +606,7 @@ unittest
     };
 
     // Create the first transaction.
-    Transaction genesisTx = newCoinbaseTX(key_pairs[0].address, 100_000);
+    Transaction genesisTx = newCoinbaseTX(key_pairs[0].address, Amount(100_000));
     Hash genesisHash = hashFull(genesisTx);
     storage[genesisHash] = genesisTx;
     genesisTx.inputs[0].signature = key_pairs[0].secret.sign(hashFull(genesisTx)[]);
@@ -617,7 +617,7 @@ unittest
             Input(genesisHash, 0)
         ],
         [
-            Output(1_000, key_pairs[1].address)
+            Output(Amount(1_000), key_pairs[1].address)
         ]
     );
 
@@ -633,7 +633,7 @@ unittest
             Input(tx1Hash, 0)
         ],
         [
-            Output(1_000, key_pairs[1].address)
+            Output(Amount(1_000), key_pairs[1].address)
         ]
     );
 

--- a/source/agora/consensus/Genesis.d
+++ b/source/agora/consensus/Genesis.d
@@ -13,6 +13,7 @@
 
 module agora.consensus.Genesis;
 
+import agora.common.Amount;
 import agora.common.Block;
 import agora.common.Data;
 import agora.common.Hash;

--- a/source/agora/consensus/Genesis.d
+++ b/source/agora/consensus/Genesis.d
@@ -60,8 +60,9 @@ public Transaction getGenesisTx ()
     import std.range;
     import std.format;
 
-    Output[] outputs = iota(Block.TxsInBlock).map!(_ =>
-        Output(40_000_000 / Block.TxsInBlock, getGenesisKeyPair().address)).array;
+    Output[] outputs = iota(Block.TxsInBlock).map!(
+        _ => Output(Amount(40_000_000 / Block.TxsInBlock), getGenesisKeyPair().address)
+        ).array;
 
     return Transaction(
         [Input(Hash.init, 0)],

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -332,7 +332,7 @@ unittest
                 Input(gen_tx_hash, 0)
             ],
             [
-                Output(1_000_000, key_pairs[idx].address)
+                Output(Amount(1_000_000), key_pairs[idx].address)
             ]
         );
         tx.inputs[0].signature = gen_key_pair.secret.sign(hashFull(tx)[]);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -13,6 +13,7 @@
 
 module agora.node.Ledger;
 
+import agora.common.Amount;
 import agora.common.API;
 import agora.common.Block;
 import agora.common.Data;

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -240,7 +240,7 @@ unittest
                 Input(gen_tx_hash, 0)
             ],
             [
-                Output(1_000_000, key_pairs[idx].address)
+                Output(Amount(1_000_000), key_pairs[idx].address)
             ]
         );
         tx.inputs[0].signature = gen_key_pair.secret.sign(hashFull(tx)[]);

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -16,6 +16,7 @@ module agora.test.Ledger;
 
 version (unittest):
 
+import agora.common.Amount;
 import agora.common.crypto.Key;
 import agora.common.Block;
 import agora.common.Data;


### PR DESCRIPTION
This type should be used for monetary operations in the future, to prevent any chance of overflow or underflow.
Currently the total supply is 500M, but in the future it should be extended to the real value.
Since this value is likely to be dependent on the chain state, we might need to move some verifications outside of this type. But for now it'll do.
Also the amount of boilerplate we need to add to support our [de]serialization, hashing and Vibe.d is already annoying. Will check how I can fix that soon.