### PR TITLE
Increase the size of the memory map to 640KByte

### DIFF
--- a/source/agora/common/BlockStorage.d
+++ b/source/agora/common/BlockStorage.d
@@ -43,7 +43,7 @@ private immutable size_t ReserveSize = 64 * 1024;
 private immutable ulong MaxBlock = 100;
 
 /// The map file size
-private immutable size_t MapSize = 64 * 1024;
+private immutable size_t MapSize = 640 * 1024;
 
 private struct HeightPosition
 {


### PR DESCRIPTION
Increase the size of the memory map to 640.
To solve problems that arise from large multi-transaction blocks. Unable to put 100 transactions in 64KByte's memory.
This problem will soon be fixed.