### PR TITLE
Add enrollments struct to the Blockheader

### DIFF
--- a/tests/system/dub.json
+++ b/tests/system/dub.json
@@ -18,6 +18,7 @@
         "../../source/agora/common/Set.d",
         "../../source/agora/common/Types.d",
         "../../source/agora/consensus/data/Block.d",
+        "../../source/agora/consensus/data/Enrollment.d",
         "../../source/agora/consensus/data/Transaction.d",
         "../../source/agora/consensus/Genesis.d",
         "../../source/agora/node/API.d",


### PR DESCRIPTION
This is to store the enrollment data in the block when creating the block.
Enrollment data is stored only in registered blocks.