### PR TITLE
Make sure tests wait for handshake to complete

### DIFF
--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -42,6 +42,7 @@ unittest
         retry_delay, max_retries, timeout, max_failed_requests);
     network.start();
     scope(exit) network.shutdown();
+    assert(network.getDiscoveredNodes().length == NodeCount);
 
     auto keys = network.apis.keys;
     auto node_1 = network.apis[keys[0]];

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -144,6 +144,7 @@ unittest
         100, 20, 100);  // reduce timeout to 100 msecs
     network.start();
     scope(exit) network.shutdown();
+    assert(network.getDiscoveredNodes().length == NodeCount);
 
     auto nodes = network.apis.values;
     auto node_1 = nodes[0];
@@ -166,6 +167,7 @@ unittest
     auto network = makeTestNetwork(NetworkTopology.Simple, NodeCount);
     network.start();
     scope(exit) network.shutdown();
+    assert(network.getDiscoveredNodes().length == NodeCount);
 
     auto nodes = network.apis.values;
     auto node_1 = nodes[0];


### PR DESCRIPTION
Note that not all tests wait for the complete handshake, but these three should.