### PR TITLE
Remove hashing requirement to have `computeHash` implemented

### DIFF
--- a/source/agora/common/Amount.d
+++ b/source/agora/common/Amount.d
@@ -67,12 +67,6 @@ public struct Amount
         this.value = units;
     }
 
-    /// Support for hashing
-    public void computeHash (scope HashDg dg) const nothrow @nogc @safe
-    {
-        hashPart(this.value, dg);
-    }
-
     /// Support for serialization
     public void serialize (scope SerializeDg dg) const @safe
     {

--- a/source/agora/common/Hash.d
+++ b/source/agora/common/Hash.d
@@ -160,6 +160,13 @@ public void hashPart (scope const(char)[] record, scope HashDg state) /*pure*/ n
     state(cast(const ubyte[])record);
 }
 
+/// Ditto
+public void hashPart (T) (scope const auto ref T[] records, scope HashDg state)
+{
+    foreach (ref record; records)
+        hashPart(record, state);
+}
+
 // Test that the implementation actually matches what the RFC gives
 nothrow @nogc @safe unittest
 {
@@ -243,6 +250,9 @@ nothrow @nogc @safe unittest
         "c2e756f276c112342ff1d6f1e74d05bdb9bf880abd74a2e512654e12d171a74");
 
     assert(hashMulti(foo, bar) == merged);
+
+    const Hash[2] array = [foo, bar];
+    assert(hashFull(array[]) == merged);
 
     static struct S
     {

--- a/source/agora/common/Hash.d
+++ b/source/agora/common/Hash.d
@@ -119,17 +119,15 @@ public void hashPart (T) (scope const auto ref T record, scope HashDg state)
     /*pure*/ nothrow @nogc
     if (is(T == struct))
 {
-    static assert(is(typeof(T.init.computeHash(HashDg.init))),
-                  "Struct `" ~ T.stringof ~
-                  "` does not implement `computeHash(scope HashDg) const nothrow @nogc` function");
-    record.computeHash(state);
-}
-
-/// Ditto
-public void hashPart () (scope const auto ref Hash record, scope HashDg state)
-    /*pure*/ nothrow @nogc @safe
-{
-    state(record[]);
+    static if (__traits(compiles, () { const ubyte[] r = T.init[]; }))
+        state(record[]);
+    else
+    {
+        static assert(is(typeof(T.init.computeHash(HashDg.init))),
+                      "Struct `" ~ T.stringof ~
+                      "` does not implement `computeHash(scope HashDg) const nothrow @nogc` function");
+        record.computeHash(state);
+    }
 }
 
 /// Ditto

--- a/source/agora/common/Hash.d
+++ b/source/agora/common/Hash.d
@@ -161,6 +161,12 @@ public void hashPart (scope const(char)[] record, scope HashDg state) /*pure*/ n
 }
 
 /// Ditto
+public void hashPart (scope const(ubyte)[] record, scope HashDg state)
+{
+    state(record);
+}
+
+/// Ditto
 public void hashPart (T) (scope const auto ref T[] records, scope HashDg state)
 {
     foreach (ref record; records)

--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -16,7 +16,6 @@ module agora.common.crypto.Key;
 import agora.common.crypto.Crc16;
 import agora.common.Types;
 import agora.common.Deserializer;
-import agora.common.Hash;
 import agora.common.Serializer;
 
 import geod24.bitblob;
@@ -170,20 +169,6 @@ public struct PublicKey
 
     /***************************************************************************
 
-        Implements hashing support
-
-        Params:
-            dg = hashing function
-
-    ***************************************************************************/
-
-    public void computeHash (scope HashDg dg) const nothrow @safe @nogc
-    {
-        dg(this.data[]);
-    }
-
-    /***************************************************************************
-
         Key Serialization
 
         Params:
@@ -214,6 +199,8 @@ public struct PublicKey
     ///
     unittest
     {
+        import agora.common.Hash;
+
         immutable address =
             `GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW`;
         PublicKey pubkey = PublicKey.fromString(address);

--- a/source/agora/common/crypto/Schnorr.d
+++ b/source/agora/common/crypto/Schnorr.d
@@ -146,14 +146,6 @@ private struct Message (T)
     public Point X;
     public Point R;
     public T     message;
-
-    ///
-    public void computeHash(scope HashDg dg) const nothrow @nogc
-    {
-        dg(this.X.data[]);
-        dg(this.R.data[]);
-        hashPart(this.message, dg);
-    }
 }
 
 

--- a/source/agora/common/crypto/Schnorr.d
+++ b/source/agora/common/crypto/Schnorr.d
@@ -152,10 +152,7 @@ private struct Message (T)
     {
         dg(this.X.data[]);
         dg(this.R.data[]);
-        static if (is(T : const(ubyte)[]))
-            dg(this.message);
-        else
-            hashPart(this.message, dg);
+        hashPart(this.message, dg);
     }
 }
 

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -55,23 +55,6 @@ public struct Transaction
     /// The list of newly created outputs to put in the UTXO
     public Output[] outputs;
 
-
-    /***************************************************************************
-
-        Implements hashing support
-
-        Params:
-            dg = hashing function
-
-    ***************************************************************************/
-
-    public void computeHash (scope HashDg dg) const nothrow @safe @nogc
-    {
-        hashPart(this.type, dg);
-        hashPart(this.inputs, dg);
-        hashPart(this.outputs, dg);
-    }
-
     /***************************************************************************
 
         Transactions Serialization
@@ -173,22 +156,6 @@ public struct Output
     /// The public key that can redeem this output (A = pubkey)
     /// Note that in Bitcoin, this is an address (the double hash of a pubkey)
     public PublicKey address;
-
-
-    /***************************************************************************
-
-        Implements hashing support
-
-        Params:
-            dg = hashing function
-
-    ***************************************************************************/
-
-    public void computeHash (scope HashDg dg) const nothrow @safe @nogc
-    {
-        hashPart(this.value, dg);
-        hashPart(this.address, dg);
-    }
 
     /***************************************************************************
 

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -68,12 +68,8 @@ public struct Transaction
     public void computeHash (scope HashDg dg) const nothrow @safe @nogc
     {
         hashPart(this.type, dg);
-
-        foreach (input; this.inputs)
-            hashPart(input, dg);
-
-        foreach (output; this.outputs)
-            hashPart(output, dg);
+        hashPart(this.inputs, dg);
+        hashPart(this.outputs, dg);
     }
 
     /***************************************************************************


### PR DESCRIPTION
Part of #432 

```
`hashPart` used to require that `computeHash` be implemented by aggregates.
However, this proved very inefficient and led to both abstraction leaks,
and repetitive code.

This commit lifts this limitation, using 'tupleof' as the default hashing mechanism.
Aggregates still have the ability to override the way hashing is done
by explicitly implementing `computeHash`.

Note that not having to implement `computeHash` makes aggregates with special requirements
(namely `Block` and `Input`) more obvious to the reader,
as otherwise the override gets lost in the noise.
```

Dev team, LGTY ?