### PR TITLE
Save and load all preimages on the database

### DIFF
--- a/source/agora/common/Deserializer.d
+++ b/source/agora/common/Deserializer.d
@@ -16,6 +16,8 @@ module agora.common.Deserializer;
 import agora.common.Types;
 import agora.common.crypto.Key;
 
+import std.range;
+
 /// test various serialization / deserialization of types
 unittest
 {
@@ -244,6 +246,17 @@ public void deserializePart (ref uint[] record, scope DeserializeDg dg)
         foreach (ref uint elem; record)
             elem = swapEndian(elem);
     }
+}
+
+/// Ditto
+public void deserializePart (ref Hash[] record, scope DeserializeDg dg)
+    @trusted
+{
+    size_t length;
+    deserializePart(length, dg);
+    record = uninitializedArray!(Hash[])(length);
+    foreach (ref val; record)
+        deserializePart(val, dg);
 }
 
 /*******************************************************************************

--- a/source/agora/common/Serializer.d
+++ b/source/agora/common/Serializer.d
@@ -168,6 +168,15 @@ public void serializePart (scope const(uint)[] record, scope SerializeDg dg)
     }
 }
 
+/// Ditto
+public void serializePart (scope const(Hash)[] record, scope SerializeDg dg)
+    @trusted
+{
+    serializePart(record.length, dg);
+    foreach (hash; record)
+        serializePart(hash, dg);
+}
+
 /*******************************************************************************
 
     Unsigned Integers to Serialized variable length integer


### PR DESCRIPTION
A validator must periodically reveal the preimages.
For that requirement, the preimages should be stored to database for a cycle.

This implementation is the first definition of done of the issue #492 