### PR TITLE
Show compiler and dub version in Github / Travis

### DIFF
--- a/.github/workflows/github_push.yaml
+++ b/.github/workflows/github_push.yaml
@@ -18,6 +18,10 @@ jobs:
       with:
           compiler: ${{ matrix.dc }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Print compiler and dub's version
+      run: |
+        ${{ matrix.dc }} --version
+        dub --version
     - name: Install dependencies
       run: |
         brew install pkg-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./ci/ci_linux_setup.sh; fi
 
 script:
+  - ${DC} --version
+  - dub --version
   - ./ci/run.sh
 
 after_success:


### PR DESCRIPTION
```
This is only useful when testing with dmd-nightly / ldc-latest-ci.
This will show the exact commit that is being used for testing,
helping to debug any future issue.
```

I am seeing a weird issue, where a deprecation on `body` is triggered, but it is disabled in master...