### PR TITLE
Add the genesis block from within the Ledger

### DIFF
--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -46,6 +46,15 @@ public interface IBlockStorage
 
     /***************************************************************************
 
+        Returns:
+            true if the storage is empty (height index was not loaded)
+
+    ***************************************************************************/
+
+    public bool isEmpty ();
+
+    /***************************************************************************
+
         Read the last block from the storage.
 
         Params:
@@ -184,11 +193,23 @@ public class BlockStorage : IBlockStorage
             assert(0);
 
         // Add Genesis if the storage is empty
-        if (this.height_idx.length == 0)
+        if (this.isEmpty())
         {
             if (!this.saveBlock(GenesisBlock))
                 assert(0);
         }
+    }
+
+    /***************************************************************************
+
+        Returns:
+            true if the storage is empty (height index was not loaded)
+
+    ***************************************************************************/
+
+    public bool isEmpty ()
+    {
+        return this.height_idx.length == 0;
     }
 
     /***************************************************************************
@@ -936,6 +957,18 @@ public class MemBlockStorage : IBlockStorage
         this.height_idx = new IndexHeight();
         this.hash_idx = new IndexHash();
         this.saveBlock(GenesisBlock);
+    }
+
+    /***************************************************************************
+
+        Returns:
+            true if the storage is empty (height index was not loaded)
+
+    ***************************************************************************/
+
+    public bool isEmpty ()
+    {
+        return this.height_idx.length == 0;
     }
 
     /***************************************************************************

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -191,13 +191,6 @@ public class BlockStorage : IBlockStorage
 
         if (!this.loadAllIndexes())
             assert(0);
-
-        // Add Genesis if the storage is empty
-        if (this.isEmpty())
-        {
-            if (!this.saveBlock(GenesisBlock))
-                assert(0);
-        }
     }
 
     /***************************************************************************
@@ -956,7 +949,6 @@ public class MemBlockStorage : IBlockStorage
     {
         this.height_idx = new IndexHeight();
         this.hash_idx = new IndexHash();
-        this.saveBlock(GenesisBlock);
     }
 
     /***************************************************************************

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -42,6 +42,20 @@ public class Ledger
     {
         this.pool = pool;
         this.storage = storage;
+
+        // add the genesis block
+        if (this.storage.isEmpty())
+        {
+            this.storage.saveBlock(GenesisBlock);
+            assert(!this.storage.isEmpty());  // sanity check
+        }
+        else
+        {
+            // ensure latest checksum can be read
+            Block last_block;
+            if (!this.storage.readLastBlock(last_block))
+                assert(0);
+        }
     }
 
     /***************************************************************************


### PR DESCRIPTION
It's not correct to add it within the BlockStorage, because then we lose track whether the block was just added, or if it was loaded from disk. The difference is important, because the Ledger keeps track of UTXOs based on newly-added blocks to the ledger (and the serialized UTXO on disk).

Required for https://github.com/bpfkorea/agora/pull/194