### PR TITLE
Add a system integration test based on docker-compose + various improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+doc/
+tests/
+
+# Various build folders
+build/
+source/scpp/build/
+.dub/
+submodules/*/.dub/
+submodules/vibe.d/*/.dub/

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,12 @@ matrix:
   include:
     - d: dmd
       services: docker
-      script:   docker run -it $(docker build -q .) --help
+      script:
+        - docker build -t agora .
+        - docker run agora --help
+        - docker-compose -f tests/system/docker-compose.yml up -d
+        - dub --root tests/system/
+        - docker-compose -f tests/system/docker-compose.yml down
 
 # `brew install` is the slowest thing ever on OSX
 # It takes at least 6 minutes to run

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.com/bpfkorea/agora.svg?branch=v0.x.x)](https://travis-ci.com/bpfkorea/agora)
 [![codecov](https://codecov.io/gh/bpfkorea/agora/branch/v0.x.x/graph/badge.svg)](https://codecov.io/gh/bpfkorea/agora)
+[![](https://images.microbadger.com/badges/image/bpfk/agora.svg)](https://microbadger.com/images/bpfk/agora)
+[![](https://images.microbadger.com/badges/version/bpfk/agora.svg)](https://microbadger.com/images/bpfk/agora)
 
 Node implementation for BOA CoinNet
 

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -213,11 +213,13 @@ private Config parseConfigFileImpl (CommandLine cmdln)
 
     Node root = Loader.fromFile(cmdln.config_path).load();
 
-    string[] parseSequence (string section)
+    string[] parseSequence (string section, bool optional = false)
     {
         if (auto node = section in root)
             enforce(root[section].type == NodeType.sequence,
                 format("`%s` section must be a sequence", section));
+        else if (optional)
+            return null;
         else
             throw new Exception(
                 format("The '%s' section is mandatory and must " ~
@@ -238,7 +240,7 @@ private Config parseConfigFileImpl (CommandLine cmdln)
         banman : parseBanManagerConfig(root["banman"]),
         node : parseNodeConfig(root["node"]),
         network : assumeUnique(parseSequence("network")),
-        dns_seeds : assumeUnique(parseSequence("dns")),
+        dns_seeds : assumeUnique(parseSequence("dns", true)),
         quorums : assumeUnique(parseQuorumSection(root["quorum"]))
     };
 

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -82,7 +82,7 @@ private int main (string[] args)
         scope(exit) node.shutdown();
 
         router.registerRestInterface(node);
-        runTask( { node.start(); });
+        runTask({ node.start(); });
 
         logInfo("About to listen to HTTP: %s", settings.port);
         listenHTTP(settings, router);

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -28,6 +28,7 @@ import vibe.http.router;
 import vibe.http.server;
 import vibe.web.rest;
 
+import std.file;
 import std.getopt;
 import std.stdio;
 
@@ -77,6 +78,8 @@ private int main (string[] args)
         auto settings = new HTTPServerSettings(config.node.address);
         settings.port = config.node.port;
         auto router = new URLRouter();
+
+        mkdirRecurse(config.node.data_dir);
 
         auto node = new Node(config);
         scope(exit) node.shutdown();

--- a/tests/system/.gitignore
+++ b/tests/system/.gitignore
@@ -1,0 +1,2 @@
+build/
+node/*/.cache/

--- a/tests/system/docker-compose.yml
+++ b/tests/system/docker-compose.yml
@@ -1,0 +1,31 @@
+# Simple system integration test
+#
+# This file starts 3 nodes and let them connect to one another.
+# The exposed ports are 4000 - 4001, although nodes use 2826 locally.
+#
+# Note: The order for binding is $LOCAL:$REMOTE ($REMOTE == in container)
+
+version: '3'
+
+services:
+  node-0:
+    image: "agora:latest"
+    command: [ "--config", "/root/wd/config.yaml" ]
+    ports:
+      - "4000:2826"
+    volumes:
+      - ./node/0/:/root/wd/
+  node-1:
+    image: "agora:latest"
+    command: [ "--config", "/root/wd/config.yaml" ]
+    ports:
+      - "4001:2826"
+    volumes:
+      - ./node/1/:/root/wd/
+  node-2:
+    image: "agora:latest"
+    command: [ "--config", "/root/wd/config.yaml" ]
+    ports:
+      - "4002:2826"
+    volumes:
+      - ./node/2/:/root/wd/

--- a/tests/system/dub.json
+++ b/tests/system/dub.json
@@ -1,0 +1,29 @@
+{
+    "name": "systemtest-simple",
+    "targetType": "executable",
+    "targetPath": "build",
+    "lflags": [ "-lsodium" ],
+
+    "sourceFiles": [
+        "../../source/agora/common/crypto/Crc16.d",
+        "../../source/agora/common/crypto/Key.d",
+        "../../source/agora/common/Amount.d",
+        "../../source/agora/common/Data.d",
+        "../../source/agora/common/Deserializer.d",
+        "../../source/agora/common/Hash.d",
+        "../../source/agora/common/Serializer.d",
+        "../../source/agora/common/Set.d",
+        "../../source/agora/consensus/data/Block.d",
+        "../../source/agora/consensus/data/Transaction.d",
+        "../../source/agora/consensus/Genesis.d",
+        "../../source/agora/node/API.d"
+    ],
+    "excludedSourceFiles": [ "source/scpp/*.d", "source/scpd/*.d" ],
+
+    "dependencies": {
+        "base32":           { "path": "../../submodules/base32/", "version": "*" },
+        "bitblob":          { "path": "../../submodules/bitblob/", "version": "*" },
+        "libsodiumd":       { "path": "../../submodules/libsodiumd/", "version": "*" },
+        "vibe-d":           { "path": "../../submodules/vibe.d/", "version": "*" }
+    }
+}

--- a/tests/system/dub.selections.json
+++ b/tests/system/dub.selections.json
@@ -1,0 +1,21 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"base32": {"path":"../../submodules/base32/"},
+		"bitblob": {"path":"../../submodules/bitblob/"},
+		"botan": { "path": "../../submodules/botan/" },
+		"botan-math": { "path": "../../submodules/botan-math/" },
+		"diet-ng": { "path": "../../submodules/diet-ng/" },
+		"eventcore": { "path": "../../submodules/eventcore/" },
+		"libasync": { "path": "../../submodules/libasync/" },
+		"libevent": { "path": "../../submodules/libevent/" },
+		"libsodiumd": {"path":"../../submodules/libsodiumd/"},
+		"memutils": { "path": "../../submodules/memutils/" },
+		"mir-linux-kernel": { "path": "../../submodules/mir-linux-kernel/" },
+		"openssl": { "path": "../../submodules/openssl/" },
+		"stdx-allocator": { "path": "../../submodules/stdx-allocator/" },
+		"taggedalgebraic": { "path": "../../submodules/taggedalgebraic/" },
+		"vibe-core": { "path": "../../submodules/vibe-core/" },
+		"vibe-d": {"path":"../../submodules/vibe.d/"}
+	}
+}

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -1,0 +1,83 @@
+################################################################################
+##                             Network interface                              ##
+################################################################################
+node:
+  is_validator: true
+  min_listeners: 2
+  max_listeners: 10
+  address: 0.0.0.0
+  port:    2826
+  retry_delay: 1.5
+  max_retries: 5
+  timeout: 50
+  # This is a randomly generated keypair
+  # If this node is not a validator, this will be ignored
+  #
+  # DO NOT USE THOSE VALUES ANYWHERE
+  # Private seed:    SCFPAX2KQEMBHCG6SJ77YTHVOYKUVHEFDROVFCKTZUG7Z6Q5IKSNG6NQ
+  # Public address:  GBUVRIIBMHKC4PE6BK7MO2O26U2NJLW4WGGWKLAVLAA2DLFZTBHHKOEK
+  seed:    SCFPAX2KQEMBHCG6SJ77YTHVOYKUVHEFDROVFCKTZUG7Z6Q5IKSNG6NQ
+  # Path to the data directory (if the path doesn't exist it will be created)
+  data_dir: .cache
+
+################################################################################
+##                         Ban manager configuration                          ##
+################################################################################
+banman:
+  max_failed_requests: 10
+  ban_duration: 86400
+
+################################################################################
+##                          Administrative interface                          ##
+################################################################################
+admin:
+  enabled: false
+  address: 127.0.0.1
+  port:    2827
+
+################################################################################
+##                               Node discovery                               ##
+##                                                                            ##
+## When the network first starts, we need to connect to some peers to learn   ##
+## the topology and find a safe intersection to listen to, and, if we are     ##
+## a validator, to insert ourselves.                                          ##
+################################################################################
+network:
+  # Supported value: IPv4, IPv6
+  - http://node-1:2826
+  - http://node-2:2826
+
+################################################################################
+##                               Quorum slices                                ##
+################################################################################
+quorum:
+  # name of the quorum
+  - name: quorum-1
+    # threshold as a percentage
+    threshold: 66%
+    # the list of nodes and sub-quorums in this quorum
+    nodes:
+      - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
+      - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
+      # a subquorum is referenced with a $ symbol
+      - $quorum-1.1
+  - name: quorum-1.1
+    threshold: 66%
+    nodes:
+      - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
+      - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
+      # references another sub-quorum
+      - $quorum-1.1.1
+  - name: quorum-1.1.1
+    threshold: 66%
+    nodes:
+      - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
+      - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
+      - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
+
+################################################################################
+##                               Logging options                              ##
+################################################################################
+logging:
+  # Values: trace, debugV, debug_, diagnostic, info, warn, error, critical, fatal, none (default)
+  level: none

--- a/tests/system/node/1/config.yaml
+++ b/tests/system/node/1/config.yaml
@@ -1,0 +1,84 @@
+################################################################################
+##                             Network interface                              ##
+################################################################################
+node:
+  is_validator: true
+  min_listeners: 2
+  max_listeners: 10
+  address: 0.0.0.0
+  port:    2826
+  retry_delay: 1.5
+  max_retries: 5
+  timeout: 50
+  # This is a randomly generated keypair
+  # If this node is not a validator, this will be ignored
+  #
+  # DO NOT USE THOSE VALUES ANYWHERE
+  # Private seed:    SCTTRCMT7DVZHQS375GWIKYQYHKA3X4IC4EOBNPRGV7DFR3X6OM5VIWL
+  # Public address:  GBJABNUCDJCIL5YJQMB5OZ7VCFPKYLMTUXM2ZKQJACT7PXL7EVOMEKNZ
+  seed:    SCTTRCMT7DVZHQS375GWIKYQYHKA3X4IC4EOBNPRGV7DFR3X6OM5VIWL
+  # Path to the data directory (if the path doesn't exist it will be created)
+  data_dir: /root/wd/.cache/
+
+################################################################################
+##                         Ban manager configuration                          ##
+################################################################################
+banman:
+  max_failed_requests: 10
+  ban_duration: 86400
+
+################################################################################
+##                          Administrative interface                          ##
+################################################################################
+admin:
+  enabled: false
+  address: 127.0.0.1
+  port:    2827
+
+################################################################################
+##                               Node discovery                               ##
+##                                                                            ##
+## When the network first starts, we need to connect to some peers to learn   ##
+## the topology and find a safe intersection to listen to, and, if we are     ##
+## a validator, to insert ourselves.                                          ##
+################################################################################
+network:
+  # Supported value: IPv4, IPv6
+  - http://node-0:2826
+  - http://node-2:2826
+
+
+################################################################################
+##                               Quorum slices                                ##
+################################################################################
+quorum:
+  # name of the quorum
+  - name: quorum-1
+    # threshold as a percentage
+    threshold: 66%
+    # the list of nodes and sub-quorums in this quorum
+    nodes:
+      - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
+      - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
+      # a subquorum is referenced with a $ symbol
+      - $quorum-1.1
+  - name: quorum-1.1
+    threshold: 66%
+    nodes:
+      - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
+      - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
+      # references another sub-quorum
+      - $quorum-1.1.1
+  - name: quorum-1.1.1
+    threshold: 66%
+    nodes:
+      - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
+      - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
+      - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
+
+################################################################################
+##                               Logging options                              ##
+################################################################################
+logging:
+  # Values: trace, debugV, debug_, diagnostic, info, warn, error, critical, fatal, none (default)
+  level: none

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -1,0 +1,83 @@
+################################################################################
+##                             Network interface                              ##
+################################################################################
+node:
+  is_validator: true
+  min_listeners: 2
+  max_listeners: 10
+  address: 0.0.0.0
+  port:    2826
+  retry_delay: 1.5
+  max_retries: 5
+  timeout: 50
+  # This is a randomly generated keypair
+  # If this node is not a validator, this will be ignored
+  #
+  # DO NOT USE THOSE VALUES ANYWHERE
+  # Private seed:    SAI4SRN2U6UQ32FXNYZSXA5OIO6BYTJMBFHJKX774IGS2RHQ7DOEW5SJ
+  # Public address:  GA3DMXTREDC4AIUTHRFIXCKWKF7BDIXRWM2KLV74OPK2OKDM2VJ235GN
+  seed:    SAI4SRN2U6UQ32FXNYZSXA5OIO6BYTJMBFHJKX774IGS2RHQ7DOEW5SJ
+  # Path to the data directory (if the path doesn't exist it will be created)
+  data_dir: .cache
+
+################################################################################
+##                         Ban manager configuration                          ##
+################################################################################
+banman:
+  max_failed_requests: 10
+  ban_duration: 86400
+
+################################################################################
+##                          Administrative interface                          ##
+################################################################################
+admin:
+  enabled: false
+  address: 127.0.0.1
+  port:    2827
+
+################################################################################
+##                               Node discovery                               ##
+##                                                                            ##
+## When the network first starts, we need to connect to some peers to learn   ##
+## the topology and find a safe intersection to listen to, and, if we are     ##
+## a validator, to insert ourselves.                                          ##
+################################################################################
+network:
+  # Supported value: IPv4, IPv6
+  - http://node-0:2826
+  - http://node-1:2826
+
+################################################################################
+##                               Quorum slices                                ##
+################################################################################
+quorum:
+  # name of the quorum
+  - name: quorum-1
+    # threshold as a percentage
+    threshold: 66%
+    # the list of nodes and sub-quorums in this quorum
+    nodes:
+      - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
+      - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
+      # a subquorum is referenced with a $ symbol
+      - $quorum-1.1
+  - name: quorum-1.1
+    threshold: 66%
+    nodes:
+      - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
+      - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
+      # references another sub-quorum
+      - $quorum-1.1.1
+  - name: quorum-1.1.1
+    threshold: 66%
+    nodes:
+      - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
+      - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
+      - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
+
+################################################################################
+##                               Logging options                              ##
+################################################################################
+logging:
+  # Values: trace, debugV, debug_, diagnostic, info, warn, error, critical, fatal, none (default)
+  level: none

--- a/tests/system/source/main.d
+++ b/tests/system/source/main.d
@@ -1,0 +1,91 @@
+/*******************************************************************************
+
+    Stand alone client to test basic functionalities of the node
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module main;
+
+import agora.consensus.data.Transaction;
+import agora.consensus.Genesis;
+import agora.common.crypto.Key;
+import agora.common.Data;
+import agora.common.Hash;
+import agora.node.API;
+
+import vibe.web.rest;
+import std.stdio;
+import core.thread;
+import core.time;
+
+private immutable Addrs = [
+    "http://127.0.0.1:4000",
+    "http://127.0.0.1:4001",
+    "http://127.0.0.1:4002"
+];
+
+void main ()
+{
+    API[3] clients;
+    foreach (idx, addr; Addrs)
+        clients[idx] = new RestInterfaceClient!API(addr);
+
+    foreach (idx, ref client; clients)
+    {
+        writefln("[%s] getPublicKey: %s", idx, client.getPublicKey());
+        writefln("[%s] getNetworkInfo: %s", idx, client.getNetworkInfo());
+        const height = client.getBlockHeight();
+        writefln("[%s] getBlockHeight: %s", idx, height);
+        writeln("----------------------------------------");
+        assert(height == 0);
+    }
+
+    auto kp = getGenesisKeyPair();
+    const gTx = getGenesisTx();
+    const gTxH = hashFull(gTx);
+
+    foreach (idx; 0 .. 8)
+    {
+        auto tx = Transaction(
+            [Input(gTxH, idx)],
+            [Output(gTx.outputs[idx].value, kp.address)]
+        );
+
+        auto signature = kp.secret.sign(hashFull(tx)[]);
+        tx.inputs[0].signature = signature;
+        clients[0].putTransaction(tx);
+    }
+
+    Thread.sleep(1.seconds);
+
+    Hash blockHash;
+    foreach (idx, ref client; clients)
+    {
+        const height = client.getBlockHeight();
+        const blocks = client.getBlocksFrom(0, 42);
+        writefln("[%s] getBlockHeight: %s", idx, height);
+        writefln("[%s] getBlocksFrom: %s", idx, blocks);
+        writeln("----------------------------------------");
+        assert(height == 1);
+        assert(blocks.length == 2);
+        if (idx != 0)
+            assert(blockHash == hashFull(blocks[1].header));
+        else
+            blockHash = hashFull(blocks[1].header);
+    }
+}
+
+/// Copied from Agora
+public KeyPair getGenesisKeyPair ()
+{
+    return KeyPair.fromSeed(
+        Seed.fromString(
+            "SCT4KKJNYLTQO4TVDPVJQZEONTVVW66YLRWAINWI3FZDY7U4JS4JJEI4"));
+}


### PR DESCRIPTION
```
The system integration test spawns a network of 3 nodes
using `docker-compose`.
Eight transactions are sent, and we verify a block
has been created as a result.
```

We need to add support for code coverage but are currently blocked by #221 