### PR TITLE
integration-test: wait for node discovery first

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -44,6 +44,7 @@ import agora.network.NetworkManager;
 import agora.node.Ledger;
 import agora.node.Node;
 import agora.utils.Log;
+public import agora.utils.Test;  // frequently needed in tests
 
 import ocean.util.log.Logger;
 
@@ -830,69 +831,6 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
     }
 
     return net;
-}
-
-/*******************************************************************************
-
-    Keeps retrying the 'check' condition until it is true,
-    or until the timeout expires. It will sleep the main
-    thread for 100 msecs between each re-try.
-
-    If the timeout expires, and the 'check' condition is still false,
-    it throws an AssertError.
-
-    Params:
-        check = the condition to check on
-        timeout = time to wait for the check to succeed
-        msg = optional AssertException message when the condition fails
-              after the timeout expires
-        file = file from the call site
-        line = line from the call site
-
-    Throws:
-        AssertError if the timeout is reached and the condition still fails
-
-*******************************************************************************/
-
-public void retryFor (lazy bool check, Duration timeout,
-    lazy string msg = "", string file = __FILE__, size_t line = __LINE__)
-{
-    import core.exception;
-    import core.thread;
-
-    // wait 100 msecs between attempts
-    const SleepTime = 100;
-    auto attempts = timeout.total!"msecs" / SleepTime;
-    const TotalAttempts = attempts;
-
-    while (attempts--)
-    {
-        if (check)
-            return;
-
-        Thread.sleep(SleepTime.msecs);
-    }
-
-    auto assert_msg = format("Check condition failed after timeout of %s " ~
-        "and %s attempts", timeout, TotalAttempts);
-
-    if (msg.length)
-        assert_msg ~= ": " ~ msg;
-
-    throw new AssertError(assert_msg, file, line);
-}
-
-///
-unittest
-{
-    import core.exception;
-    import std.exception;
-
-    static bool willSucceed () { static int x; return ++x == 2; }
-    willSucceed().retryFor(1.seconds);
-
-    static bool willFail () { return false; }
-    assertThrown!AssertError(willFail().retryFor(300.msecs));
 }
 
 /// Returns: the entire ledger from the provided node

--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -32,6 +32,8 @@ module agora.utils.Test;
 import std.file;
 import std.path;
 
+import core.time;
+
 /*******************************************************************************
 
     Get a temporary directory for unit integration tests
@@ -61,4 +63,68 @@ public string makeCleanTempDir (string postfix = __MODULE__)
     if (path.exists) rmdirRecurse(path);
     mkdirRecurse(path);
     return path;
+}
+
+/*******************************************************************************
+
+    Keeps retrying the 'check' condition until it is true,
+    or until the timeout expires. It will sleep the main
+    thread for 100 msecs between each re-try.
+
+    If the timeout expires, and the 'check' condition is still false,
+    it throws an AssertError.
+
+    Params:
+        check = the condition to check on
+        timeout = time to wait for the check to succeed
+        msg = optional AssertException message when the condition fails
+              after the timeout expires
+        file = file from the call site
+        line = line from the call site
+
+    Throws:
+        AssertError if the timeout is reached and the condition still fails
+
+*******************************************************************************/
+
+public void retryFor (lazy bool check, Duration timeout,
+    lazy string msg = "", string file = __FILE__, size_t line = __LINE__)
+{
+    import core.exception;
+    import core.thread;
+    import std.format;
+
+    // wait 100 msecs between attempts
+    const SleepTime = 100;
+    auto attempts = timeout.total!"msecs" / SleepTime;
+    const TotalAttempts = attempts;
+
+    while (attempts--)
+    {
+        if (check)
+            return;
+
+        Thread.sleep(SleepTime.msecs);
+    }
+
+    auto assert_msg = format("Check condition failed after timeout of %s " ~
+        "and %s attempts", timeout, TotalAttempts);
+
+    if (msg.length)
+        assert_msg ~= ": " ~ msg;
+
+    throw new AssertError(assert_msg, file, line);
+}
+
+///
+unittest
+{
+    import core.exception;
+    import std.exception;
+
+    static bool willSucceed () { static int x; return ++x == 2; }
+    willSucceed().retryFor(1.seconds);
+
+    static bool willFail () { return false; }
+    assertThrown!AssertError(willFail().retryFor(300.msecs));
 }


### PR DESCRIPTION
I've noticed this issue in the last week. I can't guarantee it fixes anything, but it follows the way we test the nodes in the test-suite.

We should also rework how the nodes work to ensure they reject any API requests until they are ready to handle such events. For example, a node should not attempt to gossip requests if its discovery stage is incomplete.

I've tested compiling this locally, but I can't verify it works yet. Having issues with Docker ports on WSL2. :/