### PR TITLE
Fix verification of the quorum section

### DIFF
--- a/doc/Style.md
+++ b/doc/Style.md
@@ -352,7 +352,7 @@ unittest
     network.waitForDiscovery();
 
    /// Use API as needed
-   foreach (/*PublicKey*/ key, ref /*API*/ node; network.apis)
+   foreach (/*PublicKey*/ key, ref /*API*/ node; network.nodes)
        node.sendTransaction(...);
 }
 ```

--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -39,7 +39,6 @@ unittest
         nodes : 3,
         retry_delay : 10,
         max_retries : 10,
-        timeout : 10,
         max_failed_requests : 4 * Block.TxsInBlock
     };
 

--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -49,10 +49,9 @@ unittest
     network.waitForDiscovery();
 
     // three nodes, two validators, and 1 non-validator
-    auto keys = network.keys;
-    auto node_1 = network.apis[keys[0]];
-    auto node_2 = network.apis[keys[1]];
-    auto node_3 = network.apis[keys[2]];  // non-validator
+    auto node_1 = network.nodes[0].client;
+    auto node_2 = network.nodes[1].client;
+    auto node_3 = network.nodes[2].client;  // non-validator
     auto nodes = [node_1, node_2, node_3];
     auto gen_key = getGenesisKeyPair();
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -22,6 +22,7 @@ module agora.test.Base;
 
 version (unittest):
 
+import agora.node.Ledger;
 import agora.api.Validator;
 import agora.common.Amount;
 import agora.common.BanManager;
@@ -590,6 +591,9 @@ public struct TestConf
 
     /// max failed requests before a node is banned
     size_t max_failed_requests = 100;
+
+    /// The threshold. If not set, it will default to the number of nodes
+    size_t threshold;
 }
 
 /*******************************************************************************
@@ -666,7 +670,11 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             banman : ban_conf,
             node : self,
             network : test_conf.configure_network ? assumeUnique(other_nodes.array) : null,
-            quorum : { nodes : quorum_keys, threshold : quorum_keys.length }
+            quorum :
+            {
+                nodes : quorum_keys,
+                threshold : (test_conf.threshold == 0) ? quorum_keys.length : test_conf.threshold
+            }
         };
 
         return conf;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -238,10 +238,20 @@ public class TestAPIManager
         this.reg.initialize();
     }
 
-    /// Initialize a new node
+    /***************************************************************************
+
+        Create a new node
+
+        Params:
+            address = the address of the node, using PublicKey in unittests
+            conf = the configuration passed on to the Node constructor
+
+    ***************************************************************************/
+
     public void createNewNode (PublicKey address, Config conf)
     {
-        auto api = RemoteAPI!TestAPI.spawn!(TestNode)(conf, &this.reg);
+        auto api = RemoteAPI!TestAPI.spawn!(TestNode)(conf, &this.reg,
+            conf.node.timeout.msecs);
         this.reg.register(address.toString(), api.tid());
         this.apis[address] = api;
         this.keys ~= address;
@@ -575,8 +585,8 @@ public struct TestConf
     /// max retries before a request is considered failed
     size_t max_retries = 20;
 
-    /// request timeout (in msecs)
-    long timeout = 500;
+    /// request timeout for each node (in msecs)
+    long timeout = 2000;
 
     /// max failed requests before a node is banned
     size_t max_failed_requests = 100;

--- a/source/agora/test/Consensus.d
+++ b/source/agora/test/Consensus.d
@@ -39,7 +39,7 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.apis.values;
+    auto nodes = network.clients;
     auto node_1 = nodes[0];
 
     auto txs = makeChainedTransactions(getGenesisKeyPair(), null, 1);

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -39,7 +39,7 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.apis.values;
+    auto nodes = network.clients;
     auto node_1 = nodes[0];
     auto node_2 = nodes[1];
 

--- a/source/agora/test/Failures.d
+++ b/source/agora/test/Failures.d
@@ -1,0 +1,47 @@
+/*******************************************************************************
+
+    Contains tests which should shut down the node due to misconfiguration.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.Failures;
+
+version (unittest):
+
+import agora.api.Validator;
+import agora.consensus.data.Transaction;
+import agora.consensus.Genesis;
+import agora.test.Base;
+import agora.utils.Log;
+
+///
+unittest
+{
+    import std.algorithm;
+    import std.range;
+    import core.thread;
+
+    TestConf conf = { threshold : 100, timeout : 1_000 };
+    auto network = makeTestNetwork(conf);
+
+    try
+    {
+        network.start();
+        assert(0);
+    }
+    catch (Exception ex)
+    {
+        // misconfiguration made the node throw in call to start()
+
+        // note: cannot check logs because they can only be accessed through
+        // TestAPI.printLog(), but RemoteAPI has already shut down when
+        // the node threw an exception in its constructor
+    }
+}

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -38,7 +38,7 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.apis.values;
+    auto nodes = network.clients;
     auto node_1 = nodes[0];
 
     nodes.each!(node => assert(node.getBlockHeight() == 0));

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -41,7 +41,7 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.apis.values;
+    auto nodes = network.clients;
     auto node_1 = nodes[0];
 
     Transaction[][] block_txes; /// per-block array of transactions (genesis not included)
@@ -102,7 +102,7 @@ unittest
     network.waitForDiscovery();
 
     // node_1 is the validator
-    auto nodes = network.keys.map!(key => network.apis[key]).array;
+    auto nodes = network.clients;
     auto node_1 = nodes[0];
 
     // ignore transaction propagation and periodically retrieve blocks via getBlocksFrom
@@ -125,7 +125,7 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.apis.values;
+    auto nodes = network.clients;
     auto node_1 = nodes[0];
 
     auto gen_key_pair = getGenesisKeyPair();
@@ -163,7 +163,7 @@ unittest
     nodes.each!(node => retryFor(node.getBlockHeight() == 1, 4.seconds));
 
     Hash[] merkle_path;
-    foreach (key, ref node; nodes)
+    foreach (node; nodes)
     {
         merkle_path = node.getMerklePath(1, hc);
         assert(merkle_path.length == 3);
@@ -202,7 +202,7 @@ unittest
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
 
-    auto nodes = network.apis.values;
+    auto nodes = network.clients;
     auto node_1 = nodes[0];
 
     auto txs = makeChainedTransactions(getGenesisKeyPair(), null, 1);

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -94,8 +94,7 @@ unittest
     import std.range;
     import core.time;
 
-    // also reduced timeout to 100 msecs
-    TestConf conf = { topology : NetworkTopology.OneValidator, timeout : 100 };
+    TestConf conf = { topology : NetworkTopology.OneValidator };
     auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();
@@ -197,8 +196,7 @@ unittest
     import core.thread;
     import agora.consensus.Validation;
 
-    // reduce timeout to 100 msecs
-    TestConf conf = { nodes : 2, timeout : 100 };
+    TestConf conf = { nodes : 2 };
     auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/Network.d
+++ b/source/agora/test/Network.d
@@ -30,9 +30,9 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    foreach (key, node; network.apis)
+    foreach (key, node; network.nodes)
     {
-        auto addresses = node.getNetworkInfo().addresses.keys;
+        auto addresses = node.client.getNetworkInfo().addresses.keys;
         assert(addresses.sort.uniq.count == conf.nodes - 1,
                format("Node %s has %d peers: %s", key, addresses.length, addresses));
     }

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -36,7 +36,7 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.apis.values;
+    auto nodes = network.clients;
     auto node_1 = nodes[0];
 
     // block periodic getBlocksFrom
@@ -71,7 +71,7 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.apis.values;
+    auto nodes = network.clients;
     auto node_1 = nodes[0];
 
     // block periodic getBlocksFrom

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -109,14 +109,20 @@ unittest
         // base class uses a hashmap, can't depend on the order of nodes
         public RemoteAPI!TestAPI[] nodes;
 
-        /// Initialize a new node
+        /// see base class
         public override void createNewNode (PublicKey address, Config conf)
         {
             RemoteAPI!TestAPI api;
             if (this.nodes.length == 2)
-                api = RemoteAPI!TestAPI.spawn!(BadNode)(conf, &this.reg);
+            {
+                api = RemoteAPI!TestAPI.spawn!(BadNode)(conf, &this.reg,
+                    conf.node.timeout.msecs);
+            }
             else
-                api = RemoteAPI!TestAPI.spawn!(TestNode)(conf, &this.reg);
+            {
+                api = RemoteAPI!TestAPI.spawn!(TestNode)(conf, &this.reg,
+                    conf.node.timeout.msecs);
+            }
 
             this.reg.register(address.toString(), api.tid());
             this.apis[address] = api;

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -33,7 +33,7 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.apis.values;
+    auto nodes = network.clients;
     auto node_1 = nodes[0];
 
     // first two nodes will fail, second two should work
@@ -106,9 +106,6 @@ unittest
 
     static class BadAPIManager : TestAPIManager
     {
-        // base class uses a hashmap, can't depend on the order of nodes
-        public RemoteAPI!TestAPI[] nodes;
-
         /// see base class
         public override void createNewNode (PublicKey address, Config conf)
         {
@@ -125,8 +122,7 @@ unittest
             }
 
             this.reg.register(address.toString(), api.tid());
-            this.apis[address] = api;
-            this.nodes ~= api;
+            this.nodes ~= NodePair(address, api);
         }
     }
 
@@ -137,7 +133,7 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.nodes;
+    auto nodes = network.clients;
     auto node_validator = nodes[0];  // validator, creates blocks
     auto node_test = nodes[1];  // full node, does not create blocks
     auto node_bad = nodes[2];  // full node, returns bad blocks in getBlocksFrom()

--- a/source/agora/test/Simple.d
+++ b/source/agora/test/Simple.d
@@ -38,7 +38,7 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.apis.values;
+    auto nodes = network.clients;
     auto node_1 = nodes[0];
 
     auto txes = makeChainedTransactions(getGenesisKeyPair(), null, 1);


### PR DESCRIPTION
The verification should be moved before `start()` is called.

While fixing this I've noticed a bunch of other issues with the tests, and included these fixes here. I also planned to add a check in the logging output of the node, but this isn't possible to do if the node throws in its constructors - because we can only reach those logs through the API, and by that point the node is dead.