### PR TITLE
Limit CRC32 checksum data length to 1MB

### DIFF
--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -811,7 +811,16 @@ public class BlockStorage : IBlockStorage
     *******************************************************************************/
 
     private static ubyte[] makeChecksum (const ubyte[] data) @safe nothrow
+    out(result)
     {
+        assert(result.length + DataSize <= MapSize,
+            "Checksum size is too large to fit in the map");
+    }
+    body
+    {
+        assert(data.length < 1 << 20,
+            "Data length for checksum should not exceed 1MB");
+
         scope crc32 = new CRC32Digest();
         crc32.put(data);
         static ubyte[4] buffer;


### PR DESCRIPTION
The CRC algorithm's effeciveness is based on the length of its data input, as well as the size of
the CRC (e.g. 8-bit, 16-bit, etc).

With CRC32, a 1MB limit is reasonable.