### PR TITLE
Add missing definition of operator() for hashing support

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -14,8 +14,10 @@
     "preGenerateCommands": [ "source/scpp/build.d" ],
     "sourceFiles": [
         "source/scpp/build/BallotProtocol.o",
+        "source/scpp/build/ByteSliceHasher.o",
         "source/scpp/build/DSCPUtils.o",
         "source/scpp/build/DUtils.o",
+        "source/scpp/build/HashOfHash.o",
         "source/scpp/build/Hex.o",
         "source/scpp/build/KeyUtils.o",
         "source/scpp/build/LocalNode.o",

--- a/dub.json
+++ b/dub.json
@@ -14,8 +14,8 @@
     "preGenerateCommands": [ "source/scpp/build.d" ],
     "sourceFiles": [
         "source/scpp/build/BallotProtocol.o",
-        "source/scpp/build/DUtils.o",
         "source/scpp/build/DSCPUtils.o",
+        "source/scpp/build/DUtils.o",
         "source/scpp/build/Hex.o",
         "source/scpp/build/KeyUtils.o",
         "source/scpp/build/LocalNode.o",

--- a/source/scpd/scp/SCP.d
+++ b/source/scpd/scp/SCP.d
@@ -26,6 +26,13 @@ import core.stdc.inttypes;
 
 extern(C++, `stellar`):
 
+// needed for some utility hashing routines
+extern(C++, `shortHash`) private void initialize_byteslice_hasher ();
+shared static this ()
+{
+    initialize_byteslice_hasher();
+}
+
 // typedef std::shared_ptr<SCPQuorumSet> SCPQuorumSetPtr;
 
 extern(C++, class) public struct SCP

--- a/source/scpp/src/crypto/ByteSliceHasher.cpp
+++ b/source/scpp/src/crypto/ByteSliceHasher.cpp
@@ -1,0 +1,29 @@
+// Copyright 2018 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ByteSliceHasher.h"
+#include <sodium.h>
+
+namespace stellar
+{
+namespace shortHash
+{
+static unsigned char sKey[crypto_shorthash_KEYBYTES];
+void
+initialize_byteslice_hasher()
+{
+    crypto_shorthash_keygen(sKey);
+}
+uint64_t
+computeHash(stellar::ByteSlice const& b)
+{
+    uint64_t res;
+    static_assert(sizeof(res) == crypto_shorthash_BYTES, "unexpected size");
+    crypto_shorthash(reinterpret_cast<unsigned char*>(&res),
+                     reinterpret_cast<const unsigned char*>(b.data()), b.size(),
+                     sKey);
+    return res;
+}
+}
+}

--- a/source/scpp/src/crypto/ByteSliceHasher.h
+++ b/source/scpp/src/crypto/ByteSliceHasher.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// Copyright 2018 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ByteSlice.h"
+
+namespace stellar
+{
+
+// shortHash provides a fast and relatively secure *randomized* hash function
+// this is suitable for keeping objects in memory but not for persisting objects
+// or cryptographic use
+namespace shortHash
+{
+void initialize_byteslice_hasher();
+uint64_t computeHash(stellar::ByteSlice const& b);
+}
+}

--- a/source/scpp/src/crypto/SecretKey.cpp
+++ b/source/scpp/src/crypto/SecretKey.cpp
@@ -5,6 +5,7 @@
 #include "crypto/SecretKey.h"
 #include "crypto/Hex.h"
 #include "crypto/StrKey.h"
+#include "util/HashOfHash.h"
 #include "util/Math.h"
 #include <sodium.h>
 
@@ -331,5 +332,16 @@ HashUtils::random()
     Hash res;
     randombytes_buf(res.data(), res.size());
     return res;
+}
+}
+
+namespace std
+{
+size_t
+hash<stellar::PublicKey>::operator()(stellar::PublicKey const& k) const noexcept
+{
+    assert(k.type() == stellar::PUBLIC_KEY_TYPE_ED25519);
+
+    return std::hash<stellar::uint256>()(k.ed25519());
 }
 }

--- a/source/scpp/src/util/HashOfHash.cpp
+++ b/source/scpp/src/util/HashOfHash.cpp
@@ -1,0 +1,15 @@
+#include "HashOfHash.h"
+#include "crypto/ByteSliceHasher.h"
+
+namespace std
+{
+
+size_t
+hash<stellar::uint256>::operator()(stellar::uint256 const& x) const noexcept
+{
+    size_t res =
+        stellar::shortHash::computeHash(stellar::ByteSlice(x.data(), 8));
+
+    return res;
+}
+}

--- a/source/scpp/src/util/HashOfHash.h
+++ b/source/scpp/src/util/HashOfHash.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <xdr/Stellar-types.h>
+
+namespace std
+{
+template <> struct hash<stellar::uint256>
+{
+    size_t operator()(stellar::uint256 const& x) const noexcept;
+};
+}


### PR DESCRIPTION
std::hash is used for things like storing structs in std::set / std::map.

Required for the quorum intersection checker.