### PR TITLE
dub: try to fix build.d not being run sometimes

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -11,7 +11,7 @@
     "targetType": "executable",
     "targetPath": "build",
     "excludedSourceFiles": [ "source/scpp/*.d" ],
-    "preBuildCommands": [ "source/scpp/build.d" ],
+    "preGenerateCommands": [ "source/scpp/build.d" ],
     "sourceFiles": [
         "source/scpp/build/BallotProtocol.o",
         "source/scpp/build/DUtils.o",


### PR DESCRIPTION
build.d contains all the logic for tracking file timestamps, but dub sometimes just doesn't run it.

I found this forum thread about it: https://forum.dlang.org/post/mzipqtnimvexeddjtcju@forum.dlang.org

This should hopefully fix that issue.