### PR TITLE
Update DMD to 2.090.0 and LDC to 1.19.0

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         os: [macOS-latest]
         # LDC testing is disabled for the time being due to random failures
-        dc: [dmd-2.089.1, dmd-master]
+        dc: [dmd-2.090.0, dmd-master]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        dc: [dmd-2.089.1, ldc-1.18.0, dmd-master, ldc-master]
+        dc: [dmd-2.090.0, ldc-1.19.0, dmd-master, ldc-master]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         submodules: true
     - name: Install D and Dub
       run: |
-        DMD_VERSION=2.088.0
+        DMD_VERSION=2.090.0
         wget http://downloads.dlang.org/releases/2.x/${DMD_VERSION}/dmd_${DMD_VERSION}-0_amd64.deb
         sudo dpkg -i dmd_${DMD_VERSION}-0_amd64.deb
         sudo apt install -f

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: d
 dist: xenial
 
 d:
-  - ldc-1.18.0
+  - ldc-1.19.0
   - dmd-nightly   # Nightlies at the end so that `fast_finish` is useful
   - ldc-latest-ci # The freshest LDC
 
@@ -13,7 +13,7 @@ os:
 
 matrix:
   include:
-    - d: dmd-2.089.1,dub-1.18.0
+    - d: dmd-2.090.0
       os: linux
     - d: dmd-2.089.1
       os: osx


### PR DESCRIPTION
Note: LDC 1.19.0 correspond to DMD 2.089.1, so we're still testing two frontends.