### PR TITLE
Split up TestNetworkManager into two separate classes

### DIFF
--- a/doc/Style.md
+++ b/doc/Style.md
@@ -347,7 +347,7 @@ import agora.test.Base; // Base functions for the test environment
 unittest
 {
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork(NetworkTopology.Simple, NodeCount);
     network.start();
     assert(network.getDiscoveredNodes().length == NodeCount);
 

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -84,9 +84,6 @@ public class NetworkManager
     /// DNS seeds
     private const(string)[] dns_seeds;
 
-    /// no-op. for use with unittests only
-    version (unittest) public this () { }
-
     /// Ctor
     public this (in NodeConfig node_config, in BanManager.Config banman_conf,
         in string[] peers, in string[] dns_seeds, Metadata metadata)

--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -38,8 +38,8 @@ unittest
     const long timeout = 10;
     const size_t max_failed_requests = 4 * Block.TxsInBlock;
 
-    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple,
-        NodeCount, true, retry_delay, max_retries, timeout, max_failed_requests);
+    auto network = makeTestNetwork(NetworkTopology.Simple, NodeCount, true,
+        retry_delay, max_retries, timeout, max_failed_requests);
     network.start();
     scope(exit) network.shutdown();
 

--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -38,7 +38,7 @@ unittest
     const long timeout = 10;
     const size_t max_failed_requests = 4 * Block.TxsInBlock;
 
-    auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple,
+    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple,
         NodeCount, true, retry_delay, max_retries, timeout, max_failed_requests);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -265,20 +265,19 @@ public class TestNetworkManager : NetworkManager
     {
         return new FakeClockBanManager(conf);
     }
-
 }
 
 /// Used to call start/shutdown outside of main, and for dependency injection
 public interface TestAPI : API
 {
     ///
-    public abstract void start();
+    public abstract void start ();
 
     ///
     public abstract void shutdown ();
 
     ///
-    public abstract void metaAddPeer(string peer);
+    public abstract void metaAddPeer (string peer);
 }
 
 /// Ditto

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -381,7 +381,7 @@ public enum NetworkTopology
 
 *******************************************************************************/
 
-public APIManager makeTestNetwork (APIManager : TestAPIManager)
+public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
     (NetworkTopology topology, size_t nodes, bool configure_network = true,
         long retry_delay = 100, size_t max_retries = 20, long timeout = 500,
         size_t max_failed_requests = 100)

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -33,7 +33,7 @@ unittest
     import core.time;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -33,7 +33,7 @@ unittest
     import core.time;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -35,7 +35,7 @@ unittest
     import core.time;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);
@@ -96,7 +96,7 @@ unittest
     import core.time;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
 
     auto nodes = network.apis.values;
     auto node_1 = nodes[0];
@@ -140,7 +140,7 @@ unittest
     import core.time;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
 
@@ -161,7 +161,7 @@ unittest
     import std.algorithm.sorting;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
 

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -35,7 +35,7 @@ unittest
     import core.time;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);
@@ -96,7 +96,7 @@ unittest
     import core.time;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork(NetworkTopology.Simple, NodeCount);
 
     auto nodes = network.apis.values;
     auto node_1 = nodes[0];
@@ -140,7 +140,7 @@ unittest
     import core.time;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
 
@@ -161,7 +161,7 @@ unittest
     import std.algorithm.sorting;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
 

--- a/source/agora/test/Metadata.d
+++ b/source/agora/test/Metadata.d
@@ -27,20 +27,10 @@ import std.array;
 import std.algorithm;
 
 ///
-class MetaNetworkManager : TestNetworkManager
+class MetaAPIManager : TestAPIManager
 {
     static import std.concurrency;
     import geod24.LocalRest;
-
-    /// Ctor
-    public this () { super(); }
-
-    /// Ditto
-    public this (NodeConfig config, BanManager.Config ban_conf, in string[] peers, in string[] dns_seeds,
-        Metadata metadata)
-    {
-        super(config, ban_conf, peers, dns_seeds, metadata);
-    }
 
     /// before we start the nodes, we want to simulate metadata configuration
     public override void start ()
@@ -65,7 +55,7 @@ class MetaNetworkManager : TestNetworkManager
 unittest
 {
     const NodeCount = 4;
-    auto network = makeTestNetwork!MetaNetworkManager(NetworkTopology.Simple, NodeCount, false);
+    auto network = makeTestNetwork!MetaAPIManager(NetworkTopology.Simple, NodeCount, false);
     network.start();
     scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);

--- a/source/agora/test/Network.d
+++ b/source/agora/test/Network.d
@@ -24,7 +24,7 @@ unittest
     import std.format;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);

--- a/source/agora/test/Network.d
+++ b/source/agora/test/Network.d
@@ -24,7 +24,7 @@ unittest
     import std.format;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -31,7 +31,7 @@ unittest
     import core.thread;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);
@@ -66,7 +66,7 @@ unittest
     import core.thread;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
 
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -31,7 +31,7 @@ unittest
     import core.thread;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);
@@ -66,7 +66,7 @@ unittest
     import core.thread;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork(NetworkTopology.Simple, NodeCount);
 
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -28,7 +28,7 @@ unittest
     import core.thread;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestNetworkManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -28,7 +28,7 @@ unittest
     import core.thread;
 
     const NodeCount = 4;
-    auto network = makeTestNetwork!TestAPIManager(NetworkTopology.Simple, NodeCount);
+    auto network = makeTestNetwork(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
     assert(network.getDiscoveredNodes().length == NodeCount);


### PR DESCRIPTION
The "TestNetworkManager" was not really a "NetworkManager". It used a special fake super constructor, which left all the fields initialized to .init. Essentially making all the functionality in `NetworkManager` unusable.