### PR TITLE
Ellide some copy of C++ structs

### DIFF
--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -623,7 +623,7 @@ public SCPQuorumSet toSCPQuorumSet ( in QuorumConfig quorum_conf )
 
 *******************************************************************************/
 
-public QuorumConfig toQuorumConfig ( in SCPQuorumSet scp_quorum )
+public QuorumConfig toQuorumConfig (const ref SCPQuorumSet scp_quorum)
 {
     import std.conv;
     import scpd.types.Stellar_types : Hash, NodeID;
@@ -634,7 +634,7 @@ public QuorumConfig toQuorumConfig ( in SCPQuorumSet scp_quorum )
         nodes ~= PublicKey(node[]);
 
     QuorumConfig[] quorums;
-    foreach (sub_quorum; scp_quorum.innerSets.constIterator)
+    foreach (ref sub_quorum; scp_quorum.innerSets.constIterator)
         quorums ~= toQuorumConfig(sub_quorum);
 
     QuorumConfig quorum =

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -107,9 +107,7 @@ extern(D):
         this.ledger = ledger;
         this.peers = peers;
 
-        // cast: see makeSharedSCPQuorumSet() in Cpp.d
-        auto local_quorum_set = this.scp.getLocalQuorumSet();
-        auto localQSet = makeSharedSCPQuorumSet(local_quorum_set);
+        auto localQSet = makeSharedSCPQuorumSet(this.scp.getLocalQuorumSet());
 
         const bytes = ByteSlice.make(XDRToOpaque(*localQSet));
         auto quorum_hash = sha256(bytes);


### PR DESCRIPTION
Pretty trivial, avoid postblitting the struct when we don't have to.