### PR TITLE
Fix the hardcoded max_listeners option in the tests

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -662,6 +662,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             max_retries : test_conf.max_retries,
             timeout : test_conf.timeout,
             min_listeners : test_conf.nodes - 1,
+            max_listeners : test_conf.nodes - 1,
         };
 
         return conf;


### PR DESCRIPTION
I haven't included a test-case because it actually triggers SCP failure more frequently when there are more nodes that are part of consensus. Until we actually fix all the C++/SCP issues it will have to remain like this.

Fixes: https://github.com/bpfkorea/agora/issues/588