### PR TITLE
Remove '-lsodium' from link flags

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -39,7 +39,7 @@
     ],
 
     "dflags": [ "-extern-std=c++14" ],
-    "lflags": [ "-lsodium", "-lstdc++", "-lsqlite3" ],
+    "lflags": [ "-lstdc++", "-lsqlite3" ],
     "buildRequirements": [ "allowWarnings" ],
 
     "configurations": [

--- a/tests/runner.d
+++ b/tests/runner.d
@@ -70,11 +70,20 @@ private string[] getImportPaths ()
 /// Get the linker flags from dub
 private string[] getLflags ()
 {
-    auto pp = pipeProcess(["dub", "--root=" ~ RootPath, "describe", "--data=lflags", "--data-list"]);
-    if (pp.pid.wait() != 0)
+    /// TODO: Those flags need to be hardcoded because of DUB issue
+    /// https://github.com/dlang/dub/issues/1032
+    version (none)
     {
-        pp.stderr.byLine.each!(a => writeln("[fatal]\t", a));
-        return null;
+        auto pp = pipeProcess(["dub", "--root=" ~ RootPath, "describe", "--data=lflags", "--data-list"]);
+        if (pp.pid.wait() != 0)
+        {
+            pp.stderr.byLine.each!(a => writeln("[fatal]\t", a));
+            return null;
+        }
+        return pp.stdout.byLineCopy.array;
     }
-    return pp.stdout.byLineCopy.array;
+    else
+    {
+        return [ "-lsodium" ];
+    }
 }


### PR DESCRIPTION
It is provided by the libsoidumd submodules, which uses 'libs',
which depends on pkgconfig (and so offers a more robust resolution).