### PR TITLE
Build a command line tool to send transactions

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -37,11 +37,21 @@
     ],
     "lflags": [ "-lsodium", "-lstdc++", "-lsqlite3" ],
 
-    "mainSourceFile": "source/agora/node/main.d",
-
     "configurations": [
         {
+            "name": "server",
+            "mainSourceFile": "source/agora/node/main.d",
+            "excludedSourceFiles": [ "source/agora/cli/*" ]
+        },
+        {
+            "name": "cli",
+            "targetName": "agora-cli",
+            "mainSourceFile": "source/agora/cli/main.d",
+            "excludedSourceFiles": [ "source/agora/node/main.d" ]
+        },
+        {
             "name": "unittest",
+            "excludedSourceFiles": [ "source/agora/cli/main.d" ],
             "sourceFiles": [
                 "source/scpp/build/DSizeChecks.o",
                 "source/scpp/build/DLayoutChecks.o"

--- a/source/agora/cli/CLIResult.d
+++ b/source/agora/cli/CLIResult.d
@@ -1,0 +1,18 @@
+/*******************************************************************************
+
+    The Agora CLI Result Constans
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.cli.CLIResult;
+
+public immutable int CLI_SUCCESS = 0;
+public immutable int CLI_INVALID_ARGUMENTS = 1;
+public immutable int CLI_EXCEPTION = 2;

--- a/source/agora/cli/DefaultProcess.d
+++ b/source/agora/cli/DefaultProcess.d
@@ -1,0 +1,82 @@
+/*******************************************************************************
+
+    The Agora CLI sub-function for default command
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.cli.DefaultProcess;
+
+import agora.cli.CLIResult;
+
+import std.getopt;
+
+/// Basic Option
+private struct DefaultOption
+{
+    /// Help of this CLI
+    public bool help;
+
+    /// Version of this CLI
+    public bool ver;
+}
+
+/// Parse the ommand-line arguments of basic (--version, --help)
+public GetoptResult parseDefaultOption (ref DefaultOption basic, string[] args)
+{
+    return getopt(
+        args,
+        "version|v",
+            "Version of this application",
+            &basic.ver,
+
+        "help|h",
+            "Help of this application",
+            &basic.help
+    );
+}
+
+/// Print help
+public void printDefaultHelp (ref string[] outputs)
+{
+    outputs ~= "usage: agora-cli [--help]";
+    outputs ~= "                  <command> [<args>]";
+    outputs ~= "";
+    outputs ~= "These are commands:";
+    outputs ~= "   sendtx      Send a transaction to node";
+    outputs ~= "";
+}
+
+/// process --version / --help
+public int defaultProcess (string[] args, ref string[] outputs)
+{
+    DefaultOption basic;
+
+    try
+    {
+        parseDefaultOption(basic, args);
+        if (basic.help)
+        {
+            printDefaultHelp(outputs);
+            return CLI_SUCCESS;
+        }
+
+        if (basic.ver)
+        {
+            outputs ~= "agora-cli version 1.00.0";
+            return CLI_SUCCESS;
+        }
+        return CLI_INVALID_ARGUMENTS;
+    }
+    catch (Exception ex)
+    {
+        printDefaultHelp(outputs);
+        return CLI_EXCEPTION;
+    }
+}

--- a/source/agora/cli/SendTxProcess.d
+++ b/source/agora/cli/SendTxProcess.d
@@ -1,0 +1,330 @@
+/*******************************************************************************
+
+    The Agora CLI sub-function for sendtx command
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.cli.SendTxProcess;
+
+import agora.cli.CLIResult;
+import agora.common.Amount;
+import agora.common.crypto.Key;
+import agora.common.Data;
+import agora.common.Hash;
+import agora.consensus.data.Block;
+import agora.consensus.data.Transaction;
+import agora.node.API;
+
+import std.format;
+import std.getopt;
+import std.stdio;
+
+public alias APIMaker = API delegate (string address);
+
+/// Option required to send transaction
+private struct SendTxOption
+{
+    /// IP address of node
+    public string host;
+
+    /// Port of node
+    public ushort port;
+
+    /// Hash of the previous transaction
+    public string txhash;
+
+    /// The index of the output in the previous transaction
+    public uint index;
+
+    /// The seed used to sign the new transaction
+    public string key;
+
+    /// The address key to send the output
+    public string address;
+
+    /// The amount to spend
+    public ulong amount;
+
+    /// dump output option
+    public bool dump;
+}
+
+/// Parse the ommand-line arguments of sendtx (--version, --help)
+public GetoptResult parseSendTxOption (ref SendTxOption op, string[] args)
+{
+    return getopt(
+        args,
+        "ip|i",
+            "IP address of node",
+            &op.host,
+
+        "port|p",
+            "Port of node",
+            &op.port,
+
+        "txhash|t",
+            "Hash of the previous transaction",
+            &op.txhash,
+
+        "index|n",
+            "The index of the output in the previous transaction",
+            &op.index,
+
+        "amount|a",
+            "The amount to spend",
+            &op.amount,
+
+        "dest|d",
+            "The address key to send the output",
+            &op.address,
+
+        "key|k",
+            "The seed used to sign the new transaction",
+            &op.key,
+
+        "dump|o",
+            "dump output option",
+            &op.dump
+            );
+
+}
+
+/// Print help
+public void printSendTxHelp (ref string[] outputs)
+{
+    outputs ~= "usage: agora-cli sendtx --ip --port --txhash --index --amount --dest --key --dump";
+    outputs ~= "";
+    outputs ~= "   sendtx      Send a transaction to node";
+    outputs ~= "";
+    outputs ~= "        -i --ip      IP address of node";
+    outputs ~= "        -p --port    Port of node";
+    outputs ~= "        -t --txhash  Hash of the previous transaction that";
+    outputs ~= "                     contains the Output which the new ";
+    outputs ~= "                     transaction will spend";
+    outputs ~= "        -n --index   The index of the output in the previous";
+    outputs ~= "                     transaction which will be spent";
+    outputs ~= "        -a --amount  The amount to spend";
+    outputs ~= "        -d --dest    The address key to send the output";
+    outputs ~= "        -k --key     The seed used to sign the new transaction";
+    outputs ~= "        -o --dump    Dump output option";
+    outputs ~= "";
+}
+
+/*******************************************************************************
+
+    Input an arguments, generate the transaction and send it to the node
+
+    Params:
+        args = Cli command line arguments
+
+*******************************************************************************/
+
+public int sendTxProcess (string[] args, ref string[] outputs,
+                            APIMaker api_maker)
+{
+    SendTxOption op;
+    GetoptResult res;
+
+    try
+    {
+        res = parseSendTxOption(op, args);
+        if (res.helpWanted)
+        {
+            printSendTxHelp(outputs);
+            return CLI_SUCCESS;
+        }
+    }
+    catch (Exception ex)
+    {
+        printSendTxHelp(outputs);
+        return CLI_EXCEPTION;
+    }
+
+    bool isValid = true;
+
+    if (op.host == "")
+        op.host = "localhost";
+
+    if (op.port == 0)
+        op.port = 2826;
+
+    if (op.txhash.length == 0)
+    {
+        if (isValid) printSendTxHelp(outputs);
+        outputs ~= "Previous Transaction hash is not entered.[--txhash]";
+        isValid = false;
+    }
+
+    if (op.amount == 0)
+    {
+        if (isValid) printSendTxHelp(outputs);
+        outputs ~= "Amount is not entered.[--amount]";
+        isValid = false;
+    }
+
+    if (op.address.length == 0)
+    {
+        if (isValid) printSendTxHelp(outputs);
+        outputs ~= "Address is not entered.[--dest]";
+        isValid = false;
+    }
+
+    if (op.key.length == 0)
+    {
+        if (isValid) printSendTxHelp(outputs);
+        outputs ~= "Key is not entered.[--key]";
+        isValid = false;
+    }
+
+    if (!isValid)
+        return CLI_INVALID_ARGUMENTS;
+
+    // create the transaction
+    auto key_pair = KeyPair.fromSeed(Seed.fromString(op.key));
+
+    Transaction tx =
+    {
+        [Input(Hash.fromString(op.txhash), op.index)],
+        [Output(Amount(op.amount), PublicKey.fromString(op.address))]
+    };
+
+    auto signature = key_pair.secret.sign(hashFull(tx)[]);
+    tx.inputs[0].signature = signature;
+
+    if (op.dump)
+    {
+        outputs ~= format("txhash = %s", op.txhash);
+        outputs ~= format("index = %s", op.index);
+        outputs ~= format("amount = %s", op.amount);
+        outputs ~= format("address = %s", op.address);
+        outputs ~= format("key = %s", op.key);
+        outputs ~= format("hash of new transaction = %s", hashFull(tx).toString);
+        return CLI_SUCCESS;
+    }
+
+    // connect to the node
+    string ip_address = format("http://%s:%s", op.host, op.port);
+    auto node = api_maker(ip_address);
+
+    // send the transaction
+    node.putTransaction(tx);
+
+    return CLI_SUCCESS;
+}
+
+/// Test of send transaction
+unittest
+{
+    class TestCLINode : API
+    {
+        /// Contains the transaction cache
+        private Transaction[Hash] tx_cache;
+
+        private KeyPair key_pair;
+
+        /// Ctor
+        public this ()
+        {
+            key_pair = KeyPair.random();
+        }
+
+        /// GET /public_key
+        public override PublicKey getPublicKey () pure nothrow @safe @nogc
+        {
+            return this.key_pair.address;
+        }
+
+        /// GET: /network_info
+        public override NetworkInfo getNetworkInfo () pure nothrow @safe @nogc
+        {
+            return NetworkInfo();
+        }
+
+        public override void putTransaction (Transaction tx) @safe
+        {
+            auto tx_hash = hashFull(tx);
+            if (this.hasTransactionHash(tx_hash))
+                return;
+
+            this.tx_cache[tx_hash] = tx;
+        }
+
+        /// GET: /hasTransactionHash
+        public override bool hasTransactionHash (Hash tx) @safe
+        {
+            return (tx in this.tx_cache) !is null;
+        }
+
+        /// GET: /block_height
+        public ulong getBlockHeight ()
+        {
+            return 0;
+        }
+
+        /// GET: /blocks_from
+        public const(Block)[] getBlocksFrom
+            (ulong block_height, size_t max_blocks)
+            @safe
+        {
+            return null;
+        }
+
+        /// GET: /merkle_path
+        public Hash[] getMerklePath (ulong block_height, Hash hash) @safe
+        {
+            return null;
+        }
+    }
+
+
+    import std.format;
+
+    string txhash = `0x893abe59f6640fe10aae19682ba982276e78e155a13e7f3ab377f426330c4732`
+    ~ `b4d46a3a6c2a81719dc953dd4d92b493281f8f7a6cef38beca135563d0fdd115`;
+    uint index = 0;
+    string key = "SCT4KKJNYLTQO4TVDPVJQZEONTVVW66YLRWAINWI3FZDY7U4JS4JJEI4";
+    string address = "GCKLKUWUDJNWPSTU7MEN55KFBKJMQIB7H5NQDJ7MGGQVNYIVHB5ZM5XP";
+    ulong amount = 1000;
+
+    string[] args =
+        [
+            "program-name",
+            "sendtx",
+            "--ip=localhost",
+            "--port=2826",
+            format("--txhash=%s", txhash),
+            format("--index=%d", index),
+            format("--amount=%d", amount),
+            format("--dest=%s", address),
+            format("--key=%s", key),
+            "--dump=false"
+        ];
+    string[] outputs;
+
+    auto node = new TestCLINode();
+    auto res = sendTxProcess(args, outputs, (address) {
+        return node;
+    });
+    assert (res == CLI_SUCCESS);
+
+    Transaction tx =
+    {
+        [Input(Hash.fromString(txhash), index)],
+        [Output(Amount(amount), PublicKey.fromString(address))]
+    };
+    Hash send_txhash = hashFull(tx);
+    auto key_pair = KeyPair.fromSeed(Seed.fromString(key));
+    tx.inputs[0].signature = key_pair.secret.sign(send_txhash[]);
+
+    foreach(ref line; outputs)
+        writeln(line);
+
+    assert(node.hasTransactionHash(send_txhash));
+}

--- a/source/agora/cli/main.d
+++ b/source/agora/cli/main.d
@@ -1,0 +1,61 @@
+/*******************************************************************************
+
+    Entry point for the Agora CLI
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.cli.main;
+
+import agora.cli.CLIResult;
+import agora.cli.DefaultProcess;
+import agora.cli.SendTxProcess;
+import agora.node.API;
+
+import vibe.core.core;
+import vibe.web.rest;
+
+import std.stdio;
+
+/// Workaround for issue likely related to dub #225,
+/// expects a main() function and invokes it after unittesting.
+version (unittest) void main () { } else:
+
+/// Application entry point
+private int main (string[] args)
+{
+    string[] outputs;
+    auto res = runProcess(args, outputs);
+
+    foreach(ref line; outputs)
+        writeln(line);
+
+    return res;
+}
+
+///
+int runProcess (string[] args, ref string[] outputs)
+{
+    if (args.length < 2)
+    {
+        printDefaultHelp(outputs);
+        return CLI_SUCCESS;
+    }
+
+    const string command = args[1];
+    switch (command)
+    {
+        case "sendtx":
+            return sendTxProcess(args, outputs, (address) {
+                return new RestInterfaceClient!API(address);
+            });
+        default :
+            return defaultProcess(args, outputs);
+    }
+}


### PR DESCRIPTION
There is a CLI tool that takes an IP/port (node address), an amount, an Outpoint (Tx hash + idx) and a private key.
The CLI tool builds a transaction from its parameters and send it to the node.
The CLI tool has a dump-only option.

Co-Authored-By: HyeonyeobKim <trusthenry@users.noreply.github.com>