### PR TITLE
Color log level in output

### DIFF
--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -26,6 +26,10 @@
 
 module agora.utils.Log;
 
+import ocean.text.convert.Formatter;
+import ocean.util.log.AppendConsole;
+import ocean.util.log.Appender;
+import ocean.util.log.Event;
 import ocean.util.log.Logger;
 
 /// Insert a logger in the current scope, named log
@@ -48,6 +52,58 @@ else
     /// Initialize the logger
     static this ()
     {
-        Log.defaultConfig();
+        auto appender = new AppendConsole();
+        appender.layout(new AgoraLayout());
+        Log.root.add(appender);
+    }
+}
+
+/// A layout with colored LogLevel
+public class AgoraLayout : Appender.Layout
+{
+    /// Format the message
+    public override void format (LogEvent event, scope FormatterSink dg)
+    {
+        import ocean.time.WallClock;
+
+        // convert time to field values
+        const tm = event.time;
+        const dt = WallClock.toDate(tm);
+
+        // format date according to ISO-8601 (lightweight formatter)
+        sformat(dg, "{u4}-{u2}-{u2} {u2}:{u2}:{u2},{u2} {} [{}] - {}",
+            dt.date.year, dt.date.month, dt.date.day,
+            dt.time.hours, dt.time.minutes, dt.time.seconds, dt.time.millis,
+            coloredName(event.level), event.name, event);
+    }
+
+    /// Returns: A colorized version of a LogLevel
+    protected static string coloredName (LogLevel lvl)
+    {
+        switch (lvl)
+        {
+            // Cyan
+        case LogLevel.Trace:
+            return "\u001b[36mTrace\u001b[0m";
+            // Green
+        case LogLevel.Info:
+            return "\u001b[32mInfo\u001b[0m";
+            // Yellow
+        case LogLevel.Warn:
+            return "\u001b[33mWarn\u001b[0m";
+            // Magenta
+        case LogLevel.Error:
+            return "\u001b[35mError\u001b[0m";
+            // Red
+        case LogLevel.Fatal:
+            return "\u001b[31mFatal\u001b[0m";
+
+            // The following two should never be printed,
+            // so use red and make them noticeable
+        case LogLevel.None:
+            return "\u001b[31mNone\u001b[0m";
+        default:
+            return "\u001b[31mUnknown\u001b[0m";
+        }
     }
 }


### PR DESCRIPTION
This makes large output easier to deal with, as warn / error will be more obvious.