### PR TITLE
Fix parsing non-native / non string type in Config

### DIFF
--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -482,7 +482,7 @@ private T get (T, string section, string name) (const ref CommandLine cmdl, Node
 
     if (node)
         if (auto val = name in *node)
-            return (*val).as!T;
+            return (*val).as!string.to!T;
 
     throw new Exception(format(
         "'%s' was not found in config's '%s' section, nor was '%s' in command line arguments",

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -9,7 +9,7 @@ node:
   port:    2826
   retry_delay: 1.5
   max_retries: 5
-  timeout: 50
+  timeout: 1000
   # This is a randomly generated keypair
   # If this node is not a validator, this will be ignored
   #

--- a/tests/system/node/1/config.yaml
+++ b/tests/system/node/1/config.yaml
@@ -9,7 +9,7 @@ node:
   port:    2826
   retry_delay: 1.5
   max_retries: 5
-  timeout: 50
+  timeout: 1000
   # This is a randomly generated keypair
   # If this node is not a validator, this will be ignored
   #

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -9,7 +9,7 @@ node:
   port:    2826
   retry_delay: 1.5
   max_retries: 5
-  timeout: 50
+  timeout: 1000
   # This is a randomly generated keypair
   # If this node is not a validator, this will be ignored
   #


### PR DESCRIPTION
```
The code wasn't doing a conversion, and would throw for e.g. LogLevel.
Unfortunately, the use of 'opt' meant such an Exception was swallowed,
and the default value was always used instead.
```

Found while working on #203 