### PR TITLE
Use CAS to make initialization of TransactionPool atomic

### DIFF
--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -38,13 +38,6 @@ import std.stdio;
 /// expects a main() function and invokes it after unittesting.
 version (unittest) void main () { } else:
 
-/// Required initialization
-shared static this ()
-{
-    import agora.common.TransactionPool;
-    TransactionPool.initialize();
-}
-
 mixin AddLogger!();
 
 /// Application entry point

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -47,13 +47,6 @@ import std.format;
 
 import core.time;
 
-/// Required initialization
-shared static this ()
-{
-    import agora.common.TransactionPool;
-    TransactionPool.initialize();
-}
-
 /*******************************************************************************
 
     Task manager backed by LocalRest's event loop.


### PR DESCRIPTION
This makes initialization more predictableand easier to verify.
Additionally, the logger callback provided to SQLite could
have created problems, as it is referencing a `null` value
(at the moment the callback is supplied).