### PR TITLE
Add computeHash function into Enrollment structure

### DIFF
--- a/source/agora/consensus/data/Enrollment.d
+++ b/source/agora/consensus/data/Enrollment.d
@@ -13,6 +13,7 @@
 
 module agora.consensus.data.Enrollment;
 
+import agora.common.Hash;
 import agora.common.Types;
 import agora.common.crypto.Schnorr : Signature;
 
@@ -36,4 +37,38 @@ public struct Enrollment
 
     /// S: A signature for the message H(K, X, n, R) and the key K, using R
     public Signature enroll_sig;
+
+    /***************************************************************************
+
+        Implements hashing support
+
+        Params:
+            dg = hashing function
+
+    ***************************************************************************/
+
+    public void computeHash (scope HashDg dg) const nothrow @safe @nogc
+    {
+        hashPart(this.utxo_key, dg);
+        hashPart(this.random_seed, dg);
+        hashPart(this.cycle_length, dg);
+    }
+}
+
+/// test for the computeHash function
+unittest
+{
+    static immutable ubyte[] hdata = [
+        0xae,0x72,0x84,0xec,0xde,0x18,0x8d,0x94,0x81,0x28,0xb0,0x4d,
+        0x31,0xae,0x2a,0xeb,
+        0x96,0x4d,0x7f,0xe4,0x8e,0x6c,0x62,0x99,0xb5,0x10,0x76,0x5c,
+        0x3f,0x0e,0x0b,0x2c,
+        0xce,0x55,0x87,0xfe,0x5b,0x76,0x84,0x96,0xe4,0x64,0x2e,0x25,
+        0x47,0x38,0xf2,0x5c,
+        0x87,0x25,0x8f,0x0f,0x0b,0xa2,0x6f,0xf3,0xc7,0x1a,0xf4,0x77,
+        0x3b,0x5b,0xbb,0xb7
+    ];
+    const enroll_exp = Hash(hdata, /*isLittleEndian:*/ true);
+    Enrollment enroll = Enrollment.init;
+    assert(enroll.hashFull() == enroll_exp);
 }


### PR DESCRIPTION
In signing and verifying a Enrollment object with Schnorr signature algorithm, the enroll_sig variable should be excluded.

The PR #465 needs this PR.

#406 