### PR TITLE
Split validator and full node APIs

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -51,7 +51,15 @@
             "name": "cli",
             "targetName": "agora-cli",
             "mainSourceFile": "source/agora/cli/main.d",
-            "excludedSourceFiles": [ "source/agora/node/main.d" ]
+            "excludedSourceFiles": [
+                "source/agora/api/Validator.d",
+                "source/agora/common/Config.d",
+                "source/agora/network/*",
+                "source/agora/node/*",
+                "source/scpp/*",
+                "source/scpd/*",
+                "source/agora/consensus/protocol/*"
+            ]
         },
         {
             "name": "unittest",

--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -1,31 +1,11 @@
 /*******************************************************************************
 
-    Definitions of the nodes (full node & validator) APIs
+    Definitions of the full node API
 
-    Two kinds of nodes exist: full nodes, and validators.
-    A full node follows the network as a passive actor, but does validation
-    on the data it receives, and can forward that data to other nodes.
-    A validator is a full node which participates in consensus.
-
-    An `API` is used as an interface to communicate with a node.
-    As such, a class that implements `API` exists (in `agora.node.Node`),
-    and in order to communicate with other nodes, it holds an `API` for
-    each of those nodes.
-
-    `API` are defined as D interfaces, following what is done in Vibe.d.
-    Those interfaces can be read by a generator to build a client or a server.
-    One such generator is Vibe.d's `vibe.web.rest`. `RestInterfaceClient`
-    allows to query a REST API, while `registerRestInterface` will route queries
-    and deserialize parameters according to the interface's definition.
-
-    Another generator which we use for unittests is "LocalRest".
-    It allows to start a node per thread, and uses `std.concurrency`
-    to do message passing between nodes.
-
-    Lastly, we plan to implement a generator which works directly on TCP/IP.
+    See agora.node.api.Validator for a full explanation on this API.
 
     Copyright:
-        Copyright (c) 2019 BOS Platform Foundation Korea
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
         All rights reserved.
 
     License:
@@ -33,9 +13,8 @@
 
 *******************************************************************************/
 
-module agora.node.API;
+module agora.api.FullNode;
 
-import agora.common.crypto.Key;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
 import agora.common.Types;
@@ -43,9 +22,6 @@ import agora.common.Set;
 import agora.common.Serializer;
 import agora.consensus.data.Transaction;
 
-import scpd.types.Stellar_SCP;
-
-import vibe.data.json;
 import vibe.web.rest;
 import vibe.http.common;
 
@@ -79,28 +55,19 @@ public struct NetworkInfo
     - Receives, stores and forwards transactions (but drop them after a timeout)
     - Does not participate in consensus
 
-   In essence, a full node provides much of the basic functionality needed
-   to verify the blockchain while lacking the ability to create new blocks.
+     In essence, a full node provides much of the basic functionality needed
+     to verify the blockchain while lacking the ability to create new blocks.
+
+     Non `Transaction` data that are part of consensus are also accepted by
+     full nodes, which simply relays them if they are valid (e.g. `Enrollment`).
 
 *******************************************************************************/
+
 @path("/")
 public interface API
 {
 // The REST generator requires @safe methods
 @safe:
-
-    /***************************************************************************
-
-        Returns:
-            The public key of this node
-
-        API:
-            GET /public_key
-
-    ***************************************************************************/
-
-    public PublicKey getPublicKey ();
-
     /***************************************************************************
 
         Returns:
@@ -143,20 +110,6 @@ public interface API
     ***************************************************************************/
 
     public ulong getBlockHeight ();
-
-    /***************************************************************************
-
-        Receives an SCP envelope and processes it
-
-        Params:
-            envelope = Envelope to process (See Stellar_SCP)
-
-        Returns:
-            true if the envelope was successfully processed
-
-    ***************************************************************************/
-
-    public bool receiveEnvelope (SCPEnvelope envelope);
 
     /***************************************************************************
 
@@ -213,7 +166,6 @@ public interface API
     ***************************************************************************/
 
     public void enrollValidator (Enrollment enroll);
-
 
     /***************************************************************************
 

--- a/source/agora/api/Validator.d
+++ b/source/agora/api/Validator.d
@@ -1,0 +1,96 @@
+/*******************************************************************************
+
+    Definitions of the validator API
+
+    Two kinds of nodes exist: full nodes, and validators.
+    A full node follows the network as a passive actor, but does validation
+    on the data it receives, and can forward that data to other nodes.
+    A validator is a full node which participates in consensus.
+
+    An `API` is used as an interface to communicate with a node.
+    As such, a class that implements `API` exists (in `agora.node.Node`),
+    and in order to communicate with other nodes, it holds an `API` for
+    each of those nodes.
+
+    Note that both full node and validator interfaces are named `API`,
+    as users are expected to use only one of them, not both in combination.
+    A client either deal with a validator because it needs the validator API
+    (only other validators so far), or needs the full node API and don't
+    care about the validators functions, and should not knoe about them as
+    they also include many more dependencies.
+
+    `API` are defined as D interfaces, following what is done in Vibe.d.
+    Those interfaces can be read by a generator to build a client or a server.
+    One such generator is Vibe.d's `vibe.web.rest`. `RestInterfaceClient`
+    allows to query a REST API, while `registerRestInterface` will route queries
+    and deserialize parameters according to the interface's definition.
+
+    Another generator which we use for unittests is "LocalRest".
+    It allows to start a node per thread, and uses `std.concurrency`
+    to do message passing between nodes.
+
+    Lastly, we plan to implement a generator which works directly on TCP/IP.
+
+    Copyright:
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.api.Validator;
+
+import agora.common.crypto.Key;
+static import agora.api.FullNode;
+
+import scpd.types.Stellar_SCP;
+
+import vibe.web.rest;
+
+///
+public import agora.api.FullNode;
+
+
+/*******************************************************************************
+
+    Define the API a validator exposes to other validators
+
+    A validator can do everything a full node does, and additionally takes
+    part of consensus.
+
+*******************************************************************************/
+
+@path("/")
+public interface API : agora.api.FullNode.API
+{
+// The REST generator requires @safe methods
+@safe:
+
+    /***************************************************************************
+
+        Returns:
+            The public key of this node
+
+        API:
+            GET /public_key
+
+    ***************************************************************************/
+
+    public PublicKey getPublicKey ();
+
+    /***************************************************************************
+
+        Receives an SCP envelope and processes it
+
+        Params:
+            envelope = Envelope to process (See Stellar_SCP)
+
+        Returns:
+            true if the envelope was successfully processed
+
+    ***************************************************************************/
+
+    public bool receiveEnvelope (SCPEnvelope envelope);
+}

--- a/source/agora/cli/SendTxProcess.d
+++ b/source/agora/cli/SendTxProcess.d
@@ -13,6 +13,7 @@
 
 module agora.cli.SendTxProcess;
 
+import agora.api.FullNode;
 import agora.cli.CLIResult;
 import agora.common.Amount;
 import agora.common.crypto.Key;
@@ -20,7 +21,6 @@ import agora.common.Hash;
 import agora.common.Types;
 import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
-import agora.node.API;
 
 import std.format;
 import std.getopt;

--- a/source/agora/cli/main.d
+++ b/source/agora/cli/main.d
@@ -13,10 +13,10 @@
 
 module agora.cli.main;
 
+import agora.api.FullNode;
 import agora.cli.CLIResult;
 import agora.cli.DefaultProcess;
 import agora.cli.SendTxProcess;
-import agora.node.API;
 
 import vibe.core.core;
 import vibe.web.rest;

--- a/source/agora/network/NetworkClient.d
+++ b/source/agora/network/NetworkClient.d
@@ -13,6 +13,7 @@
 
 module agora.network.NetworkClient;
 
+import agora.api.Validator;
 import agora.common.BanManager;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
@@ -21,7 +22,6 @@ import agora.common.Types;
 import agora.common.Set;
 import agora.common.Task;
 import agora.consensus.data.Transaction;
-import agora.node.API;
 import scpd.types.Stellar_SCP;
 
 import agora.utils.Log;

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -22,6 +22,7 @@
 
 module agora.network.NetworkManager;
 
+import agora.api.Validator;
 import agora.common.BanManager;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
@@ -33,7 +34,6 @@ import agora.common.Set;
 import agora.common.Task;
 import agora.consensus.data.Transaction;
 import agora.network.NetworkClient;
-import agora.node.API;
 import agora.node.Ledger;
 import agora.utils.Log;
 

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -25,7 +25,6 @@ import agora.consensus.data.Transaction;
 import agora.consensus.data.UTXOSet;
 import agora.consensus.Genesis;
 import agora.consensus.Validation;
-import agora.node.API;
 import agora.node.BlockStorage;
 import agora.utils.Log;
 import agora.utils.PrettyPrinter;

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -13,6 +13,7 @@
 
 module agora.node.Node;
 
+import agora.api.Validator;
 import agora.consensus.data.Block;
 import agora.common.Amount;
 import agora.common.BanManager;
@@ -28,7 +29,6 @@ import agora.consensus.data.UTXOSet;
 import agora.consensus.EnrollmentManager;
 import agora.consensus.protocol.Nominator;
 import agora.network.NetworkManager;
-import agora.node.API;
 import agora.node.BlockStorage;
 import agora.node.GossipProtocol;
 import agora.node.Ledger;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -22,6 +22,7 @@ module agora.test.Base;
 
 version (unittest):
 
+import agora.api.Validator;
 import agora.common.Amount;
 import agora.common.BanManager;
 import agora.common.Config;
@@ -38,7 +39,6 @@ import agora.consensus.data.Transaction;
 import agora.consensus.data.UTXOSet;
 import agora.consensus.EnrollmentManager;
 import agora.network.NetworkManager;
-import agora.node.API;
 import agora.node.Ledger;
 import agora.node.Node;
 import agora.utils.Log;

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -15,9 +15,9 @@ module agora.test.NetworkManager;
 
 version (unittest):
 
+import agora.api.Validator;
 import agora.consensus.data.Transaction;
 import agora.consensus.Genesis;
-import agora.node.API;
 import agora.test.Base;
 
 /// test behavior when getBlockHeight() call fails

--- a/tests/system/dub.json
+++ b/tests/system/dub.json
@@ -2,14 +2,14 @@
     "name": "systemtest-simple",
     "targetType": "executable",
     "targetPath": "build",
-    "lflags": [ "-lsodium", "-lstdc++" ],
+    "lflags": [ "-lsodium" ],
     "importPaths": [
         "../../source",
         "../../submodules/d2sqlite3/source",
     ],
 
-    "preBuildCommands": [ "../../source/scpp/build.d" ],
     "sourceFiles": [
+        "../../source/agora/api/FullNode.d",
         "../../source/agora/common/crypto/Crc16.d",
         "../../source/agora/common/crypto/ECC.d",
         "../../source/agora/common/crypto/Key.d",
@@ -27,18 +27,8 @@
         "../../source/agora/consensus/data/UTXOSet.d",
         "../../source/agora/consensus/Validation.d",
         "../../source/agora/consensus/Genesis.d",
-        "../../source/agora/node/API.d",
         "../../source/agora/utils/Log.d",
-        "../../source/agora/utils/PrettyPrinter.d",
-        "../../source/scpd/Cpp.d",
-        "../../source/scpd/Util.d",
-        "../../source/scpd/types/Stellar_SCP.d",
-        "../../source/scpd/types/Stellar_types.d",
-        "../../source/scpd/types/Utils.d",
-        "../../source/scpd/types/XDRBase.d",
-
-        "../../source/scpp/build/DUtils.o",
-        "../../source/scpp/build/marshal.o",
+        "../../source/agora/utils/PrettyPrinter.d"
     ],
     "excludedSourceFiles": [ "source/scpp/*.d" ],
 

--- a/tests/system/source/main.d
+++ b/tests/system/source/main.d
@@ -13,12 +13,12 @@
 
 module main;
 
+import agora.api.FullNode;
 import agora.consensus.data.Transaction;
 import agora.consensus.Genesis;
 import agora.common.crypto.Key;
 import agora.common.Hash;
 import agora.common.Set;
-import agora.node.API;
 import agora.utils.PrettyPrinter;
 
 import vibe.web.rest;
@@ -60,7 +60,6 @@ void main ()
 
         foreach (idx, ref client; clients)
         {
-            writefln("[%s] getPublicKey: %s", idx, client.getPublicKey());
             writefln("[%s] getNetworkInfo: %s", idx, client.getNetworkInfo());
             const height = client.getBlockHeight();
             writefln("[%s] getBlockHeight: %s", idx, height);


### PR DESCRIPTION
```
This allow us to reduce dependency and not import the SCP code in clients,
as can be seen from the change of the CLI app and the system test.
```

Note that this triggers https://github.com/vibe-d/vibe.d/issues/2414 but the testsuite still pass, so... Yay ?
Fixes #509 