### PR TITLE
 Remove requirement for aggregates to implement [de]serialize

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -52,9 +52,6 @@ public class BanManager
         /// To set an IP as banned, we simply set its un-ban time in the future.
         /// By default it's set to the past (therefore un-banned)
         private time_t banned_until = 0;
-
-        mixin DefaultSerializer!();
-        mixin DefaultDeserializer!();
     }
 
     /// configuration

--- a/source/agora/node/API.d
+++ b/source/agora/node/API.d
@@ -38,7 +38,6 @@ module agora.node.API;
 import agora.common.crypto.Key;
 import agora.consensus.data.Block;
 import agora.common.Types;
-import agora.common.Deserializer;
 import agora.common.Set;
 import agora.common.Serializer;
 import agora.consensus.data.Transaction;
@@ -64,9 +63,6 @@ public struct NetworkInfo
 
     /// Partial or full view of the addresses of the node's quorum (based on is_complete)
     public Set!string addresses;
-
-    mixin DefaultDeserializer!();
-    mixin DefaultSerializer!();
 }
 
 /*******************************************************************************


### PR DESCRIPTION
```
Aggregates are now default-[de]serialized to the tupleof of their members by default.
Any aggregate wishing a special handling can do so by defining '[de]serialize' as before.
Additionally, `DefaultSerializer` and `DefaultDeserializer` have been removed,
as they are now redundant with the default.
```

Fixes #432 

The `serialize` / `deserialize` methods haven't been removed yet, as there are some more room for improvements (in particular for deserialization) that require some more research.