### PR TITLE
Make node shutdown explicit

### DIFF
--- a/source/agora/app.d
+++ b/source/agora/app.d
@@ -72,6 +72,8 @@ private int main (string[] args)
         auto router = new URLRouter();
 
         auto node = new Node!NetworkManager(config);
+        scope(exit) node.shutdown();
+
         router.registerRestInterface(node);
         runTask( { node.start(); });
 

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -91,7 +91,20 @@ public class Node (Network) : API
         this.network.discover();
 
         this.network.retrieveLatestBlocks(this.ledger);
+    }
 
+    /***************************************************************************
+
+        Called on node shutdown.
+
+        Note that this is called explicitly before any destructors,
+        to allow clean shutdown of e.g. databases, which may require
+        GC allocations during the shutdown phase.
+
+    ***************************************************************************/
+
+    public void shutdown ()
+    {
         logInfo("Dumping metadata..");
         this.network.dumpMetadata();
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -156,6 +156,17 @@ public class TestNetworkManager : NetworkManager
 
     /***************************************************************************
 
+        Shut down each of the nodes
+
+    ***************************************************************************/
+
+    public void shutdown ()
+    {
+        this.apis.each!(a => a.shutdown());
+    }
+
+    /***************************************************************************
+
         Keep polling and waiting for nodes to all reach discovery,
         up to 10 attempts and a sleep time between each attempt;
 
@@ -213,11 +224,14 @@ public class TestNetworkManager : NetworkManager
     }
 }
 
-/// Temporary hack to work around the inability to do 'start' from main
+/// Used to call start/shutdown outside of main, and for dependency injection
 public interface TestAPI : API
 {
     ///
     public abstract void start();
+
+    ///
+    public abstract void shutdown ();
 
     ///
     public abstract void metaAddPeer(string peer);
@@ -236,6 +250,12 @@ public final class TestNode (Net) : Node!Net, TestAPI
     public override void start ()
     {
         super.start();
+    }
+
+    ///
+    public override void shutdown ()
+    {
+        super.shutdown();
     }
 
     /// Used by the node

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -35,6 +35,7 @@ unittest
     const NodeCount = 4;
     auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
     network.start();
+    scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);
 
     auto nodes = network.apis.values;

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -78,6 +78,7 @@ unittest
     const NodeCount = 4;
     auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
     network.start();
+    scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);
 
     auto nodes = network.apis.values;
@@ -169,6 +170,7 @@ unittest
 
     // now start the network, let other nodes catch-up the latest blocks
     network.start();
+    scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);
 
     auto attempts = 80;  // wait up to 80*100 msecs (8 seconds)
@@ -192,6 +194,7 @@ unittest
     const NodeCount = 4;
     auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
     network.start();
+    scope(exit) network.shutdown();
 
     auto nodes = network.apis.values;
     auto node_1 = nodes[0];
@@ -223,6 +226,7 @@ unittest
     const NodeCount = 4;
     auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
     network.start();
+    scope(exit) network.shutdown();
 
     auto nodes = network.apis.values;
     auto node_1 = nodes[0];

--- a/source/agora/test/Metadata.d
+++ b/source/agora/test/Metadata.d
@@ -67,5 +67,6 @@ unittest
     const NodeCount = 4;
     auto network = makeTestNetwork!MetaNetworkManager(NetworkTopology.Simple, NodeCount, false);
     network.start();
+    scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);
 }

--- a/source/agora/test/Network.d
+++ b/source/agora/test/Network.d
@@ -26,6 +26,7 @@ unittest
     const NodeCount = 4;
     auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
     network.start();
+    scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);
     // Check that each node knows of the others
     assert(network.apis.byKey().count == NodeCount);

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -33,6 +33,7 @@ unittest
     const NodeCount = 4;
     auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
     network.start();
+    scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);
 
     auto nodes = network.apis.values;


### PR DESCRIPTION
I need this for https://github.com/biozic/d2sqlite3/blob/fea5016f1b08f4e3135a0f4ebcb0ef5f522be4cd/source/d2sqlite3/database.d#L89

If you don't explicitly call `database.close()` **before** the destructors kick-in, it will throw an exception thanks to that check above which calls this: https://github.com/biozic/d2sqlite3/blob/08e77f5f2da3ead57d62c80226bd85e41c27fbd7/source/d2sqlite3/internal/memory.d#L70

I think we will probably need shutdown functionality at some point, so in my mind it makes sense to add it.