### PR TITLE
utils: Make Logger wrapper more usable

### DIFF
--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -75,6 +75,22 @@ public template AddLogger (string moduleName = __MODULE__)
                 assert(0, ex.msg);
             }
         }
+
+        // Supports `log = Log.lookup("yo")`,
+        // where `log` is of `typeof(this)` type
+        public ref Logger opAssign (Ocean.Logger newLogger)
+            @safe pure nothrow @nogc
+        {
+            this.logger = newLogger;
+            return this;
+        }
+
+        // Support `Logger log = Log.lookup("yo")` (initialization)
+        public this (Ocean.Logger initRef)
+            @safe pure nothrow @nogc
+        {
+            this.logger = initRef;
+        }
     }
 
     private Logger log;


### PR DESCRIPTION
When Log.lookup is used and 'agora.utils.Log' is imported,
the 'Logger' type would refer to this struct but be non-assignable.