### PR TITLE
Add the findUTXO feature of the UTXOSet.

### DIFF
--- a/source/agora/consensus/data/UTXOSet.d
+++ b/source/agora/consensus/data/UTXOSet.d
@@ -254,7 +254,7 @@ public class UTXOSet
 
     ***************************************************************************/
 
-    private static Hash getHash (Hash hash, ulong index) @safe nothrow
+    public static Hash getHash (Hash hash, ulong index) @safe nothrow
     {
         return hashMulti(hash, index);
     }

--- a/source/agora/consensus/data/UTXOSet.d
+++ b/source/agora/consensus/data/UTXOSet.d
@@ -213,6 +213,7 @@ public class UTXOSet
         Params:
             hash = the hash of transation
             index = the index of the output
+                If size_t.max, find the hash parameter by UTXO Hash.
             output = will contain the UTXOSetValue if found
 
         Return:
@@ -223,7 +224,12 @@ public class UTXOSet
     private bool findUTXO (Hash hash, size_t index, out UTXOSetValue value)
         nothrow @safe
     {
-        auto utxo_hash = getHash(hash, index);
+        Hash utxo_hash;
+
+        if (index == size_t.max)
+            utxo_hash = hash;
+        else
+            utxo_hash = getHash(hash, index);
 
         if (utxo_hash in this.used_utxos)
             return false;  // double-spend

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -599,6 +599,12 @@ unittest
     UTXOSetValue _val;
     new_txs.each!(tx => assert(finder(tx.inputs[0].previous, tx.inputs[0].index,
         _val)));
+
+    auto findUTXO = utxo_set.getUTXOFinder();
+    Transaction find_tx = new_txs[0];
+    Hash utxo_hash = utxo_set.getHash(find_tx.inputs[0].previous, find_tx.inputs[0].index);
+    UTXOSetValue value;
+    assert(findUTXO(utxo_hash, size_t.max, value));
 }
 
 version (unittest)


### PR DESCRIPTION
Currently, the required parameters hash, index are required in the findUTXO in UTXOSet.
In addition, it is necessary to find UTXO setHash directly without index in UTXO pool.

Index is If size_t.max, find the hash parameter by UTXO hash

#205 