### PR TITLE
Change API for 'hasPreimage' to 'getPreimage'

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -17,6 +17,7 @@ module agora.api.FullNode;
 
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
+import agora.consensus.data.PreimageInfo;
 import agora.common.Types;
 import agora.common.Set;
 import agora.common.Serializer;
@@ -184,4 +185,23 @@ public interface API
 
     @method(HTTPMethod.GET)
     public bool hasEnrollment (Hash enroll_hash);
+
+    /***************************************************************************
+
+        Get validator's pre-image inforamtion
+
+        API:
+            GET /get_preimage
+
+        Params:
+            enroll_key = The key for the enrollment in which the pre-image is
+                contained.
+
+        Returns:
+            preimage information of the validator if exists, otherwise
+                PreimageInfo.init
+
+    ***************************************************************************/
+
+    public PreimageInfo getPreimage (Hash enroll_key);
 }

--- a/source/agora/api/Validator.d
+++ b/source/agora/api/Validator.d
@@ -105,20 +105,4 @@ public interface API : agora.api.FullNode.API
     ***************************************************************************/
 
     public void receivePreimage (PreimageInfo preimage);
-
-    /***************************************************************************
-
-        Checks if a pre-image exists
-
-        Params:
-            enroll_key = The key for the enrollment in which the pre-image is
-                contained.
-            height = The block height of the preimage to check existence
-
-        Returns:
-            true if the pre-image exists
-
-    ***************************************************************************/
-
-    public bool hasPreimage (Hash enroll_key, ulong height);
 }

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -497,12 +497,6 @@ public class Node : API
             this.network.sendPreimage(preimage);
     }
 
-    /// GET: /has_preimage
-    public bool hasPreimage (Hash enroll_key, ulong height)
-    {
-        return this.enroll_man.hasPreimage(enroll_key, height);
-    }
-
     /// GET: /get_preimage
     public PreimageInfo getPreimage (Hash enroll_key)
     {

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -502,6 +502,14 @@ public class Node : API
     {
         return this.enroll_man.hasPreimage(enroll_key, height);
     }
+
+    /// GET: /get_preimage
+    public PreimageInfo getPreimage (Hash enroll_key)
+    {
+        PreimageInfo preimage;
+        this.enroll_man.getValidatorPreimage(enroll_key, preimage);
+        return preimage;
+    }
 }
 
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -450,7 +450,7 @@ public interface TestAPI : API
     public abstract Enrollment createEnrollmentData();
 
     ///
-    public abstract PreimageInfo getPreimage (uint height);
+    public abstract void broadcastPreimage (uint height);
 
     ///
     public abstract void updateEnrolledHeight (Hash enroll_key, ulong height);
@@ -555,12 +555,12 @@ public class TestNode : Node, TestAPI
         return enroll;
     }
 
-    /// Get a node's own pre-image information used when revealing it
-    public override PreimageInfo getPreimage (uint height)
+    /// Broadcast a pre-image information to the network
+    public override void broadcastPreimage (uint height)
     {
         PreimageInfo preimage;
         this.enroll_man.getPreimage(height, preimage);
-        return preimage;
+        this.receivePreimage(preimage);
     }
 
     /// Set a enrolled height for the enrollment

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -77,12 +77,11 @@ unittest
         retryFor(node.hasEnrollment(enroll.utxo_key) == true, 5.seconds));
 
     // tests for revealing a pre-image
-    auto preimage = node_1.getPreimage(1000);
-    node_1.receivePreimage(preimage);
+    node_1.broadcastPreimage(1000);
 
     // check if nodes contains the pre-image previously sent.
     nodes.each!(node =>
-        retryFor(node.hasPreimage(preimage.enroll_key, 999) == true, 5.seconds));
+        retryFor(node.hasPreimage(enroll.utxo_key, 999) == true, 5.seconds));
 }
 
 /// test for revealing a pre-image periodically

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -76,12 +76,18 @@ unittest
     nodes.each!(node =>
         retryFor(node.hasEnrollment(enroll.utxo_key) == true, 5.seconds));
 
+    // check if nodes don't have a pre-image yet
+    nodes.each!(node =>
+        retryFor(node.getPreimage(enroll.utxo_key) == PreimageInfo.init,
+            5.seconds));
+
     // tests for revealing a pre-image
     node_1.broadcastPreimage(1000);
 
-    // check if nodes contains the pre-image previously sent.
+    // check if nodes have a pre-image previously sent
     nodes.each!(node =>
-        retryFor(node.hasPreimage(enroll.utxo_key, 999) == true, 5.seconds));
+        retryFor(node.getPreimage(enroll.utxo_key) != PreimageInfo.init,
+            5.seconds));
 }
 
 /// test for revealing a pre-image periodically
@@ -140,6 +146,11 @@ unittest
     // making block but now the code is not merged so calling it is needed.
     nodes.each!(node => node.updateEnrolledHeight(enroll.utxo_key, 1));
 
+    // check if nodes don't have a validator's pre-image yet
+    nodes.each!(node =>
+        retryFor(node.getPreimage(enroll.utxo_key) == PreimageInfo.init,
+            5.seconds));
+
     // make a block with height of 2
     Transaction[] txs2;
     foreach (idx; 0 .. Block.TxsInBlock)
@@ -163,6 +174,6 @@ unittest
     // check if nodes have a pre-image newly sent
     // during creating transactions for the new block
     nodes.each!(node =>
-        retryFor(node.hasPreimage(enroll.utxo_key,
-            EnrollmentManager.PreimageRevealPeriod + 2), 5.seconds));
+        retryFor(node.getPreimage(enroll.utxo_key) != PreimageInfo.init,
+            5.seconds));
 }


### PR DESCRIPTION
The getPreimage API is created into the FullNode API and the hasPreimage API is removed. 

In EnrollmentManager, there are two functions getting a pre-image information for a validator or a node, which is confusing now but will be handled in bpfkorea#604 issue.

For unit test, the broadcastPreimage API is added in TestAPI.

Fixes #567
Fixes #566