### PR TITLE
Make 'rest' import in Node specialized

### DIFF
--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -29,7 +29,7 @@ import agora.node.GossipProtocol;
 
 import vibe.core.log;
 import vibe.data.json;
-import vibe.web.rest;
+import vibe.web.rest : RestException;
 
 import std.algorithm;
 import std.exception;


### PR DESCRIPTION
Makes it more obvious what it is used for.
It should probably be removed in the future.