### PR TITLE
Fix network discovery & start Node asynchronously

### DIFF
--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -410,6 +410,7 @@ public class NetworkManager
             try
             {
                 auto net_info = node.getNetworkInfo();
+                this.addAddresses(net_info.addresses);
                 if (net_info.state == NetworkState.Complete)
                     return;  // done
 

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -134,16 +134,19 @@ public class Node : API
     /// The first task method, loading from disk, node discovery, etc
     public void start ()
     {
-        log.info("Doing network discovery..");
-        this.network.discover();
-
-        bool isNominating ()
+        this.taskman.runTask(
         {
-            return this.config.node.is_validator &&
-                this.nominator.isNominating();
-        }
+            log.info("Doing network discovery..");
+            this.network.discover();
 
-        this.network.startPeriodicCatchup(this.ledger, &isNominating);
+            bool isNominating ()
+            {
+                return this.config.node.is_validator &&
+                    this.nominator.isNominating();
+            }
+
+            this.network.startPeriodicCatchup(this.ledger, &isNominating);
+        });
     }
 
     /***************************************************************************

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -613,6 +613,9 @@ public struct TestConf
     /// the delay between request retries (in msecs)
     long retry_delay = 100;
 
+    /// minimum clients to connect to (defaults to nodes.length - 1)
+    size_t min_listeners;
+
     /// max retries before a request is considered failed
     size_t max_retries = 20;
 
@@ -674,7 +677,8 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             retry_delay : test_conf.retry_delay, // msecs
             max_retries : test_conf.max_retries,
             timeout : test_conf.timeout,
-            min_listeners : test_conf.nodes - 1,
+            min_listeners : test_conf.min_listeners == 0
+                ? test_conf.nodes - 1 : test_conf.min_listeners,
             max_listeners : (test_conf.max_listeners == 0)
                 ? test_conf.nodes - 1 : test_conf.max_listeners
         };

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -88,6 +88,9 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
+    import core.thread;
+    Thread.sleep(2.seconds);  // registerListener() can take a while..
+
     auto nodes = network.clients;
     auto node_1 = nodes[0];
 

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -37,3 +37,34 @@ unittest
                format("Node %s has %d peers: %s", key, addresses.length, addresses));
     }
 }
+
+/// test network discovery through the getNetworkInfo() API
+unittest
+{
+    import std.algorithm;
+    import std.format;
+
+    TestConf conf =
+    {
+        topology : NetworkTopology.FindNetwork,
+        nodes : 4,
+        min_listeners : 3,
+    };
+    auto network = makeTestNetwork(conf);
+
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+
+    try
+    {
+        network.waitForDiscovery();
+    }
+    catch (Throwable ex)
+    {
+        // discovery never reached
+        return;
+    }
+
+    assert(0);  // should not be reached
+}

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    Contains tests for the node network (P2P) behavior
+    Contains tests for the node discovery behavior
 
     Copyright:
         Copyright (c) 2019 BOS Platform Foundation Korea
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-module agora.test.Network;
+module agora.test.NetworkDiscovery;
 
 version (unittest):
 

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -55,16 +55,12 @@ unittest
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
+    network.waitForDiscovery();
 
-    try
+    foreach (key, node; network.nodes)
     {
-        network.waitForDiscovery();
+        auto addresses = node.client.getNetworkInfo().addresses.keys;
+        assert(addresses.sort.uniq.count == 3,
+               format("Node %s has %d peers: %s", key, addresses.length, addresses));
     }
-    catch (Throwable ex)
-    {
-        // discovery never reached
-        return;
-    }
-
-    assert(0);  // should not be reached
 }


### PR DESCRIPTION
This fixes the network discovery issue #647. While creating a test-case I've realized that #276 is actually blocking the implementation of a test-case. So this PR includes two fixes.

Fixes #276
Fixes #647