### PR TITLE
Update Github actions to v0.4.2

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         submodules: true
     - name: Prepare compiler
-      uses: mihails-strasuns/setup-dlang@v0.4.1
+      uses: mihails-strasuns/setup-dlang@v0.4.2
       with:
           compiler: ${{ matrix.dc }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
       with:
         submodules: true
     - name: Prepare compiler
-      uses: mihails-strasuns/setup-dlang@v0.4.1
+      uses: mihails-strasuns/setup-dlang@v0.4.2
       with:
         compiler: ${{ matrix.dc }}
         gh_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Cannot access 'latest' before initialization #19
The solution version is likely to be released.