### PR TITLE
Validation: Make 'isValid' only usable in unittests

### DIFF
--- a/source/agora/consensus/Validation.d
+++ b/source/agora/consensus/Validation.d
@@ -129,8 +129,9 @@ public string isInvalidReason (const Transaction tx, UTXOFinder findUTXO,
     return null;
 }
 
-/// Ditto but returns a bool
-public bool isValid (const Transaction tx, UTXOFinder findUTXO, const ulong height)
+/// Ditto but returns a bool, only used in unittests
+version (unittest)
+public bool isValid (const Transaction tx, UTXOFinder findUTXO, ulong height)
     @safe nothrow
 {
     return isInvalidReason(tx, findUTXO, height) is null;
@@ -702,9 +703,10 @@ public string isInvalidReason (const ref Block block, in ulong prev_height,
     return null;
 }
 
-/// Ditto but returns `bool`
-public bool isValid (const ref Block block, in ulong prev_height,
-    in Hash prev_hash, UTXOFinder findUTXO) nothrow @safe
+/// Ditto but returns `bool`, only usable in unittests
+version (unittest)
+public bool isValid (const ref Block block, ulong prev_height,
+    Hash prev_hash, UTXOFinder findUTXO) nothrow @safe
 {
     return isInvalidReason(block, prev_height, prev_hash, findUTXO) is null;
 }

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -210,14 +210,12 @@ public class Ledger
         auto utxo_finder = this.utxo_set.getUTXOFinder();
         foreach (hash, tx; this.pool)
         {
-            if (tx.isValid(utxo_finder, expect_height))
+            if (auto reason = tx.isInvalidReason(utxo_finder, expect_height))
+                log.trace("Rejected invalid ('{}') tx: {}", reason, tx);
+            else
             {
                 hashes ~= hash;
                 txs ~= tx;
-            }
-            else
-            {
-                log.trace("Rejected double-spend tx: {}", tx);
             }
 
             if (txs.length >= Block.TxsInBlock)
@@ -251,7 +249,7 @@ public class Ledger
     public bool isValidTransaction (const ref Transaction tx) nothrow @safe
     {
         const ulong expect_height = this.getBlockHeight() + 1;
-        return tx.isValid(this.utxo_set.getUTXOFinder(), expect_height);
+        return tx.isInvalidReason(this.utxo_set.getUTXOFinder(), expect_height) is null;
     }
 
     /***************************************************************************


### PR DESCRIPTION
`isValid` is the "pedestrian usage" but we aim to propagate more information to the user.
Having it available in unittests allow for simpler tests, while we still ensure the message is passed up outside of unittests.

Part of #277  (kinda)