### PR TITLE
Make a logger for SCP and logging functions

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -21,6 +21,7 @@
         "source/scpp/build/Hex.o",
         "source/scpp/build/KeyUtils.o",
         "source/scpp/build/LocalNode.o",
+        "source/scpp/build/Logging.o",
         "source/scpp/build/Math.o",
         "source/scpp/build/NominationProtocol.o",
         "source/scpp/build/QuorumSetUtils.o",

--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -115,3 +115,28 @@ public class AgoraLayout : Appender.Layout
         }
     }
 }
+
+/***************************************************************************
+
+    Logging function which is only called from C++ code
+
+    It's for C++ code to use agora's logger instead of C++ stdout 
+
+    Params:
+        logger = the logger name
+        level = the logging level
+        msg = the log message
+
+***************************************************************************/
+
+private extern (C++) void writeDLog (const char* logger, int level, const char* msg)
+{
+    if (level >= Level.min && level <= Level.max)
+    {
+        import std.string;
+
+        auto log = Log.lookup(fromStringz(logger));
+        assert(log !is null);
+        log.format(cast(Level) level, fromStringz(msg));
+    }
+}

--- a/source/scpp/src/util/Logging.cpp
+++ b/source/scpp/src/util/Logging.cpp
@@ -1,0 +1,24 @@
+// Copyright 2014 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include <cstdarg>
+#include <iostream>
+#include <vector>
+#include "Logging.h"
+
+using namespace std;
+
+namespace stellar
+{
+DLogger::DLogger(int level, std::string const& loggerName)
+{
+    mLevel = level;
+    mLoggerName = std::string(loggerName);
+}
+
+DLogger::~DLogger()
+{
+    writeDLog(mLoggerName.c_str(), mLevel, mOutStream.str().c_str());
+}
+}

--- a/source/scpp/src/util/Logging.h
+++ b/source/scpp/src/util/Logging.h
@@ -8,12 +8,16 @@
 #include <sstream>
 #include <iostream>
 
-#define TRACE "trace"
-#define DEBUG "debug"
-#define INFO "info"
-#define ERROR "error"
-#define FATAL "fatal"
-#define CLOG(LEVEL, MOD) std::cout << "[" << LEVEL << ", " << MOD << "] "
+#define TRACE 0
+#define DEBUG 0
+#define INFO  1
+#define WARN  2
+#define ERROR 3
+#define FATAL 4
+#define CLOG(LEVEL, MOD) stellar::DLogger(LEVEL, MOD)
+
+// Logging function to D code
+void writeDLog(const char* logger, int level, const char* msg);
 
 namespace stellar
 {
@@ -26,5 +30,24 @@ class Logging
     static bool logDebug(std::string const& partition) { return true; }
     static bool logTrace(std::string const& partition) { return true; }
     static void rotate();
+};
+
+struct DLogger
+{
+  private:
+    std::string mLoggerName;
+    int mLevel;
+    std::ostringstream mOutStream;
+
+  public:
+    DLogger(int level, std::string const& loggerName);
+    ~DLogger();
+
+    template <class T>
+    DLogger &operator<<(const T &value)
+    {
+        mOutStream << value;
+        return *this;
+    }
 };
 }


### PR DESCRIPTION
The logger for SCP module is created in agora.utils.Log module.
The logging function in SCP module makes a formatted message and call a logging function in D.
Unittest code is added.

Related to #346 