### PR TITLE
Fix a potential timing issue with timers in setupTimer()

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -399,29 +399,29 @@ extern(D):
 
         Params:
             slot_idx = the slot index we're currently reaching consensus for.
-            timer_ID = the timer ID. required in case the timer gets cancelled.
+            timer_type = the timer type (see Slot.timerIDs).
             timeout = the timeout of the timer, in milliseconds.
             callback = the C++ callback to call.
 
     ***************************************************************************/
 
-    public override void setupTimer (ulong slot_idx, int timer_ID,
+    public override void setupTimer (ulong slot_idx, int timer_type,
         milliseconds timeout, CPPDelegate!SCPCallback* callback)
     {
         scope (failure) assert(0);
 
         if (callback is null || timeout == 0)
         {
-            this.timers.remove(timer_ID);
+            this.timers.remove(timer_type);
             return;
         }
 
-        this.timers.put(timer_ID);
+        this.timers.put(timer_type);
 
         this.taskman.runTask(
         {
             this.taskman.wait(timeout.msecs);
-            if (timer_ID !in this.timers)  // timer was cancelled
+            if (timer_type !in this.timers)  // timer was cancelled
                 return;
 
             callCPPDelegate(callback);


### PR DESCRIPTION
I noticed this piece of code while debugging. 

We don't have a proper Timer implementation yet, so we usually use:

```
runTask(() { sleep(timeout); ... }
```

But in the current code there was an issue with how older timers got deactivated. It has not triggered so far, but I'm pretty sure it could.