### PR TITLE
Add a timeout to integration test runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,3 +46,4 @@ jobs:
           command: |
             source $HOME/dlang/dmd-2.088.0/activate
             ci/system_integration_test.d
+          no_output_timeout: 15m

--- a/ci/system_integration_test.d
+++ b/ci/system_integration_test.d
@@ -61,6 +61,7 @@ private int main (string[] args)
 /// Utility function to run a command and throw on error
 private void runCmd (const string[] cmd)
 {
+    writeln(cmd);
     auto pid = spawnProcess(cmd);
     if (pid.wait() != 0)
         throw new Exception(format("Command failed: %s", cmd));


### PR DESCRIPTION
Let's see if this works. Found this solution on https://discuss.circleci.com/t/how-to-increase-timeout-for-command-in-circle-2-0/20254