### PR TITLE
Implement UTXOSetValue for freezing

### DIFF
--- a/source/agora/consensus/data/UTXOSet.d
+++ b/source/agora/consensus/data/UTXOSet.d
@@ -191,38 +191,6 @@ public class UTXOSet
 
     /***************************************************************************
 
-        Find an UTXOSetValue in the UTXO set.
-
-        Params:
-            hash = the hash of transation
-            index = the index of the output
-            value = will contain the UTXOSetValue if found
-
-        Return:
-            Return true if the UTXO was found
-
-    ***************************************************************************/
-
-    private bool findUTXOSetValue (Hash hash, size_t index,
-                                        out UTXOSetValue value)
-        nothrow @safe
-    {
-        auto utxo_hash = getHash(hash, index);
-
-        if (utxo_hash in this.used_utxos)
-            return false;  // double-spend
-
-        if (this.utxo_db.find(utxo_hash, value))
-        {
-            this.used_utxos.put(utxo_hash);
-            return true;
-        }
-
-        return false;
-    }
-
-    /***************************************************************************
-
         Prepare tracking double-spent transactions and
         return the UTXOFinder delegate
 
@@ -239,19 +207,19 @@ public class UTXOSet
 
     /***************************************************************************
 
-        Find an unspent Output in the UTXO set.
+        Find an UTXOSetValue in the UTXO set.
 
         Params:
             hash = the hash of transation
             index = the index of the output
-            output = will contain the UTXO if found
+            output = will contain the UTXOSetValue if found
 
         Return:
             Return true if the UTXO was found
 
     ***************************************************************************/
 
-    private bool findUTXO (Hash hash, size_t index, out Output output)
+    private bool findUTXO (Hash hash, size_t index, out UTXOSetValue value)
         nothrow @safe
     {
         auto utxo_hash = getHash(hash, index);
@@ -259,10 +227,8 @@ public class UTXOSet
         if (utxo_hash in this.used_utxos)
             return false;  // double-spend
 
-        UTXOSetValue value;
         if (this.utxo_db.find(utxo_hash, value))
         {
-            output = value.output;
             this.used_utxos.put(utxo_hash);
             return true;
         }

--- a/source/agora/consensus/data/UTXOSet.d
+++ b/source/agora/consensus/data/UTXOSet.d
@@ -27,6 +27,51 @@ import std.file;
 
 mixin AddLogger!();
 
+/// The structure of spendable transaction output
+public struct UTXOSetValue
+{
+    /// Height of the block to be unlock
+    ulong unlock_height;
+
+    /// Transaction type
+    TxType type;
+
+    /// Unspend transaction output
+    Output output;
+
+    /***************************************************************************
+
+        Input Serialization
+
+        Params:
+             dg = serialize function
+
+    ***************************************************************************/
+
+    public void serialize (scope SerializeDg dg) const @safe
+    {
+        serializePart(this.unlock_height, dg);
+        serializePart(this.type, dg);
+        serializePart(this.output, dg);
+    }
+
+    /***************************************************************************
+
+        Input deserialization
+
+        Params:
+             dg = deserialize function
+
+    ***************************************************************************/
+
+    public void deserialize (scope DeserializeDg dg) @safe
+    {
+        deserializePart(this.unlock_height, dg);
+        deserializePart(this.type, dg);
+        deserializePart(this.output, dg);
+    }
+}
+
 /// ditto
 public class UTXOSet
 {

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -543,9 +543,9 @@ unittest
     auto new_txs = makeChainedTransactions(gen_key, txs, 1);
 
     assert(new_txs.length > 0);
-    Output _out;
+    UTXOSetValue _val;
     new_txs.each!(tx => assert(finder(tx.inputs[0].previous, tx.inputs[0].index,
-        _out)));
+        _val)));
 }
 
 // Use a transaction with the type 'TxType.Freeze' to create a block and test UTXOSet.

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -18,10 +18,11 @@ version (unittest):
 
 import agora.common.Amount;
 import agora.common.crypto.Key;
-import agora.consensus.data.Block;
-import agora.common.Types;
 import agora.common.Hash;
+import agora.common.Types;
+import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
+import agora.consensus.data.UTXOSet;
 import agora.consensus.Genesis;
 import agora.test.Base;
 
@@ -270,8 +271,16 @@ unittest
 
     // make sure the transaction is still authentic (signature is correct),
     // even if it's double spending
-    assert(txs[0].isValid((Hash hash, size_t index, out Output output)
-        { output = GenesisTransaction.outputs[0]; return true; }));
+    assert(txs[0].isValid((Hash hash, size_t index, out UTXOSetValue value)
+        {
+            value =
+            UTXOSetValue(
+                0,
+                TxType.Payment,
+                GenesisTransaction.outputs[0]
+            );
+            return true;
+        }));
 
     txs.each!(tx => node_1.putTransaction(tx));
 


### PR DESCRIPTION
Add freezing capability to UTXO #204 of part

UTXOSetValue is used by UTXOSet
To freeze UTXO, add the following information to UTXOSet:
The height of block.
The type of transaction.

![UTXO 008](https://user-images.githubusercontent.com/11639939/65367117-899caf00-dc67-11e9-87fb-90c0f0c91b15.jpeg)

![Block_Tx_UTXO](https://user-images.githubusercontent.com/11639939/65367140-e7c99200-dc67-11e9-9187-796bec123aa9.gif)

<img width="920" alt="Transaction & UTXO in Freeze" src="https://user-images.githubusercontent.com/11639939/65112733-9c22a880-da1b-11e9-9f1b-55f4b00098c5.png">
