### PR TITLE
newCoinBaseTX: Pass an `Amount` as default parameter, not `int`

### DIFF
--- a/source/agora/common/Transaction.d
+++ b/source/agora/common/Transaction.d
@@ -282,7 +282,7 @@ public bool isCoinbaseTx (Transaction tx) nothrow pure @safe @nogc
 
 *******************************************************************************/
 
-public Transaction newCoinbaseTX (PublicKey address, Amount value = 0)
+public Transaction newCoinbaseTX (PublicKey address, Amount value = Amount(0))
 {
     return Transaction(
         [Input(Hash.init, 0)],


### PR DESCRIPTION
It was only working because no one was calling it with the default value.