### PR TITLE
Replace fromBinary() with deserialize() to make it consistent

### DIFF
--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -198,20 +198,17 @@ public struct PublicKey
 
     /***************************************************************************
 
-        PublicKey fromBinary
+        Key Deserialization
 
         Params:
             dg = deserialize function
 
-        Returns:
-            `PublicKey` Public key address
-
     ***************************************************************************/
 
-    public static PublicKey fromBinary (scope DeserializeDg dg) @safe
+    public void deserialize (scope DeserializeDg dg) @safe
     {
         alias DType = typeof(this.data);
-        return PublicKey(DType(dg(DType.sizeof)));
+        this.data = DType(dg(DType.sizeof));
     }
 
     ///
@@ -229,6 +226,15 @@ public struct PublicKey
                 "774bffea9918411d0c4c8ac403c");
             assert(hash == exp_hash);
         }();
+    }
+
+    /// PublicKey serialize & deserialize
+    unittest
+    {
+        KeyPair kp = KeyPair.random();
+        PublicKey address = kp.address;
+        auto bytes_address = serializeFull(address);
+        assert(deserializeFull!PublicKey(bytes_address) == address);
     }
 
     /***************************************************************************

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -221,7 +221,7 @@ public struct Output
     public void deserialize (scope DeserializeDg dg) @safe
     {
         deserializePart(this.value, dg);
-        this.address = PublicKey.fromBinary(dg);
+        deserializePart(this.address, dg);
     }
 }
 


### PR DESCRIPTION
We need serialize and deserialize to add a publickey in the block structure to be added.
issue #205 