### PR TITLE
Change GossipProtocol.hasTransactionHash() to check tx hash in the pool

### DIFF
--- a/source/agora/node/GossipProtocol.d
+++ b/source/agora/node/GossipProtocol.d
@@ -29,9 +29,6 @@ public class GossipProtocol
     /// Blockchain ledger
     private Ledger ledger;
 
-    /// Contains the transaction cache
-    private Transaction[Hash] tx_cache;
-
 
     /***************************************************************************
 
@@ -67,14 +64,13 @@ public class GossipProtocol
 
         if (this.ledger.acceptTransaction(tx))
         {
-            this.tx_cache[tx_hash] = tx;
             this.network.sendTransaction(tx);
         }
     }
 
     /***************************************************************************
 
-        Check if this transaction is in the transaction cache.
+        Check if this transaction is in the transaction pool.
 
         Params:
             hash = hash of a transaction
@@ -86,6 +82,6 @@ public class GossipProtocol
 
     public bool hasTransactionHash (Hash hash) @safe
     {
-        return (hash in this.tx_cache) !is null;
+        return this.ledger.hasTransactionHash(hash);
     }
 }

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -336,6 +336,23 @@ public class Ledger
             return null;
         return block.getMerklePath(index);
     }
+
+    /***************************************************************************
+
+        Check if a transaction hash exists in the transaction pool.
+
+        Params:
+            tx = the transaction hash
+
+        Returns:
+            true if the transaction pool has the transaction hash.
+
+    ***************************************************************************/
+
+    public bool hasTransactionHash (const ref Hash tx) @safe
+    {
+        return this.pool.hasTransactionHash(tx);
+    }
 }
 
 ///


### PR DESCRIPTION
We never remove items from the Gossip cache.
So, This deletes the transaction cache of the Gossipprotocol and queries it directly from the transaction pool.
For #345 