### PR TITLE
Test with Xenial only on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: d
 
+dist: xenial
+
 d:
   - dmd-2.087.1 # 2.087.0 has regressions
   - dmd-2.086.1


### PR DESCRIPTION
Trusty is already quite outdated and lacks the latests
versions of the packages we need (e.g. SQLite).

Standard support for Trusty ended in May 2019.