### PR TITLE
Don't accept outdated SCP messages

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -67,9 +67,6 @@ public extern (C++) class Nominator : SCPDriver
     /// Similar to how we use FakeClockBanManager!
     private Set!ulong timers;
 
-    /// The set of externalized slot indices
-    private Set!uint64_t externalized_slots;
-
     /// The quorum set
     private SCPQuorumSetPtr[StellarHash] quorum_set;
 
@@ -371,9 +368,8 @@ extern(D):
     {
         scope (failure) assert(0);
 
-        if (slot_idx in this.externalized_slots)
+        if (slot_idx <= this.ledger.getBlockHeight())
             return;  // slot was already externalized
-        this.externalized_slots.put(slot_idx);
 
         auto bytes = cast(ubyte[])value[];
         auto data = deserializeFull!ConsensusData(bytes);

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -292,6 +292,14 @@ extern(D):
 
     public void receiveEnvelope (SCPEnvelope envelope) @trusted
     {
+        const cur_height = this.ledger.getBlockHeight();
+        if (envelope.statement.slotIndex <= cur_height)
+        {
+            log.trace("Rejected envelope with outdated slot #{} (ledger: #{})",
+                envelope.statement.slotIndex, cur_height);
+            return;  // slot was already externalized, ignore outdated message
+        }
+
         if (this.scp.receiveEnvelope(envelope) != SCP.EnvelopeState.VALID)
             log.info("Rejected invalid envelope: {}", envelope);
     }


### PR DESCRIPTION
I can't really think of a way to test this, because the only thing that changes here is the logging. The state machine (Ledger) wouldn't change if for example an outdated SCP Externalize message was accepted (it would be a double-spend).

This eliminates the various "tx not found in tx set" error messages we frequently saw in the CI logs.