### PR TITLE
Add logic to validate enrollments of blockheader

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -140,8 +140,8 @@ public class EnrollmentManager
         static ubyte[] buffer;
 
         // check validity of the enrollment data
-        if (auto reason = isInvalidEnrollmentReason(block_height + 1,
-            enroll, finder))
+        if (auto reason = isInvalidEnrollmentReason(enroll, block_height + 1,
+            finder))
         {
             this.logMessage("Invalid enrollment data, Reason: " ~ reason,
                 enroll);

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -584,8 +584,23 @@ unittest
     // create and add the first Enrollment object
     auto utxo_hash = utxo_hashes[0];
     Enrollment enroll;
+    Enrollment enroll2;
+    Enrollment fail_enroll;
+
+    Pair signature_noise = Pair.random;
+    Pair fail_enroll_key_pair;
+    fail_enroll_key_pair.v = secretKeyToCurveScalar(gen_key_pair.secret);
+    fail_enroll_key_pair.V = fail_enroll_key_pair.v.toPoint();
+
+    fail_enroll.utxo_key = utxo_hash;
+    fail_enroll.random_seed = hashFull(Scalar.random());
+    fail_enroll.cycle_length = 1008;
+    fail_enroll.enroll_sig = sign(fail_enroll_key_pair.v, fail_enroll_key_pair.V,
+        signature_noise.V, signature_noise.v, fail_enroll);
+
     assert(man.createEnrollment(utxo_hash, enroll));
     assert(!man.hasEnrollment(utxo_hash));
+    assert(!man.addEnrollment(0, &storage.findUTXO, fail_enroll));
     assert(man.addEnrollment(0, &storage.findUTXO, enroll));
     assert(man.getEnrollmentLength() == 1);
     assert(man.hasEnrollment(utxo_hash));
@@ -593,7 +608,6 @@ unittest
 
     // create and add the second Enrollment object
     auto utxo_hash2 = utxo_hashes[1];
-    Enrollment enroll2;
     assert(man.createEnrollment(utxo_hash2, enroll2));
     assert(man.addEnrollment(0, &storage.findUTXO, enroll2));
     assert(man.getEnrollmentLength() == 2);

--- a/source/agora/consensus/Validation.d
+++ b/source/agora/consensus/Validation.d
@@ -902,8 +902,8 @@ public string isInvalidReason (const ref Block block, in ulong prev_height,
 
 *******************************************************************************/
 
-public string isInvalidEnrollmentReason (const ulong block_height,
-    const ref Enrollment enrollment, UTXOFinder findUTXO) nothrow @safe
+public string isInvalidEnrollmentReason (const ref Enrollment enrollment,
+    const ulong block_height, UTXOFinder findUTXO) nothrow @safe
 {
     UTXOSetValue utxo_set_value;
     if (!findUTXO(enrollment.utxo_key, size_t.max, utxo_set_value))
@@ -940,10 +940,10 @@ public string isInvalidEnrollmentReason (const ulong block_height,
 
 /// Ditto but returns `bool`, only usable in unittests
 version (unittest)
-public bool isValidEnrollment (const ulong block_height,
-    const ref Enrollment enrollment, UTXOFinder findUTXO) nothrow @safe
+public bool isValidEnrollment (const ref Enrollment enrollment,
+    const ulong block_height, UTXOFinder findUTXO) nothrow @safe
 {
-    return isInvalidEnrollmentReason(block_height, enrollment, findUTXO) is null;
+    return isInvalidEnrollmentReason(enrollment, block_height, findUTXO) is null;
 }
 
 /// Ditto but returns `bool`, only usable in unittests
@@ -1225,10 +1225,10 @@ unittest
     enroll4.enroll_sig = sign(node_key_pair_4.v, node_key_pair_4.V, signature_noise.V,
         signature_noise.v, enroll4);
 
-    assert(!isValidEnrollment(1, enroll1, utxoFinder));
-    assert(!isValidEnrollment(1, enroll2, utxoFinder));
-    assert(!isValidEnrollment(1, enroll3, utxoFinder));
-    assert(!isValidEnrollment(1, enroll4, utxoFinder));
+    assert(!isValidEnrollment(enroll1, 1, utxoFinder));
+    assert(!isValidEnrollment(enroll2, 1, utxoFinder));
+    assert(!isValidEnrollment(enroll3, 1, utxoFinder));
+    assert(!isValidEnrollment(enroll4, 1, utxoFinder));
 
     utxo_set.updateUTXOCache(tx1, 0);
     utxo_set.updateUTXOCache(tx2, 0);
@@ -1245,17 +1245,17 @@ unittest
     assert(utxos4[utxo_hash4].output.address == key_pairs[3].address);
 
     // Nomal
-    assert(isValidEnrollment(1, enroll1, utxoFinder));
+    assert(isValidEnrollment(enroll1, 1, utxoFinder));
 
     // Unspent frozen UTXO not found for the validator.
-    assert(!isValidEnrollment(1, enroll1, utxoFinder));
+    assert(!isValidEnrollment(enroll1, 1, utxoFinder));
 
     // UTXO is not frozen.
-    assert(!isValidEnrollment(1, enroll2, utxoFinder));
+    assert(!isValidEnrollment(enroll2, 1, utxoFinder));
 
     // The frozen amount must be equal to or greater than 40,000 BOA.
-    assert(!isValidEnrollment(1, enroll3, utxoFinder));
+    assert(!isValidEnrollment(enroll3, 1, utxoFinder));
 
     // Enrollment signature verification has an error.
-    assert(!isValidEnrollment(1, enroll4, utxoFinder));
+    assert(!isValidEnrollment(enroll4, 1, utxoFinder));
 }


### PR DESCRIPTION
This verifies the qualification of the `enrollments` included in the `blockheader` when verifying the block.
And for some grammatical modification, the parameter order of `isInvalidEnrollmentReason` was changed.
#205 