### PR TITLE
Remove superfluous deserializePart overload

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -294,18 +294,13 @@ public class BanManager
 
     private void deserialize (scope DeserializeDg dg) @safe
     {
-        size_t length;
-        deserializePart(length, dg);
+        size_t length = deserializeFull!size_t(dg);
 
         // deserialize and generate inputs
         foreach (idx; 0 .. length)
         {
-            Address key;
-            deserializePart(key, dg);
-
-            Status value;
-            deserializePart(value, dg);
-
+            Address key = deserializeFull!Address(dg);
+            Status value = deserializeFull!Status(dg);
             this.ips[key] = value;
         }
     }

--- a/source/agora/common/Deserializer.d
+++ b/source/agora/common/Deserializer.d
@@ -68,10 +68,8 @@ unittest
 
         void deserialize (scope DeserializeDg dg) @safe
         {
-            deserializePart(this.i, dg);
-            char[] buffer;
-            deserializePart(buffer, dg);
-            this.s = buffer.idup;
+            this.i = deserializeFull!uint( dg);
+            this.s = deserializeFull!string(dg);
         }
     }
 
@@ -138,12 +136,6 @@ public T deserializeFull (T) (scope ubyte[] data) @safe
         return res;
     };
     return deserializeFull!T(dg);
-}
-
-/// Ditto
-public void deserializePart (T) (ref T record, scope DeserializeDg dg) @safe
-{
-    record = deserializeFull!T(dg);
 }
 
 /// Ditto

--- a/source/agora/common/Set.d
+++ b/source/agora/common/Set.d
@@ -98,29 +98,11 @@ public struct Set (T)
 
     public void deserialize (scope DeserializeDg dg) @safe
     {
-        size_t length;
-        deserializePart(length, dg);
+        size_t length = deserializeFull!size_t(dg);
 
         // deserialize and generate inputs
         foreach (idx; 0 .. length)
-        {
-            import std.range;
-            import std.traits;
-
-            static if (isArray!T)  // special-case
-            {
-                alias MutableArray(T) = Unqual!(ElementEncodingType!T)[];
-                MutableArray!T value;
-                deserializePart(value, dg);
-                this._set[value.idup] = true;
-            }
-            else
-            {
-                T value;
-                deserializePart(value, dg);
-                this._set[value] = true;
-            }
-        }
+            this._set[deserializeFull!T(dg)] = true;
     }
 }
 

--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -95,7 +95,7 @@ private void testSymmetryImpl (T) (const auto ref T value, string typename)
                 stderr.writeln("Deserialization of ", typename, " failed. Binary data:");
                 stderr.writeln(serialized);
             }
-        T deserialized = serialized.deserializeFull!T();
+        const deserialized = serialized.deserializeFull!(T)();
         testing = true;
         assert(deserialized == value,
                format("Serialization mismatch for %s! Expected:\n%s\n\ngot:\n%s\n\nBinary data:\n%s",

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -336,6 +336,13 @@ unittest
     testSymmetry(freeze_tx);
 }
 
+unittest
+{
+    import agora.common.Set;
+    auto tx_set = Set!Transaction.from([Transaction.init]);
+    testSymmetry(tx_set);
+}
+
 /// Transaction type hashing for unittest
 unittest
 {


### PR DESCRIPTION
It is not necessary anymore, since it doesn't do anything in place.
The whole distinction between deserializePart / deserializeFull is also moot,
and should be removed in a later commit.