### PR TITLE
tests: Add missing network.waitForDiscovery() call

### DIFF
--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -201,6 +201,7 @@ unittest
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
+    network.waitForDiscovery();
 
     auto nodes = network.clients;
     auto node_1 = nodes[0];


### PR DESCRIPTION
Without this there are intermittent test-suite failures.