### PR TITLE
Allow DeserializeDg to throw

### DIFF
--- a/source/agora/common/Amount.d
+++ b/source/agora/common/Amount.d
@@ -77,7 +77,7 @@ public struct Amount
     }
 
     /// Support for deserialization
-    public void deserialize (scope DeserializeDg dg) nothrow @safe
+    public void deserialize (scope DeserializeDg dg) @safe
     {
         deserializePart(this.value, dg);
     }

--- a/source/agora/common/Deserializer.d
+++ b/source/agora/common/Deserializer.d
@@ -17,7 +17,7 @@ import agora.common.Data;
 import agora.common.crypto.Key;
 
 /// Type of delegate deserializeDg
-public alias DeserializeDg = ubyte[] delegate(size_t size) nothrow @safe;
+public alias DeserializeDg = ubyte[] delegate(size_t size) @safe;
 
 /*******************************************************************************
 
@@ -32,12 +32,12 @@ public alias DeserializeDg = ubyte[] delegate(size_t size) nothrow @safe;
 
 *******************************************************************************/
 
-public T deserialize (T) (scope ubyte[] data) nothrow @safe
+public T deserialize (T) (scope ubyte[] data) @safe
     if (is(T == struct) && is(typeof(T.init.deserialize(DeserializeDg.init))))
 {
     T value;
 
-    scope DeserializeDg dg = (size) nothrow @safe
+    scope DeserializeDg dg = (size) @safe
     {
         ubyte[] res = data[0 .. size];
         data = data[size .. $];
@@ -49,8 +49,7 @@ public T deserialize (T) (scope ubyte[] data) nothrow @safe
 }
 
 /// Ditto
-public void deserializePart (T) (ref T record, scope DeserializeDg dg)
-    nothrow @safe
+public void deserializePart (T) (ref T record, scope DeserializeDg dg) @safe
     if (is(T == struct))
 {
     static assert(is(typeof(T.init.deserialize(DeserializeDg.init))),
@@ -61,7 +60,7 @@ public void deserializePart (T) (ref T record, scope DeserializeDg dg)
 
 /// Enum support
 public void deserializePart (T)(ref T record, scope DeserializeDg dg)
-    nothrow @trusted
+    @trusted
     if (is(T == enum))
 {
     import std.traits;
@@ -72,56 +71,56 @@ public void deserializePart (T)(ref T record, scope DeserializeDg dg)
 
 /// Ditto
 public void deserializePart (ref Hash record, scope DeserializeDg dg)
-    nothrow @safe
+    @safe
 {
     record = Hash(dg(Hash.sizeof));
 }
 
 /// Ditto
 public void deserializePart (ref ubyte record, scope DeserializeDg dg)
-    nothrow @trusted
+    @trusted
 {
     record = dg(record.sizeof)[0];
 }
 
 /// Ditto
 public void deserializePart (ref ushort record, scope DeserializeDg dg)
-    nothrow @trusted
+    @trusted
 {
     record = *cast(ushort*)(dg(record.sizeof).ptr);
 }
 
 /// Ditto
 public void deserializePart (ref int record, scope DeserializeDg dg)
-    nothrow @trusted
+    @trusted
 {
     record = *cast(int*)(dg(record.sizeof).ptr);
 }
 
 /// Ditto
 public void deserializePart (ref uint record, scope DeserializeDg dg)
-    nothrow @trusted
+    @trusted
 {
     record = *cast(uint*)(dg(record.sizeof).ptr);
 }
 
 /// Ditto
 public void deserializePart (ref ulong record, scope DeserializeDg dg)
-    nothrow @trusted
+    @trusted
 {
     record = *cast(ulong*)(dg(record.sizeof).ptr);
 }
 
 /// Ditto
 public void deserializePart (ref long record, scope DeserializeDg dg)
-    nothrow @trusted
+    @trusted
 {
     record = *cast(long*)(dg(record.sizeof).ptr);
 }
 
 /// Ditto
 public void deserializePart (ref char[] record, scope DeserializeDg dg)
-    nothrow @trusted
+    @trusted
 {
     auto length = *cast(size_t*)(dg(size_t.sizeof).ptr);
     record = cast(char[])dg(length);
@@ -143,9 +142,9 @@ unittest
     // Check that there is no trailing data
     ubyte[] blocks_data = serializeFull(GenesisBlock) ~ serializeFull(GenesisBlock);
 
-    void deserializeArrayEntry () nothrow @safe
+    void deserializeArrayEntry () @safe
     {
-        scope DeserializeDg dg = (size) nothrow @safe
+        scope DeserializeDg dg = (size) @safe
         {
             scope(exit) blocks_data = blocks_data[size .. $];
             return blocks_data[0 .. size];
@@ -176,7 +175,7 @@ unittest
             serializePart(this.s, dg);
         }
 
-        void deserialize (scope DeserializeDg dg) nothrow @safe
+        void deserialize (scope DeserializeDg dg) @safe
         {
             deserializePart(this.i, dg);
             char[] buffer;

--- a/source/agora/common/Set.d
+++ b/source/agora/common/Set.d
@@ -96,7 +96,7 @@ public struct Set (T)
 
     ***************************************************************************/
 
-    public void deserialize (scope DeserializeDg dg) nothrow @safe
+    public void deserialize (scope DeserializeDg dg) @safe
     {
         size_t length;
         deserializePart(length, dg);

--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -208,7 +208,7 @@ public struct PublicKey
 
     ***************************************************************************/
 
-    public static PublicKey fromBinary (scope DeserializeDg dg) nothrow @safe
+    public static PublicKey fromBinary (scope DeserializeDg dg) @safe
     {
         alias DType = typeof(this.data);
         return PublicKey(DType(dg(DType.sizeof)));

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -90,7 +90,7 @@ public struct BlockHeader
 
     ***************************************************************************/
 
-    public void deserialize (scope DeserializeDg dg) nothrow @safe
+    public void deserialize (scope DeserializeDg dg) @safe
     {
         this.prev_block = Hash(dg(Hash.sizeof));
         deserializePart(this.height, dg);
@@ -174,7 +174,7 @@ public struct Block
 
     ***************************************************************************/
 
-    public void deserialize (scope DeserializeDg dg) nothrow @safe
+    public void deserialize (scope DeserializeDg dg) @safe
     {
         deserializePart(this.header, dg);
 

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -107,7 +107,7 @@ public struct Transaction
 
     ***************************************************************************/
 
-    public void deserialize (scope DeserializeDg dg) nothrow @safe
+    public void deserialize (scope DeserializeDg dg) @safe
     {
         deserializePart(this.type, dg);
 
@@ -218,7 +218,7 @@ public struct Output
 
     ***************************************************************************/
 
-    public void deserialize (scope DeserializeDg dg) nothrow @safe
+    public void deserialize (scope DeserializeDg dg) @safe
     {
         deserializePart(this.value, dg);
         this.address = PublicKey.fromBinary(dg);
@@ -278,7 +278,7 @@ public struct Input
 
     ***************************************************************************/
 
-    public void deserialize (scope DeserializeDg dg) nothrow @safe
+    public void deserialize (scope DeserializeDg dg) @safe
     {
         this.previous = Hash(dg(Hash.sizeof));
         deserializePart(this.index, dg);

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -42,7 +42,7 @@ import std.stdio;
 
 public interface IBlockStorage
 {
-    @safe nothrow:
+    @safe:
 
     /***************************************************************************
 
@@ -989,7 +989,7 @@ public class MemBlockStorage : IBlockStorage
 
     ***************************************************************************/
 
-    public bool readLastBlock (ref Block block) @safe nothrow
+    public bool readLastBlock (ref Block block) @safe
     {
         if (this.height_idx.length == 0)
             return false;
@@ -1052,7 +1052,7 @@ public class MemBlockStorage : IBlockStorage
 
     ***************************************************************************/
 
-    public bool readBlock (ref Block block, size_t height) @safe nothrow
+    public bool readBlock (ref Block block, size_t height) @safe
     {
         if ((this.height_idx.length == 0) ||
             (this.height_idx.back.height < height))
@@ -1081,7 +1081,7 @@ public class MemBlockStorage : IBlockStorage
 
     ***************************************************************************/
 
-    public bool readBlock (ref Block block, Hash hash) @safe nothrow
+    public bool readBlock (ref Block block, Hash hash) @safe
     {
         ubyte[Hash.sizeof] hash_bytes = hash[];
 

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -296,7 +296,7 @@ public class Ledger
     ***************************************************************************/
 
     public const(Block)[] getBlocksFrom (ulong block_height, size_t max_blocks)
-        @safe nothrow
+        @safe
     {
         assert(max_blocks > 0);
 


### PR DESCRIPTION
Unfortunately, `DeserializeDg` could potentially `throw`:
The (badly named) delegate provides data to the deserialization function,
according to the requested size.
This data could potentially be read from a network socket.
In the event said socket terminate, an Exception could be thrown.