### PR TITLE
Reveal a pre-image periodically

### DIFF
--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -248,6 +248,16 @@ public class Node : API
             this.network.sendTransaction(tx);
             this.ledger.tryNominateTXSet();
         }
+
+        if (this.enroll_man.needRevealPreimage(this.ledger.getBlockHeight()))
+        {
+            PreimageInfo preimage;
+            if (this.enroll_man.getNextPreimage(preimage))
+            {
+                this.receivePreimage(preimage);
+                this.enroll_man.increaseNextRevealHeight();
+            }
+        }
     }
 
     /***************************************************************************

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -444,6 +444,9 @@ public interface TestAPI : API
 
     ///
     public abstract PreimageInfo getPreimage (uint height);
+
+    ///
+    public abstract void updateEnrolledHeight (Hash enroll_key, ulong height);
 }
 
 /// Ditto
@@ -551,6 +554,12 @@ public class TestNode : Node, TestAPI
         PreimageInfo preimage;
         this.enroll_man.getPreimage(height, preimage);
         return preimage;
+    }
+
+    /// Set a enrolled height for the enrollment
+    public override void updateEnrolledHeight (Hash enroll_key, ulong height)
+    {
+        this.enroll_man.updateEnrolledHeight(enroll_key, height);
     }
 }
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -84,3 +84,86 @@ unittest
     nodes.each!(node =>
         retryFor(node.hasPreimage(preimage.enroll_key, 999) == true, 5.seconds));
 }
+
+/// test for revealing a pre-image periodically
+unittest
+{
+    import std.algorithm;
+    import std.conv;
+    import core.time;
+
+    auto network = makeTestNetwork(TestConf.init);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[0];
+    auto node_2 = nodes[1];
+
+    // make transactions which have UTXOs for the node.
+    auto gen_key_pair = getGenesisKeyPair();
+    auto pubkey_1 = node_1.getPublicKey();
+
+    Transaction[] txs;
+    foreach (idx; 0 .. Block.TxsInBlock)
+    {
+        auto input = Input(hashFull(GenesisTransaction), idx.to!uint);
+
+        Transaction tx =
+        {
+            TxType.Freeze,
+            [input],
+            [Output(Amount.MinFreezeAmount, pubkey_1),
+                Output(Amount(100), gen_key_pair.address)]
+        };
+
+        auto signature = gen_key_pair.secret.sign(hashFull(tx)[]);
+        tx.inputs[0].signature = signature;
+        txs ~= tx;
+    }
+    txs.each!(tx => node_1.putTransaction(tx));
+    containSameBlocks(nodes, 1).retryFor(8.seconds);
+
+    // create enrollment data
+    Enrollment enroll = node_1.createEnrollmentData();
+
+    // send a request to enroll as a Validator
+    node_1.enrollValidator(enroll);
+
+    // check if nodes contains enrollment data previously sent.
+    nodes.each!(node =>
+        retryFor(node.hasEnrollment(enroll.utxo_key) == true, 5.seconds));
+
+    // set enrolled height to all nodes
+    // the updateEnrolledHeight function is actually called in the middle of
+    // making block but now the code is not merged so calling it is needed.
+    nodes.each!(node => node.updateEnrolledHeight(enroll.utxo_key, 1));
+
+    // make a block with height of 2
+    Transaction[] txs2;
+    foreach (idx; 0 .. Block.TxsInBlock)
+    {
+        auto input = Input(hashFull(txs[idx]), 1);
+
+        Transaction tx =
+        {
+            TxType.Payment,
+            [input],
+            [Output(Amount(100), pubkey_1)]
+        };
+
+        auto signature = gen_key_pair.secret.sign(hashFull(tx)[]);
+        tx.inputs[0].signature = signature;
+        txs2 ~= tx;
+    }
+    txs2.each!(tx => node_1.putTransaction(tx));
+    containSameBlocks(nodes, 2).retryFor(8.seconds);
+
+    // check if nodes have a pre-image newly sent
+    // during creating transactions for the new block
+    nodes.each!(node =>
+        retryFor(node.hasPreimage(enroll.utxo_key,
+            EnrollmentManager.PreimageRevealPeriod + 2), 5.seconds));
+}


### PR DESCRIPTION
A validator reveals a pre-image periodically.
- Every 1 hour, or 6 blocks. 
- The revelation period could become configurable in another issue.
- The pre-image has the data for double the period because it make the validator to be able to skip to next revelation timing In case of a failure of the revelation.
- For unittest, the updateEnrolledHeight function is called manually because the PR #504 is being reviewed now. The PR has the code setting an enrolled height for an enrollment.

#492 