### PR TITLE
[do not merge] Custom unittest runner + explicit thread shutdown

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	url = https://github.com/Geod24/libsodiumd.git
 [submodule "localrest"]
 	path = submodules/localrest
-	url = https://github.com/Geod24/localrest.git
+	url = https://github.com/AndrejMitrovic/localrest.git
 [submodule "memutils"]
 	path = submodules/memutils
 	url = https://github.com/etcimon/memutils.git

--- a/source/agora/consensus/data/UTXOSet.d
+++ b/source/agora/consensus/data/UTXOSet.d
@@ -105,6 +105,7 @@ public class UTXOSet
     public void shutdown ()
     {
         this.utxo_db.shutdown();
+        this.utxo_db = null;
     }
 
     /***************************************************************************

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -123,7 +123,9 @@ public class Node : API
         log.info("Shutting down..");
         this.network.dumpMetadata();
         this.pool.shutdown();
+        this.pool = null;
         this.utxo_set.shutdown();
+        this.utxo_set = null;
     }
 
     /// GET /public_key

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -205,7 +205,14 @@ public class TestAPIManager
 
     public void shutdown ()
     {
-        this.apis.each!(a => a.shutdown());
+        foreach (key, ref api; this.apis)
+        {
+            api.shutdown();
+            api.ctrl.shutdown();
+            api = null;
+        }
+
+        this.apis = null;
     }
 
     /// fill in the in-memory metadata with the peers before nodes are started


### PR DESCRIPTION
I want to see if the combo of not running ocean tests + having explicit shutdown will get rid of these random failures we have in travis on a mac.