### PR TITLE
Fix undefined identifier error on v0.x.x

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -373,8 +373,8 @@ extern(D):
 
             if (auto fail_reason = this.ledger.validateConsensusData(data))
             {
-                log.error("validateValue(): Invalid tx set: {}. Reason: {}",
-                    tx_set, fail_reason);
+                log.error("validateValue(): Validation failed: {}. Data: {}",
+                    fail_reason, data);
                 return ValidationLevel.kInvalidValue;
             }
         }


### PR DESCRIPTION
This is currently triggering because two PRs that conflicted were rebased.
In particular, the logging was extended, but tx_set was wrapped in ConsensusData.
This also invert the order of argument, putting the reason first,
as it makes it more visible, both by being first and by being much shorter
than ConsensusData.