### PR TITLE
Make QuorumConfig fields non-immutable

### DIFF
--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -133,7 +133,7 @@ public class Node : API
 
     ***************************************************************************/
 
-    private static SCPQuorumSet verifyBuildSCPConfig (QuorumConfig config)
+    private static SCPQuorumSet verifyBuildSCPConfig (in QuorumConfig config)
     {
         import scpd.scp.QuorumSetUtils;
 
@@ -170,7 +170,7 @@ public class Node : API
         import agora.common.Set;
         import std.typecons;
 
-        void getNodes (QuorumConfig conf, ref bool[PublicKey] nodes)
+        void getNodes (in QuorumConfig conf, ref bool[PublicKey] nodes)
         {
             foreach (node; conf.nodes)
                 nodes[node] = true;


### PR DESCRIPTION
It is only the Config class that needs immutable fields,
due to being shared accross threads in our test-suite.

An immutable QuorumConfig can easily be constructed,
but forcing the fields to always be immutable makes
it impossible to use iterative building of quorums.

Required for #240