### PR TITLE
Add freezing capability to UTXO

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -205,11 +205,12 @@ public class Ledger
     {
         Hash[] hashes;
         Transaction[] txs;
+        ulong expect_height = this.getBlockHeight() + 1;
 
         auto utxo_finder = this.utxo_set.getUTXOFinder();
         foreach (hash, tx; this.pool)
         {
-            if (tx.isValid(utxo_finder))
+            if (tx.isValid(utxo_finder, expect_height))
             {
                 hashes ~= hash;
                 txs ~= tx;
@@ -249,7 +250,8 @@ public class Ledger
 
     public bool isValidTransaction (const ref Transaction tx) nothrow @safe
     {
-        return tx.isValid(this.utxo_set.getUTXOFinder());
+        const ulong expect_height = this.getBlockHeight() + 1;
+        return tx.isValid(this.utxo_set.getUTXOFinder(), expect_height);
     }
 
     /***************************************************************************
@@ -576,7 +578,7 @@ unittest
         Transaction[] transactions;
 
         // always use the same amount, for simplicity
-        const Amount AmountPerTx = Amount(40_000);
+        const Amount AmountPerTx = Amount(400_000_000_000L);
 
         foreach (idx; 0 .. TxCount)
         {

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -280,7 +280,7 @@ unittest
                 GenesisTransaction.outputs[0]
             );
             return true;
-        }));
+        }, 0));
 
     txs.each!(tx => node_1.putTransaction(tx));
 


### PR DESCRIPTION
Add freezing capability to UTXO #204 of part

### Transaction & UTXO in Freeze
The design was based on **Definition of Done**.
Illustrated the changing situation over time for **Block / Transaction / UTXOSet.**
<img width="920" alt="Transaction & UTXO in Freeze" src="https://user-images.githubusercontent.com/11639939/65112733-9c22a880-da1b-11e9-9f1b-55f4b00098c5.png">

Implement validation when receive transaction 'freeze' in melted and , receive transaction 'payment' in frozen.(TX2, TX3 in upper diagram)
Implement validation when receive transaction 'payment' in various status (melting, melted)(TX4, TX5 in upper diagram)
