### PR TITLE
Minor code & CI improvements

### DIFF
--- a/source/agora/common/BlockStorage.d
+++ b/source/agora/common/BlockStorage.d
@@ -753,13 +753,8 @@ public class BlockStorage : IBlockStorage
 
     private void writeLog (string func, Exception ex) @trusted nothrow
     {
-        try
-        {
-            stderr.writeln(func, ex.message);
-        }
-        catch (Exception ex)
-        {
-        }
+        scope (failure) assert(0);
+        stderr.writeln(func, ex.message);
     }
 }
 

--- a/source/agora/network/NetworkClient.d
+++ b/source/agora/network/NetworkClient.d
@@ -145,8 +145,7 @@ class NetworkClient
     {
         this.taskman.runTask(
         {
-            this.attemptRequest!(LogLevel.debug_)(this.api.putTransaction(tx),
-                null);
+            this.attemptRequest(this.api.putTransaction(tx), null);
         });
     }
 
@@ -210,7 +209,7 @@ class NetworkClient
 
     ***************************************************************************/
 
-    private T attemptRequest (LogLevel log_level = LogLevel.error, T)(
+    private T attemptRequest (LogLevel log_level = LogLevel.debug_, T)(
         lazy T dg, Exception ex)
     {
         foreach (idx; 0 .. this.max_retries)


### PR DESCRIPTION
It seems we're running into constant timeout much more often nowadays.
Since it produces output, the build would take 50 minutes to timeout.
Reduce this to 5 minutes.