### PR TITLE
Automatically deploy documentation through Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,55 @@
+name: Documentation deployment
+
+on:
+  push:
+    branches:
+      - v0.x.x
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Install D and Dub
+      run: |
+        DMD_VERSION=2.088.0
+        wget http://downloads.dlang.org/releases/2.x/${DMD_VERSION}/dmd_${DMD_VERSION}-0_amd64.deb
+        sudo dpkg -i dmd_${DMD_VERSION}-0_amd64.deb
+        sudo apt install -f
+        rm -fv dmd_${DMD_VERSION}-0_amd64.deb
+    - name: Install dependencies
+      run: |
+        # This step is needed because ddox build triggers preBuildCommand
+        sudo apt-get update
+        sudo apt-get install libsodium-dev
+    - name: Generate docs.json
+      run: |
+        dub build -b ddox
+    - name: Filter out libraries
+      # `x:ddocFilterArgs` in `dub.json` does not seem to work,
+      # so we do it manually
+      run: |
+        jq '[ .[] | select(.file|startswith("source/")) ]' docs.json > docs.filtered.json
+    - name: Generate documentation
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Generate the HTML to docs
+        dub run ddox -- generate-html docs.filtered.json ./docs/
+        # Remove gh-branch if it already exists, check it out
+        git branch -D gh-pages || true
+        git checkout --orphan gh-pages
+        # Remove all staged files - We only need the docs
+        git rm -rf $(git ls-files)
+        # We can have some leftover files (e.g. build)
+        # So add docs (which is only what we need), then `git mv` it.
+        git add docs/
+        git mv -k docs/* ./
+        # Configure user
+        git config --global user.email "geod24@users.noreply.github.com"
+        git config --global user.name "Geod24"
+        # We're done
+        git commit -m "Documentation for commit ${GITHUB_SHA}"
+        git push -f https://Geod24:${GITHUB_TOKEN}@github.com/bpfkorea/agora.git gh-pages:gh-pages

--- a/dub.json
+++ b/dub.json
@@ -36,6 +36,7 @@
         "source/scpp/build/uint128_t.o"
     ],
     "lflags": [ "-lsodium", "-lstdc++", "-lsqlite3" ],
+    "buildRequirements": [ "allowWarnings" ],
 
     "configurations": [
         {


### PR DESCRIPTION
There's a 50% chance this doesn't work on the first try, as I need to check if `GITHUB_TOKEN` has proper access, and can't test this in my fork. But we'll only see after merging 🤷‍♂ 