### PR TITLE
Emit reason for failed block transaction validation

### DIFF
--- a/source/agora/consensus/Validation.d
+++ b/source/agora/consensus/Validation.d
@@ -310,8 +310,11 @@ public string isInvalidReason (const ref Block block, in ulong prev_height,
     if (!block.txs.isSorted())
         return "Block: Transactions are not sorted";
 
-    if (block.txs.any!(tx => !tx.isValid(findUTXO)))
-        return "Block: Some transactions are invalid";
+    foreach (const ref tx; block.txs)
+    {
+        if (auto fail_reason = tx.isInvalidReason(findUTXO))
+            return fail_reason;
+    }
 
     Hash[] merkle_tree;
     if (block.header.merkle_root != Block.buildMerkleTree(block.txs, merkle_tree))


### PR DESCRIPTION
If one of the transactions in a block failed validation,
it's useful to know which validation rule failed.

The parent logger already emits that the Block itself failed,
and the block is dumped to the logger.