### PR TITLE
Fix the NetworkManager BadNode test

### DIFF
--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -269,8 +269,12 @@ public class NetworkManager
             do
             {
                 auto blocks = pair.client.getBlocksFrom(block_height, MaxBlocks);
-                log.info("Received blocks [{}..{}] out of {}..", block_height,
-                    block_height + blocks.length, pair.height + 1);  // genesis block
+                if (blocks.length == 0)
+                    continue LNextNode;
+
+                log.info("Received blocks [{}..{}] out of {}..",
+                    blocks[0].header.height, blocks[$ - 1].header.height,
+                    pair.height + 1);  // +1 for genesis block
 
                 // one or more blocks were rejected, stop retrieval from node
                 if (!onReceivedBlocks(blocks))

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -79,18 +79,16 @@ unittest
             Block[] blocks;
             Transaction[] last_tx;
 
-            auto gen_key = () @trusted { return getGenesisKeyPair(); }();
+            auto prev_key = () @trusted { return KeyPair.random(); }();
 
             Block last_block;
             // make 20 blocks which have an invalid previous hash
             foreach (idx; 0 .. 20)
             {
-                auto txs = () @trusted { return makeChainedTransactions(gen_key, last_tx, 1); }();
+                auto txs = () @trusted { return makeChainedTransactions(prev_key, last_tx, 1); }();
                 last_tx = txs;
                 auto block = makeNewBlock(last_block, txs);
 
-                // currently the only block validation the Ledger does is the height
-                block.header.height = idx + 10;
                 blocks ~= block;
                 last_block = block;
             }


### PR DESCRIPTION
This test was originally written before we had any block validation, so back then only the `height` was checked. But it still had issues with timing.

I've simplified the test, because all it's supposed to test is sending bad blocks in `getBlocksFrom`.