### PR TITLE
Move Travis setup / execution to a shell script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,7 @@ matrix:
   include:
     - d: dmd
       services: docker
-      script:
-        - docker build -t agora .
-        - docker run agora --help
+      script:   ./ci/travis_system_integration.sh
 
 # `brew install` is the slowest thing ever on OSX
 # It takes at least 6 minutes to run
@@ -56,18 +54,11 @@ env:
 # As a result, instead of relying on the Homebrew-provided formula,
 # the bottle used had been extracted, and is force-fed to brew.
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ];   then mkdir -p $HOME/Dependencies/; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ];   then wget -P $HOME/Dependencies/ https://homebrew.bintray.com/bottles/libsodium-1.0.18.high_sierra.bottle.tar.gz; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ];   then tar -C /usr/local/Cellar/ -xf $HOME/Dependencies/libsodium-1.0.18.high_sierra.bottle.tar.gz; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ];   then brew link libsodium; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then mkdir -p $HOME/bin/; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ln -s `which gcc-9` $HOME/bin/gcc; fi # /usr/bin/gcc-9
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ln -s `which g++-9` $HOME/bin/g++; fi # /usr/bin/g++-9
+  - if [ "$TRAVIS_OS_NAME" = "osx" ];   then ./ci/travis_osx_setup.sh; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./ci/travis_linux_setup.sh; fi
 
 script:
-  - dub test -b unittest-cov --skip-registry=all --compiler=${DC}
-  - rdmd --compiler=${DC} ./tests/runner.d --compiler=${DC} -cov
-  - dub build --skip-registry=all --compiler=${DC}
+  - ./ci/run.sh
 
 after_success:
  - bash <(curl -s https://codecov.io/bash) -cF unittests

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -xeu
+set -o pipefail
+
+dub test -b unittest-cov --skip-registry=all --compiler=${DC}
+rdmd --compiler=${DC} ./tests/runner.d --compiler=${DC} -cov
+dub build --skip-registry=all --compiler=${DC}

--- a/ci/travis_linux_setup.sh
+++ b/ci/travis_linux_setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -xeu
+set -o pipefail
+
+mkdir -p $HOME/bin/
+ln -s `which gcc-9` $HOME/bin/gcc # /usr/bin/gcc-9
+ln -s `which g++-9` $HOME/bin/g++ # /usr/bin/g++-9

--- a/ci/travis_osx_setup.sh
+++ b/ci/travis_osx_setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -xeu
+set -o pipefail
+
+mkdir -p $HOME/Dependencies/
+wget -P $HOME/Dependencies/ https://homebrew.bintray.com/bottles/libsodium-1.0.18.high_sierra.bottle.tar.gz
+tar -C /usr/local/Cellar/ -xf $HOME/Dependencies/libsodium-1.0.18.high_sierra.bottle.tar.gz
+brew link libsodium

--- a/ci/travis_system_integration.sh
+++ b/ci/travis_system_integration.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -xeu
+set -o pipefail
+
+docker build -t agora .
+docker run agora --help


### PR DESCRIPTION
One issue with Travis is that if a test fails early in the pipeline,
it does not immediately exit, instead continuing the other tests.
By setting '-e' we enable this behavior.