### PR TITLE
tests: Remove unnecessary tryNominateTXSet() call

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -708,7 +708,6 @@ unittest
     UTXOSetValue _val;
     new_txs.each!(tx => assert(finder(tx.inputs[0].previous, tx.inputs[0].index,
         _val)));
-    ledger.tryNominateTXSet();
 
     auto findUTXO = utxo_set.getUTXOFinder();
     Transaction find_tx = new_txs[0];


### PR DESCRIPTION
Caught this while untangling the Ledger & Nominator tight coupling that will be fixed in #572 