### PR TITLE
Reach consensus on transaction and enrollment set

### DIFF
--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -117,9 +117,9 @@ public class Node : API
         scope (failure) this.pool.shutdown();
         this.utxo_set = this.getUtxoSet(config.node.data_dir);
         scope (failure) this.utxo_set.shutdown();
-        this.ledger = new Ledger(this.pool, this.utxo_set, this.storage, config.node);
         this.enroll_man = this.getEnrollmentManager(config.node.data_dir, config.node);
         scope (failure) this.enroll_man.shutdown();
+        this.ledger = new Ledger(this.pool, this.utxo_set, this.storage, this.enroll_man, config.node);
         this.exception = new RestException(
             400, Json("The query was incorrect"), string.init, int.init);
 


### PR DESCRIPTION
The enrollments to be included in a block must first
be voted on by the consensus protocol.

Changed the Nominator class to reach consensus on
a structure which includes both transactions
and the enrollment set.

@AndrejMitrovic ref https://github.com/AndrejMitrovic/agora/commit/999e03196020621476f71c025e8f18e2f0bfbf0c

Relates to #565 