### PR TITLE
Fix broken test in Ledger.d

### DIFF
--- a/source/agora/common/Transaction.d
+++ b/source/agora/common/Transaction.d
@@ -330,6 +330,7 @@ public Transaction[] makeChainedTransactions (KeyPair key_pair,
     import agora.common.Block;
     import std.conv;
 
+    assert(prev_txs.length == 0 || prev_txs.length == Block.TxsInBlock);
     const TxCount = block_count * Block.TxsInBlock;
 
     // in unittests we use the following blockchain layout:

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -252,7 +252,8 @@ unittest
                 assert(ledger.acceptTransaction(tx));
             });
 
-        last_txs = txes;
+        // keep track of last tx's to chain them to
+        last_txs = txes[$ - Block.TxsInBlock .. $];
     }
 
     genBlockTransactions(2);


### PR DESCRIPTION
This problem showed up once I started using a tx pool in the Ledger. It started erroring about duplicate transactions. Turns out the test was wrong here.