### PR TITLE
Re-add system integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,11 @@
-version: 2
+version: 2.1
 
 jobs:
   # Build the Docker image
   build:
-    docker:
-      - image: bpfk/circleci:latest
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Install dependencies
-          command: apk add --no-cache bash docker git openssh-client
       - checkout
       - run:
           name: Checkout merge commit
@@ -29,5 +24,25 @@ jobs:
             git submodule sync
             git submodule update --init
       - run:
+          name: Install DMD
+          command: |
+            mkdir -p $HOME/dlang && wget https://dlang.org/install.sh -O $HOME/dlang/install.sh
+            chmod +x $HOME/dlang/install.sh
+            $HOME/dlang/install.sh install dmd-2.088.0
+      - run:
+          name: Install libsodium
+          command: |
+            pushd $HOME
+            wget https://github.com/jedisct1/libsodium/archive/1.0.18-RELEASE.tar.gz
+            tar xvfz 1.0.18-RELEASE.tar.gz
+            cd libsodium-1.0.18-RELEASE
+            ./configure
+            make -j4
+            sudo make install
+            sudo ldconfig # Refresh cache
+            popd
+      - run:
           name: Build & test docker image
-          command: ci/system_integration_test.d
+          command: |
+            source $HOME/dlang/dmd-2.088.0/activate
+            ci/system_integration_test.d

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -106,5 +106,5 @@ quorum:
 ##                               Logging options                              ##
 ################################################################################
 logging:
-  # Values: trace, debugV, debug_, diagnostic, info, warn, error, critical, fatal, none (default)
-  level: none
+  # Values: Trace, Info, Warn, Error, Fatal, None (default)
+  level: None

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -34,7 +34,7 @@ public auto prettify (T) (const ref T input)
 {
     static if (is(T : const Amount))
         return AmountFmt(input);
-    else static if (is(T : const Amount))
+    else static if (is(T : const Hash))
         return HashFmt(input);
     else static if (is(T : const Input))
         return InputFmt(input);

--- a/tests/system/dub.json
+++ b/tests/system/dub.json
@@ -16,7 +16,8 @@
         "../../source/agora/consensus/data/Block.d",
         "../../source/agora/consensus/data/Transaction.d",
         "../../source/agora/consensus/Genesis.d",
-        "../../source/agora/node/API.d"
+        "../../source/agora/node/API.d",
+        "../../source/agora/utils/PrettyPrinter.d",
     ],
     "excludedSourceFiles": [ "source/scpp/*.d", "source/scpd/*.d" ],
 

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -71,5 +71,5 @@ quorum:
 ##                               Logging options                              ##
 ################################################################################
 logging:
-  # Values: trace, debugV, debug_, diagnostic, info, warn, error, critical, fatal, none (default)
-  level: debug_
+  # Values: Trace, Info, Warn, Error, Fatal, None (default)
+  level: Trace

--- a/tests/system/node/1/config.yaml
+++ b/tests/system/node/1/config.yaml
@@ -72,5 +72,5 @@ quorum:
 ##                               Logging options                              ##
 ################################################################################
 logging:
-  # Values: trace, debugV, debug_, diagnostic, info, warn, error, critical, fatal, none (default)
-  level: debug_
+  # Values: Trace, Info, Warn, Error, Fatal, None (default)
+  level: Trace

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -71,5 +71,5 @@ quorum:
 ##                               Logging options                              ##
 ################################################################################
 logging:
-  # Values: trace, debugV, debug_, diagnostic, info, warn, error, critical, fatal, none (default)
-  level: debug_
+  # Values: Trace, Info, Warn, Error, Fatal, None (default)
+  level: Trace


### PR DESCRIPTION
```
They were disabled in a previous PR because they were inadvertently broken.
This commit also allows them to be run locally multiple times without manual intervention.
Additionally, they can be re-run without rebuilding the Docker image.
Finally, the output is much more readable now.
```

Lost a lot of time before I could find https://github.com/bpfkorea/agora/issues/312 , which is going to be a big blocker for everyone.