### PR TITLE
Add rudimentary bindings to std::unordered_map

### DIFF
--- a/source/scpp/extra/DUtils.cpp
+++ b/source/scpp/extra/DUtils.cpp
@@ -59,6 +59,21 @@ CPPSETEMPTYINST(SCPBallot)
 CPPSETEMPTYINST(PublicKey)
 CPPSETEMPTYINST(unsigned int)
 
+#define CPPUNORDEREDMAPASSIGNINST(K, V) template void cpp_unordered_map_assign<K, V>(void*, const K&, const V&);
+CPPUNORDEREDMAPASSIGNINST(NodeID, std::shared_ptr<SCPQuorumSet>)
+CPPUNORDEREDMAPASSIGNINST(int, int)
+
+#define CPPUNORDEREDMAPLENGTHINST(K, V) template std::size_t cpp_unordered_map_length<K, V>(const void*);
+CPPUNORDEREDMAPLENGTHINST(NodeID, std::shared_ptr<SCPQuorumSet>)
+CPPUNORDEREDMAPLENGTHINST(int, int)
+
+// @bug with substitution
+// https://issues.dlang.org/show_bug.cgi?id=20679
+// #define CPPUNORDEREDMAPCREATEINST(K, V) template std::unordered_map<K, V>* cpp_unordered_map_create<K, V>();
+#define CPPUNORDEREDMAPCREATEINST(K, V) template void* cpp_unordered_map_create<K, V>();
+CPPUNORDEREDMAPCREATEINST(NodeID, std::shared_ptr<SCPQuorumSet>)
+CPPUNORDEREDMAPCREATEINST(int, int)
+
 void callCPPDelegate (void* cb)
 {
     auto callback = (std::function<void()>*)cb;

--- a/source/scpp/extra/DUtils.h
+++ b/source/scpp/extra/DUtils.h
@@ -4,7 +4,10 @@
 // Not originally part of SCP but required for the D side to work
 
 #include <set>
+#include <unordered_map>
 #include <vector>
+
+#include "crypto/SecretKey.h"  // for operator() (hashing support)
 
 // rudimentary support for walking through an std::set
 // note: can't use proper callback type due to
@@ -29,6 +32,34 @@ bool cpp_set_empty(const void* setptr)
 {
     return ((const std::set<T>*)setptr)->empty();
 }
+
+template<typename K, typename V>
+void cpp_unordered_map_assign (void* map, const K& key, const V& value)
+{
+    auto m = (std::unordered_map<K, V>*)map;
+    (*m)[key] = value;
+}
+
+template<typename K, typename V>
+std::size_t cpp_unordered_map_length (const void* map)
+{
+    auto m = (const std::unordered_map<K, V>*)map;
+    return m->size();
+}
+
+template<typename K, typename V>
+void* cpp_unordered_map_create ()
+{
+    return new std::unordered_map<K, V>();
+}
+
+// @bug with substitution
+// https://issues.dlang.org/show_bug.cgi?id=20679
+// template<typename K, typename V>
+// std::unordered_map<K, V> * cpp_unordered_map_create ()
+// {
+//     return new std::unordered_map<K, V>();
+// }
 
 template<typename T, typename VectorT>
 void push_back(VectorT& this_, T& value)


### PR DESCRIPTION
@Geod24 there seems to be a linking issue when I change `cpp_unordered_map_create` to return a proper type rather than just a `void*`. See all the `// todo` comments.

```
.dub/build/unittest-unittest-linux.posix-x86_64-dmd_2090-B745E6F9C1062E73969E8A9A1EE52EEC/agora-unittests.o: In function `_D4scpd3Cpp__T13unordered_mapTiTiZQu6createFNaNbNiNeZSQCaQBy__TQBxTiTiZQCf':
/mnt/c/dev/agora/source/scpd/Cpp.d:158: undefined reference to `std::unordered_map<int, int>* cpp_unordered_map_create<int, int>()'
```