### PR TITLE
Correct the definitions of SCP wrappers

### DIFF
--- a/source/scpd/scp/SCP.d
+++ b/source/scpd/scp/SCP.d
@@ -44,9 +44,6 @@ extern(C++, class) public struct SCP
     this(SCPDriver driver, ref const(NodeID) nodeID, bool isValidator,
          ref const(SCPQuorumSet) qSetLocal);
 
-    static SCP* create (SCPDriver driver, ref const(NodeID) nodeID, bool isValidator,
-                        ref const(SCPQuorumSet) qSetLocal);
-
     enum EnvelopeState
     {
         INVALID, // the envelope is considered invalid

--- a/source/scpd/types/Utils.d
+++ b/source/scpd/types/Utils.d
@@ -14,6 +14,8 @@
 module scpd.types.Utils;
 
 import scpd.Cpp;
+import scpd.scp.SCP;
+import scpd.scp.SCPDriver;
 import scpd.types.Stellar_SCP;
 import scpd.types.Stellar_types;
 import scpd.types.XDRBase;
@@ -88,3 +90,7 @@ extern(C++, `stellar`)
         }
     }
 }
+
+/// SCP constructor wrapper
+SCP* createSCP (SCPDriver driver, ref const(NodeID) nodeID, bool isValidator,
+    ref const(SCPQuorumSet) qSetLocal);


### PR DESCRIPTION
The static SCP.create() function was replaced a while ago with the createSCP() function.