### PR TITLE
Move agora.common.API to agora.node.API

### DIFF
--- a/source/agora/network/NetworkClient.d
+++ b/source/agora/network/NetworkClient.d
@@ -13,7 +13,6 @@
 
 module agora.network.NetworkClient;
 
-import agora.common.API;
 import agora.common.BanManager;
 import agora.common.Block;
 import agora.common.Config;
@@ -22,6 +21,7 @@ import agora.common.Data;
 import agora.common.Set;
 import agora.common.Task;
 import agora.common.Transaction;
+import agora.node.API;
 
 import vibe.core.log;
 

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -22,7 +22,6 @@
 
 module agora.network.NetworkManager;
 
-import agora.common.API;
 import agora.common.BanManager;
 import agora.common.Block;
 import agora.common.crypto.Key;
@@ -33,6 +32,7 @@ import agora.common.Set;
 import agora.common.Task;
 import agora.common.Transaction;
 import agora.network.NetworkClient;
+import agora.node.API;
 import agora.node.Ledger;
 
 import vibe.core.log;

--- a/source/agora/node/API.d
+++ b/source/agora/node/API.d
@@ -33,7 +33,7 @@
 
 *******************************************************************************/
 
-module agora.common.API;
+module agora.node.API;
 
 import agora.common.crypto.Key;
 import agora.common.Block;

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -14,12 +14,12 @@
 module agora.node.Ledger;
 
 import agora.common.Amount;
-import agora.common.API;
 import agora.common.Block;
 import agora.common.Data;
 import agora.common.Hash;
 import agora.common.Transaction;
 import agora.consensus.Genesis;
+import agora.node.API;
 
 import vibe.core.log;
 

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -13,7 +13,6 @@
 
 module agora.node.Node;
 
-import agora.common.API;
 import agora.common.Block;
 import agora.common.Config;
 import agora.common.Metadata;
@@ -21,6 +20,7 @@ import agora.common.crypto.Key;
 import agora.common.Data;
 import agora.common.Transaction;
 import agora.network.NetworkManager;
+import agora.node.API;
 import agora.node.Ledger;
 
 import agora.node.GossipProtocol;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -22,7 +22,6 @@ module agora.test.Base;
 
 version (unittest):
 
-import agora.common.API;
 import agora.common.BanManager;
 import agora.common.Block;
 import agora.common.Config;
@@ -34,6 +33,7 @@ import agora.common.Task;
 import agora.common.Transaction;
 import agora.common.crypto.Key;
 import agora.network.NetworkManager;
+import agora.node.API;
 import agora.node.Ledger;
 import agora.node.Node;
 

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -15,9 +15,9 @@ module agora.test.NetworkManager;
 
 version (unittest):
 
-import agora.common.API;
 import agora.common.Transaction;
 import agora.consensus.Genesis;
+import agora.node.API;
 import agora.test.Base;
 
 /// test behavior when getBlockHeight() call fails


### PR DESCRIPTION
API was out of place in common, as it depends on a lot of types.
Since it basically defines the communication interface for a node,
it is better located in agora.node itself.