### PR TITLE
Remove extra dependencies from EnrollmentManager

### DIFF
--- a/source/agora/node/GossipProtocol.d
+++ b/source/agora/node/GossipProtocol.d
@@ -18,6 +18,7 @@ import agora.common.Hash;
 import agora.common.Set;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
+import agora.consensus.data.UTXOSet;
 import agora.consensus.EnrollmentManager;
 import agora.network.NetworkManager;
 import agora.node.Ledger;
@@ -104,12 +105,14 @@ public class GossipProtocol
 
         Params:
             enroll = the received data for the enrollment
+            finder = the UTXO finder delegate
 
     ***************************************************************************/
 
-    public void receiveEnrollment (Enrollment enroll) @safe
+    public void receiveEnrollment (Enrollment enroll, scope UTXOFinder finder) @safe
     {
-        if (this.enroll_man.addEnrollment(enroll))
+        if (this.enroll_man.addEnrollment(this.ledger.getBlockHeight(), finder,
+            enroll))
         {
             this.network.sendEnrollment(enroll);
         }

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -112,8 +112,7 @@ public class Node : API
         this.pool = this.getPool(config.node.data_dir);
         this.utxo_set = this.getUtxoSet(config.node.data_dir);
         this.ledger = new Ledger(this.pool, this.utxo_set, this.storage, config.node);
-        this.enroll_man = this.getEnrollmentManager(config.node.data_dir, config.node,
-            this.ledger, this.utxo_set);
+        this.enroll_man = this.getEnrollmentManager(config.node.data_dir, config.node);
         this.gossip = new GossipProtocol(this.network, this.ledger, this.enroll_man);
         this.exception = new RestException(
             400, Json("The query was incorrect"), string.init, int.init);
@@ -411,10 +410,10 @@ public class Node : API
     ***************************************************************************/
 
     protected EnrollmentManager getEnrollmentManager (string data_dir,
-        in NodeConfig node_config, Ledger ledger, UTXOSet utxo_set)
+        in NodeConfig node_config)
     {
         return new EnrollmentManager(buildPath(data_dir, "validator_set.dat"),
-            node_config.key_pair, ledger, utxo_set);
+            node_config.key_pair);
     }
 
     /***************************************************************************
@@ -449,7 +448,7 @@ public class Node : API
     {
         log.trace("Received Enrollment: {}", prettify(enroll));
 
-        this.gossip.receiveEnrollment(enroll);
+        this.gossip.receiveEnrollment(enroll, this.utxo_set.getUTXOFinder());
     }
 
     /// GET: /has_enrollment

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -508,11 +508,9 @@ public class TestNode : Node, TestAPI
 
     /// Return an enrollment manager backed by an in-memory SQLite db
     protected override EnrollmentManager getEnrollmentManager (
-        string data_dir, in NodeConfig node_config, Ledger ledger,
-        UTXOSet utxo_set)
+        string data_dir, in NodeConfig node_config)
     {
-        return new EnrollmentManager(":memory:", node_config.key_pair, ledger,
-            utxo_set);
+        return new EnrollmentManager(":memory:", node_config.key_pair);
     }
 
     /// Create an enrollment data used as information for an validator


### PR DESCRIPTION
This simplifies the class a bit, since it only uses one method in each class, so this has now become just a parameter in the `addEnrollment` method.

Further work could be done on other classes, such as GossipProtocol. We should take a look at it soon.