### PR TITLE
Mark the Schnorr crypto routines @safe

### DIFF
--- a/source/agora/common/crypto/ECC.d
+++ b/source/agora/common/crypto/ECC.d
@@ -106,7 +106,7 @@ public struct Scalar
 
     /// Operator overloads for `+`, `-`, `*`
     public Scalar opBinary (string op)(const scope auto ref Scalar rhs)
-        const nothrow @nogc
+        const nothrow @nogc @trusted
     {
         Scalar result = void;
         static if (op == "+")
@@ -125,7 +125,7 @@ public struct Scalar
 
     /// Get the complement of this scalar
     public Scalar opUnary (string s)()
-        const nothrow @nogc
+        const nothrow @nogc @trusted
         if (s == "-")
     {
         Scalar result = void;
@@ -134,7 +134,7 @@ public struct Scalar
     }
 
     /// Generate a random scalar
-    public static Scalar random () nothrow @nogc
+    public static Scalar random () nothrow @nogc @trusted
     {
         Scalar ret = void;
         crypto_core_ed25519_scalar_random(ret.data[].ptr);
@@ -142,7 +142,7 @@ public struct Scalar
     }
 
     /// Return the point corresponding to this scalar multiplied by the generator
-    public Point toPoint () const nothrow @nogc
+    public Point toPoint () const nothrow @nogc @trusted
     out (val) { assert(crypto_core_ed25519_is_valid_point(val.data[].ptr)); }
     do {
         Point ret = void;
@@ -237,7 +237,7 @@ public struct Point
 
     /// Operator overloads for points additions
     public Point opBinary (string op)(const scope auto ref Point rhs)
-        const nothrow @nogc
+        const nothrow @nogc @trusted
         if (op == "+" || op == "-")
     {
         Point result = void;
@@ -259,7 +259,7 @@ public struct Point
 
     /// Operator overloads for scalar multiplication
     public Point opBinary (string op)(const scope auto ref Scalar rhs)
-        const nothrow @nogc
+        const nothrow @nogc @trusted
         if (op == "*")
     {
         Point result = void;
@@ -271,7 +271,7 @@ public struct Point
 
     /// Ditto
     public Point opBinaryRight (string op)(const scope auto ref Scalar lhs)
-        const nothrow @nogc
+        const nothrow @nogc @trusted
         if (op == "*")
     {
         Point result = void;

--- a/source/agora/common/crypto/Schnorr.d
+++ b/source/agora/common/crypto/Schnorr.d
@@ -54,7 +54,7 @@ import std.range;
 
 
 /// Single signature example
-nothrow @nogc unittest
+nothrow @nogc @safe unittest
 {
     Pair kp = Pair.random();
     auto signature = sign(kp, "Hello world");
@@ -62,7 +62,7 @@ nothrow @nogc unittest
 }
 
 /// Multi-signature example
-nothrow @nogc unittest
+nothrow @nogc @safe unittest
 {
     // Setup
     static immutable string secret = "BOSAGORA for the win";
@@ -128,7 +128,7 @@ public struct Pair
     public Point V;
 
     /// Generate a random value `v` and a point on the curve `V` where `V = v.G`
-    public static Pair random () nothrow @nogc
+    public static Pair random () nothrow @nogc @safe
     {
         Scalar sc = Scalar.random();
         return Pair(sc, sc.toPoint());
@@ -137,7 +137,7 @@ public struct Pair
 
 /// Single-signer trivial API
 public Signature sign (T) (const ref Pair kp, auto ref T data)
-    nothrow @nogc
+    nothrow @nogc @safe
 {
     const R = Pair.random();
     return sign!T(kp.v, kp.V, R.V, R.v, data);
@@ -145,7 +145,7 @@ public Signature sign (T) (const ref Pair kp, auto ref T data)
 
 /// Single-signer privkey API
 public Signature sign (T) (const ref Scalar privateKey, T data)
-    nothrow @nogc
+    nothrow @nogc @safe
 {
     const R = Pair.random();
     return sign!T(privateKey, privateKey.toPoint(), R.V, R.v, data);
@@ -156,7 +156,7 @@ public Signature sign (T) (
     const ref Scalar x, const ref Point X,
     const ref Point R, const ref Scalar r,
     auto ref T data)
-    nothrow @nogc
+    nothrow @nogc @trusted
 {
     /*
       G := Generator point:
@@ -198,7 +198,7 @@ public Signature sign (T) (
 *******************************************************************************/
 
 public bool verify (T) (const ref Point X, const ref Signature s, auto ref T data)
-    nothrow @nogc
+    nothrow @nogc @trusted
 {
     // Compute the challenge and reduce the hash to a scalar
     Scalar c = hashFull(Message!T(X, s.R, data));
@@ -210,7 +210,7 @@ public bool verify (T) (const ref Point X, const ref Signature s, auto ref T dat
 }
 
 ///
-nothrow @nogc unittest
+nothrow @nogc @safe unittest
 {
     Scalar key = Scalar(`0x074360d5eab8e888df07d862c4fc845ebd10b6a6c530919d66221219bba50216`);
     Pair kp = Pair(key, key.toPoint());
@@ -218,7 +218,7 @@ nothrow @nogc unittest
     assert(verify(kp.V, signature, "Hello world"));
 }
 
-nothrow @nogc unittest
+nothrow @nogc @safe unittest
 {
     Scalar key = Scalar(`0x074360d5eab8e888df07d862c4fc845ebd10b6a6c530919d66221219bba50216`);
     Pair kp = Pair(key, key.toPoint());
@@ -226,7 +226,7 @@ nothrow @nogc unittest
     assert(!verify(kp.V, signature, "Hello world"));
 }
 
-nothrow @nogc unittest
+nothrow @nogc @safe unittest
 {
     static immutable string secret = "BOSAGORA for the win";
     Pair kp1 = Pair.random();


### PR DESCRIPTION
As discovered in https://github.com/bpfkorea/agora/pull/465 they were not marked `@safe`.