### PR TITLE
Nominator: Don't try to communicate with ourselves

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -220,7 +220,10 @@ extern(D):
         void getNodes (in QuorumConfig conf, ref Set!PublicKey nodes)
         {
             foreach (node; conf.nodes)
-                nodes.put(node);
+            {
+                if (node != this.key_pair.address)  // filter ourselves
+                    nodes.put(node);
+            }
 
             foreach (sub_conf; conf.quorums)
                 getNodes(sub_conf, nodes);


### PR DESCRIPTION
The quorum configuration includes the node itself, so it needs to be filtered out.

It didn't cause any damage because SCP just treats it as an invalid message.