### PR TITLE
Make acceptBlock() return a status code

### DIFF
--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -219,6 +219,7 @@ public class NetworkManager
 
         Params:
             block_height = the starting block height to begin retrieval from
+            onReceivedBlocks = delegate to call with the received blocks
 
     ***************************************************************************/
 


### PR DESCRIPTION
When receiving a batch of blocks from another node, we call `acceptBlock` for each block. However if any of the blocks in the sequence are not accepted, we should discard the rest of the blocks. This hasn't been implemented yet.

To implement this, I need acceptBlock() to signal whether it accepted the block or not.