### PR TITLE
Remove ConfigException, use Exception directly

### DIFF
--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -189,17 +189,6 @@ public GetoptResult parseCommandLine (ref CommandLine cmdline, string[] args)
         );
 }
 
-/// Thrown when parsing the config fails
-class ConfigException : Exception
-{
-    ///
-    public this (string msg, string file = __FILE__, size_t line = __LINE__)
-        @nogc @safe pure nothrow
-    {
-        super(msg, file, line);
-    }
-}
-
 /*******************************************************************************
 
     Parses the config file and returns a `Config` instance.
@@ -208,7 +197,7 @@ class ConfigException : Exception
         cmdln = command-line arguments (containing the path to the config)
 
     Throws:
-        `ConfigException` if parsing the config file failed.
+        `Exception` if parsing the config file failed.
 
     Returns:
         `Config` instance
@@ -217,14 +206,7 @@ class ConfigException : Exception
 
 public Config parseConfigFile (ref const CommandLine cmdln)
 {
-    try
-    {
-        return parseConfigFileImpl(cmdln);
-    }
-    catch (Exception ex)
-    {
-        throw new ConfigException(ex.msg, ex.file, ex.line);
-    }
+    return parseConfigFileImpl(cmdln);
 }
 
 /// ditto


### PR DESCRIPTION
```
ConfigException was an attempt at simplifying the code that didn't turn quite right.
The whole point of having it seemed to avoid declaring the 'Config' variable outside
of the 'try' block, but it resulted in an extra level of indentation for everything,
and a try-catch-throw which worked around the fact that only the YAML parser throws.
```