### PR TITLE
Support deserialization of `const` and `immutable` types

### DIFF
--- a/source/agora/common/Deserializer.d
+++ b/source/agora/common/Deserializer.d
@@ -15,7 +15,6 @@ module agora.common.Deserializer;
 
 import agora.common.Types;
 import agora.common.crypto.Key;
-import std.range.primitives;
 
 import std.range;
 import std.traits;

--- a/source/agora/consensus/Genesis.d
+++ b/source/agora/consensus/Genesis.d
@@ -115,3 +115,9 @@ version (unittest)
         assert(getGenesisKeyPair().address == GenesisOutputAddress);
     }
 }
+
+unittest
+{
+    testSymmetry(GenesisTransaction);
+    testSymmetry(GenesisBlock);
+}

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -782,9 +782,9 @@ public class BlockStorage : IBlockStorage
         ubyte[Hash.sizeof] hash;
         foreach (idx; 0 .. record_count)
         {
-            deserializePart(height, dg, CompactMode.No);
+            height = deserializeFull!size_t(dg, CompactMode.No);
             idx_file.rawRead(hash);
-            deserializePart(pos, dg, CompactMode.No);
+            pos    = deserializeFull!size_t(dg, CompactMode.No);
             // add to index of heigth
             this.height_idx.insert(HeightPosition(height, pos));
             // add to index of hash


### PR DESCRIPTION
Here we are.
There are two things left to do after this:
- Replace `deserialize` with `T.fromBinary!T(dg)` and return new instances;
- Unify `deserializePart` / `deserializeFull` into two overloads that take either a delegate or a `ubyte[]` as first argument, and `CompactMode` as second argument

But since we can now deserialize `immutable(Block)` it is pretty neat.