### PR TITLE
add isInvalidEnrollmentReason Function in Validation

### DIFF
--- a/source/agora/common/EnrollmentManager.d
+++ b/source/agora/common/EnrollmentManager.d
@@ -517,3 +517,72 @@ unittest
     assert(!man.updateEnrolledHeight(utxo_hash, 9));
     assert(man.getEnrolledHeight(utxo_hash2) == 0);
 }
+
+///
+unittest
+{
+    import agora.common.Amount;
+    import agora.common.EnrollmentManager;
+    import agora.consensus.data.Enrollment;
+    import agora.consensus.data.Transaction;
+    import agora.consensus.data.UTXOSet;
+    import agora.consensus.Validation;
+
+    KeyPair key_pair = KeyPair.random;
+
+    auto utxo_set = new UTXOSet(":memory:");
+    scope (exit) utxo_set.shutdown();
+    UTXOFinder utxoFinder = utxo_set.getUTXOFinder();
+    auto man = new EnrollmentManager(":memory:", key_pair);
+    scope (exit) man.shutdown();
+
+    // normal frozen transaction
+    Transaction tx1 = Transaction(
+        TxType.Freeze,
+        [Input(Hash.init, 0)],
+        [Output(Amount.MinFreezeAmount, key_pair.address)]
+    );
+
+    // payment transaction
+    Transaction tx2 = Transaction(
+        TxType.Payment,
+        [Input(Hash.init, 0)],
+        [Output(Amount.MinFreezeAmount, key_pair.address)]
+    );
+
+    // Insufficient freeze amount transaction
+    Transaction tx3 = Transaction(
+        TxType.Freeze,
+        [Input(Hash.init, 0)],
+        [Output(Amount(1), key_pair.address)]
+    );
+
+    auto utxo_hash1 = utxo_set.getHash(hashFull(tx1), 0);
+    auto utxo_hash2 = utxo_set.getHash(hashFull(tx2), 0);
+    auto utxo_hash3 = utxo_set.getHash(hashFull(tx3), 0);
+
+    Enrollment enroll1;
+    Enrollment enroll2;
+    Enrollment enroll3;
+    man.createEnrollment(utxo_hash1, enroll1);
+    man.createEnrollment(utxo_hash2, enroll2);
+    man.createEnrollment(utxo_hash3, enroll3);
+
+    assert(!isValidEnrollment(1, enroll1, utxoFinder));
+    assert(!isValidEnrollment(1, enroll2, utxoFinder));
+    assert(!isValidEnrollment(1, enroll3, utxoFinder));
+
+    utxo_set.updateUTXOCache(tx1, 0);
+    utxo_set.updateUTXOCache(tx2, 0);
+    utxo_set.updateUTXOCache(tx3, 0);
+
+    auto utxos = utxo_set.getUTXOs(key_pair.address);
+    assert(utxos[utxo_hash1].output.address == key_pair.address);
+    assert(utxos[utxo_hash2].output.address == key_pair.address);
+    assert(utxos[utxo_hash3].output.address == key_pair.address);
+
+    assert(isValidEnrollment(1, enroll1, utxoFinder));
+    assert(!isValidEnrollment(0, enroll1, utxoFinder));
+    assert(!isValidEnrollment(1, enroll2, utxoFinder));
+    assert(!isValidEnrollment(1, enroll3, utxoFinder));
+}


### PR DESCRIPTION
This checks the validation of UTXO of the enrollment.

Currently, it is used to generate or add an enrollment, but later it will also be used to verify the enrollments of the blockHeader.

Has dependence on PR #460
Once you get the block height of the enrollmentData, we can validate the cycle_length of the enrollment.

Required #467 
#205 