### PR TITLE
Add isValidEnrollment unittest into Validation

### DIFF
--- a/source/agora/common/EnrollmentManager.d
+++ b/source/agora/common/EnrollmentManager.d
@@ -564,9 +564,9 @@ unittest
     Enrollment enroll1;
     Enrollment enroll2;
     Enrollment enroll3;
-    man.createEnrollment(utxo_hash1, enroll1);
-    man.createEnrollment(utxo_hash2, enroll2);
-    man.createEnrollment(utxo_hash3, enroll3);
+    assert(man.createEnrollment(utxo_hash1, enroll1));
+    assert(man.createEnrollment(utxo_hash2, enroll2));
+    assert(man.createEnrollment(utxo_hash3, enroll3));
 
     assert(!isValidEnrollment(1, enroll1, utxoFinder));
     assert(!isValidEnrollment(1, enroll2, utxoFinder));


### PR DESCRIPTION
#475 improvement work.
#468 Move validation test to its proper location 

This removes the existing cyclic imports. 
manually switch the enrollment unittest