### PR TITLE
Short-circuit when blocks fail validation.

### DIFF
--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -170,7 +170,7 @@ public class NetworkManager
             {
                 this.getBlocksFrom(
                     ledger.getLastBlock().header.height + 1,
-                    (blocks) { blocks.each!(block => ledger.acceptBlock(block)); });
+                    blocks => blocks.all!(block => ledger.acceptBlock(block)));
 
                 this.taskman.wait(2.seconds);
             }
@@ -220,11 +220,14 @@ public class NetworkManager
         Params:
             block_height = the starting block height to begin retrieval from
             onReceivedBlocks = delegate to call with the received blocks
+                               if it returns false, further processing of blocks
+                               from the same node is rejected due to invalid
+                               block data.
 
     ***************************************************************************/
 
     private void getBlocksFrom (ulong block_height,
-        scope void delegate(const(Block)[]) @safe onReceivedBlocks) nothrow
+        scope bool delegate(const(Block)[]) @safe onReceivedBlocks) nothrow
     {
         // return size_t.max if getBlockHeight() fails
         size_t getHeight (NetworkClient node)
@@ -257,7 +260,10 @@ public class NetworkManager
                 logInfo("Received blocks [%s..%s] out of %s..", block_height,
                     block_height + blocks.length, highest_block + 1);  // genesis block
 
-                onReceivedBlocks(blocks);
+                // one or more blocks were rejected, stop retrieval from node
+                if (!onReceivedBlocks(blocks))
+                    return;
+
                 block_height += blocks.length;
             }
             while (block_height < highest_block);


### PR DESCRIPTION
If one in a series of blocks which another node sent to a node fail validation, then there is no reason to continue reading the rest of the batch of blocks as they will most likely fail validation too.

I don't have a test-case for this yet until https://github.com/bpfkorea/agora/pull/177 is merged.