### PR TITLE
Rename methods in EnrollmentManager

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -150,7 +150,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public bool addEnrollment (ulong block_height, scope UTXOFinder finder,
+    public bool add (ulong block_height, scope UTXOFinder finder,
         const ref Enrollment enroll) @safe nothrow
     {
         static ubyte[] buffer;
@@ -806,22 +806,22 @@ unittest
 
     assert(man.createEnrollment(utxo_hash, enroll));
     assert(!man.hasEnrollment(utxo_hash));
-    assert(!man.addEnrollment(0, &storage.findUTXO, fail_enroll));
-    assert(man.addEnrollment(0, &storage.findUTXO, enroll));
+    assert(!man.add(0, &storage.findUTXO, fail_enroll));
+    assert(man.add(0, &storage.findUTXO, enroll));
     assert(man.count() == 1);
     assert(man.hasEnrollment(utxo_hash));
-    assert(!man.addEnrollment(0, &storage.findUTXO, enroll));
+    assert(!man.add(0, &storage.findUTXO, enroll));
 
     // create and add the second Enrollment object
     auto utxo_hash2 = utxo_hashes[1];
     assert(man.createEnrollment(utxo_hash2, enroll2));
-    assert(man.addEnrollment(0, &storage.findUTXO, enroll2));
+    assert(man.add(0, &storage.findUTXO, enroll2));
     assert(man.count() == 2);
 
     auto utxo_hash3 = utxo_hashes[2];
     Enrollment enroll3;
     assert(man.createEnrollment(utxo_hash3, enroll3));
-    assert(man.addEnrollment(0, &storage.findUTXO, enroll3));
+    assert(man.add(0, &storage.findUTXO, enroll3));
     assert(man.count() == 3);
 
     Enrollment[] enrolls;
@@ -863,7 +863,7 @@ unittest
     // Reverse ordering
     ordered_enrollments.sort!("a.utxo_key > b.utxo_key");
     foreach (ordered_enroll; ordered_enrollments)
-        assert(man.addEnrollment(0, &storage.findUTXO, ordered_enroll));
+        assert(man.add(0, &storage.findUTXO, ordered_enroll));
     man.getUnregistered(enrolls);
     assert(enrolls.length == 3);
     assert(enrolls.isStrictlyMonotonic!("a.utxo_key < b.utxo_key"));
@@ -922,7 +922,7 @@ unittest
     auto utxo_hash = utxo_hashes[0];
     Enrollment enroll;
     assert(man.createEnrollment(utxo_hash, enroll));
-    assert(man.addEnrollment(0, &storage.findUTXO, enroll));
+    assert(man.add(0, &storage.findUTXO, enroll));
     assert(man.hasEnrollment(utxo_hash));
 
     auto preimage = PreimageInfo(utxo_hash, enroll.random_seed, 1);

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -240,7 +240,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public void removeEnrollment (const ref Hash enroll_hash) @trusted
+    public void remove (const ref Hash enroll_hash) @trusted
     {
         this.db.execute("DELETE FROM validator_set WHERE key = ?",
             enroll_hash.toString());
@@ -835,7 +835,7 @@ unittest
     assert(stored_enroll == enroll2);
 
     // remove an Enrollment object
-    man.removeEnrollment(utxo_hash2);
+    man.remove(utxo_hash2);
     assert(man.count() == 2);
 
     // test for getEnrollment with removed enrollment
@@ -851,9 +851,9 @@ unittest
     assert(enrolls.length == 1);
     assert(man.count() == 2);  // has not changed
 
-    man.removeEnrollment(utxo_hash);
-    man.removeEnrollment(utxo_hash2);
-    man.removeEnrollment(utxo_hash3);
+    man.remove(utxo_hash);
+    man.remove(utxo_hash2);
+    man.remove(utxo_hash3);
     assert(man.getUnregistered(enrolls).length == 0);
 
     Enrollment[] ordered_enrollments;

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -224,7 +224,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public size_t getEnrollmentLength () @safe
+    public size_t count () @safe
     {
         return () @trusted {
             return this.db.execute("SELECT count(*) FROM validator_set").oneValue!size_t;
@@ -808,7 +808,7 @@ unittest
     assert(!man.hasEnrollment(utxo_hash));
     assert(!man.addEnrollment(0, &storage.findUTXO, fail_enroll));
     assert(man.addEnrollment(0, &storage.findUTXO, enroll));
-    assert(man.getEnrollmentLength() == 1);
+    assert(man.count() == 1);
     assert(man.hasEnrollment(utxo_hash));
     assert(!man.addEnrollment(0, &storage.findUTXO, enroll));
 
@@ -816,13 +816,13 @@ unittest
     auto utxo_hash2 = utxo_hashes[1];
     assert(man.createEnrollment(utxo_hash2, enroll2));
     assert(man.addEnrollment(0, &storage.findUTXO, enroll2));
-    assert(man.getEnrollmentLength() == 2);
+    assert(man.count() == 2);
 
     auto utxo_hash3 = utxo_hashes[2];
     Enrollment enroll3;
     assert(man.createEnrollment(utxo_hash3, enroll3));
     assert(man.addEnrollment(0, &storage.findUTXO, enroll3));
-    assert(man.getEnrollmentLength() == 3);
+    assert(man.count() == 3);
 
     Enrollment[] enrolls;
     man.getUnregistered(enrolls);
@@ -836,7 +836,7 @@ unittest
 
     // remove an Enrollment object
     man.removeEnrollment(utxo_hash2);
-    assert(man.getEnrollmentLength() == 2);
+    assert(man.count() == 2);
 
     // test for getEnrollment with removed enrollment
     assert(!man.getEnrollment(utxo_hash2, stored_enroll));
@@ -849,7 +849,7 @@ unittest
     assert(man.getEnrolledHeight(utxo_hash2) == 0);
     man.getUnregistered(enrolls);
     assert(enrolls.length == 1);
-    assert(man.getEnrollmentLength() == 2);  // has not changed
+    assert(man.count() == 2);  // has not changed
 
     man.removeEnrollment(utxo_hash);
     man.removeEnrollment(utxo_hash2);

--- a/source/agora/node/GossipProtocol.d
+++ b/source/agora/node/GossipProtocol.d
@@ -112,7 +112,7 @@ public class GossipProtocol
 
     public void receiveEnrollment (Enrollment enroll, scope UTXOFinder finder) @safe
     {
-        if (this.enroll_man.addEnrollment(this.ledger.getBlockHeight(), finder,
+        if (this.enroll_man.add(this.ledger.getBlockHeight(), finder,
             enroll))
         {
             this.network.sendEnrollment(enroll);


### PR DESCRIPTION
There is a reason for this:
* Since `getEnrollmentLength` and `removeEnrollment` and `addEnrollment` is a method of EnrollmentManager


https://github.com/bpfkorea/agora/pull/558#issuecomment-588033469