### PR TITLE
Implement a workaround for the LDC segfault bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ matrix:
   allow_failures:
     - d: dmd-nightly
     - d: ldc-latest-ci
-    - d: ldc-1.17.0
-      os: osx
-    - d: ldc-1.16.0
-      os: osx
   fast_finish: true
 
 # `brew install` is the slowest thing ever on OSX

--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -35,7 +35,15 @@ public template AddLogger (string moduleName = __MODULE__)
     private Logger log;
     static this ()
     {
+        import core.memory;
         log = Log.lookup(moduleName);
+        GC.addRoot(cast(void*)log);
+    }
+
+    static ~this()
+    {
+        import core.memory;
+        GC.removeRoot(cast(void*)log);
     }
 }
 


### PR DESCRIPTION
There seems to be an issue with tracking module-scoped variables when compiling with LDC.

It's possibly a DRuntime bug.

Re-enabled Travis LDC testing.