### PR TITLE
Introduce opApply() and remove() for the TransactionPool

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -129,12 +129,22 @@ public class Ledger
 
     private void makeBlock () @safe
     {
-        auto txs = this.pool.take(Block.TxsInBlock);
+        Hash[] hashes;
+        Transaction[] txs;
+
+        foreach (hash, tx; this.pool)
+        {
+            hashes ~= hash;
+            txs ~= tx;
+        }
+
         assert(txs.length == Block.TxsInBlock);
 
         auto block = makeNewBlock(this.last_block, txs);
         if (!this.acceptBlock(block))
             assert(0);
+
+        hashes.each!(hash => this.pool.remove(hash));
     }
 
     /***************************************************************************


### PR DESCRIPTION
I considered making it an input range, but then there are issues with `@system` destructors being called from within wherever the input range is being used at the call site. Maybe I can make this work better in the future, but for no `opApply` works well.

Required for https://github.com/bpfkorea/agora/pull/194