### PR TITLE
Write Enrollments data to the block.

### DIFF
--- a/source/agora/consensus/Validation.d
+++ b/source/agora/consensus/Validation.d
@@ -1362,7 +1362,6 @@ unittest
         tx.inputs[0].signature = keypair.secret.sign(hashFull(tx)[]);
         txs_3 ~= tx;
     }
-    auto block3 = makeNewBlock(block2, txs_3);
 
     Pair signature_noise = Pair.random;
     Pair node_key_pair;
@@ -1376,7 +1375,7 @@ unittest
     enroll1.cycle_length = 1008;
     enroll1.enroll_sig = sign(node_key_pair.v, node_key_pair.V, signature_noise.V,
         signature_noise.v, enroll1);
- 
+
     auto utxo_hash2 = utxo_set.getHash(hashFull(txs_2[1]), 0);
     Enrollment enroll2;
     enroll2.utxo_key = utxo_hash2;
@@ -1389,13 +1388,9 @@ unittest
     enrollments ~= enroll1;
     enrollments ~= enroll2;
     enrollments.sort!("a.utxo_key < b.utxo_key");
-    block3.header.enrollments.length = 0;
-    block3.header.enrollments = enrollments;
+    auto block3 = makeNewBlock(block2, txs_3, enrollments);
     assert(block3.isValid(block2.header.height, hashFull(block2.header), findUTXO));
-
     enrollments.sort!("a.utxo_key > b.utxo_key");
-    block3.header.enrollments.length = 0;
-    block3.header.enrollments = enrollments;
     findUTXO = utxo_set.getUTXOFinder();
     // Block: The enrollments are not sorted in ascending order
     assert(!block3.isValid(block2.header.height, hashFull(block2.header), findUTXO));

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -383,11 +383,12 @@ unittest
     Params:
         prev_block = the previous block
         txs = the transactions that will be contained in the new block
+        enrollments = the enrollments that will be contained in the new block
 
 *******************************************************************************/
 
 public Block makeNewBlock (Transactions)(const ref Block prev_block,
-    Transactions txs) @safe nothrow
+    Transactions txs, Enrollment[] enrollments) @safe nothrow
     if (isInputRange!Transactions)
 {
     Block block;
@@ -398,8 +399,21 @@ public Block makeNewBlock (Transactions)(const ref Block prev_block,
     block.txs.sort;
 
     block.header.merkle_root = block.buildMerkleTree();
-
+    block.header.enrollments = enrollments;
+    assert(block.header.enrollments.isStrictlyMonotonic!
+        ("a.utxo_key < b.utxo_key"));
     return block;
+}
+
+/// only used in unittests
+version (unittest)
+{
+    public Block makeNewBlock (Transactions)(const ref Block prev_block,
+        Transactions txs) @safe nothrow
+        if (isInputRange!Transactions)
+    {
+        return makeNewBlock(prev_block, txs, null);
+    }
 }
 
 ///

--- a/tests/unit/BlockStorage.d
+++ b/tests/unit/BlockStorage.d
@@ -66,7 +66,7 @@ private void main ()
             ]
         );
         tx.inputs[0].signature = gen_key_pair.secret.sign(hashFull(tx)[]);
-        blocks ~= makeNewBlock(blocks[$ - 1], [tx]);
+        blocks ~= makeNewBlock(blocks[$ - 1], [tx], null);
         block_hashes ~= hashFull(blocks[$ - 1].header);
         storage.saveBlock(blocks[$ - 1]);
     }

--- a/tests/unit/BlockStorageChecksum.d
+++ b/tests/unit/BlockStorageChecksum.d
@@ -53,7 +53,7 @@ private void writeBlocks (string path)
     foreach (block_idx; 0 .. BlockCount)
     {
         Transaction[8] txs;
-        auto block = makeNewBlock(blocks[$ - 1], txs[]);
+        auto block = makeNewBlock(blocks[$ - 1], txs[], null);
         storage.saveBlock(block);
         blocks ~= block;
     }

--- a/tests/unit/BlockStorageMultiTx.d
+++ b/tests/unit/BlockStorageMultiTx.d
@@ -53,7 +53,7 @@ private void main ()
         // create enough tx's for a single block
         auto txs = makeChainedTransactions(gen_key_pair, last_txs, 1);
 
-        auto block = makeNewBlock(blocks[$ - 1], txs);
+        auto block = makeNewBlock(blocks[$ - 1], txs, null);
         storage.saveBlock(block);
         blocks ~= block;
         last_txs = txs;


### PR DESCRIPTION
Writing Enrollment data to a block determines the height of the block that can participate in the validation as a validator.
Validators needed for the consensus process can be determined and the number of validators between nodes can be set.
- The Enrollment data should be recorded only in the enroll start block.
- The node store the enrolled block height.

~~Reach consensus on transaction and enrollment set
The enrollments to be included in a block must first
be voted on by the consensus protocol.~~

Relates to #493 `Enrollment data should be written to the block.`
~~Relates to  #565 `Make Enrollment Part of Consensus`~~
