### PR TITLE
Change `agora-cli` to `agora-client`

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -6,4 +6,4 @@ set -o pipefail
 dub test -b unittest-cov --skip-registry=all --compiler=${DC}
 rdmd --compiler=${DC} ./tests/runner.d --compiler=${DC} -cov
 dub build --skip-registry=all --compiler=${DC}
-dub build -c cli --skip-registry=all --compiler=${DC}
+dub build -c client --skip-registry=all --compiler=${DC}

--- a/dub.json
+++ b/dub.json
@@ -46,8 +46,8 @@
             "excludedSourceFiles": [ "source/agora/cli/client/*" ]
         },
         {
-            "name": "cli",
-            "targetName": "agora-cli",
+            "name": "client",
+            "targetName": "agora-client",
             "mainSourceFile": "source/agora/cli/client/main.d",
             "excludedSourceFiles": [
                 "source/agora/api/Validator.d",

--- a/dub.json
+++ b/dub.json
@@ -43,12 +43,12 @@
             "name": "server",
             "targetName": "agora",
             "mainSourceFile": "source/agora/node/main.d",
-            "excludedSourceFiles": [ "source/agora/cli/*" ]
+            "excludedSourceFiles": [ "source/agora/cli/client/*" ]
         },
         {
             "name": "cli",
             "targetName": "agora-cli",
-            "mainSourceFile": "source/agora/cli/main.d",
+            "mainSourceFile": "source/agora/cli/client/main.d",
             "excludedSourceFiles": [
                 "source/agora/api/Validator.d",
                 "source/agora/common/Config.d",
@@ -62,7 +62,7 @@
         {
             "name": "unittest",
             "targetName": "agora-unittests",
-            "excludedSourceFiles": [ "source/agora/cli/main.d" ],
+            "excludedSourceFiles": [ "source/agora/cli/client/main.d" ],
             "sourceFiles": [
                 "source/scpp/build/DSizeChecks.o",
                 "source/scpp/build/DLayoutChecks.o"

--- a/source/agora/cli/client/CLIResult.d
+++ b/source/agora/cli/client/CLIResult.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-module agora.cli.CLIResult;
+module agora.client.CLIResult;
 
 public immutable int CLI_SUCCESS = 0;
 public immutable int CLI_INVALID_ARGUMENTS = 1;

--- a/source/agora/cli/client/DefaultProcess.d
+++ b/source/agora/cli/client/DefaultProcess.d
@@ -11,9 +11,9 @@
 
 *******************************************************************************/
 
-module agora.cli.DefaultProcess;
+module agora.client.DefaultProcess;
 
-import agora.cli.CLIResult;
+import agora.client.CLIResult;
 
 import std.getopt;
 

--- a/source/agora/cli/client/DefaultProcess.d
+++ b/source/agora/cli/client/DefaultProcess.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    The Agora CLI sub-function for default command
+    The Agora client sub-function for default command
 
     Copyright:
         Copyright (c) 2019 BOS Platform Foundation Korea
@@ -13,7 +13,7 @@
 
 module agora.client.DefaultProcess;
 
-import agora.client.CLIResult;
+import agora.client.Result;
 
 import std.getopt;
 
@@ -45,7 +45,7 @@ public GetoptResult parseDefaultOption (ref DefaultOption basic, string[] args)
 /// Print help
 public void printDefaultHelp (ref string[] outputs)
 {
-    outputs ~= "usage: agora-cli [--help]";
+    outputs ~= "usage: agora-client [--help]";
     outputs ~= "                  <command> [<args>]";
     outputs ~= "";
     outputs ~= "These are commands:";
@@ -64,19 +64,19 @@ public int defaultProcess (string[] args, ref string[] outputs)
         if (basic.help)
         {
             printDefaultHelp(outputs);
-            return CLI_SUCCESS;
+            return CLIENT_SUCCESS;
         }
 
         if (basic.ver)
         {
-            outputs ~= "agora-cli version 1.00.0";
-            return CLI_SUCCESS;
+            outputs ~= "agora-client version 1.00.0";
+            return CLIENT_SUCCESS;
         }
-        return CLI_INVALID_ARGUMENTS;
+        return CLIENT_INVALID_ARGUMENTS;
     }
     catch (Exception ex)
     {
         printDefaultHelp(outputs);
-        return CLI_EXCEPTION;
+        return CLIENT_EXCEPTION;
     }
 }

--- a/source/agora/cli/client/Result.d
+++ b/source/agora/cli/client/Result.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    The Agora CLI Result Constans
+    The Agora client Result Constans
 
     Copyright:
         Copyright (c) 2019 BOS Platform Foundation Korea
@@ -11,8 +11,8 @@
 
 *******************************************************************************/
 
-module agora.client.CLIResult;
+module agora.client.Result;
 
-public immutable int CLI_SUCCESS = 0;
-public immutable int CLI_INVALID_ARGUMENTS = 1;
-public immutable int CLI_EXCEPTION = 2;
+public immutable int CLIENT_SUCCESS = 0;
+public immutable int CLIENT_INVALID_ARGUMENTS = 1;
+public immutable int CLIENT_EXCEPTION = 2;

--- a/source/agora/cli/client/SendTxProcess.d
+++ b/source/agora/cli/client/SendTxProcess.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    The Agora CLI sub-function for sendtx command
+    The Agora client sub-function for sendtx command
 
     Copyright:
         Copyright (c) 2019 BOS Platform Foundation Korea
@@ -14,7 +14,7 @@
 module agora.client.SendTxProcess;
 
 import agora.api.FullNode;
-import agora.client.CLIResult;
+import agora.client.Result;
 import agora.common.Amount;
 import agora.common.crypto.Key;
 import agora.common.Hash;
@@ -99,7 +99,7 @@ public GetoptResult parseSendTxOption (ref SendTxOption op, string[] args)
 /// Print help
 public void printSendTxHelp (ref string[] outputs)
 {
-    outputs ~= "usage: agora-cli sendtx [--dump] [--ip addr] [--port port] --txhash --index --amount --dest --key";
+    outputs ~= "usage: agora-client sendtx [--dump] [--ip addr] [--port port] --txhash --index --amount --dest --key";
     outputs ~= "";
     outputs ~= "   sendtx      Send a transaction to node";
     outputs ~= "";
@@ -122,7 +122,7 @@ public void printSendTxHelp (ref string[] outputs)
     Input an arguments, generate the transaction and send it to the node
 
     Params:
-        args = Cli command line arguments
+        args = client command line arguments
 
 *******************************************************************************/
 
@@ -138,13 +138,13 @@ public int sendTxProcess (string[] args, ref string[] outputs,
         if (res.helpWanted)
         {
             printSendTxHelp(outputs);
-            return CLI_SUCCESS;
+            return CLIENT_SUCCESS;
         }
     }
     catch (Exception ex)
     {
         printSendTxHelp(outputs);
-        return CLI_EXCEPTION;
+        return CLIENT_EXCEPTION;
     }
 
     bool isValid = true;
@@ -178,7 +178,7 @@ public int sendTxProcess (string[] args, ref string[] outputs,
     }
 
     if (!isValid)
-        return CLI_INVALID_ARGUMENTS;
+        return CLIENT_INVALID_ARGUMENTS;
 
     // create the transaction
     auto key_pair = KeyPair.fromSeed(Seed.fromString(op.key));
@@ -201,7 +201,7 @@ public int sendTxProcess (string[] args, ref string[] outputs,
         outputs ~= format("address = %s", op.address);
         outputs ~= format("key = %s", op.key);
         outputs ~= format("hash of new transaction = %s", hashFull(tx).toString);
-        return CLI_SUCCESS;
+        return CLIENT_SUCCESS;
     }
 
     // connect to the node
@@ -211,7 +211,7 @@ public int sendTxProcess (string[] args, ref string[] outputs,
     // send the transaction
     node.putTransaction(tx);
 
-    return CLI_SUCCESS;
+    return CLIENT_SUCCESS;
 }
 
 /// Test of send transaction
@@ -267,7 +267,7 @@ unittest
     auto res = sendTxProcess(args, outputs, (address) {
         return node;
     });
-    assert (res == CLI_SUCCESS);
+    assert (res == CLIENT_SUCCESS);
 
     Transaction tx =
     {

--- a/source/agora/cli/client/SendTxProcess.d
+++ b/source/agora/cli/client/SendTxProcess.d
@@ -11,10 +11,10 @@
 
 *******************************************************************************/
 
-module agora.cli.SendTxProcess;
+module agora.client.SendTxProcess;
 
 import agora.api.FullNode;
-import agora.cli.CLIResult;
+import agora.client.CLIResult;
 import agora.common.Amount;
 import agora.common.crypto.Key;
 import agora.common.Hash;

--- a/source/agora/cli/client/main.d
+++ b/source/agora/cli/client/main.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    Entry point for the Agora CLI
+    Entry point for the Agora client
 
     Copyright:
         Copyright (c) 2019 BOS Platform Foundation Korea
@@ -14,7 +14,7 @@
 module agora.client.main;
 
 import agora.api.FullNode;
-import agora.client.CLIResult;
+import agora.client.Result;
 import agora.client.DefaultProcess;
 import agora.client.SendTxProcess;
 
@@ -45,7 +45,7 @@ int runProcess (string[] args, ref string[] outputs)
     if (args.length < 2)
     {
         printDefaultHelp(outputs);
-        return CLI_SUCCESS;
+        return CLIENT_SUCCESS;
     }
 
     const string command = args[1];

--- a/source/agora/cli/client/main.d
+++ b/source/agora/cli/client/main.d
@@ -11,12 +11,12 @@
 
 *******************************************************************************/
 
-module agora.cli.main;
+module agora.client.main;
 
 import agora.api.FullNode;
-import agora.cli.CLIResult;
-import agora.cli.DefaultProcess;
-import agora.cli.SendTxProcess;
+import agora.client.CLIResult;
+import agora.client.DefaultProcess;
+import agora.client.SendTxProcess;
 
 import vibe.core.core;
 import vibe.web.rest;


### PR DESCRIPTION
I would like to include various CLI programs in `source/agora/cli`.
I want to change the previously developed `agora-cli` to `agora-client`.
The detailed processing order is as follows.

1. Change a source directory of `agora-cli`; "source/cli" => "source/cli/client".
2. Change binary name `agora-cli` to `agora-client`.
3. Update `cli` to `client` in source code.
4. Update CI (run.sh).
5. Update a CI of the 'agora-client'

After this, I will add a test CLI called `agora-nettest` under the "source/cli".
The new folder is "source/cli/nettest".