### PR TITLE
CI: Disable ldc-master on Linux too

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        dc: [dmd-2.089.1, ldc-1.18.0, dmd-master, ldc-master]
+        dc: [dmd-2.089.1, ldc-1.18.0, dmd-master]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Because at the moment github action is broken.