### PR TITLE
Allow dmd-nightly to fail instead of dmd-beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
 
 matrix:
   allow_failures:
-    - d: dmd-beta
+    - d: dmd-nightly
     - d: ldc-latest-ci
   fast_finish: true
 


### PR DESCRIPTION
How did we not catch this ?