### PR TITLE
Implement and use a Transaction Pool

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,3 +43,6 @@
 [submodule "vibe.d"]
 	path = submodules/vibe.d
 	url = https://github.com/bpfkorea/vibe.d.git
+[submodule "d2sqlite3"]
+	path = submodules/d2sqlite3
+	url = https://github.com/biozic/d2sqlite3.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,15 @@ addons:
     packages:
       - libsodium-dev
       - g++-9
+      - libsqlite3-dev
 
 env:
-  - PATH=$HOME/bin/:$PATH
+  - PATH=$HOME/bin/:$PATH; export PKG_CONFIG_PATH="/usr/local/opt/sqlite/lib/pkgconfig"
 
 # No way to install the apt package, so...
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ];   then brew install libsodium; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ];   then brew install sqlite3; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then mkdir -p $HOME/bin/; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ln -s `which gcc-9` $HOME/bin/gcc; fi # /usr/bin/gcc-9
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ln -s `which g++-9` $HOME/bin/g++; fi # /usr/bin/g++-9

--- a/dub.json
+++ b/dub.json
@@ -35,7 +35,7 @@
         "source/scpp/build/numeric.o",
         "source/scpp/build/uint128_t.o"
     ],
-    "lflags": [ "-lsodium", "-lstdc++" ],
+    "lflags": [ "-lsodium", "-lstdc++", "-lsqlite3" ],
 
     "mainSourceFile": "source/agora/node/main.d",
 
@@ -52,6 +52,7 @@
     "dependencies": {
         "base32":           { "path": "submodules/base32/", "version": "*" },
         "bitblob":          { "path": "submodules/bitblob/", "version": "*" },
+        "d2sqlite3":        { "path": "submodules/d2sqlite3/", "version": "*" },
         "dyaml":            { "path": "submodules/dyaml/", "version": "*" },
         "libsodiumd":       { "path": "submodules/libsodiumd/", "version": "*" },
         "localrest":        { "path": "submodules/localrest/", "version": "*" },

--- a/source/agora/common/TransactionPool.d
+++ b/source/agora/common/TransactionPool.d
@@ -1,0 +1,277 @@
+/*******************************************************************************
+
+    Contains a transaction pool that is serializable to disk,
+    using SQLite as a backing store.
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.common.TransactionPool;
+
+import agora.common.Data;
+import agora.common.Deserializer;
+import agora.common.Hash;
+import agora.common.Serializer;
+import agora.common.Transaction;
+
+import d2sqlite3.database;
+import d2sqlite3.library;
+import d2sqlite3.results;
+import d2sqlite3.sqlite3;
+
+import vibe.core.log;
+
+import std.algorithm;
+import std.conv : to;
+import std.exception : collectException, enforce;
+import std.file : exists;
+import std.range;
+
+/// Ditto
+public class TransactionPool
+{
+    /***************************************************************************
+
+        Initialization function. Must be called once per-process
+        (not per-thread!) before the class can be used.
+
+    ***************************************************************************/
+
+    public static void initialize ()
+    {
+        .shutdown();
+        .config(SQLITE_CONFIG_MULTITHREAD);
+        version (unittest) {} else
+            .config(SQLITE_CONFIG_LOG, &loggerCallback, null);
+        .initialize();
+    }
+
+    /// SQLite db instance
+    private Database db;
+
+
+    /***************************************************************************
+
+        Params:
+            db_path = path to the database file, or in-memory storage if
+                      :memory: was passed
+
+    ***************************************************************************/
+
+    public this (in string db_path)
+    {
+        const db_exists = db_path.exists;
+        if (db_exists)
+            logInfo("Loading database from: %s", db_path);
+
+        // note: can fail. we may want to just recover txes from the network instead.
+        this.db = Database(db_path);
+
+        if (db_exists)
+            logInfo("Loaded database from: %s", db_path);
+
+        // create the table if it doesn't exist yet
+        this.db.execute("CREATE TABLE IF NOT EXISTS tx_pool " ~
+            "(key BLOB PRIMARY KEY, val BLOB NOT NULL)");
+    }
+
+    /***************************************************************************
+
+        Callback used
+
+        Params:
+            arg = unused (null)
+            code = the error code
+            msg = the error message
+
+    ***************************************************************************/
+
+    private static extern(C) void loggerCallback (void *arg, int code,
+        const(char)* msg) nothrow
+    {
+        try
+        {
+            logError("SQLite error: (%s) %s", code, msg.to!string);
+        }
+        catch (Exception ex)
+        {
+            // should not propagate exceptions to C code
+        }
+    }
+
+    /***************************************************************************
+
+        Shut down the database
+
+        Note: this method must be called explicitly, and not inside of
+        a destructor.
+
+    ***************************************************************************/
+
+    public void shutdown ()
+    {
+        this.db.close();
+    }
+
+    /***************************************************************************
+
+        Add a transaction to the pool
+
+        Params:
+            tx = the transaction to add
+
+        Throws:
+            SqliteException if the transaction failed to be added
+
+    ***************************************************************************/
+
+    public void add (Transaction tx) @safe
+    {
+        static ubyte[] buffer;
+        buffer.length = 0;
+        () @trusted { assumeSafeAppend(buffer); }();
+
+        scope SerializeDg dg = (scope const(ubyte[]) data) nothrow @safe
+        {
+            buffer ~= data;
+        };
+
+        serializePart(tx, dg);
+
+        () @trusted {
+            db.execute("INSERT INTO tx_pool (key, val) VALUES (?, ?)",
+                hashFull(tx)[], buffer);
+        }();
+    }
+
+    /***************************************************************************
+
+        Returns:
+            the number of transactions in the pool
+
+    ***************************************************************************/
+
+    public size_t length () @safe
+    {
+        // todo: optimize / cache this
+        return () @trusted {
+            return db.execute("SELECT count(*) FROM tx_pool").oneValue!size_t;
+        }();
+    }
+
+    /***************************************************************************
+
+        Params:
+            amount = how many transactions to return
+
+        Returns:
+            an array of 'amount' transactions
+
+        Note:
+            @trusted because most of the body executes non-@safe code,
+            which is assumed to be safe
+
+    ***************************************************************************/
+
+    public Transaction[] take (size_t amount) @trusted
+    {
+        assert(amount <= this.length());
+
+        Hash[] hashes;
+        Transaction[] txs;
+
+        auto results = db.execute("SELECT key, val FROM tx_pool LIMIT ?",
+            amount);
+
+        foreach (row; results)
+        {
+            hashes ~= *cast(Hash*)row.peek!(ubyte[])(0).ptr;
+            txs ~= deserialize!Transaction(row.peek!(ubyte[])(1));
+        }
+
+        const len_prev = this.length();
+
+        hashes.each!(hash => db.execute("DELETE FROM tx_pool WHERE key = ?",
+            hash[]));
+
+        enforce(this.length() == len_prev - amount, "Did not delete txs properly");
+
+        return txs;
+    }
+}
+
+/// add / take tests
+unittest
+{
+    import agora.consensus.Genesis;
+    import std.exception;
+
+    auto pool = new TransactionPool(":memory:");
+    scope(exit) pool.shutdown();  // note: must call outside destructor
+
+    auto gen_key = getGenesisKeyPair();
+    auto txs = makeChainedTransactions(gen_key, null, 1);
+
+    txs.each!(tx => pool.add(tx));
+    assert(pool.length == txs.length);
+
+    auto pool_txs = pool.take(txs.length);
+    assert(pool.length == 0);
+    assert(txs == pool_txs);
+
+    // adding duplicate tx hash => exception throw
+    pool.add(txs[0]);
+    assertThrown!SqliteException(pool.add(txs[0]));
+}
+
+/// memory reclamation tests
+unittest
+{
+    import agora.common.Block;
+    import agora.common.Deserializer;
+    import agora.common.Serializer;
+    import agora.consensus.Genesis;
+    import std.exception;
+    import core.memory;
+
+    auto pool = new TransactionPool(":memory:");
+    scope(exit) pool.shutdown();
+
+    auto gen_key = getGenesisKeyPair();
+    auto txs = makeChainedTransactions(gen_key, null, 1);
+
+    txs.each!(tx => pool.add(tx));
+    assert(pool.length == txs.length);
+
+    // store the txes in serialized form
+    ubyte[][] txs_bytes;
+    txs.each!(tx => txs_bytes ~= serializeFull(tx));
+
+    txs = null;
+    GC.collect();  // GC should not have collected the transactions
+
+    // deserialize the transactions
+    txs_bytes.each!((data)
+        {
+            Transaction tx;
+            scope DeserializeDg dg = (size) nothrow @safe
+            {
+                ubyte[] res = data[0 .. size];
+                data = data[size .. $];
+                return res;
+            };
+
+            tx.deserialize(dg);
+            txs ~= tx;
+        });
+
+    auto pool_txs = pool.take(txs.length);
+    assert(pool.length == 0);
+    assert(txs == pool_txs);
+}

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -35,6 +35,13 @@ import std.stdio;
 /// expects a main() function and invokes it after unittesting.
 version (unittest) void main () { } else:
 
+/// Required initialization
+shared static this ()
+{
+    import agora.common.TransactionPool;
+    TransactionPool.initialize();
+}
+
 /// Application entry point
 private int main (string[] args)
 {

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -31,6 +31,7 @@ import agora.common.Metadata;
 import agora.common.Set;
 import agora.common.Task;
 import agora.common.Transaction;
+import agora.common.TransactionPool;
 import agora.common.crypto.Key;
 import agora.network.NetworkManager;
 import agora.node.API;
@@ -269,6 +270,12 @@ public final class TestNode (Net) : Node!Net, TestAPI
     public override Metadata getMetadata (string _unused) @system
     {
         return new MemMetadata();
+    }
+
+    /// Return a transaction pool backed by an in-memory SQLite db
+    public override TransactionPool getPool (string) @system
+    {
+        return new TransactionPool(":memory:");
     }
 
     /// Used by unittests

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -44,6 +44,13 @@ import std.format;
 
 import core.time;
 
+/// Required initialization
+shared static this ()
+{
+    import agora.common.TransactionPool;
+    TransactionPool.initialize();
+}
+
 /*******************************************************************************
 
     Task manager backed by LocalRest's event loop.

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -69,6 +69,7 @@ unittest
     auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
 
     network.start();
+    scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);
 
     auto nodes = network.apis.values;

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -30,6 +30,7 @@ unittest
     const NodeCount = 4;
     auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
     network.start();
+    scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);
 
     auto nodes = network.apis.values;


### PR DESCRIPTION
This is the most basic implementation of a transaction pool.

There's a bunch of things that will probably need to be improved:
- caching (e.g. caching .length() calls)
- avoiding excessive memory allocations

The first three commits are part of other PRs. Needed here to make this go green, I'll rebase it after the other PRs are merged.