### PR TITLE
Add type parameters to the transaction output struct.

### DIFF
--- a/source/agora/cli/SendTxProcess.d
+++ b/source/agora/cli/SendTxProcess.d
@@ -192,7 +192,7 @@ public int sendTxProcess (string[] args, ref string[] outputs,
     Transaction tx =
     {
         [Input(Hash.fromString(op.txhash), op.index)],
-        [Output(Amount(op.amount), PublicKey.fromString(op.address))]
+        [Output(Amount(op.amount), PublicKey.fromString(op.address), TXO_PAYMENT)]
     };
 
     auto signature = key_pair.secret.sign(hashFull(tx)[]);
@@ -317,7 +317,7 @@ unittest
     Transaction tx =
     {
         [Input(Hash.fromString(txhash), index)],
-        [Output(Amount(amount), PublicKey.fromString(address))]
+        [Output(Amount(amount), PublicKey.fromString(address), TXO_PAYMENT)]
     };
     Hash send_txhash = hashFull(tx);
     auto key_pair = KeyPair.fromSeed(Seed.fromString(key));

--- a/source/agora/consensus/Genesis.d
+++ b/source/agora/consensus/Genesis.d
@@ -54,14 +54,14 @@ public immutable Transaction GenesisTransaction =
 {
     inputs: [ Input.init ],
     outputs: [
-        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress),
-        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress),
-        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress),
-        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress),
-        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress),
-        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress),
-        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress),
-        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress),
+        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress, TXO_PAYMENT),
+        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress, TXO_PAYMENT),
+        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress, TXO_PAYMENT),
+        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress, TXO_PAYMENT),
+        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress, TXO_PAYMENT),
+        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress, TXO_PAYMENT),
+        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress, TXO_PAYMENT),
+        Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress, TXO_PAYMENT),
     ],
 };
 

--- a/source/agora/consensus/Validation.d
+++ b/source/agora/consensus/Validation.d
@@ -105,7 +105,7 @@ unittest
             Input(previousHash, 0)
         ],
         [
-            Output(Amount(50), key_pairs[1].address)
+            Output(Amount(50), key_pairs[1].address, TXO_PAYMENT)
         ]
     );
 
@@ -124,13 +124,13 @@ unittest
     // It is validated. (the sum of `Output` < the sum of `Input`)
     assert(secondTx.isValid(findUTXO), format("Transaction data is not validated %s", secondTx));
 
-    secondTx.outputs ~= Output(Amount(50), key_pairs[2].address);
+    secondTx.outputs ~= Output(Amount(50), key_pairs[2].address, TXO_PAYMENT);
     secondTx.inputs[0].signature = key_pairs[0].secret.sign(hashFull(secondTx)[]);
 
     // It is validated. (the sum of `Output` == the sum of `Input`)
     assert(secondTx.isValid(findUTXO), format("Transaction data is not validated %s", secondTx));
 
-    secondTx.outputs ~= Output(Amount(50), key_pairs[3].address);
+    secondTx.outputs ~= Output(Amount(50), key_pairs[3].address, TXO_PAYMENT);
     secondTx.inputs[0].signature = key_pairs[0].secret.sign(hashFull(secondTx)[]);
 
     // It isn't validated. (the sum of `Output` > the sum of `Input`)
@@ -161,7 +161,7 @@ unittest
     {
         inputs  : [Input(tx_1_hash, 0)],
         // oops
-        outputs : [Output(Amount.invalid(-400_000), key_pairs[1].address)]
+        outputs : [Output(Amount.invalid(-400_000), key_pairs[1].address, TXO_PAYMENT)]
     };
 
     tx_2.inputs[0].signature = key_pairs[0].secret.sign(hashFull(tx_2)[]);
@@ -204,7 +204,7 @@ unittest
             Input(genesisHash, 0)
         ],
         [
-            Output(Amount(1_000), key_pairs[1].address)
+            Output(Amount(1_000), key_pairs[1].address, TXO_PAYMENT)
         ]
     );
 
@@ -220,7 +220,7 @@ unittest
             Input(tx1Hash, 0)
         ],
         [
-            Output(Amount(1_000), key_pairs[1].address)
+            Output(Amount(1_000), key_pairs[1].address, TXO_PAYMENT)
         ]
     );
 

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -108,7 +108,7 @@ unittest
     // above parts not @safe/@nogc yet
     () @safe @nogc nothrow
     {
-        Output[1] outputs = [ Output(Amount(100), pubkey) ];
+        Output[1] outputs = [ Output(Amount(100), pubkey, TXO_PAYMENT) ];
         Transaction tx = { outputs: outputs[] };
         BlockHeader header = { merkle_root : tx.hashFull() };
 
@@ -396,7 +396,7 @@ unittest
     Hash last_hash = Hash.init;
     for (int idx = 0; idx < 8; idx++)
     {
-        tx = Transaction([Input(last_hash, 0)],[Output(Amount(100_000), key_pairs[idx+1].address)]);
+        tx = Transaction([Input(last_hash, 0)],[Output(Amount(100_000), key_pairs[idx+1].address, TXO_PAYMENT)]);
         last_hash = hashFull(tx);
         tx.inputs[0].signature = key_pairs[idx].secret.sign(last_hash[]);
         txs ~= tx;

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -155,6 +155,17 @@ unittest
 
 *******************************************************************************/
 
+/// The Agora Transaction Output Type constans
+
+/// General payment type
+public immutable int TXO_PAYMENT = 0;
+
+/// Freezing capability to UTXO type
+public immutable int TXO_FREEZE = 1;
+
+/// Unfreezing capability to UTXO type
+public immutable int TXO_UNFREEZE = 2;
+
 public struct Output
 {
     /// The monetary value of this output, in 1/10^7
@@ -164,6 +175,8 @@ public struct Output
     /// Note that in Bitcoin, this is an address (the double hash of a pubkey)
     public PublicKey address;
 
+    /// Transation Output Type
+    public uint type;
 
     /***************************************************************************
 
@@ -178,6 +191,7 @@ public struct Output
     {
         hashPart(this.value, dg);
         hashPart(this.address, dg);
+        hashPart(this.type, dg);
     }
 
     /***************************************************************************
@@ -193,6 +207,7 @@ public struct Output
     {
         serializePart(this.value, dg);
         serializePart(this.address, dg);
+        serializePart(this.type, dg);
     }
 
     /***************************************************************************
@@ -208,6 +223,7 @@ public struct Output
     {
         deserializePart(this.value, dg);
         this.address = PublicKey.fromBinary(dg);
+        deserializePart(this.type, dg);
     }
 }
 

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -322,7 +322,7 @@ public Transaction newCoinbaseTX (PublicKey address, Amount value = Amount(0))
 {
     return Transaction(
         [Input(Hash.init, 0)],
-        [Output(value, address)]
+        [Output(value, address, TXO_PAYMENT)]
     );
 }
 
@@ -388,7 +388,7 @@ public Transaction[] makeChainedTransactions (KeyPair key_pair,
         Transaction tx =
         {
             [input],
-            [Output(AmountPerTx, key_pair.address)]  // send to the same address
+            [Output(AmountPerTx, key_pair.address, TXO_PAYMENT)]  // send to the same address
         };
 
         auto signature = key_pair.secret.sign(hashFull(tx)[]);

--- a/tests/system/source/main.d
+++ b/tests/system/source/main.d
@@ -53,7 +53,7 @@ void main ()
     {
         auto tx = Transaction(
             [Input(GenesisBlock.header.merkle_root, idx)],
-            [Output(GenesisTransaction.outputs[idx].value, kp.address)]
+            [Output(GenesisTransaction.outputs[idx].value, kp.address, TXO_PAYMENT)]
         );
 
         auto signature = kp.secret.sign(hashFull(tx)[]);

--- a/tests/unit/BlockStorage.d
+++ b/tests/unit/BlockStorage.d
@@ -67,7 +67,7 @@ private void main ()
                 Input(gen_tx_hash, 0)
             ],
             [
-                Output(Amount(1_000), key_pairs[idx % 8].address)
+                Output(Amount(1_000), key_pairs[idx % 8].address, TXO_PAYMENT)
             ]
         );
         tx.inputs[0].signature = gen_key_pair.secret.sign(hashFull(tx)[]);

--- a/tests/unit/BlockStorageMultiTx.d
+++ b/tests/unit/BlockStorageMultiTx.d
@@ -117,7 +117,7 @@ private Transaction[] makeChainedTransactions (KeyPair key_pair,
         Transaction tx =
         {
             [input],
-            [Output(AmountPerTx, key_pair.address)]  // send to the same address
+            [Output(AmountPerTx, key_pair.address, TXO_PAYMENT]  // send to the same address
         };
 
         auto signature = key_pair.secret.sign(hashFull(tx)[]);


### PR DESCRIPTION
The function of transaction output is divided into types.
The type currently defined is the same as 

/// General payment type
public immutable int TXO_PAYMENT = 0;

/// Freezing capability to UTXO type
public immutable int TXO_FREEZE = 1;

https://github.com/bpfkorea/agora/issues/204