### PR TITLE
Use SCPStatementType type directly in _pledges_t

### DIFF
--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -93,7 +93,7 @@ struct SCPStatement {
         //using _xdr_case_type = xdr::xdr_traits<SCPStatementType>::case_type;
         //private:
         //_xdr_case_type type_;
-        int32_t type_;
+        SCPStatementType type_;
         union {
             _prepare_t prepare_;
             _confirm_t confirm_;
@@ -104,7 +104,7 @@ struct SCPStatement {
         /// Support (de)serialization from Vibe.d
         extern(D) string toString () const @trusted
         {
-            switch (this.type_)
+            final switch (this.type_)
             {
             case SCPStatementType.SCP_ST_PREPARE:
                 return "0" ~ serializeToJsonString(this.prepare_);
@@ -114,8 +114,6 @@ struct SCPStatement {
                 return "2" ~ serializeToJsonString(this.externalize_);
             case SCPStatementType.SCP_ST_NOMINATE:
                 return "3" ~ serializeToJsonString(this.nominate_);
-            default:
-                assert(0);
             }
         }
 


### PR DESCRIPTION
@Geod24 I've noticed that `log.info` doesn't format enums nicely. For example, it will not print out the name of the enum, but instead just its value. So stringification will only be better if `format` is used from Phobos.

E.g.:

```D
enum E { foo, bar }
E e = E.bar;
log.info("{}", e);  // will just print out '1' instead of 'bar'
```