### PR TITLE
Add bindings to std::function & a workaround for calling it in a timer

### DIFF
--- a/source/scpd/Cpp.d
+++ b/source/scpd/Cpp.d
@@ -111,6 +111,24 @@ extern(C++, `std`) {
     {
         void*[3] ptr;
     }
+
+    // only used at compile-time on the C++ side, here for mangling
+    struct ratio (int _Num, int _Den = 1)
+    {
+    }
+
+    /// Simple bindings to std::chrono
+    extern(C++, `chrono`)
+    {
+        public struct duration (_Rep, _Period = ratio!1)
+        {
+            _Rep __r;
+            alias __r this;
+        }
+
+        alias milli = ratio!(1, 1000);
+        alias milliseconds = duration!(long, milli);
+    }
 }
 
 private extern(C++) set!uint* makeTestSet();

--- a/source/scpd/Cpp.d
+++ b/source/scpd/Cpp.d
@@ -129,7 +129,22 @@ extern(C++, `std`) {
         alias milli = ratio!(1, 1000);
         alias milliseconds = duration!(long, milli);
     }
+
+    /// Simple wrapper around std::function
+    /// note: pragma(mangle) doesn't currently work on types
+    align(1) public struct CPPDelegate (Callback)
+    {
+    align(1):
+        shared_ptr!int __ptr_;
+        ubyte[24] _1;
+        ubyte[24] _2;
+    }
+
+    static assert(CPPDelegate!SCPCallback.sizeof == 64);
 }
+
+/// Type of SCP function callback called by a timer
+public alias SCPCallback = extern(C++) void function();
 
 private extern(C++) set!uint* makeTestSet();
 

--- a/source/scpd/Util.d
+++ b/source/scpd/Util.d
@@ -94,3 +94,6 @@ private Tuple!(string, string) getParams (alias func)()
 
     return tuple(params.join(", "), args.join(", "));
 }
+
+/// Invoke an std::function pointer (note: must be void* due to mangling issues)
+extern(C++) void callCPPDelegate (void* cb);

--- a/source/scpd/scp/SCPDriver.d
+++ b/source/scpd/scp/SCPDriver.d
@@ -101,12 +101,9 @@ public abstract class SCPDriver
 
     // `setupTimer`: requests to trigger 'cb' after timeout
     // if cb is nullptr, the timer is cancelled
-    /*
-    abstract void setupTimer(uint64 slotIndex, int timerID,
+    abstract void setupTimer(ulong slotIndex, int timerID,
                              milliseconds timeout,
-                             std::function<void()> cb);
-    */
-    abstract void setupTimer();
+                             CPPDelegate!(void function())*);
 
     // `computeTimeout` computes a timeout given a round number
     // it should be sufficiently large such that nodes in a

--- a/source/scpd/scp/SCPDriver.d
+++ b/source/scpd/scp/SCPDriver.d
@@ -103,7 +103,7 @@ public abstract class SCPDriver
     // if cb is nullptr, the timer is cancelled
     /*
     abstract void setupTimer(uint64 slotIndex, int timerID,
-                             std::chrono::milliseconds timeout,
+                             milliseconds timeout,
                              std::function<void()> cb);
     */
     abstract void setupTimer();
@@ -111,8 +111,7 @@ public abstract class SCPDriver
     // `computeTimeout` computes a timeout given a round number
     // it should be sufficiently large such that nodes in a
     // quorum can exchange 4 messages
-    //std::chrono::milliseconds computeTimeout(uint32 roundNumber);
-    void computeTimeout(uint32_t roundNumber); // Slot in the vtable
+    milliseconds computeTimeout(uint32_t roundNumber);  // Slot in the vtable
 
     // Inform about events happening within the consensus algorithm.
 

--- a/source/scpp/extra/DUtils.cpp
+++ b/source/scpp/extra/DUtils.cpp
@@ -4,6 +4,7 @@
 #include "DUtils.h"
 #include "xdrpp/marshal.h"
 #include "xdr/Stellar-SCP.h"
+#include <functional>
 
 using namespace xdr;
 using namespace stellar;
@@ -47,3 +48,10 @@ CPPSETFOREACHINST(Value)
 CPPSETFOREACHINST(SCPBallot)
 CPPSETFOREACHINST(PublicKey)
 CPPSETFOREACHINST(unsigned int)
+
+void callCPPDelegate (void* cb)
+{
+    auto callback = (std::function<void()>*)cb;
+    (*callback)();
+    delete callback;
+}

--- a/source/scpp/src/scp/BallotProtocol.cpp
+++ b/source/scpp/src/scp/BallotProtocol.cpp
@@ -500,9 +500,12 @@ BallotProtocol::startBallotProtocolTimer()
         mSlot.getSCPDriver().computeTimeout(mCurrentBallot->counter);
 
     std::shared_ptr<Slot> slot = mSlot.shared_from_this();
+
+    std::function<void()>* func = new std::function<void()>;
+    *func = [slot]() { slot->getBallotProtocol().ballotProtocolTimerExpired(); };
+
     mSlot.getSCPDriver().setupTimer(
-        mSlot.getSlotIndex(), Slot::BALLOT_PROTOCOL_TIMER, timeout,
-        [slot]() { slot->getBallotProtocol().ballotProtocolTimerExpired(); });
+        mSlot.getSlotIndex(), Slot::BALLOT_PROTOCOL_TIMER, timeout, func);
 }
 
 void

--- a/source/scpp/src/scp/NominationProtocol.cpp
+++ b/source/scpp/src/scp/NominationProtocol.cpp
@@ -518,11 +518,14 @@ NominationProtocol::nominate(Value const& value, Value const& previousValue,
     mSlot.getSCPDriver().nominatingValue(mSlot.getSlotIndex(), nominatingValue);
 
     std::shared_ptr<Slot> slot = mSlot.shared_from_this();
-    mSlot.getSCPDriver().setupTimer(
-        mSlot.getSlotIndex(), Slot::NOMINATION_TIMER, timeout,
-        [slot, value, previousValue]() {
+
+    std::function<void()>* func = new std::function<void()>;
+    *func = [slot, value, previousValue]() {
             slot->nominate(value, previousValue, true);
-        });
+        };
+
+    mSlot.getSCPDriver().setupTimer(
+        mSlot.getSlotIndex(), Slot::NOMINATION_TIMER, timeout, func);
 
     if (updated)
     {

--- a/source/scpp/src/scp/SCPDriver.h
+++ b/source/scpp/src/scp/SCPDriver.h
@@ -113,7 +113,7 @@ class SCPDriver
     // if cb is nullptr, the timer is cancelled
     virtual void setupTimer(uint64 slotIndex, int timerID,
                             std::chrono::milliseconds timeout,
-                            std::function<void()> cb) = 0;
+                            std::function<void()>* cb) = 0;
 
     // `computeTimeout` computes a timeout given a round number
     // it should be sufficiently large such that nodes in a


### PR DESCRIPTION
The API change might make it more difficult to apply new SCP change-sets from upstream.

I've tried to find a way to increment the refcount for `std::function` with a bit of googling, but with no luck. Maybe there is a better way to do this though, I'm open to suggestions.