### PR TITLE
Add an Agora-Cli compilation to the CI test entry.

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -6,3 +6,4 @@ set -o pipefail
 dub test -b unittest-cov --skip-registry=all --compiler=${DC}
 rdmd --compiler=${DC} ./tests/runner.d --compiler=${DC} -cov
 dub build --skip-registry=all --compiler=${DC}
+dub build -c cli --skip-registry=all --compiler=${DC}


### PR DESCRIPTION
Currently, nothing in the CI tries to compile agora-cli.
This is tested in `Github-actions` and `Travis CI`

Fixes #513 