### PR TITLE
Temporarily disable parallel GC

### DIFF
--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -34,6 +34,13 @@ import std.file;
 import std.getopt;
 import std.stdio;
 
+/**
+ * Workaround for segfault similar (or identical) to https://github.com/dlang/dub/issues/1812
+ * https://dlang.org/changelog/2.087.0.html#gc_parallel
+ */
+static if (__VERSION__ >= 2087)
+    extern(C) __gshared string[] rt_options = [ "gcopt=parallel:0" ];
+
 /// Workaround for issue likely related to dub #225,
 /// expects a main() function and invokes it after unittesting.
 version (unittest) void main () { } else:


### PR DESCRIPTION
There is a semi-frequent segfault bug in Agora that seems
to point to a bug in Druntime. A similar / identical issue
happened in Dub in:

https://github.com/dlang/dub/issues/1812