### PR TITLE
Added unit test for FreezeAmount on Amount

### DIFF
--- a/source/agora/common/Amount.d
+++ b/source/agora/common/Amount.d
@@ -259,6 +259,9 @@ pure @safe nothrow @nogc unittest
 
     assert(Amount(100_500_000).integral() == 10);
     assert(Amount(100_500_000).decimal() == 500_000);
+
+    assert(Amount.FreezeAmount.decimal() == 0);
+    assert(Amount.FreezeAmount.integral() == 40_000);
 }
 
 unittest


### PR DESCRIPTION
Make sure there are no decimal places in the FreezeAmount.
Compare the same as 40,000BOA.
It tests the function of Amount.integral