### PR TITLE
Deserializer: Always validate strings, introduce fromBinary, handle pointers

### DIFF
--- a/source/agora/common/Serializer.d
+++ b/source/agora/common/Serializer.d
@@ -428,7 +428,7 @@ public size_t deserializeLength (
         T = Type of data to deserialize
         data = Binary serialized representation of `T` to be deserialized
         dg   = Delegate to read binary data for deserialization
-        compact = Whether integers are serialized in variable-length form
+        opts = Deserialization options (see the type's documentation for a list)
 
     Returns:
         The deserialized data type

--- a/source/agora/common/Serializer.d
+++ b/source/agora/common/Serializer.d
@@ -469,21 +469,18 @@ public T deserializeFull (T) (scope DeserializeDg dg,
     else static if (is(T : BitBlob!N, size_t N))
         return T(dg(T.Width));
 
-    // Array deserialization can be optimized in many occasions
+    // Validate strings as they are supposed to be UTF-8 encoded
     else static if (isNarrowString!T)
     {
         alias E = ElementEncodingType!T;
         size_t length = deserializeLength(dg, opts.maxLength);
         T process () @trusted
-        out (record)
         {
-            debug
-            {
-                import std.utf;
-                record.validate();
-            }
+            import std.utf;
+            auto record = cast(E[]) (dg(E.sizeof * length));
+            record.validate();
+            return record;
         }
-        do { return cast(E[]) (dg(E.sizeof * length)); }
         return process().dup;
     }
 


### PR DESCRIPTION
Yet another deserialization PR. Better reviewed commit-by-commit.