### PR TITLE
Implement support for walking through an std::set

### DIFF
--- a/source/scpd/Cpp.d
+++ b/source/scpd/Cpp.d
@@ -113,13 +113,13 @@ extern(C++, `std`) {
     }
 }
 
-private extern(C++) set!uint makeTestSet();
+private extern(C++) set!uint* makeTestSet();
 
 unittest
 {
     auto set = makeTestSet;
     uint[] values;
-    foreach (val; set)
+    foreach (val; *set)
         values ~= val;
     assert(values == [1, 2, 3, 4, 5]);
 }

--- a/source/scpd/scp/SCPDriver.d
+++ b/source/scpd/scp/SCPDriver.d
@@ -14,6 +14,7 @@
 
 module scpd.scp.SCPDriver;
 
+import scpd.Cpp;
 import scpd.types.Stellar_SCP;
 import scpd.types.Stellar_types;
 import scpd.types.XDRBase;
@@ -95,10 +96,8 @@ public abstract class SCPDriver
 
     // `combineCandidates` computes the composite value based off a list
     // of candidate values.
-    //abstract Value combineCandidates(
-    // uint64 slotIndex, ref const(std::set!Value) candidates);
     abstract Value combineCandidates(
-        uint64_t slotIndex, ref const(Value)* candidates);
+        uint64_t slotIndex, ref const(set!Value) candidates);
 
     // `setupTimer`: requests to trigger 'cb' after timeout
     // if cb is nullptr, the timer is cancelled

--- a/source/scpp/extra/DUtils.cpp
+++ b/source/scpp/extra/DUtils.cpp
@@ -27,9 +27,9 @@ int cpp_set_foreach(void* setptr, void* ctx, void* func)
     return 0;
 }
 
-std::set<unsigned int> makeTestSet()
+std::set<unsigned int>* makeTestSet()
 {
-    std::set<unsigned int> set = {1, 2, 3, 4, 5};
+    std::set<unsigned int>* set = new std::set<unsigned int>({1, 2, 3, 4, 5});
     return set;
 }
 

--- a/source/scpp/extra/DUtils.cpp
+++ b/source/scpp/extra/DUtils.cpp
@@ -9,6 +9,30 @@
 using namespace xdr;
 using namespace stellar;
 
+// rudimentary support for walking through an std::set
+// note: can't use proper callback type due to
+// https://issues.dlang.org/show_bug.cgi?id=20223
+template<typename T>
+int cpp_set_foreach(void* setptr, void* ctx, void* func)
+{
+    auto wrapper = (int (*)(void* ctx, const T& value))func;
+
+    for (auto const &elem : *(std::set<T>*)setptr)
+    {
+        int res = wrapper(ctx, elem);
+        if (res != 0)
+            return res;
+    }
+
+    return 0;
+}
+
+std::set<unsigned int> makeTestSet()
+{
+    std::set<unsigned int> set = {1, 2, 3, 4, 5};
+    return set;
+}
+
 SCP* createSCP(SCPDriver* driver, NodeID const& nodeID, bool isValidator, SCPQuorumSet const& qSetLocal)
 {
     return new stellar::SCP(*driver, nodeID, isValidator, qSetLocal);
@@ -57,3 +81,9 @@ PUSHBACKINST3(SCPQuorumSet, std::vector)
 PUSHBACKINST3(Slot::HistoricalStatement, std::vector)
 
 template opaque_vec<> duplicate<opaque_vec<>>(opaque_vec<> const&);
+
+#define CPPSETFOREACHINST(T) template int cpp_set_foreach<T>(void*, void*, void*);
+CPPSETFOREACHINST(Value)
+CPPSETFOREACHINST(SCPBallot)
+CPPSETFOREACHINST(PublicKey)
+CPPSETFOREACHINST(unsigned int)


### PR DESCRIPTION
This is mainly needed for `SCPDriver.combineCandidates()` which selects one value out of a given set of candidate values.

C++ can't (easily) call D delegates, so I worked around this with a wrapper function.