### PR TITLE
Make coverage work with integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,4 +46,11 @@ jobs:
           command: |
             source $HOME/dlang/dmd-2.088.0/activate
             ci/system_integration_test.d
+            # Work around druntime setting the permissions to 600..
+            sudo chmod 644 tests/system/node/*/*.lst
           no_output_timeout: 15m
+      - run:
+          name: Upload code coverage
+          command: |
+             curl -s https://codecov.io/bash | bash -s -- \
+               -n "CircleCI" -F "integration" -Z || echo 'Codecov upload failed'

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN dub build --skip-registry=all --compiler=ldc2 ${DUB_OPTIONS}
 
 # Runner
 FROM alpine:edge
-COPY --from=Builder /root/agora/build/agora /root/agora
 RUN apk --no-cache add libexecinfo libgcc libsodium libstdc++ sqlite-libs
-WORKDIR /root/
-ENTRYPOINT [ "/root/agora" ]
+COPY --from=Builder /root/agora/build/agora /usr/local/bin/agora
+WORKDIR /agora/
+ENTRYPOINT [ "/usr/local/bin/agora" ]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ before you first build agora.
 
 For a test run, try:
 ```console
-docker run -p 127.0.0.1:4000:2826/tcp -v `pwd`/doc/:/root/etc/ agora -c etc/config.example.yaml
+docker run -p 127.0.0.1:4000:2826/tcp -v `pwd`/doc/:/agora/etc/ agora -c etc/config.example.yaml
 ```
 This will start a node with the example config file,
 and make the port locally accessible (See http://127.0.0.1:4000/) .

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -77,16 +77,6 @@ private int main (string[] args)
         auto router = new URLRouter();
 
         mkdirRecurse(config.node.data_dir);
-        // Support code coverage being written to the data directory
-        // This way we can collect data from docker containers
-        // Note: This DOES NOT WORK WITH LDC (#221)
-        version (D_Coverage)
-        {
-            import core.runtime;
-            import std.path : buildPath;
-            immutable coverPath = config.node.data_dir.buildPath("coverage");
-            dmd_coverDestPath(coverPath);
-        }
 
         auto node = new Node(config);
         scope(exit) node.shutdown();

--- a/tests/system/docker-compose.yml
+++ b/tests/system/docker-compose.yml
@@ -13,16 +13,22 @@ services:
     ports:
       - "4000:2826"
     volumes:
-      - ./node/0/:/agora/
+      - "./node/0/:/agora/"
+      - "../../source:/agora/source/"
+      - "../../submodules:/agora/submodules/"
   node-1:
     image: "agora:latest"
     ports:
       - "4001:2826"
     volumes:
-      - ./node/1/:/agora/
+      - "./node/1/:/agora/"
+      - "../../source:/agora/source/"
+      - "../../submodules:/agora/submodules/"
   node-2:
     image: "agora:latest"
     ports:
       - "4002:2826"
     volumes:
-      - ./node/2/:/agora/
+      - "./node/2/:/agora/"
+      - "../../source:/agora/source/"
+      - "../../submodules:/agora/submodules/"

--- a/tests/system/docker-compose.yml
+++ b/tests/system/docker-compose.yml
@@ -10,22 +10,19 @@ version: '3'
 services:
   node-0:
     image: "agora:latest"
-    command: [ "--config", "/root/wd/config.yaml" ]
     ports:
       - "4000:2826"
     volumes:
-      - ./node/0/:/root/wd/
+      - ./node/0/:/agora/
   node-1:
     image: "agora:latest"
-    command: [ "--config", "/root/wd/config.yaml" ]
     ports:
       - "4001:2826"
     volumes:
-      - ./node/1/:/root/wd/
+      - ./node/1/:/agora/
   node-2:
     image: "agora:latest"
-    command: [ "--config", "/root/wd/config.yaml" ]
     ports:
       - "4002:2826"
     volumes:
-      - ./node/2/:/root/wd/
+      - ./node/2/:/agora/

--- a/tests/system/node/1/config.yaml
+++ b/tests/system/node/1/config.yaml
@@ -18,7 +18,7 @@ node:
   # Public address:  GBJABNUCDJCIL5YJQMB5OZ7VCFPKYLMTUXM2ZKQJACT7PXL7EVOMEKNZ
   seed:    SCTTRCMT7DVZHQS375GWIKYQYHKA3X4IC4EOBNPRGV7DFR3X6OM5VIWL
   # Path to the data directory (if the path doesn't exist it will be created)
-  data_dir: /root/wd/.cache/
+  data_dir: .cache/
 
 ################################################################################
 ##                         Ban manager configuration                          ##


### PR DESCRIPTION
```
The only thing we need to do is to mount `source` and `submodules`
in the working directory so that the coverage code can access it
(otherwise it's unable to generate reports).
Since coverage won't be enabled very often, or by end user,
the option to store it in the data directory is removed
(it also became moot since the reshuffling of the docker image).
```

The Dockerfile has also been slightly improved.