### PR TITLE
Implement a custom unittest runner + manual thread shutdown

### DIFF
--- a/source/agora/consensus/data/UTXOSet.d
+++ b/source/agora/consensus/data/UTXOSet.d
@@ -105,6 +105,7 @@ public class UTXOSet
     public void shutdown ()
     {
         this.utxo_db.shutdown();
+        this.utxo_db = null;
     }
 
     /***************************************************************************

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -123,7 +123,9 @@ public class Node : API
         log.info("Shutting down..");
         this.network.dumpMetadata();
         this.pool.shutdown();
+        this.pool = null;
         this.utxo_set.shutdown();
+        this.utxo_set = null;
     }
 
     /// GET /public_key

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -154,7 +154,14 @@ public class TestAPIManager
 
     public void shutdown ()
     {
-        this.apis.each!(a => a.shutdown());
+        foreach (key, ref api; this.apis)
+        {
+            api.shutdown();
+            api.ctrl.shutdown();
+            api = null;
+        }
+
+        this.apis = null;
     }
 
     /// fill in the in-memory metadata with the peers before nodes are started


### PR DESCRIPTION
This should fix most issues with the random segfaults in ocean and when using SCP.