### PR TITLE
Update list of supported compilers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: |
             mkdir -p $HOME/dlang && wget https://dlang.org/install.sh -O $HOME/dlang/install.sh
             chmod +x $HOME/dlang/install.sh
-            $HOME/dlang/install.sh install dmd-2.088.0
+            $HOME/dlang/install.sh install dmd-2.089.1
       - run:
           name: Install libsodium
           command: |
@@ -44,7 +44,7 @@ jobs:
       - run:
           name: Build & test docker image
           command: |
-            source $HOME/dlang/dmd-2.088.0/activate
+            source $HOME/dlang/dmd-2.089.1/activate
             ci/system_integration_test.d
             # Work around druntime setting the permissions to 600..
             sudo chmod 644 tests/system/node/*/*.lst

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         os: [macOS-latest]
         # LDC testing is disabled for the time being due to random failures
-        dc: [dmd-2.089.0, dmd-2.088.1, dmd-master]
+        dc: [dmd-2.089.1, dmd-master]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        dc: [dmd-2.089.0, dmd-2.088.1, ldc-1.18.0, ldc-1.17.0, dmd-master, ldc-master]
+        dc: [dmd-2.089.1, ldc-1.18.0, dmd-master, ldc-master]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ language: d
 dist: xenial
 
 d:
-  - dmd-2.088.1
-  - dmd-2.087.1   # 2.087.0 has regressions
+  - dmd-2.089.1
   - ldc-1.18.0
-  - ldc-1.17.0
   - dmd-nightly   # Nightlies at the end so that `fast_finish` is useful
   - ldc-latest-ci # The freshest LDC
 


### PR DESCRIPTION
Only use DMD v2.089.1 due to the swath of regressions with C++ support.
Also drop any LDC version that is not the most recent.
Once LDC 1.19.0 gets released, we can replace LDC 1.18.0 with it
(however the Docker-dependent tests will still need an upstream update).