### PR TITLE
Disable OSX testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ d:
 
 os:
   - linux
-  - osx
+#  - osx
 
 # `brew install` is the slowest thing ever on OSX
 # It takes at least 6 minutes to run


### PR DESCRIPTION
OSX tests have been failing on slow machines lately.
However they do not fail for the developers.
Disable them to not block progress while we work on a fix.