### PR TITLE
Drop support for DMD 2.085.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ d:
   - dmd-2.087.1 # 2.087.0 has regressions
   - dmd-2.086.1
   - ldc-1.16.0  # Older version don't work
-  - dmd-2.085.1
   - dmd-beta    # Last so that `fast_finish` is useful
 
 os:


### PR DESCRIPTION
We only support the latest 2 versions at this point.