### PR TITLE
Make MemBlockStorage closer to BlockStorage, allow loadAllIndex to throw

### DIFF
--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -756,10 +756,6 @@ public class BlockStorage : IBlockStorage
     {
         try
         {
-            size_t height;
-            ubyte[Hash.sizeof] hash;
-            size_t pos;
-
             this.height_idx.clear();
             this.hash_idx.clear();
 
@@ -779,17 +775,15 @@ public class BlockStorage : IBlockStorage
                 return res;
             };
 
+            size_t height, pos;
+            ubyte[Hash.sizeof] hash;
             foreach (idx; 0 .. record_count)
             {
                 deserializePart(height, dg, CompactMode.No);
-
                 idx_file.rawRead(hash);
-
                 deserializePart(pos, dg, CompactMode.No);
-
                 // add to index of heigth
                 this.height_idx.insert(HeightPosition(height, pos));
-
                 // add to index of hash
                 this.hash_idx.insert(HashPosition(hash, pos));
             }

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -919,11 +919,15 @@ public class MemBlockStorage : IBlockStorage
     {
         this.height_idx = new IndexHeight();
         this.hash_idx = new IndexHash();
-        this.saveBlock(GenesisBlock);
     }
 
     /// No-op: MemBlockStorage does no I/O
-    public override bool load () { return true; }
+    public override bool load ()
+    {
+        if (this.blocks.length == 0)
+            this.saveBlock(GenesisBlock);
+        return true;
+    }
 
     /***************************************************************************
 

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -929,6 +929,17 @@ public class MemBlockStorage : IBlockStorage
         return true;
     }
 
+    invariant ()
+    {
+        // Basic consistenty checks
+        assert(this.height_idx.length == this.hash_idx.length);
+        assert(this.height_idx.length == this.blocks.length);
+
+        // Make sure we have no empty block
+        foreach (blk; this.blocks)
+            assert(blk.length > 0);
+    }
+
     /***************************************************************************
 
         Read the last block from array.

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -679,14 +679,13 @@ unittest
     import agora.common.Types;
     import agora.common.Hash;
 
-    auto storage = new MemBlockStorage();
     auto gen_key = getGenesisKeyPair();
+    auto storage = new MemBlockStorage();
+    storage.load();
+
+    // First block
     auto txs = makeChainedTransactions(gen_key, null, 1);
     auto block = makeNewBlock(GenesisBlock, txs);
-    assert(storage.saveBlock(block));
-
-    txs = makeChainedTransactions(gen_key, txs, 1);
-    block = makeNewBlock(block, txs);
     assert(storage.saveBlock(block));
 
     auto pool = new TransactionPool(":memory:");

--- a/tests/unit/BlockStorage.d
+++ b/tests/unit/BlockStorage.d
@@ -44,7 +44,7 @@ private void main ()
     Hash[] block_hashes;
 
     blocks ~= GenesisBlock;
-    storage.saveBlock(blocks[$ - 1]);
+    assert(storage.load());
 
     // We can use a random keypair because blocks are not validated
     auto gen_key_pair = KeyPair.random();


### PR DESCRIPTION
Better reviewed commit-by-commit.
As mentioned the two important parts of this PR are the `loadAllIndex` one and the `MemBlockStorage`, which fixes a small issue with the injected dependency diverging in behavior from the actual class.