### PR TITLE
Add config.node parameter in Ledger Constructor

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -14,6 +14,7 @@
 module agora.node.Ledger;
 
 import agora.common.Amount;
+import agora.common.Config;
 import agora.common.crypto.Key;
 import agora.common.Hash;
 import agora.common.TransactionPool;
@@ -48,6 +49,8 @@ public class Ledger
     /// UTXO set
     private UTXOSet utxo_set;
 
+    /// Node config
+    private NodeConfig node_config;
 
     /***************************************************************************
 
@@ -60,11 +63,15 @@ public class Ledger
 
     ***************************************************************************/
 
-    public this (TransactionPool pool, UTXOSet utxo_set, IBlockStorage storage)
+    public this (TransactionPool pool,
+        UTXOSet utxo_set,
+        IBlockStorage storage,
+        NodeConfig node_config)
     {
         this.pool = pool;
         this.utxo_set = utxo_set;
         this.storage = storage;
+        this.node_config = node_config;
         if (!this.storage.load())
             assert(0);
 
@@ -367,7 +374,8 @@ unittest
     scope(exit) pool.shutdown();
     auto utxo_set = new UTXOSet(":memory:");
     scope (exit) utxo_set.shutdown();
-    scope ledger = new Ledger(pool, utxo_set, storage);
+    auto config = new Config();
+    scope ledger = new Ledger(pool, utxo_set, storage, config.node);
     assert(ledger.getBlockHeight() == 0);
 
     auto blocks = ledger.getBlocksFrom(0).take(10);
@@ -448,7 +456,8 @@ unittest
     scope(exit) pool.shutdown();
     auto utxo_set = new UTXOSet(":memory:");
     scope (exit) utxo_set.shutdown();
-    scope ledger = new Ledger(pool, utxo_set, storage);
+    auto config = new Config();
+    scope ledger = new Ledger(pool, utxo_set, storage, config.node);
 
     // Valid case
     auto gen_key_pair = getGenesisKeyPair();
@@ -492,7 +501,8 @@ unittest
     scope(exit) pool.shutdown();
     auto utxo_set = new UTXOSet(":memory:");
     scope (exit) utxo_set.shutdown();
-    scope ledger = new Ledger(pool, utxo_set, storage);
+    auto config = new Config();
+    scope ledger = new Ledger(pool, utxo_set, storage, config.node);
 
     Block invalid_block;  // default-initialized should be invalid
     assert(!ledger.acceptBlock(invalid_block));
@@ -514,7 +524,8 @@ unittest
     scope(exit) pool.shutdown();
     auto utxo_set = new UTXOSet(":memory:");
     scope (exit) utxo_set.shutdown();
-    scope ledger = new Ledger(pool, utxo_set, storage);
+    auto config = new Config();
+    scope ledger = new Ledger(pool, utxo_set, storage, config.node);
 
     auto gen_key_pair = getGenesisKeyPair();
     auto txs = makeChainedTransactions(gen_key_pair, null, 1);
@@ -589,7 +600,8 @@ unittest
     scope(exit) pool.shutdown();
     auto utxo_set = new UTXOSet(":memory:");
     scope (exit) utxo_set.shutdown();
-    scope ledger = new Ledger(pool, utxo_set, storage);
+    auto config = new Config();
+    scope ledger = new Ledger(pool, utxo_set, storage, config.node);
 
     assert(utxo_set.length == 8);
     auto finder = utxo_set.getUTXOFinder();
@@ -691,7 +703,8 @@ unittest
     auto utxo_set = new UTXOSet(":memory:");
     scope (exit) utxo_set.shutdown();
 
-    scope ledger = new Ledger(pool, utxo_set, storage);
+    auto config = new Config();
+    scope ledger = new Ledger(pool, utxo_set, storage, config.node);
 
     KeyPair[] in_key_pairs;
     KeyPair[] out_key_pairs;
@@ -786,7 +799,8 @@ unittest
     auto utxo_set = new UTXOSet(":memory:");
     scope (exit) utxo_set.shutdown();
 
-    scope ledger = new Ledger(pool, utxo_set, storage);
+    auto config = new Config();
+    scope ledger = new Ledger(pool, utxo_set, storage, config.node);
 
     KeyPair[] splited_keys = getRandomKeyPairs();
 

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -98,7 +98,7 @@ public class Node : API
         this.storage = this.getBlockStorage(config.node.data_dir);
         this.pool = this.getPool(config.node.data_dir);
         this.utxo_set = this.getUtxoSet(config.node.data_dir);
-        this.ledger = new Ledger(this.pool, this.utxo_set, this.storage);
+        this.ledger = new Ledger(this.pool, this.utxo_set, this.storage, config.node);
         this.gossip = new GossipProtocol(this.network, this.ledger);
         this.exception = new RestException(
             400, Json("The query was incorrect"), string.init, int.init);


### PR DESCRIPTION
We need to use config.node in Ledger.
In order to make a block, it is necessary to read the publickey and seed of a node, and to check whether the node is intended to be a validator.
issue #205