### PR TITLE
Correctly print compiler's version on push

### DIFF
--- a/.github/workflows/github_push.yaml
+++ b/.github/workflows/github_push.yaml
@@ -20,7 +20,7 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Print compiler and dub's version
       run: |
-        ${{ matrix.dc }} --version
+        ${DC} --version
         dub --version
     - name: Install dependencies
       run: |
@@ -50,6 +50,10 @@ jobs:
       with:
         compiler: ${{ matrix.dc }}
         gh_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Print compiler and dub's version
+      run: |
+        ${DC} --version
+        dub --version
     - name: Build & test Agora
       run: |
         ./ci/ci_linux_setup.sh


### PR DESCRIPTION
```
The step was missing on Linux, and the definition on Mac OSX was wrong,
because matrix.dc is 'dmd-nightly' or 'dmd-latest-ci'.
```

See https://github.com/bpfkorea/agora/runs/469345840