### PR TITLE
Add type parameters to the transaction struct

### DIFF
--- a/source/agora/cli/SendTxProcess.d
+++ b/source/agora/cli/SendTxProcess.d
@@ -185,6 +185,7 @@ public int sendTxProcess (string[] args, ref string[] outputs,
 
     Transaction tx =
     {
+        TxType.Payment,
         [Input(Hash.fromString(op.txhash), op.index)],
         [Output(Amount(op.amount), PublicKey.fromString(op.address))]
     };
@@ -310,6 +311,7 @@ unittest
 
     Transaction tx =
     {
+        TxType.Payment,
         [Input(Hash.fromString(txhash), index)],
         [Output(Amount(amount), PublicKey.fromString(address))]
     };

--- a/source/agora/common/Deserializer.d
+++ b/source/agora/common/Deserializer.d
@@ -59,6 +59,17 @@ public void deserializePart (T) (ref T record, scope DeserializeDg dg)
     record.deserialize(dg);
 }
 
+/// Enum support
+public void deserializePart (T)(ref T record, scope DeserializeDg dg)
+    nothrow @trusted
+    if (is(T == enum))
+{
+    import std.traits;
+    OriginalType!T orig_val;
+    deserializePart(orig_val, dg);
+    record = cast(T)(orig_val);
+}
+
 /// Ditto
 public void deserializePart (ref Hash record, scope DeserializeDg dg)
     nothrow @safe

--- a/source/agora/consensus/Genesis.d
+++ b/source/agora/consensus/Genesis.d
@@ -46,12 +46,13 @@ unittest
 
 ///
 private immutable Hash GenesisMerkleRoot =
-    Hash(`0x893abe59f6640fe10aae19682ba982276e78e155a13e7f3ab377f426330c4732`
-         ~ `b4d46a3a6c2a81719dc953dd4d92b493281f8f7a6cef38beca135563d0fdd115`);
+    Hash(`0xd04f8dd627ec5245129527b2327ad73d1157d483441a249d7eecd086ee1c4775`
+         ~ `3ad14d410f2bf128d8737366038c85d223e5701b73c7238089f52898ecd0e1b2`);
 
 /// The single transaction that are part of the genesis block
 public immutable Transaction GenesisTransaction =
 {
+    TxType.Payment,
     inputs: [ Input.init ],
     outputs: [
         Output(Amount(40_000_000 / Block.TxsInBlock), GenesisOutputAddress),

--- a/source/agora/consensus/Validation.d
+++ b/source/agora/consensus/Validation.d
@@ -101,6 +101,7 @@ unittest
 
     // Creates the second transaction.
     Transaction secondTx = Transaction(
+        TxType.Payment,
         [
             Input(previousHash, 0)
         ],
@@ -170,6 +171,7 @@ unittest
     // Creates the second transaction.
     Transaction tx_2 =
     {
+        TxType.Payment,
         inputs  : [Input(tx_1_hash, 0)],
         // oops
         outputs : [Output(Amount.invalid(-400_000), key_pairs[1].address)]
@@ -216,6 +218,7 @@ unittest
 
     // Create the second transaction.
     Transaction tx1 = Transaction(
+        TxType.Payment,
         [
             Input(genesisHash, 0)
         ],
@@ -232,6 +235,7 @@ unittest
     assert(tx1.isValid(findUTXO), format("Transaction signature is not validated %s", tx1));
 
     Transaction tx2 = Transaction(
+        TxType.Payment,
         [
             Input(tx1Hash, 0)
         ],

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -113,9 +113,9 @@ unittest
         BlockHeader header = { merkle_root : tx.hashFull() };
 
         auto hash = hashFull(header);
-        auto exp_hash = Hash("0xc45f765d063deece0348f9e7d47287fec5324395b1c" ~
-            "065cde457dbb3c809cbb680450e86ac86bac50ce0d5cd8b1f9b04b29c1b2e5" ~
-            "4cee5d6d5aaac38bb4dca3c");
+        auto exp_hash = Hash("0xc04f3226bdc07c6d3141e3ac14888cd3b4199d84877" ~
+            "e591927063af65e5f56b14f9236e764bacb980aed5acefb98981b221e5c99e" ~
+            "aaaf1100c87c250cec2f32c");
         assert(hash == exp_hash);
     }();
 }
@@ -396,7 +396,7 @@ unittest
     Hash last_hash = Hash.init;
     for (int idx = 0; idx < 8; idx++)
     {
-        tx = Transaction([Input(last_hash, 0)],[Output(Amount(100_000), key_pairs[idx+1].address)]);
+        tx = Transaction(TxType.Payment, [Input(last_hash, 0)],[Output(Amount(100_000), key_pairs[idx+1].address)]);
         last_hash = hashFull(tx);
         tx.inputs[0].signature = key_pairs[idx].secret.sign(last_hash[]);
         txs ~= tx;

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -222,7 +222,8 @@ private struct TransactionFmt
         enum InputPerLine = 3;
         enum OutputPerLine = 3;
 
-        formattedWrite(sink, "Inputs (%d): %(%(%s, %),\n%)\n",
+        formattedWrite(sink, "Type : %s, Inputs (%d): %(%(%s, %),\n%)\n",
+            this.value.type,
             this.value.inputs.length,
             this.value.inputs.map!(v => InputFmt(v)).chunks(InputPerLine));
 
@@ -235,7 +236,7 @@ private struct TransactionFmt
 @safe unittest
 {
     import agora.consensus.Genesis;
-    static immutable ResultStr = `Inputs (1): 0x0000...0000[0]:0x0000...0000
+    static immutable ResultStr = `Type : Payment, Inputs (1): 0x0000...0000[0]:0x0000...0000
 Outputs (8): GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5),
 GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5),
 GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5)`;
@@ -264,7 +265,7 @@ private struct BlockHeaderFmt
 @safe unittest
 {
     import agora.consensus.Genesis;
-    static immutable GenesisHStr = `Height: 0, Prev: 0x0000...0000, Root: 0x893a...d115`;
+    static immutable GenesisHStr = `Height: 0, Prev: 0x0000...0000, Root: 0xd04f...e1b2`;
     assert(GenesisHStr == format("%s", BlockHeaderFmt(GenesisBlock.header)));
 }
 
@@ -290,8 +291,8 @@ private struct BlockFmt
 @safe unittest
 {
     import agora.consensus.Genesis;
-    static immutable ResultStr = `Height: 0, Prev: 0x0000...0000, Root: 0x893a...d115, Transactions: 1
-Inputs (1): 0x0000...0000[0]:0x0000...0000
+    static immutable ResultStr = `Height: 0, Prev: 0x0000...0000, Root: 0xd04f...e1b2, Transactions: 1
+Type : Payment, Inputs (1): 0x0000...0000[0]:0x0000...0000
 Outputs (8): GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5),
 GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5),
 GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5)`;
@@ -303,12 +304,12 @@ GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5)`;
     import agora.common.Hash;
     import agora.consensus.Genesis;
 
-    static immutable ResultStr = `Height: 1, Prev: 0xf4ec...dcba, Root: 0xd63e...0715, Transactions: 2
-Inputs (1): 0x0000...0000[0]:0x0000...0000
+    static immutable ResultStr = `Height: 1, Prev: 0xcdc3...00e1, Root: 0x4203...1ec3, Transactions: 2
+Type : Payment, Inputs (1): 0x0000...0000[0]:0x0000...0000
 Outputs (8): GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5),
 GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5),
 GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5)
-Inputs (1): 0x0000...0000[0]:0x0000...0000
+Type : Payment, Inputs (1): 0x0000...0000[0]:0x0000...0000
 Outputs (8): GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5),
 GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5),
 GCOQ...LRIJ(0.5), GCOQ...LRIJ(0.5)`;

--- a/tests/system/source/main.d
+++ b/tests/system/source/main.d
@@ -52,6 +52,7 @@ void main ()
     foreach (idx; 0 .. 8)
     {
         auto tx = Transaction(
+            TxType.Payment,
             [Input(GenesisBlock.header.merkle_root, idx)],
             [Output(GenesisTransaction.outputs[idx].value, kp.address)]
         );

--- a/tests/unit/BlockStorage.d
+++ b/tests/unit/BlockStorage.d
@@ -63,6 +63,7 @@ private void main ()
     foreach (idx; 1 .. count)
     {
         tx = Transaction(
+            TxType.Payment,
             [
                 Input(gen_tx_hash, 0)
             ],

--- a/tests/unit/BlockStorageMultiTx.d
+++ b/tests/unit/BlockStorageMultiTx.d
@@ -116,6 +116,7 @@ private Transaction[] makeChainedTransactions (KeyPair key_pair,
 
         Transaction tx =
         {
+            TxType.Payment,
             [input],
             [Output(AmountPerTx, key_pair.address)]  // send to the same address
         };


### PR DESCRIPTION
Add freezing capability to UTXO #204 of part
The function of transaction is divided into types.
The type currently defined is the same as
(Payment, Freeze)
Unittest code change and hash changed due to structure change of transaction.