### PR TITLE
Rename mergeHash() to hashMulti() and make it generic

### DIFF
--- a/source/agora/common/Hash.d
+++ b/source/agora/common/Hash.d
@@ -233,3 +233,15 @@ public Hash mergeHash (Hash h1, Hash h2) nothrow @nogc @safe
 
     return hashFull(MergeHash(h1, h2));
 }
+
+///
+unittest
+{
+    Hash foo = hashFull("foo");
+    Hash bar = hashFull("bar");
+    const merged = Hash(
+        "0xe0343d063b14c52630563ec81b0f91a84ddb05f2cf05a2e4330ddc79bd3a06e57" ~
+        "c2e756f276c112342ff1d6f1e74d05bdb9bf880abd74a2e512654e12d171a74");
+
+    assert(mergeHash(foo, bar) == merged);
+}

--- a/source/agora/common/Hash.d
+++ b/source/agora/common/Hash.d
@@ -162,36 +162,6 @@ public void hashPart (scope const(char)[] record, scope HashDg state) /*pure*/ n
     state(cast(const ubyte[])record);
 }
 
-/*******************************************************************************
-
-    Merges two hashes together
-
-    Params:
-        h1 = the first hash
-        h2 = the second hash
-
-    Returns:
-        the merged hash
-
-*******************************************************************************/
-
-public Hash mergeHash (Hash h1, Hash h2) nothrow @nogc @safe
-{
-    static struct MergeHash
-    {
-        Hash left;
-        Hash right;
-
-        public void computeHash (scope HashDg dg) const nothrow @safe @nogc
-        {
-            hashPart(this.left, dg);
-            hashPart(this.right, dg);
-        }
-    }
-
-    return hashFull(MergeHash(h1, h2));
-}
-
 // Test that the implementation actually matches what the RFC gives
 nothrow @nogc @safe unittest
 {
@@ -232,4 +202,34 @@ nothrow @nogc @safe unittest
     str.c1 = 'b';
     str.c2 = 'c';
     assert(hashFull(str) == abc_exp);
+}
+
+/*******************************************************************************
+
+    Merges two hashes together
+
+    Params:
+        h1 = the first hash
+        h2 = the second hash
+
+    Returns:
+        the merged hash
+
+*******************************************************************************/
+
+public Hash mergeHash (Hash h1, Hash h2) nothrow @nogc @safe
+{
+    static struct MergeHash
+    {
+        Hash left;
+        Hash right;
+
+        public void computeHash (scope HashDg dg) const nothrow @safe @nogc
+        {
+            hashPart(this.left, dg);
+            hashPart(this.right, dg);
+        }
+    }
+
+    return hashFull(MergeHash(h1, h2));
 }

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -246,7 +246,7 @@ public struct Block
             immutable start = len - (len >> (order));
             immutable end   = len - (len >> (order + 1));
             merkle_tree[start .. end].chunks(2)
-                .map!(tup => mergeHash(tup[0], tup[1]))
+                .map!(tup => hashMulti(tup[0], tup[1]))
                 .enumerate(size_t(end))
                 .each!((idx, val) => merkle_tree[idx] = val);
         }
@@ -301,9 +301,9 @@ public struct Block
         foreach (const ref otherside; merkle_path)
         {
             if (index & 1)
-                hash = mergeHash(otherside, hash);
+                hash = hashMulti(otherside, hash);
             else
-                hash = mergeHash(hash, otherside);
+                hash = hashMulti(hash, otherside);
 
             index >>= 1;
         }
@@ -442,15 +442,15 @@ unittest
     const Hash hg = hashes[6];
     const Hash hh = hashes[7];
 
-    const Hash hab = mergeHash(ha, hb);
-    const Hash hcd = mergeHash(hc, hd);
-    const Hash hef = mergeHash(he, hf);
-    const Hash hgh = mergeHash(hg, hh);
+    const Hash hab = hashMulti(ha, hb);
+    const Hash hcd = hashMulti(hc, hd);
+    const Hash hef = hashMulti(he, hf);
+    const Hash hgh = hashMulti(hg, hh);
 
-    const Hash habcd = mergeHash(hab, hcd);
-    const Hash hefgh = mergeHash(hef, hgh);
+    const Hash habcd = hashMulti(hab, hcd);
+    const Hash hefgh = hashMulti(hef, hgh);
 
-    const Hash habcdefgh = mergeHash(habcd, hefgh);
+    const Hash habcdefgh = hashMulti(habcd, hefgh);
 
     assert(block.header.merkle_root == habcdefgh);
 

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -371,15 +371,15 @@ unittest
     const Hash hg = hashes[6];
     const Hash hh = hashes[7];
 
-    const Hash hab = mergeHash(ha, hb);
-    const Hash hcd = mergeHash(hc, hd);
-    const Hash hef = mergeHash(he, hf);
-    const Hash hgh = mergeHash(hg, hh);
+    const Hash hab = hashMulti(ha, hb);
+    const Hash hcd = hashMulti(hc, hd);
+    const Hash hef = hashMulti(he, hf);
+    const Hash hgh = hashMulti(hg, hh);
 
-    const Hash habcd = mergeHash(hab, hcd);
-    const Hash hefgh = mergeHash(hef, hgh);
+    const Hash habcd = hashMulti(hab, hcd);
+    const Hash hefgh = hashMulti(hef, hgh);
 
-    const Hash habcdefgh = mergeHash(habcd, hefgh);
+    const Hash habcdefgh = hashMulti(habcd, hefgh);
 
     Hash[] merkle_path;
     merkle_path = ledger.getMerklePath(1, hc);

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -189,15 +189,15 @@ unittest
     const Hash hg = hashes[6];
     const Hash hh = hashes[7];
 
-    const Hash hab = mergeHash(ha, hb);
-    const Hash hcd = mergeHash(hc, hd);
-    const Hash hef = mergeHash(he, hf);
-    const Hash hgh = mergeHash(hg, hh);
+    const Hash hab = hashMulti(ha, hb);
+    const Hash hcd = hashMulti(hc, hd);
+    const Hash hef = hashMulti(he, hf);
+    const Hash hgh = hashMulti(hg, hh);
 
-    const Hash habcd = mergeHash(hab, hcd);
-    const Hash hefgh = mergeHash(hef, hgh);
+    const Hash habcd = hashMulti(hab, hcd);
+    const Hash hefgh = hashMulti(hef, hgh);
 
-    const Hash habcdefgh = mergeHash(habcd, hefgh);
+    const Hash habcdefgh = hashMulti(habcd, hefgh);
 
     Hash[] merkle_path;
     foreach (key, ref node; nodes)


### PR DESCRIPTION
If you have an idea for a better name, please let me know.