### PR TITLE
Various test-suite fixes & proper cleanup in ctor

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -984,10 +984,11 @@ unittest
                 {
                     assert(ledger.acceptTransaction(tx) == is_valid);
                 });
-            ledger.tryNominateTXSet();
 
             if (is_valid)
             {
+                ledger.tryNominateTXSet();
+
                 // keep track of last tx's to chain them to
                 last_txs_freeze = txes[$ - Block.TxsInBlock .. $];
 

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -111,9 +111,12 @@ public class Node : API
             config.network, config.dns_seeds, this.metadata, this.taskman);
         this.storage = this.getBlockStorage(config.node.data_dir);
         this.pool = this.getPool(config.node.data_dir);
+        scope (failure) this.pool.shutdown();
         this.utxo_set = this.getUtxoSet(config.node.data_dir);
+        scope (failure) this.utxo_set.shutdown();
         this.ledger = new Ledger(this.pool, this.utxo_set, this.storage, config.node);
         this.enroll_man = this.getEnrollmentManager(config.node.data_dir, config.node);
+        scope (failure) this.enroll_man.shutdown();
         this.exception = new RestException(
             400, Json("The query was incorrect"), string.init, int.init);
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -293,6 +293,9 @@ public class TestAPIManager
 
     public void shutdown ()
     {
+        foreach (node; this.nodes)
+            enforce(this.reg.unregister(node.key.toString()));
+
         foreach (ref node; this.nodes)
         {
             node.client.shutdown();


### PR DESCRIPTION
The last commit in particular seems to get rid of bizarre "unrelated" errors whenever there is a failing test-case. It usually displays SQL cleanup errors.