### PR TITLE
Refactor some Nominator & NetworkManager code

### DIFF
--- a/source/agora/api/Validator.d
+++ b/source/agora/api/Validator.d
@@ -84,17 +84,16 @@ public interface API : agora.api.FullNode.API
 
     /***************************************************************************
 
-        Receives an SCP envelope and processes it
+        Receives an SCP envelope and processes it.
+        The node does not respond with any status code,
+        clients which call this API can & should call it asynchronously.
 
         Params:
             envelope = Envelope to process (See Stellar_SCP)
 
-        Returns:
-            true if the envelope was successfully processed
-
     ***************************************************************************/
 
-    public bool receiveEnvelope (SCPEnvelope envelope);
+    public void receiveEnvelope (SCPEnvelope envelope);
 
     /***************************************************************************
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -23,7 +23,7 @@ import agora.consensus.data.Block;
 import agora.consensus.data.ConsensusData;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
-import agora.network.NetworkClient;
+import agora.network.NetworkManager;
 import agora.node.Ledger;
 import agora.utils.Log;
 import agora.utils.PrettyPrinter;
@@ -50,6 +50,9 @@ public extern (C++) class Nominator : SCPDriver
     /// SCP instance
     protected SCP* scp;
 
+    /// Network manager for gossiping SCPEnvelopes
+    private NetworkManager network;
+
     /// Key pair of this node
     private KeyPair key_pair;
 
@@ -58,9 +61,6 @@ public extern (C++) class Nominator : SCPDriver
 
     /// Ledger instance
     private Ledger ledger;
-
-    /// This node's quorum node clients
-    private NetworkClient[PublicKey] peers;
 
     /// The set of active timers
     /// Todo: SCPTests.cpp uses fake timers,
@@ -95,6 +95,7 @@ extern(D):
         Constructor
 
         Params:
+            network = the network manager for gossiping SCP messages
             key_pair = the key pair of this node
             ledger = needed for SCP state restoration & block validation
             taskman = used to run timers
@@ -102,9 +103,10 @@ extern(D):
 
     ***************************************************************************/
 
-    public this (KeyPair key_pair, Ledger ledger, TaskManager taskman,
-        ref const QuorumConfig config)
+    public this (NetworkManager network, KeyPair key_pair, Ledger ledger,
+        TaskManager taskman, ref const QuorumConfig config)
     {
+        this.network = network;
         this.quorum_conf = config;
         this.key_pair = key_pair;
         auto node_id = NodeID(StellarHash(key_pair.address[]));
@@ -183,7 +185,6 @@ extern(D):
     {
         import scpd.scp.QuorumSetUtils;
 
-        import agora.network.NetworkClient;
         auto scp_quorum = toSCPQuorumSet(config);
         normalizeQSet(scp_quorum);
 
@@ -200,41 +201,6 @@ extern(D):
         }
 
         return scp_quorum;
-    }
-
-    /***************************************************************************
-
-        Set up the clients to which we'll be exchanging consensus messages with.
-
-        Params:
-            clients = the set of all clients we're networked with. A subset
-                      of the clients are in our quorum set, these will be
-                      the clients we exchange SCP messages with.
-
-    ***************************************************************************/
-
-    public void setupNetwork (NetworkClient[PublicKey] clients)
-    {
-        import std.algorithm;
-        import std.array;
-        import std.typecons;
-
-        void getNodes (in QuorumConfig conf, ref Set!PublicKey nodes)
-        {
-            foreach (node; conf.nodes)
-                nodes.put(node);
-
-            foreach (sub_conf; conf.quorums)
-                getNodes(sub_conf, nodes);
-        }
-
-        Set!PublicKey quorum_keys;
-        getNodes(this.quorum_conf, quorum_keys);
-
-        this.peers = clients.byKeyValue
-            .filter!(item => item.key in quorum_keys)
-            .map!(item => tuple(item.key, item.value))
-            .assocArray();
     }
 
     /***************************************************************************
@@ -452,15 +418,12 @@ extern(D):
     {
         try
         {
-            foreach (key, node; this.peers)
-            {
-                SCPEnvelope env = cast()envelope;
+            SCPEnvelope env = cast()envelope;
 
-                // deep-dup as SCP stores pointers to memory on the stack
-                env.statement.pledges = SCPStatement._pledges_t.fromString(
-                    env.statement.pledges.toString());
-                node.sendEnvelope(env);
-            }
+            // deep-dup as SCP stores pointers to memory on the stack
+            env.statement.pledges = SCPStatement._pledges_t.fromString(
+                env.statement.pledges.toString());
+            this.network.gossipEnvelope(env);
         }
         catch (Exception ex)
         {

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -327,9 +327,10 @@ extern(D):
 
     ***************************************************************************/
 
-    public bool receiveEnvelope (SCPEnvelope envelope) @trusted
+    public void receiveEnvelope (SCPEnvelope envelope) @trusted
     {
-        return this.scp.receiveEnvelope(envelope) == SCP.EnvelopeState.VALID;
+        if (this.scp.receiveEnvelope(envelope) != SCP.EnvelopeState.VALID)
+            log.info("Rejected invalid envelope: {}", envelope);
     }
 
     extern (C++):

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -480,14 +480,14 @@ public class NetworkManager
 
     /***************************************************************************
 
-        Sends the transaction to all the listeners.
+        Gossips the transaction to all the listeners.
 
         Params:
-            tx = the transaction to send
+            tx = the transaction to gossip
 
     ***************************************************************************/
 
-    public void sendTransaction (Transaction tx) @safe
+    public void gossipTransaction (Transaction tx) @safe
     {
         foreach (ref node; this.peers)
         {

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -203,7 +203,7 @@ public class Node : API
         if (this.ledger.acceptTransaction(tx))
         {
             // gossip first
-            this.network.sendTransaction(tx);
+            this.network.gossipTransaction(tx);
 
             // then nominate
             if (this.config.node.is_validator)

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -231,18 +231,15 @@ public class Node : API
         Params:
             envelope = the SCP envelope
 
-        Returns:
-            true if the envelope was accepted
-
     ***************************************************************************/
 
-    public bool receiveEnvelope (SCPEnvelope envelope)
+    public void receiveEnvelope (SCPEnvelope envelope)
     {
         // we should not receive SCP messages unless we're a validator node
         if (!this.config.node.is_validator)
-            return false;
+            return;
 
-        return this.nominator.receiveEnvelope(envelope);
+        this.nominator.receiveEnvelope(envelope);
     }
 
     /// GET: /has_transaction_hash

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -124,18 +124,18 @@ public class Node : API
             400, Json("The query was incorrect"), string.init, int.init);
 
         if (this.config.node.is_validator)
-            this.nominator = this.getNominator(this.config.node.key_pair,
-                this.ledger, this.taskman, this.config.quorum);
+        {
+            this.nominator = this.getNominator(this.network,
+                this.config.node.key_pair, this.ledger, this.taskman,
+                this.config.quorum);
+        }
     }
 
     /// The first task method, loading from disk, node discovery, etc
     public void start ()
     {
         log.info("Doing network discovery..");
-        auto peers = this.network.discover();
-
-        if (this.config.node.is_validator)
-            this.nominator.setupNetwork(peers);
+        this.network.discover();
 
         bool isNominating ()
         {
@@ -425,6 +425,7 @@ public class Node : API
         simulate byzantine nodes.
 
         Params:
+            network = the network manager for gossiping SCPEnvelopes
             key_pair = the key pair of the node
             ledger = Ledger instance
             taskman = the task manager
@@ -435,10 +436,10 @@ public class Node : API
 
     ***************************************************************************/
 
-    protected Nominator getNominator (KeyPair key_pair, Ledger ledger,
-        TaskManager taskman, in QuorumConfig quorum_config)
+    protected Nominator getNominator (NetworkManager network, KeyPair key_pair,
+        Ledger ledger, TaskManager taskman, in QuorumConfig quorum_config)
     {
-        return new Nominator(key_pair, ledger, taskman, quorum_config);
+        return new Nominator(network, key_pair, ledger, taskman, quorum_config);
     }
 
     /***************************************************************************


### PR DESCRIPTION
This is the first part of fixing https://github.com/bpfkorea/agora/issues/606

While implementing the feature, I've realized there are leaky abstractions here. In fact SCP only requires two networking functionalities:

- receive an SCP message
- gossip it

The second part can be left to the NetworkManager, as it also deals with features such as node banning, receiving new network connections (to be done), etc.