### PR TITLE
Test runner: Simplify compiler argument passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_install:
 
 script:
   - dub test -b unittest-cov --skip-registry=all --compiler=${DC}
-  - rdmd --compiler=${DC} ./tests/runner.d ${DC}
+  - rdmd --compiler=${DC} ./tests/runner.d --compiler=${DC} -cov
   - dub build --skip-registry=all --compiler=${DC}
 
 after_success:

--- a/tests/runner.d
+++ b/tests/runner.d
@@ -29,14 +29,11 @@ private int main (string[] args)
 {
     size_t count;
 
-    // For convenience, if no compiler is provided, uses `dmd`
-    immutable compiler = args.length >= 2 ? args[1] : "dmd";
-
     const importPaths = getImportPaths();
     const lflags = getLflags();
     if (!importPaths.length || !lflags.length)
         return 1;
-    const Args = ["rdmd", "--compiler=" ~ compiler, "-cov", ] ~
+    const Args = ["rdmd", ] ~ args[1 .. $] ~
         importPaths.map!(v => "-I" ~ v).array ~
         lflags.map!(v => "-L" ~ v).array;
 


### PR DESCRIPTION
This allow users to have a better experience,
and prevents coverage reports from being generated all the time.