### PR TITLE
[temporary] Add printouts to test where the segfault originates

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -235,6 +235,8 @@ public class Ledger
 ///
 unittest
 {
+    import std.stdio;
+    writefln("Running unittest %s:%s", __FILE__, __LINE__);
     import agora.common.crypto.Key;
 
     scope ledger = new Ledger;
@@ -309,6 +311,8 @@ unittest
 /// Merkle Proof
 unittest
 {
+    import std.stdio;
+    writefln("Running unittest %s:%s", __FILE__, __LINE__);
     import agora.common.crypto.Key;
 
     KeyPair[] key_pairs = [

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -26,6 +26,8 @@ import agora.test.Base;
 ///
 unittest
 {
+    import std.stdio;
+    writefln("Running unittest %s:%s", __FILE__, __LINE__);
     import core.thread;
     import std.algorithm;
     import std.conv;

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -69,6 +69,8 @@ private bool containSameBlocks (API)(API[] nodes, size_t height)
 ///
 unittest
 {
+    import std.stdio;
+    writefln("Running unittest %s:%s", __FILE__, __LINE__);
     import core.thread;
     import std.algorithm;
     import std.conv;
@@ -130,6 +132,8 @@ unittest
 /// test catch-up phase during booting
 unittest
 {
+    import std.stdio;
+    writefln("Running unittest %s:%s", __FILE__, __LINE__);
     import core.thread;
     import std.algorithm;
     import std.conv;
@@ -185,6 +189,8 @@ unittest
 /// test catch-up phase after initial booting (periodic catch-up)
 unittest
 {
+    import std.stdio;
+    writefln("Running unittest %s:%s", __FILE__, __LINE__);
     import core.thread;
     import std.algorithm;
     import std.range;
@@ -218,6 +224,8 @@ unittest
 /// Merkle Proof
 unittest
 {
+    import std.stdio;
+    writefln("Running unittest %s:%s", __FILE__, __LINE__);
     import std.algorithm.sorting;
 
     const NodeCount = 4;

--- a/source/agora/test/Metadata.d
+++ b/source/agora/test/Metadata.d
@@ -64,6 +64,8 @@ class MetaNetworkManager : TestNetworkManager
 ///
 unittest
 {
+    import std.stdio;
+    writefln("Running unittest %s:%s", __FILE__, __LINE__);
     const NodeCount = 4;
     auto network = makeTestNetwork!MetaNetworkManager(NetworkTopology.Simple, NodeCount, false);
     network.start();

--- a/source/agora/test/Network.d
+++ b/source/agora/test/Network.d
@@ -20,6 +20,8 @@ import agora.test.Base;
 ///
 unittest
 {
+    import std.stdio;
+    writefln("Running unittest %s:%s", __FILE__, __LINE__);
     import std.algorithm;
     import std.format;
 

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -26,6 +26,8 @@ import agora.test.Base;
 /// test retrying requests after failure
 unittest
 {
+    import std.stdio;
+    writefln("Running unittest %s:%s", __FILE__, __LINE__);
     import vibe.core.log;
     import core.thread;
     import std.algorithm;


### PR DESCRIPTION
We want to figure out which of the unittests fail in v0.x.x. Hopefully this uncovers it.