### PR TITLE
Add a Dockerfile to build on Alpine Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
     - d: dmd-nightly
     - d: ldc-latest-ci
   fast_finish: true
+  include:
+    - d: dmd
+      services: docker
+      script:   docker run -it $(docker build -q .) --help
 
 # `brew install` is the slowest thing ever on OSX
 # It takes at least 6 minutes to run

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Build Agora from source
+FROM alpine:3.10.1 AS Builder
+RUN apk --no-cache add build-base git libsodium-dev openssl-dev sqlite-dev zlib-dev
+COPY --from=bpfk/pkgbuilder:latest --chown=root:root /home/effortman/.abuild/*.rsa.pub /etc/apk/keys/
+COPY --from=bpfk/ldc:latest /root/packages/ /root/packages/
+COPY --from=bpfk/dub:latest /root/packages/ /root/packages/
+RUN apk --no-cache add /root/packages/effortman/x86_64/ldc-1.16.0-r0.apk \
+    /root/packages/effortman/x86_64/ldc-runtime-1.16.0-r0.apk \
+    /root/packages/effortman/x86_64/ldc-static-1.16.0-r0.apk \
+    /root/packages/effortman/x86_64/dub-1.16.0-r0.apk \
+    /root/packages/effortman/x86_64/dtools-rdmd-2.087.1-r0.apk \
+    && rm -rf /root/packages/
+ADD . /root/agora/
+WORKDIR /root/agora/
+RUN dub build --compiler=ldc2 --override-config vibe-d:tls/openssl-1.1
+
+# Runner
+FROM alpine:3.10.1
+COPY --from=Builder /root/agora/build/agora /root/agora
+RUN apk --no-cache add libgcc libsodium libstdc++ sqlite-libs
+ENTRYPOINT [ "/root/agora" ]


### PR DESCRIPTION
This will allow us to:
- Deploy lightweight containers on our infrastructure
- Make running agora accessible
- Write system integration tests