### PR TITLE
Remove support for serializing signed integers [for VarInt support]

### DIFF
--- a/source/agora/common/Deserializer.d
+++ b/source/agora/common/Deserializer.d
@@ -56,7 +56,7 @@ unittest
     // test of various field types
     static struct S
     {
-        int i;
+        uint i;
         string s;
 
         void serialize (scope SerializeDg dg) const @safe
@@ -192,13 +192,6 @@ public void deserializePart (ref ushort record, scope DeserializeDg dg)
 }
 
 /// Ditto
-public void deserializePart (ref int record, scope DeserializeDg dg)
-    @trusted
-{
-    record = *cast(int*)(dg(record.sizeof).ptr);
-}
-
-/// Ditto
 public void deserializePart (ref uint record, scope DeserializeDg dg)
     @trusted
 {
@@ -210,13 +203,6 @@ public void deserializePart (ref ulong record, scope DeserializeDg dg)
     @trusted
 {
     record = *cast(ulong*)(dg(record.sizeof).ptr);
-}
-
-/// Ditto
-public void deserializePart (ref long record, scope DeserializeDg dg)
-    @trusted
-{
-    record = *cast(long*)(dg(record.sizeof).ptr);
 }
 
 /// Ditto

--- a/source/agora/common/Set.d
+++ b/source/agora/common/Set.d
@@ -173,7 +173,7 @@ public T[] pickRandom (T) (Set!T input, size_t count = 0)
 ///
 unittest
 {
-    auto set = Set!int.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    auto set = Set!uint.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     auto randoms = set.pickRandom(5);
     sort(randoms);
     assert(randoms.uniq.count == 5);
@@ -186,9 +186,9 @@ unittest
 /// serialization test for Set!int
 unittest
 {
-    auto old_set = Set!int.from([2, 4, 6, 8]);
+    auto old_set = Set!uint.from([2, 4, 6, 8]);
     auto bytes = old_set.serializeFull();
-    auto new_set = deserializeFull!(Set!int)(bytes);
+    auto new_set = deserializeFull!(Set!uint)(bytes);
 
     assert(new_set.length == old_set.length);
     old_set.each!(value => assert(value in new_set));
@@ -224,7 +224,7 @@ private void dropIndex (T) (ref T[] arr, size_t index)
 ///
 unittest
 {
-    int[] arr = [1, 2, 3];
+    uint[] arr = [1, 2, 3];
     arr.dropIndex(1);
     assert(arr == [1, 3]);
 }

--- a/source/agora/node/API.d
+++ b/source/agora/node/API.d
@@ -48,7 +48,7 @@ import vibe.web.rest;
 import vibe.http.common;
 
 /// The network state (completed when sufficient validators are connected to)
-public enum NetworkState
+public enum NetworkState : ubyte
 {
     Incomplete,
     Complete


### PR DESCRIPTION
Our Serializer and Deserializer are used only by unsigned Integers. 
So delete unused int,long and Modifying the int used in unittest to uint