### PR TITLE
Ensure that validators sign with a frozen UTXO

### DIFF
--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -290,7 +290,7 @@ public struct SecretKey
 
     ***************************************************************************/
 
-    public Signature sign (scope const(ubyte)[] msg) const
+    public Signature sign (scope const(ubyte)[] msg) const @trusted
     {
         Signature result;
         // The second argument, `siglen_p`, a pointer to the length of the

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -233,6 +233,19 @@ public class Ledger
             return;  // not enough valid txs
 
         auto block = makeNewBlock(this.last_block, txs);
+
+        // Sign the block as long as the Validator is enabled.
+        if (this.node_config.is_validator)
+        {
+            ValidatorSig validator_sig;
+            validator_sig.key = this.node_config.key_pair.address;
+            // When the operating process is introduced, the corresponding UTXO is applied.
+            // validator_sig.utxo_hash;
+            validator_sig.sig =
+                this.node_config.key_pair.secret.sign(hashFull(block.header)[]);
+            block.header.validator_sigs ~= validator_sig;
+        }
+
         if (!this.acceptBlock(block))  // txs should be valid
             assert(0);
     }


### PR DESCRIPTION
#205 issues.
#365 and #406 are implemented, we can adapt my solution and change the block header so it works with the Schnorr signature scheme and with the Enrollment process.

This adds ValidatorSig to the blockhead.
Hash and sign the BlockHead of Validators to Blockheader.ValidatorSigs.
The blockhead verifies the signature of Validators of the block in Validation.isInvalidReason.
Check the Unspent Freeze UTXO associated with the Publickey used to sign Validators.

This can identify the Freeze UTXO proof of Validator, which can generate blocks.
