### PR TITLE
BlockStorage test: Do not create the test folder in cwd

### DIFF
--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -1,0 +1,64 @@
+/*******************************************************************************
+
+    Various utilities for testing purpose
+
+    Utilities in this module can be used in test code.
+    There are currently multiple testing approaches:
+    - Unittests in the various `agora` module, the most common, cheapest,
+      and a way to do white box testing;
+    - Unittests under `agora.test`: Those unittests rely on the LocalRest
+      library to simulate a network where nodes are thread who communicate
+      via message passing.
+    - Unit integration tests in `${ROOT}/tests/unit/` which are similar to
+      unittests but provide a way to test IO-using code.
+    - System integration tests: those are fully fledged tests that spawns
+      unmodified, real nodes within Docker containers and act as a client.
+
+    Any symbol in this module can be used by any of those method,
+    which is why this module is neither restricted by `package(agora):`
+    nor `version(unittest):`.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.utils.Test;
+
+import std.file;
+import std.path;
+
+/*******************************************************************************
+
+    Get a temporary directory for unit integration tests
+
+    Tests that do IO usually write or read files from disk.
+    We want our tests to be reliable, reproducible, and re-runnable.
+    For this reason, this function returns a path which has been `mkdir`ed
+    after having been cleaned, which is located in the temporary directory.
+    Consistent usage of this allows unit integration tests to be run in parallel
+    (however the same test cannot be run multiple times in parallel,
+    unless a different postfix is specified each time).
+
+    Params:
+      postfix = A unique postfix for the calling test
+
+    Returns:
+      The path of a clean, empty directory
+
+*******************************************************************************/
+
+public string makeCleanTempDir (string postfix = __MODULE__)
+{
+    string path = tempDir().buildPath("agora_testing_framework", postfix);
+    // Note: The following path is only triggered when rebuilding locally,
+    // code coverage is run from a clean slate so the `rmdirRecurse`
+    // is never tested, hence the single-line statement helps with code coverage.
+    if (path.exists) rmdirRecurse(path);
+    mkdirRecurse(path);
+    return path;
+}

--- a/tests/unit/BanManager.d
+++ b/tests/unit/BanManager.d
@@ -14,6 +14,7 @@
 module unit.BanManager;
 
 import agora.common.BanManager;
+import agora.utils.Test;
 
 import ocean.time.WallClock;
 
@@ -25,12 +26,7 @@ import std.range;
 ///
 private void main ()
 {
-    string path = buildPath(getcwd, ".cache");
-    // Note: The following path is only triggered when rebuilding locally,
-    // code coverage is run from a clean slate so the `rmdirRecurse`
-    // is never tested.
-    if (path.exists) rmdirRecurse(path);
-    mkdir(path);
+    auto path = makeCleanTempDir();
 
     BanManager.Config conf = { max_failed_requests : 10, ban_duration : 60 };
     auto banman = new BanManager(conf, path);

--- a/tests/unit/BlockStorage.d
+++ b/tests/unit/BlockStorage.d
@@ -23,6 +23,7 @@ import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
 import agora.consensus.Genesis;
 import agora.node.BlockStorage;
+import agora.utils.Test;
 
 import std.algorithm.comparison;
 import std.file;
@@ -33,15 +34,8 @@ private void main ()
 {
     const size_t count = 300;
 
-    string path = buildPath(getcwd, ".cache");
-    if (path.exists)
-        rmdirRecurse(path);
-
-    mkdir(path);
-
-    BlockStorage.removeIndexFile(path);
+    auto path = makeCleanTempDir();
     BlockStorage storage = new BlockStorage(path);
-
     KeyPair[] key_pairs = [
         KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random,
         KeyPair.random, KeyPair.random, KeyPair.random, KeyPair.random

--- a/tests/unit/BlockStorageChecksum.d
+++ b/tests/unit/BlockStorageChecksum.d
@@ -17,6 +17,7 @@ import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
 import agora.consensus.Genesis;
 import agora.node.BlockStorage;
+import agora.utils.Test;
 
 import std.file;
 import std.path;
@@ -28,15 +29,12 @@ const size_t BlockCount = 300;
 ///
 private void main ()
 {
-    string dir_path = buildPath(getcwd, ".cache");
-    if (dir_path.exists)
-        rmdirRecurse(dir_path);
+    auto path = makeCleanTempDir();
 
-    mkdir(dir_path);
-    writeBlocks(dir_path);
-    corruptBlocks(dir_path);
+    writeBlocks(path);
+    corruptBlocks(path);
 
-    BlockStorage storage = new BlockStorage(dir_path);
+    BlockStorage storage = new BlockStorage(path);
     scope (exit) storage.release();
 
     Block block;

--- a/tests/unit/BlockStorageMultiTx.d
+++ b/tests/unit/BlockStorageMultiTx.d
@@ -22,6 +22,7 @@ import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
 import agora.consensus.Genesis;
 import agora.node.BlockStorage;
+import agora.utils.Test;
 
 import std.algorithm.comparison;
 import std.file;
@@ -36,17 +37,11 @@ const size_t BlockCount = 300;
 ///
 private void main ()
 {
-    string path = buildPath(getcwd, ".cache");
-    if (path.exists)
-        rmdirRecurse(path);
+    auto path = makeCleanTempDir();
 
-    mkdir(path);
-
-    BlockStorage.removeIndexFile(path);
     BlockStorage storage = new BlockStorage(path);
     storage.load();
     const(Block)[] blocks;
-
     blocks ~= GenesisBlock;
 
     // We can use a random keypair because blocks are not validated


### PR DESCRIPTION
```
Avoids clashing with whatever the user is doing (e.g. a node could be running).
Instead use the temporary directory, but make sure we only ever write at
one unique location.
```

Yeah, no more corrupting `.cache` when doing `dmd -run ./tests/runner.d`.

Regarding the module, I have in mind to add something for the `unittest` which provides a testing env (instantiate a ledger, perhaps?). But in the meantime I didn't have a good place to put this function.