### PR TITLE
Travis: Build & run the tests before building the app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,5 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ln -s `which g++-9` $HOME/bin/g++; fi # /usr/bin/g++-9
 
 script:
-  - dub build --skip-registry=all --compiler=${DC}
   - dub test --skip-registry=all --compiler=${DC}
+  - dub build --skip-registry=all --compiler=${DC}


### PR DESCRIPTION
This ensures we fail early, as most of the failures are from the tests.