### PR TITLE
Ignore submodules in coverage reports

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,2 @@
+ignore:
+  - "*submodules-*.lst"


### PR DESCRIPTION
This should massively speed up upload and improve coverage.