### PR TITLE
Make isQuorumSetSane() more informative

### DIFF
--- a/source/scpd/scp/QuorumSetUtils.d
+++ b/source/scpd/scp/QuorumSetUtils.d
@@ -18,7 +18,8 @@ import scpd.types.Stellar_types;
 
 extern(C++, `stellar`):
 
-bool isQuorumSetSane(ref const SCPQuorumSet qSet, bool extraChecks);
+bool isQuorumSetSane(ref const SCPQuorumSet qSet, bool extraChecks,
+    const(char)** reason = null);
 
 // normalize the quorum set, optionally removing idToRemove
 void normalizeQSet(ref SCPQuorumSet qSet, const NodeID* idToRemove = null);

--- a/source/scpp/src/scp/BallotProtocol.cpp
+++ b/source/scpp/src/scp/BallotProtocol.cpp
@@ -247,10 +247,17 @@ bool
 BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
 {
     auto qSet = mSlot.getQuorumSetFromStatement(st);
-    bool res = qSet != nullptr && isQuorumSetSane(*qSet, false);
+    const char* reason = nullptr;
+    bool res = qSet != nullptr && isQuorumSetSane(*qSet, false, &reason);
     if (!res)
     {
         CLOG(DEBUG, "SCP") << "Invalid quorum set received";
+        if (reason != nullptr)
+        {
+            std::string msg(reason);
+            CLOG(DEBUG, "SCP") << msg;
+        }
+
         return false;
     }
 

--- a/source/scpp/src/scp/QuorumSetUtils.cpp
+++ b/source/scpp/src/scp/QuorumSetUtils.cpp
@@ -20,7 +20,8 @@ namespace
 class QuorumSetSanityChecker
 {
   public:
-    explicit QuorumSetSanityChecker(SCPQuorumSet const& qSet, bool extraChecks);
+    explicit QuorumSetSanityChecker(SCPQuorumSet const& qSet, bool extraChecks,
+                                    const char** reason);
     bool
     isSane() const
     {
@@ -33,24 +34,49 @@ class QuorumSetSanityChecker
     bool mIsSane;
     size_t mCount{0};
 
-    bool checkSanity(SCPQuorumSet const& qSet, int depth);
+    bool checkSanity(SCPQuorumSet const& qSet, int depth, const char** reason);
 };
 
 QuorumSetSanityChecker::QuorumSetSanityChecker(SCPQuorumSet const& qSet,
-                                               bool extraChecks)
+                                               bool extraChecks,
+                                               const char** reason)
     : mExtraChecks{extraChecks}
 {
-    mIsSane = checkSanity(qSet, 0) && mCount >= 1 && mCount <= 1000;
+    const char* msg = nullptr;
+    if (reason == nullptr)
+        reason = &msg;  // avoid null checks in checkSanity()
+
+    mIsSane = checkSanity(qSet, 0, reason);
+    if (mCount < 1)
+    {
+        *reason = "Number of validator nodes is zero";
+        mIsSane = false;
+    }
+    else if (mCount > 1000)
+    {
+        *reason = "Number of validator nodes exceeds the limit of 1000";
+        mIsSane = false;
+    }
+
+    // only one of the two may be true
+    assert(mIsSane ^ (*reason != nullptr));
 }
 
 bool
-QuorumSetSanityChecker::checkSanity(SCPQuorumSet const& qSet, int depth)
+QuorumSetSanityChecker::checkSanity(SCPQuorumSet const& qSet, int depth,
+                                    const char** reason)
 {
     if (depth > 2)
+    {
+        *reason = "Cannot have sub-quorums with depth exceeding 2 levels";
         return false;
+    }
 
     if (qSet.threshold < 1)
+    {
+        *reason = "The threshold for a quorum must equal at least 1";
         return false;
+    }
 
     auto& v = qSet.validators;
     auto& i = qSet.innerSets;
@@ -60,17 +86,24 @@ QuorumSetSanityChecker::checkSanity(SCPQuorumSet const& qSet, int depth)
     mCount += v.size();
 
     if (qSet.threshold > totEntries)
+    {
+        *reason = "The threshold for a quorum exceeds total number of entries";
         return false;
+    }
 
     // threshold is within the proper range
     if (mExtraChecks && qSet.threshold < vBlockingSize)
+    {
+        *reason = "Extra check: the threshold for a quorum is too low";
         return false;
+    }
 
     for (auto const& n : v)
     {
         auto r = mKnownNodes.insert(n);
         if (!r.second)
         {
+            *reason = "A duplicate node was configured within another quorum";
             // n was already present
             return false;
         }
@@ -78,7 +111,7 @@ QuorumSetSanityChecker::checkSanity(SCPQuorumSet const& qSet, int depth)
 
     for (auto const& iSet : i)
     {
-        if (!checkSanity(iSet, depth + 1))
+        if (!checkSanity(iSet, depth + 1, reason))
         {
             return false;
         }
@@ -89,9 +122,9 @@ QuorumSetSanityChecker::checkSanity(SCPQuorumSet const& qSet, int depth)
 }
 
 bool
-isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks)
+isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks, const char** reason)
 {
-    QuorumSetSanityChecker checker{qSet, extraChecks};
+    QuorumSetSanityChecker checker{qSet, extraChecks, reason};
     return checker.isSane();
 }
 

--- a/source/scpp/src/scp/QuorumSetUtils.h
+++ b/source/scpp/src/scp/QuorumSetUtils.h
@@ -9,7 +9,8 @@
 namespace stellar
 {
 
-bool isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks);
+bool isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks,
+    const char** reason = nullptr);
 
 // normalize the quorum set, optionally removing idToRemove
 void normalizeQSet(SCPQuorumSet& qSet, NodeID const* idToRemove = nullptr);


### PR DESCRIPTION
If this looks good to you, I will also submit a PR upstream.

However in upstream they already use a different set of rules for `isQuorumSetSane`, so we would have to update our bindings to the latest version first. And that's not trivial as of now.

Part of #515