### PR TITLE
Tests: Make starting the nodes asynchronous

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -204,6 +204,7 @@ public class TestAPIManager
     {
         import std.stdio;
         import core.thread;
+        import vibe.core.log;
 
         // sleep 1000 times until 1 second is reached
         const attempts = 1000;
@@ -229,10 +230,13 @@ public class TestAPIManager
 
             // try again
             auto sleep_time = 10.msecs;
-            writefln("Sleeping for %s. Discovered %s/%s nodes", sleep_time,
+            logInfo("Sleeping for %s. Discovered %s/%s nodes", sleep_time,
                 fully_discovered.length, this.apis.length);
             Thread.sleep(sleep_time);
         }
+
+        logInfo("Discovered %s/%s nodes", fully_discovered.length,
+            this.apis.length);
 
         return fully_discovered.byKey.array;
     }


### PR DESCRIPTION
Previously what happened during boot in the tests was:

- for each node N in M:
=> node.start();
  => calls discover();
    => tries to reach other nodes
      => other nodes haven't had their start() method called yet, therefore they are not ready to communicate (blocks are not loaded from disk yet, etc)

This is all because in LocalRest after we send a message to a node's thread we also wait for a response back.

With this PR the asynchronous starting of nodes is more thoroughly tested, and this also speeds up the tests a bit.

P.S.: Is there a better way to do this without using a `__gshared`?

Fixes #276 