### PR TITLE
Fix #600: Remove dependency on ocean.core.BitArray

### DIFF
--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -51,7 +51,7 @@ public struct BlockHeader
     public Hash merkle_root;
 
     /// Bitfield containing the validators' key indices which signed the block
-    public BitField validators;
+    public BitField!uint validators;
 
     /// Schnorr multisig of all validators which signed this block
     public Signature signature;
@@ -396,7 +396,7 @@ unittest
         ],
     };
 
-    auto validators = BitField(6);
+    auto validators = typeof(BlockHeader.validators)(6);
     validators[0] = true;
     validators[2] = true;
     validators[4] = true;


### PR DESCRIPTION
This is a simpler implementation of BitArray, which works better with the (de)serializer,
has less overhead, is easier to work with, has a configurable granularity (type),
and proper attributes.