### PR TITLE
Sets the address of the node to the argument in system integration test

### DIFF
--- a/ci/system_integration_test.d
+++ b/ci/system_integration_test.d
@@ -25,7 +25,10 @@ immutable TestContainer = [ "docker", "run", "agora", "--help", ];
 immutable DockerComposeUp = [ "docker-compose", "-f", ComposeFile, "up", "-d", ];
 immutable DockerComposeDown = [ "docker-compose", "-f", ComposeFile, "down", ];
 immutable DockerComposeLogs = [ "docker-compose", "-f", ComposeFile, "logs", "-t", ];
-immutable RunIntegrationTests = [ "dub", "--root", IntegrationPath, ];
+immutable RunIntegrationTests = [ "dub", "--root", IntegrationPath, "--",
+                                    "http://127.0.0.1:4000",
+                                    "http://127.0.0.1:4001",
+                                    "http://127.0.0.1:4002"];
 immutable Cleanup = [ "rm", "-rf", IntegrationPath.buildPath("node/0/.cache/"),
                       IntegrationPath.buildPath("node/1/.cache/"),
                       IntegrationPath.buildPath("node/2/.cache/")];


### PR DESCRIPTION
I have improved the system integration test so that I can set the address of the node as an argument.

Fixed #592 
