### PR TITLE
Remove redundant deserialize methods

### DIFF
--- a/source/agora/common/Deserializer.d
+++ b/source/agora/common/Deserializer.d
@@ -30,8 +30,7 @@ unittest
     import agora.consensus.Genesis;
 
     ubyte[] block_bytes = serializeFull(GenesisBlock);
-    // TODO: This trigger a DMD bug about array comparison
-    assert(cast(const)deserializeFull!Block(block_bytes) == GenesisBlock);
+    assert(deserializeFull!(const(Block))(block_bytes) == GenesisBlock);
 
     // Check that there is no trailing data
     ubyte[] blocks_data = serializeFull(GenesisBlock) ~ serializeFull(GenesisBlock);
@@ -44,10 +43,8 @@ unittest
             return blocks_data[0 .. size];
         };
 
-        Block newblock;
-        newblock.deserialize(dg);
-        // TODO: This trigger a DMD bug about array comparison
-        assert(cast(const)newblock == GenesisBlock);
+        const newblock = deserializeFull!Block(dg);
+        assert(newblock == GenesisBlock);
     }
 
     deserializeArrayEntry();

--- a/source/agora/common/TransactionPool.d
+++ b/source/agora/common/TransactionPool.d
@@ -443,7 +443,6 @@ unittest
     // deserialize the transactions
     txs_bytes.each!((data)
         {
-            Transaction tx;
             scope DeserializeDg dg = (size) nothrow @safe
             {
                 ubyte[] res = data[0 .. size];
@@ -451,8 +450,7 @@ unittest
                 return res;
             };
 
-            tx.deserialize(dg);
-            txs ~= tx;
+            txs ~= deserializeFull!Transaction(dg);
         });
 
     auto pool_txs = pool.take(txs.length);

--- a/source/agora/common/crypto/ECC.d
+++ b/source/agora/common/crypto/ECC.d
@@ -20,6 +20,7 @@ module agora.common.crypto.ECC;
 import agora.common.Deserializer;
 import agora.common.Hash;
 import agora.common.Serializer;
+import agora.common.Types;
 
 import geod24.bitblob;
 import libsodium;
@@ -164,28 +165,13 @@ public struct Scalar
     {
         dg(this.data[]);
     }
-
-    /***************************************************************************
-
-        Deserialization
-
-        Params:
-            dg = deserialize function accumulator
-
-    ***************************************************************************/
-
-    public void deserialize (scope DeserializeDg dg) @safe
-    {
-        this.data = typeof(this.data)(dg(crypto_core_ed25519_SCALARBYTES));
-    }
 }
 
 ///
 unittest
 {
-    Scalar scalar = Scalar.random();
-    auto bytes = scalar.serializeFull();
-    assert(bytes.deserializeFull!Scalar == scalar);
+    testSymmetry!Scalar();
+    testSymmetry(Scalar.random());
 }
 
 /*******************************************************************************
@@ -306,29 +292,18 @@ public struct Point
     {
         dg(this.data[]);
     }
-
-    /***************************************************************************
-
-        Deserialization
-
-        Params:
-            dg = deserialize function accumulator
-
-    ***************************************************************************/
-
-    public void deserialize (scope DeserializeDg dg) @safe
-    {
-        this.data = typeof(this.data)(dg(crypto_core_ed25519_BYTES));
-    }
 }
 
-///
+// Test serialization
 unittest
 {
-    Point point = Scalar.random().toPoint();
-    auto bytes = point.serializeFull();
-    assert(bytes.deserializeFull!Point == point);
+    testSymmetry!Point();
+    testSymmetry(Scalar.random().toPoint());
+}
 
+// Test sorting (`opCmp`)
+unittest
+{
     Point[] points = [
         Point.fromString(
             "0x44404b654d6ddf71e2446eada6acd1f462348b1b17272ff8f36dda3248e08c81"),

--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -61,13 +61,6 @@ public struct KeyPair
     /// Seed
     public const Seed seed;
 
-
-    /// Constructor accepting only 3 arguments
-    private this (typeof(KeyPair.tupleof) args) pure nothrow @safe @nogc
-    {
-        this.tupleof = args;
-    }
-
     /// Create a keypair from a `Seed`
     public static KeyPair fromSeed (Seed seed) nothrow @nogc
     {
@@ -97,6 +90,13 @@ public struct KeyPair
             assert(0);
         return KeyPair(pk, sk, seed);
     }
+}
+
+// Test (de)serialization
+unittest
+{
+    testSymmetry!KeyPair();
+    testSymmetry(KeyPair.random());
 }
 
 /// Represent a public key / address
@@ -242,14 +242,22 @@ public struct PublicKey
 public struct SecretKey
 {
     nothrow @nogc:
+    /// Alias to the BitBlob type
+    private alias DataType = BitBlob!(crypto_sign_ed25519_SECRETKEYBYTES * 8);
 
-    /*private*/ BitBlob!(crypto_sign_ed25519_SECRETKEYBYTES * 8) data;
+    /*private*/ DataType data;
     alias data this;
 
-    /// Constructor accepting only 1 argument
-    private this (typeof(this.tupleof) args)
+    /// Construct an instance from binary data
+    public this (const DataType args) pure nothrow @safe @nogc
     {
-        this.tupleof = args;
+        this.data = args;
+    }
+
+    /// Ditto
+    public this (const ubyte[] args) pure nothrow @safe @nogc
+    {
+        this.data = args;
     }
 
     /***************************************************************************
@@ -275,16 +283,33 @@ public struct SecretKey
     }
 }
 
+
+// Test (de)serialization
+unittest
+{
+    testSymmetry!SecretKey();
+    testSymmetry(KeyPair.random().secret);
+}
+
 /// A Stellar seed
 public struct Seed
 {
-    /*private*/ BitBlob!(crypto_sign_ed25519_SEEDBYTES * 8) data;
+    /// Alias to the BitBlob type
+    private alias DataType = BitBlob!(crypto_sign_ed25519_SEEDBYTES * 8);
+
+    /*private*/ DataType data;
     alias data this;
 
-    /// Constructor accepting only 1 argument
-    private this (typeof(Seed.tupleof) args)
+    /// Construct an instance from binary data
+    public this (const DataType args) pure nothrow @safe @nogc
     {
-        this.tupleof = args;
+        this.data = args;
+    }
+
+    /// Ditto
+    public this (const ubyte[] args) pure nothrow @safe @nogc
+    {
+        this.data = args;
     }
 
     /// Uses Stellar's representation instead of hex
@@ -316,6 +341,13 @@ public struct Seed
         assert(validate(bin[0 .. $ - 2], bin[$ - 2 .. $]));
         return Seed(typeof(this.data)(bin[1 .. $ - 2]));
     }
+}
+
+// Test (de)serialization
+unittest
+{
+    testSymmetry!Seed();
+    testSymmetry(KeyPair.random().seed);
 }
 
 /// Discriminant for Stellar binary-encoded user-facing data

--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -102,13 +102,16 @@ public struct KeyPair
 /// Represent a public key / address
 public struct PublicKey
 {
-    /*private*/ BitBlob!(crypto_sign_ed25519_PUBLICKEYBYTES * 8) data;
+    /// Alias to the BitBlob type
+    private alias DataType = BitBlob!(crypto_sign_ed25519_PUBLICKEYBYTES * 8);
+
+    /*private*/ DataType data;
     alias data this;
 
-    /// Construct an instance from the binary representation
-    private this (typeof(PublicKey.tupleof) args) pure nothrow @safe @nogc
+    /// Construct an instance from binary data
+    public this (const DataType args) pure nothrow @safe @nogc
     {
-        this.tupleof = args;
+        this.data = args;
     }
 
     /// Ditto
@@ -182,21 +185,6 @@ public struct PublicKey
         dg(this.data[]);
     }
 
-    /***************************************************************************
-
-        Key Deserialization
-
-        Params:
-            dg = deserialize function
-
-    ***************************************************************************/
-
-    public void deserialize (scope DeserializeDg dg) @safe
-    {
-        alias DType = typeof(this.data);
-        this.data = DType(dg(DType.sizeof));
-    }
-
     ///
     unittest
     {
@@ -219,10 +207,8 @@ public struct PublicKey
     /// PublicKey serialize & deserialize
     unittest
     {
-        KeyPair kp = KeyPair.random();
-        PublicKey address = kp.address;
-        auto bytes_address = serializeFull(address);
-        assert(deserializeFull!PublicKey(bytes_address) == address);
+        testSymmetry!PublicKey();
+        testSymmetry(KeyPair.random().address);
     }
 
     /***************************************************************************

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -100,30 +100,6 @@ public struct BlockHeader
         foreach (enrollment; this.enrollments)
             serializePart(enrollment, dg);
     }
-
-    /***************************************************************************
-
-        Block Header Deserialization
-
-        Params:
-            dg = deserialize function accumulator
-
-    ***************************************************************************/
-
-    public void deserialize (scope DeserializeDg dg) @safe
-    {
-        this.prev_block = Hash(dg(Hash.sizeof));
-        deserializePart(this.height, dg);
-        this.merkle_root = Hash(dg(Hash.sizeof));
-        deserializePart(this.validators, dg);
-        deserializePart(this.signature, dg);
-
-        size_t enrollments_size;
-        deserializePart(enrollments_size, dg);
-        this.enrollments = uninitializedArray!(Enrollment[])(enrollments_size);
-        foreach (ref val; this.enrollments)
-            deserializePart(val, dg);
-    }
 }
 
 /// hashing test
@@ -191,31 +167,6 @@ public struct Block
         serializePart(this.merkle_tree.length, dg);
         foreach (ref merkle; this.merkle_tree)
             dg(merkle[]);
-    }
-
-    /***************************************************************************
-
-        Block Deserialization
-
-        Params:
-            dg = deserialize function accumulator
-
-    ***************************************************************************/
-
-    public void deserialize (scope DeserializeDg dg) @safe
-    {
-        deserializePart(this.header, dg);
-
-        size_t size;
-        deserializePart(size, dg);
-        this.txs.length = size;
-        foreach (ref tx; this.txs)
-            deserializePart(tx, dg);
-
-        deserializePart(size, dg);
-        this.merkle_tree.length = size;
-        foreach (ref h; this.merkle_tree)
-            deserializePart(h, dg);
     }
 
     /***************************************************************************

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -77,36 +77,6 @@ public struct Transaction
             serializePart(output, dg);
     }
 
-    /***************************************************************************
-
-        Transactions deserialization
-
-        Params:
-            dg = Deserialize function
-
-    ***************************************************************************/
-
-    public void deserialize (scope DeserializeDg dg) @safe
-    {
-        deserializePart(this.type, dg);
-
-        size_t input_size;
-        deserializePart(input_size, dg);
-        this.inputs.length = input_size;
-
-        // deserialize and generate inputs
-        foreach (ref input; this.inputs)
-            deserializePart(input , dg);
-
-        size_t output_size;
-        deserializePart(output_size, dg);
-        this.outputs.length = output_size;
-
-        // deserialize and generate outputs
-        foreach (ref output; this.outputs)
-            deserializePart(output, dg);
-    }
-
     /// Support for sorting transactions
     public int opCmp (ref const(Transaction) other) const nothrow @safe @nogc
     {

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -541,7 +541,7 @@ public class BlockStorage : IBlockStorage
             pos += size;
             return res;
         };
-        block.deserialize(dg);
+        block = deserializeFull!Block(dg);
     }
 
     /***************************************************************************


### PR DESCRIPTION
Now that the deserializer is a lot smarter, we don't need all that code.
Also added tests for things which lacked them.

Note that currently, `SecretKey`, `Seed`, and `KeyPair` are not serialized, only `PublicKey`.
Nonetheless, added a test for it just in case. In the future we can probably make it smarter (e.g. for `KeyPair` one just have to serialize the seed...)