### PR TITLE
Make logging easily toggle-able

### DIFF
--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -54,11 +54,16 @@ public template AddLogger (string moduleName = __MODULE__)
 /// Convenience alias
 public alias LogLevel = Level;
 
-version (unittest) {}
+/// Whether logging is enabled (by default disabled in unittests)
+version (unittest)
+    __gshared bool EnableLogging = false;
 else
+    __gshared bool EnableLogging = true;
+
+/// Initialize the logger
+static this ()
 {
-    /// Initialize the logger
-    static this ()
+    if (EnableLogging)
     {
         auto appender = new AppendConsole();
         appender.layout(new AgoraLayout());


### PR DESCRIPTION
This has been an annoyance to me, because each time I wanted to log something in a test I would have to touch `Log.d` (and make sure I don't accidentally stage it).