### PR TITLE
Remove parsing the quorum configuration from the config file

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -80,29 +80,6 @@ dns:
   - seed.bosagora.io
 
 ################################################################################
-##                               Quorum slices                                ##
-################################################################################
-quorum:
-  # threshold as a percentage
-  threshold: 66%
-  # the list of nodes in this quorum
-  nodes:
-    - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
-    - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
-  # the list of sub-quorums in this quorum
-  sub_quorums:
-  - threshold: 66%
-    nodes:
-      - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
-      - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
-    sub_quorums:
-    - threshold: 66%
-      nodes:
-        - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
-        - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
-        - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
-
-################################################################################
 ##                               Logging options                              ##
 ################################################################################
 logging:

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -128,8 +128,21 @@ public class Node : API
         if (!this.config.node.is_validator)
             return;
 
+        // TODO: This is a workaround as we want to test nodes
+        // before quorum balancing is implemented
+        // Remove in the future and infer from the network.
+        QuorumConfig default_;
+        scope const(QuorumConfig)* ptr = &this.config.quorum;
+        if (this.config.quorum.nodes.length == 0)
+        {
+            default_.nodes = peers.keys().idup;
+            // 66% or more
+            default_.threshold = default_.nodes.length - (default_.nodes.length / 3);
+            ptr = &default_;
+        }
+
         import agora.network.NetworkClient;
-        auto quorum_set = toSCPQuorumSet(this.config.quorum);
+        auto quorum_set = toSCPQuorumSet(*ptr);
         normalizeQSet(quorum_set);
 
         // todo: assertion fails do the misconfigured(?) threshold of 1 which

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -48,16 +48,6 @@ network:
   - http://node-2:2826
 
 ################################################################################
-##                               Quorum slices                                ##
-################################################################################
-quorum:
-  threshold: 66%
-  nodes:
-    - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
-    - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
-    - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
-
-################################################################################
 ##                               Logging options                              ##
 ################################################################################
 logging:

--- a/tests/system/node/1/config.yaml
+++ b/tests/system/node/1/config.yaml
@@ -47,17 +47,6 @@ network:
   - http://node-0:2826
   - http://node-2:2826
 
-
-################################################################################
-##                               Quorum slices                                ##
-################################################################################
-quorum:
-  threshold: 66%
-  nodes:
-    - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
-    - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
-    - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
-
 ################################################################################
 ##                               Logging options                              ##
 ################################################################################

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -48,16 +48,6 @@ network:
   - http://node-1:2826
 
 ################################################################################
-##                               Quorum slices                                ##
-################################################################################
-quorum:
-  threshold: 66%
-  nodes:
-    - GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN
-    - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
-    - GBYK4I37MZKLL4A2QS7VJCTDIIJK7UXWQWKXKTQ5WZGT2FPCGIVIQCY5
-
-################################################################################
 ##                               Logging options                              ##
 ################################################################################
 logging:


### PR DESCRIPTION
```
Quorum configurations were never intended to be public.
Instead, they should be dynamically adjusted by the quorum balancing algorithm.
For the moment we still need to provide them explicitly to SCP,
as the algorithm is being developped.

As a concession to simplicity we devised 2 use cases:
- Providing the quorum sets to nodes in unittests, in order to test SCP;
- Using the set of peers as validators with a fixed threshold of 67%;
```

Required for #483 