### PR TITLE
Make an overload of buildMerkleTree() which has no side-effects

### DIFF
--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -205,7 +205,7 @@ public struct Block
     }
 
     /// Ditto
-    public Hash buildMerkleTreeImpl () nothrow @safe @nogc
+    private Hash buildMerkleTreeImpl () nothrow @safe @nogc
     {
         import core.bitop;
         const log2 = bsf(this.txs.length);


### PR DESCRIPTION
This will make it easier (and possible) to validate the merkle root when rebuilding the merkle tree during block validation.