### PR TITLE
Rename 'deserialize' to 'deserializeFull'

### DIFF
--- a/source/agora/common/Deserializer.d
+++ b/source/agora/common/Deserializer.d
@@ -32,8 +32,7 @@ public alias DeserializeDg = ubyte[] delegate(size_t size) @safe;
 
 *******************************************************************************/
 
-public T deserialize (T) (scope ubyte[] data) @safe
-    if (is(T == struct) && is(typeof(T.init.deserialize(DeserializeDg.init))))
+public T deserializeFull (T) (scope ubyte[] data) @safe
 {
     T value;
 
@@ -44,7 +43,7 @@ public T deserialize (T) (scope ubyte[] data) @safe
         return res;
     };
 
-    value.deserialize(dg);
+    deserializePart(value, dg);
     return value;
 }
 
@@ -137,7 +136,7 @@ unittest
 
     ubyte[] block_bytes = serializeFull(GenesisBlock);
     // TODO: This trigger a DMD bug about array comparison
-    assert(cast(const)deserialize!Block(block_bytes) == GenesisBlock);
+    assert(cast(const)deserializeFull!Block(block_bytes) == GenesisBlock);
 
     // Check that there is no trailing data
     ubyte[] blocks_data = serializeFull(GenesisBlock) ~ serializeFull(GenesisBlock);
@@ -161,7 +160,7 @@ unittest
 
     // transaction test
     auto tx_bytes = serializeFull(GenesisTransaction);
-    assert(deserialize!Transaction(tx_bytes) == GenesisTransaction);
+    assert(deserializeFull!Transaction(tx_bytes) == GenesisTransaction);
 
     // test of various field types
     static struct S
@@ -186,5 +185,5 @@ unittest
 
     auto s = S(42, "foo");
     auto bytes = serializeFull(s);
-    assert(bytes.deserialize!S == s);
+    assert(deserializeFull!S(bytes) == s);
 }

--- a/source/agora/common/Metadata.d
+++ b/source/agora/common/Metadata.d
@@ -95,7 +95,7 @@ public class DiskMetadata : Metadata
         try if (this.file_path.exists)
         {
             auto bytes = cast(ubyte[])std.file.read(file_path);
-            this.peers = deserialize!(typeof(this.peers))(bytes);
+            this.peers = deserializeFull!(typeof(this.peers))(bytes);
         }
         catch (Exception ex)
         {

--- a/source/agora/common/Set.d
+++ b/source/agora/common/Set.d
@@ -188,7 +188,7 @@ unittest
 {
     auto old_set = Set!int.from([2, 4, 6, 8]);
     auto bytes = old_set.serializeFull();
-    auto new_set = deserialize!(Set!int)(bytes);
+    auto new_set = deserializeFull!(Set!int)(bytes);
 
     assert(new_set.length == old_set.length);
     old_set.each!(value => assert(value in new_set));
@@ -199,7 +199,7 @@ unittest
 {
     auto old_set = Set!string.from(["foo", "bar", "agora"]);
     auto bytes = old_set.serializeFull();
-    auto new_set = deserialize!(Set!string)(bytes);
+    auto new_set = deserializeFull!(Set!string)(bytes);
 
     assert(new_set.length == old_set.length);
     old_set.each!(value => assert(value in new_set));

--- a/source/agora/common/TransactionPool.d
+++ b/source/agora/common/TransactionPool.d
@@ -186,7 +186,7 @@ public class TransactionPool
         foreach (row; results)
         {
             auto hash = *cast(Hash*)row.peek!(ubyte[])(0).ptr;
-            auto tx = deserialize!Transaction(row.peek!(ubyte[])(1));
+            auto tx = deserializeFull!Transaction(row.peek!(ubyte[])(1));
 
             // break
             if (auto ret = dg(hash, tx))

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -454,14 +454,14 @@ unittest
         [Input(Hash.init, 0)],
         [Output.init]
     );
-    assert(agora.common.Deserializer.deserialize!Transaction(serializeFull(payment_tx)) == payment_tx);
+    assert(agora.common.Deserializer.deserializeFull!Transaction(serializeFull(payment_tx)) == payment_tx);
 
     Transaction freeze_tx = Transaction(
         TxType.Freeze,
         [Input(Hash.init, 0)],
         [Output.init]
     );
-    assert(agora.common.Deserializer.deserialize!Transaction(serializeFull(freeze_tx)) == freeze_tx);
+    assert(agora.common.Deserializer.deserializeFull!Transaction(serializeFull(freeze_tx)) == freeze_tx);
 }
 
 /// Transaction type hashing for unittest

--- a/source/agora/consensus/data/UTXOSet.d
+++ b/source/agora/consensus/data/UTXOSet.d
@@ -254,7 +254,7 @@ private class UTXODB
 
         foreach (row; results)
         {
-            output = deserialize!Output(row.peek!(ubyte[])(0));
+            output = deserializeFull!Output(row.peek!(ubyte[])(0));
             return true;
         }
 

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -1064,7 +1064,7 @@ public class MemBlockStorage : IBlockStorage
         if (finds.empty)
             return false;
 
-        block = deserialize!Block(this.blocks[finds.front.position]);
+        block = deserializeFull!Block(this.blocks[finds.front.position]);
         return true;
     }
 
@@ -1091,7 +1091,7 @@ public class MemBlockStorage : IBlockStorage
         if (finds.empty)
             return false;
 
-        block = deserialize!Block(this.blocks[finds.front.position]);
+        block = deserializeFull!Block(this.blocks[finds.front.position]);
         return true;
     }
 

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -260,7 +260,7 @@ unittest
     txs = makeChainedTransactions(getGenesisKeyPair(), txs, 1);
 
     // create a deep-copy of the first tx
-    auto backup_tx = deserialize!Transaction(serializeFull(txs[0]));
+    auto backup_tx = deserializeFull!Transaction(serializeFull(txs[0]));
 
     // create a double-spend tx
     txs[0].inputs[0] = txs[1].inputs[0];


### PR DESCRIPTION
There are two reason for this:
- We do not want to encourage the use of 'deserialize', as it allocates memory.
  However having such a prominent name makes it the first tool a developer will reach for.
- The previous behaviour wasn't friendly to generic code, and only supported aggregates,
  so one had to 'switch' over the types in the calling code.
  This now mirror the approach of 'serializeFull' and is usable in generic code.