### PR TITLE
Implement variable length integers for Serializer and Deserializer.

### DIFF
--- a/source/agora/common/Serializer.d
+++ b/source/agora/common/Serializer.d
@@ -43,16 +43,25 @@ public mixin template DefaultSerializer ()
 ///
 unittest
 {
+    import agora.common.Amount;
     static struct Foo
     {
-        uint a;
-        ubyte[] b;
-
+        ubyte a;
+        ushort b;
+        uint c;
+        ulong d;
+        Amount e;
+        ubyte[] f;
         mixin DefaultSerializer!();
     }
-
-    const Foo f = Foo(uint.max, [1, 2, 3]);
-    assert(serializeFull(f) == [255, 255, 255, 255, 3, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3]);
+    const Foo f = Foo(1, ushort.max, uint.max, ulong.max, Amount(100), [1, 2, 3]);
+    assert(serializeFull(f) == [
+        1,                       // ubyte(1)     == 1 byte
+        253,255, 255,            // ushort.max   == 3 bytes
+        254, 255, 255, 255, 255, // uint.max     == 5 bytes
+        255, 255, 255, 255, 255, 255, 255, 255, 255, // ulong.max == 9bytes
+        100,                     // Amount(100)  == 1 byte
+        3, 1, 2, 3]);            // ubyte[1,2,3] == 4 bytes
 }
 
 /*******************************************************************************
@@ -63,6 +72,7 @@ unittest
         T = Type of struct to serialize
         record = Instance of `T` to serialize
         dg  = Serialization delegate, when this struct is a nested struct
+        compact = Whether integers are serialized in variable-length form
 
     Returns:
         The serialized `ubyte[]`
@@ -119,21 +129,24 @@ public void serializePart (ubyte record, scope SerializeDg dg)
 public void serializePart (ushort record, scope SerializeDg dg)
     @trusted
 {
-    dg((cast(ubyte*)&record)[0 .. ushort.sizeof]);
+    toVarInt(record, dg);
 }
 
 /// Ditto
 public void serializePart (uint record, scope SerializeDg dg)
     @trusted
 {
-    dg((cast(ubyte*)&record)[0 .. uint.sizeof]);
+    toVarInt(record, dg);
 }
 
 /// Ditto
-public void serializePart (ulong record, scope SerializeDg dg)
+public void serializePart (ulong record, scope SerializeDg dg, CompactMode compact = CompactMode.Yes)
     @trusted
 {
-    dg((cast(ubyte*)&record)[0 .. ulong.sizeof]);
+    if (compact == CompactMode.Yes)
+        toVarInt(record, dg);
+    else
+        dg((cast(ubyte*)&record)[0 .. ulong.sizeof]);
 }
 
 /// Ditto
@@ -150,4 +163,87 @@ public void serializePart (scope const(ubyte)[] record, scope SerializeDg dg)
 {
     serializePart(record.length, dg);
     dg(record);
+}
+
+/*******************************************************************************
+
+    Unsigned Integers to Serialized variable length integer
+    and return it as a ubyte[].
+
+    VarInt Size
+    size <= 0xFC(252)  -- 1 byte   ubyte
+    size <= USHORT_MAX -- 3 bytes  (0xFD + ushort)
+    size <= UINT_MAX   -- 5 bytes  (0xFE + uint)
+    size <= ULONG_MAX  -- 9 bytes  (0xFF + ulong)
+
+    Params:
+        T = Type of unsigned integer to serialize
+        var = Instance of `T` to serialize
+        dg  = Serialization delegate
+    Returns:
+        The serialized convert variable length integer
+
+*******************************************************************************/
+
+private void toVarInt (T) (const T var, scope SerializeDg dg)
+    @trusted
+    if (is(T == ushort) || is(T == uint) || is(T == ulong))
+{
+    assert(var >= 0);
+    static immutable ubyte[] type = [0xFD, 0xFE, 0xFF];
+    if (var <= 0xFC)
+        dg((cast(ubyte*)&(*cast(ubyte*)&var))[0 .. 1]);
+    else if (var <= ushort.max)
+    {
+        dg(type[0..1]);
+        dg((cast(ubyte*)&(*cast(ushort*)&var))[0 .. ushort.sizeof]);
+    }
+    else if (var <= uint.max)
+    {
+        dg(type[1..2]);
+        dg((cast(ubyte*)&(*cast(uint*)&var))[0 .. uint.sizeof]);
+    }
+    else if (var <= ulong.max)
+    {
+        dg(type[2..3]);
+        dg((cast(ubyte*)&(*cast(ulong*)&var))[0 .. ulong.sizeof]);
+    }
+    else
+        assert(0);
+}
+
+/// For varint
+unittest
+{
+    ubyte[] res;
+    scope SerializeDg dg = (scope const(ubyte[]) data)
+    {
+        res ~= data;
+    };
+    toVarInt(ulong.init, dg);
+    assert(res == [0x00]);
+    res.length = 0;
+    toVarInt(252uL, dg);
+    assert(res == [0xFC]);
+    res.length = 0;
+    toVarInt(253uL, dg);
+    assert(res == [0xFD, 0xFD, 0x00]);
+    res.length = 0;
+    toVarInt(255uL, dg);
+    assert(res == [0xFD, 0xFF, 0x00]);
+    res.length = 0;
+    toVarInt(ushort.max, dg);
+    assert(res == [0xFD, 0xFF, 0xFF]);
+    res.length = 0;
+    toVarInt(0x10000u, dg);
+    assert(res == [0xFE, 0x00, 0x00, 0x01, 0x00]);
+    res.length = 0;
+    toVarInt(uint.max, dg);
+    assert(res == [0xFE, 0xFF, 0xFF, 0xFF, 0xFF]);
+    res.length = 0;
+    toVarInt(0x100000000u, dg);
+    assert(res == [0xFF, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]);
+    res.length = 0;
+    toVarInt(ulong.max, dg);
+    assert(res == [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]);
 }

--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -28,6 +28,13 @@ public alias Address = string;
 /// The type of a signature
 public alias Signature = BitBlob!512;
 
+/// Whether integers are serialized in variable-length form
+public enum CompactMode : bool
+{
+    No,
+    Yes
+}
+
 unittest
 {
     // Check that our type match libsodium's definition

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -742,9 +742,9 @@ public class BlockStorage : IBlockStorage
             File idx_file = File(this.index_path, "a+b");
             idx_file.seek(0, SEEK_END);
 
-            serializePart(height, (scope v) => idx_file.rawWrite(v));
+            serializePart(height, (scope v) => idx_file.rawWrite(v), CompactMode.No);
             idx_file.rawWrite(hash);
-            serializePart(pos, (scope v) => idx_file.rawWrite(v));
+            serializePart(pos, (scope v) => idx_file.rawWrite(v), CompactMode.No);
 
             idx_file.close();
 
@@ -795,11 +795,11 @@ public class BlockStorage : IBlockStorage
 
             foreach (idx; 0 .. record_count)
             {
-                deserializePart(height, dg);
+                deserializePart(height, dg, CompactMode.No);
 
                 idx_file.rawRead(hash);
 
-                deserializePart(pos, dg);
+                deserializePart(pos, dg, CompactMode.No);
 
                 // add to index of heigth
                 this.height_idx.insert(HeightPosition(height, pos));


### PR DESCRIPTION
#328 Unsigned Integers(ushort, uint, ulong) to Serialized variable length integer
&  Deserialize variable length integer 

We need to flexibly reduce the data in most small unsigned integer data.
This can significantly reduce the storage capacity of the ledger.

VarInt Size
size <= 252(0xFC)  -- 1 byte   ubyte
size <= USHORT_MAX -- 3 bytes  (0xFD + ushort)
size <= UINT_MAX   -- 5 bytes  (0xFE + uint)
size <= ULONG_MAX  -- 9 bytes  (0xFF + ulong)

