### PR TITLE
Emit module name when a test fails

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -120,6 +120,7 @@ private UnitTestResult customModuleUnitTester ()
         }
         catch (Throwable ex)
         {
+            writefln("Module tests failed: %s", mod.name);
             writeln(ex);
         }
     }


### PR DESCRIPTION
Sometimes the stack trace doesn't show the
origin of the module for which the tests ran.

Now the name of the failing module is shown.