### PR TITLE
Use a checksum in BlockStorage for data integrity validation

### DIFF
--- a/tests/unit/BlockStorageChecksum.d
+++ b/tests/unit/BlockStorageChecksum.d
@@ -1,0 +1,85 @@
+/*******************************************************************************
+
+    Contains checksum tests.
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module unit.BlockStorageChecksum;
+
+import agora.consensus.data.Block;
+import agora.consensus.data.Transaction;
+import agora.consensus.Genesis;
+import agora.node.BlockStorage;
+
+import std.file;
+import std.path;
+import std.stdio;
+
+/// blocks to write
+const size_t BlockCount = 300;
+
+///
+private void main ()
+{
+    string dir_path = buildPath(getcwd, ".cache");
+    if (dir_path.exists)
+        rmdirRecurse(dir_path);
+
+    mkdir(dir_path);
+    writeBlocks(dir_path);
+    corruptBlocks(dir_path);
+
+    BlockStorage storage = new BlockStorage(dir_path);
+    scope (exit) storage.release();
+
+    Block block;
+    // storage.readBlock(block, 0);  // will halt due to checksum failure
+}
+
+/// Write the block data to disk
+private void writeBlocks (string path)
+{
+    BlockStorage.removeIndexFile(path);
+    BlockStorage storage = new BlockStorage(path);
+
+    const(Block)[] blocks;
+    blocks ~= GenesisBlock;
+    storage.saveBlock(blocks[$ - 1]);
+
+    foreach (block_idx; 0 .. BlockCount)
+    {
+        Transaction[8] txs;
+        auto block = makeNewBlock(blocks[$ - 1], txs[]);
+        storage.saveBlock(block);
+        blocks ~= block;
+    }
+
+    storage.release();
+}
+
+/// Corrupt the block data on disk
+private void corruptBlocks (string dir_path)
+{
+    foreach (string path; dirEntries(dir_path, SpanMode.shallow))
+    {
+        if (!path.isFile)
+            continue;
+
+        auto block_file = File(path, "r+b");
+        block_file.seek(5, SEEK_SET);
+
+        ubyte[1] bytes;
+        block_file.rawRead(bytes);
+
+        // write a modified byte
+        bytes[0]++;
+        block_file.rawWrite(bytes);
+    }
+}


### PR DESCRIPTION
If there is damage to the block file, calculate the checksum in a way that can verify it and save it to the beginning of the file.
We can check the damage by reading the checksum and comparing it.

Requires #162 