### PR TITLE
Implement full block validation

### DIFF
--- a/source/agora/consensus/Genesis.d
+++ b/source/agora/consensus/Genesis.d
@@ -31,7 +31,7 @@ import agora.consensus.data.Transaction;
 
 *******************************************************************************/
 
-public const(Block) getGenesisBlock ()
+public const(Block) getGenesisBlock () nothrow @safe
 {
     Block block;
     block.header.height = 0;
@@ -54,7 +54,7 @@ unittest
 
 *******************************************************************************/
 
-public Transaction getGenesisTx ()
+public Transaction getGenesisTx () nothrow @safe
 {
     import agora.consensus.data.Block;
     import std.algorithm;

--- a/source/agora/consensus/Validation.d
+++ b/source/agora/consensus/Validation.d
@@ -16,6 +16,7 @@ module agora.consensus.Validation;
 import agora.common.Amount;
 import agora.common.crypto.Key;
 import agora.common.Hash;
+import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
 
 /// Delegate to find an unspent UTXO
@@ -216,4 +217,44 @@ unittest
     storage[tx2Hash] = tx2;
     // Signature verification must be error
     assert(!tx2.isValid(findUTXO), format("Transaction signature is not validated %s", tx2));
+}
+
+/*******************************************************************************
+
+    Check the validity of a block.
+
+    Currently only the height of the block is
+    checked against the previous height.
+
+    Params:
+        block = the block to check
+        prev_height = the height of the previous block which this
+                      block should point to
+
+    Returns:
+        true if the block is considered valid
+
+*******************************************************************************/
+
+public bool isValid (const ref Block block, in ulong prev_height)
+    pure nothrow @safe @nogc
+{
+    if (block.header.height != prev_height + 1)
+        return false;
+
+    return true;
+}
+
+///
+unittest
+{
+    import agora.consensus.Genesis;
+    auto gen_block = getGenesisBlock();
+    Block block;
+    block.header.prev_block = gen_block.header.hashFull();
+    block.header.height = gen_block.header.height + 1;
+    assert(block.isValid(gen_block.header.height));
+
+    block.header.height = 100;
+    assert(!block.isValid(gen_block.header.height));
 }

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -64,7 +64,7 @@ public class Ledger
 
     public bool acceptBlock (const ref Block block) nothrow @safe
     {
-        if (!this.isValidBlock(block))
+        if (!block.isValid(this.last_block.header.height))
         {
             logDebug("Rejected block. %s", block);
             return false;
@@ -154,25 +154,6 @@ public class Ledger
             return null;
 
         return this.ledger[block_height .. min(block_height + max_blocks, $)];
-    }
-
-    /***************************************************************************
-
-        Check the validity of a block.
-        Currently only the height of the block is
-        checked against the last block in the ledger.
-
-        Params:
-            block = the block to check
-
-        Returns:
-            true if the block is considered valid
-
-    ***************************************************************************/
-
-    private bool isValidBlock (const ref Block block) pure nothrow @safe @nogc
-    {
-        return block.header.height == this.last_block.header.height + 1;
     }
 
     /***************************************************************************

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -64,7 +64,8 @@ public class Ledger
 
     public bool acceptBlock (const ref Block block) nothrow @safe
     {
-        if (!block.isValid(this.last_block.header.height))
+        if (!block.isValid(this.last_block.header.height,
+            this.last_block.header.hashFull, &this.findUTXO))
         {
             logDebug("Rejected block. %s", block);
             return false;

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -45,8 +45,7 @@ public class Ledger
     public this (TransactionPool pool)
     {
         this.pool = pool;
-        auto block = getGenesisBlock();
-        assert(this.acceptBlock(block));
+        this.addGenesisBlock();
     }
 
     /***************************************************************************
@@ -173,11 +172,7 @@ public class Ledger
 
     private bool isValidBlock (const ref Block block) pure nothrow @safe @nogc
     {
-        const expected_height = this.last_block !is null
-            ? (this.last_block.header.height + 1)
-            : 0;
-
-        return block.header.height == expected_height;
+        return block.header.height == this.last_block.header.height + 1;
     }
 
     /***************************************************************************
@@ -237,6 +232,20 @@ public class Ledger
             return block.getMerklePath(index);
         else
             return null;
+    }
+
+    /***************************************************************************
+
+        Add the genesis block to the ledger.
+
+    ***************************************************************************/
+
+    private void addGenesisBlock ()
+    {
+        assert(this.ledger.length == 0);
+        auto block = getGenesisBlock();
+        this.ledger ~= block;
+        this.last_block = &this.ledger[$ - 1];
     }
 }
 


### PR DESCRIPTION
Note: Checking for double-spend requires a UTXO set, and this is part of my upcoming PR.

However, the unittests do include tests for double-spend.