### PR TITLE
Implement getting node's pre-image based on block height

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -61,6 +61,9 @@ public class EnrollmentManager
     /// Enrollment data object
     private Enrollment data;
 
+    /// The cycle length for a valdator
+    public static immutable uint ValidatorCycle = 1008; // freezing period / 2
+
     /***************************************************************************
 
         Constructor
@@ -318,7 +321,7 @@ public class EnrollmentManager
         this.data.utxo_key = frozen_utxo_hash;
 
         // N, cycle length
-        this.data.cycle_length = 1008; // freezing period / 2
+        this.data.cycle_length = ValidatorCycle;
 
         // generate random seed value
         this.random_seed_src = Scalar.random();

--- a/source/agora/consensus/data/PreimageInfo.d
+++ b/source/agora/consensus/data/PreimageInfo.d
@@ -1,0 +1,34 @@
+/*******************************************************************************
+
+    Contains supporting code for enrollment process.
+
+    Copyright:
+        Copyright (c) 2019 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.consensus.data.PreimageInfo;
+
+import agora.common.Hash;
+
+/*******************************************************************************
+
+    Define pre-image information
+
+*******************************************************************************/
+
+public struct PreimageInfo
+{
+    /// The key for the enrollment
+    public Hash enroll_key;
+
+    /// A pre-image at a certain height
+    public Hash hash;
+
+    /// The height number
+    public ulong height;
+}


### PR DESCRIPTION
This PR is for a function getting a pre-image at a certain height from a node. As discussed with @Geod24  in PR #530 , the information for a pre-image(a.k.a. PreimageInfo) becomes to have the block height at which it exists not the round number.

- Make the cycle length value constant
- Add the PreimageInfo structure
- Add the getPreimage function used to get a node's pre-image at a certain block height.
- Unittest

#492 