### PR TITLE
Add the BitSet implementation from stellar-core

### DIFF
--- a/source/scpp/README.md
+++ b/source/scpp/README.md
@@ -9,6 +9,12 @@ Files in `extra` are extra C++ files added to the build (e.g. to instantiate tem
 Commit used for extraction: [v11.2.0](https://github.com/stellar/stellar-core/releases/tag/v11.2.0)
 Timestamp of commit: Wed Jun 26 11:16:38 2019 -0700
 
+# Porting notes
+
+Some files have been modified after porting:
+
+- Some `private` declarations were changed to `public`. This allows us to test size & layout checks for our D glue layer, for example: https://github.com/bpfkorea/agora/blob/76e4ca7d77b123ef867d3ce99c1c1b26afab761d/source/scpp/src/crypto/ByteSlice.h#L21 used in https://github.com/bpfkorea/agora/blob/76e4ca7d77b123ef867d3ce99c1c1b26afab761d/source/scpp/extra/DSizeChecks.cpp and https://github.com/bpfkorea/agora/blob/76e4ca7d77b123ef867d3ce99c1c1b26afab761d/source/scpp/extra/DLayoutChecks.cpp.
+
 # Update process
 
 - Checkout stellar-core

--- a/source/scpp/build.d
+++ b/source/scpp/build.d
@@ -43,6 +43,7 @@ immutable CppFlags = [
     "-W",
     "-Wall",
     "-Wno-unused-parameter",
+    "-Wno-comment",
     "-fPIC",
     "-D_GLIBCXX_USE_CXX11_ABI=0",
     "-std=c++14",

--- a/source/scpp/lib/util/cbitset.cpp
+++ b/source/scpp/lib/util/cbitset.cpp
@@ -1,0 +1,459 @@
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Initial code copyright 2016-2019 Daniel Lemire (lemire@gmail.com). Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root of
+// this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Subsequent changes copyright 2019 Stellar Development Foundation and
+// contributors. Licensed under the Apache License, Version 2.0. See the COPYING
+// file at the root of this distribution or at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#include "cbitset.h"
+
+/* Create a new bitset. Return NULL in case of failure. */
+bitset_t*
+bitset_create()
+{
+    bitset_t* bitset = NULL;
+    /* Allocate the bitset itself. */
+    if ((bitset = (bitset_t*)malloc(sizeof(bitset_t))) == NULL)
+    {
+        abort();
+    }
+    bitset->array = NULL;
+    bitset->arraysize = 0;
+    bitset->capacity = 0;
+    return bitset;
+}
+
+/* Create a new bitset able to contain size bits. Return NULL in case of
+ * failure. */
+bitset_t*
+bitset_create_with_capacity(size_t size)
+{
+    bitset_t* bitset = NULL;
+    /* Allocate the bitset itself. */
+    if ((bitset = (bitset_t*)malloc(sizeof(bitset_t))) == NULL)
+    {
+        abort();
+    }
+    bitset->arraysize =
+        (size + sizeof(uint64_t) * 8 - 1) / (sizeof(uint64_t) * 8);
+    bitset->capacity = bitset->arraysize;
+    if ((bitset->array =
+             (uint64_t*)malloc(sizeof(uint64_t) * bitset->arraysize)) == NULL)
+    {
+        free(bitset);
+        abort();
+    }
+    memset(bitset->array, 0, sizeof(uint64_t) * bitset->arraysize);
+    return bitset;
+}
+
+/* Create a copy */
+bitset_t*
+bitset_copy(const bitset_t* bitset)
+{
+    bitset_t* copy = NULL;
+    /* Allocate the bitset itself. */
+    if ((copy = (bitset_t*)malloc(sizeof(bitset_t))) == NULL)
+    {
+        abort();
+    }
+    memcpy(copy, bitset, sizeof(bitset_t));
+    copy->capacity = copy->arraysize;
+    if ((copy->array =
+             (uint64_t*)malloc(sizeof(uint64_t) * bitset->arraysize)) == NULL)
+    {
+        free(copy);
+        abort();
+    }
+    memcpy(copy->array, bitset->array, sizeof(uint64_t) * bitset->arraysize);
+    return copy;
+}
+
+void
+bitset_clear(bitset_t* bitset)
+{
+    memset(bitset->array, 0, sizeof(uint64_t) * bitset->arraysize);
+}
+
+void
+bitset_shift_left(bitset_t* bitset, size_t s)
+{
+    size_t extra_words = s / 64;
+    int inword_shift = s % 64;
+    size_t as = bitset->arraysize;
+    if (inword_shift == 0)
+    {
+        bitset_resize(bitset, as + extra_words, false);
+        // could be done with a memmove
+        for (size_t i = as + extra_words; i > extra_words; i--)
+        {
+            bitset->array[i - 1] = bitset->array[i - 1 - extra_words];
+        }
+    }
+    else
+    {
+        bitset_resize(bitset, as + extra_words + 1, true);
+        bitset->array[as + extra_words] =
+            bitset->array[as - 1] >> (64 - inword_shift);
+        for (size_t i = as + extra_words; i >= extra_words + 2; i--)
+        {
+            bitset->array[i - 1] =
+                (bitset->array[i - 1 - extra_words] << inword_shift) |
+                (bitset->array[i - 2 - extra_words] >> (64 - inword_shift));
+        }
+        bitset->array[extra_words] = bitset->array[0] << inword_shift;
+    }
+    for (size_t i = 0; i < extra_words; i++)
+    {
+        bitset->array[i] = 0;
+    }
+}
+
+void
+bitset_shift_right(bitset_t* bitset, size_t s)
+{
+    size_t extra_words = s / 64;
+    int inword_shift = s % 64;
+    size_t as = bitset->arraysize;
+    if (inword_shift == 0)
+    {
+        // could be done with a memmove
+        for (size_t i = 0; i < as - extra_words; i++)
+        {
+            bitset->array[i] = bitset->array[i + extra_words];
+        }
+        bitset_resize(bitset, as - extra_words, false);
+    }
+    else
+    {
+        for (size_t i = 0; i + extra_words + 1 < as; i++)
+        {
+            bitset->array[i] =
+                (bitset->array[i + extra_words] >> inword_shift) |
+                (bitset->array[i + extra_words + 1] << (64 - inword_shift));
+        }
+        bitset->array[as - extra_words - 1] =
+            (bitset->array[as - 1] >> inword_shift);
+        bitset_resize(bitset, as - extra_words, false);
+    }
+}
+
+/* Free memory. */
+void
+bitset_free(bitset_t* bitset)
+{
+    free(bitset->array);
+    free(bitset);
+}
+/* Resize the bitset so that it can support newarraysize * 64 bits. Return true
+ * in case of success, false for failure. */
+bool
+bitset_resize(bitset_t* bitset, size_t newarraysize, bool padwithzeroes)
+{
+    size_t smallest =
+        newarraysize < bitset->arraysize ? newarraysize : bitset->arraysize;
+    if (bitset->capacity < newarraysize)
+    {
+        uint64_t* newarray;
+        bitset->capacity = newarraysize * 2;
+        if ((newarray = (uint64_t*)realloc(
+                 bitset->array, sizeof(uint64_t) * bitset->capacity)) == NULL)
+        {
+            free(bitset->array);
+            abort();
+        }
+        bitset->array = newarray;
+    }
+    if (padwithzeroes && (newarraysize > smallest))
+        memset(bitset->array + smallest, 0,
+               sizeof(uint64_t) * (newarraysize - smallest));
+    bitset->arraysize = newarraysize;
+    return true; // success!
+}
+
+size_t
+bitset_count(const bitset_t* bitset)
+{
+    size_t card = 0;
+    size_t k = 0;
+    // assumes that long long is 8 bytes
+    for (; k + 7 < bitset->arraysize; k += 8)
+    {
+        card += __builtin_popcountll(bitset->array[k]);
+        card += __builtin_popcountll(bitset->array[k + 1]);
+        card += __builtin_popcountll(bitset->array[k + 2]);
+        card += __builtin_popcountll(bitset->array[k + 3]);
+        card += __builtin_popcountll(bitset->array[k + 4]);
+        card += __builtin_popcountll(bitset->array[k + 5]);
+        card += __builtin_popcountll(bitset->array[k + 6]);
+        card += __builtin_popcountll(bitset->array[k + 7]);
+    }
+    for (; k + 3 < bitset->arraysize; k += 4)
+    {
+        card += __builtin_popcountll(bitset->array[k]);
+        card += __builtin_popcountll(bitset->array[k + 1]);
+        card += __builtin_popcountll(bitset->array[k + 2]);
+        card += __builtin_popcountll(bitset->array[k + 3]);
+    }
+    for (; k < bitset->arraysize; k++)
+    {
+        card += __builtin_popcountll(bitset->array[k]);
+    }
+    return card;
+}
+
+bool
+bitset_inplace_union(bitset_t* b1, const bitset_t* b2)
+{
+    size_t minlength =
+        b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
+    for (size_t k = 0; k < minlength; ++k)
+    {
+        b1->array[k] |= b2->array[k];
+    }
+    if (b2->arraysize > b1->arraysize)
+    {
+        size_t oldsize = b1->arraysize;
+        if (!bitset_resize(b1, b2->arraysize, false))
+            return false;
+        memcpy(b1->array + oldsize, b2->array + oldsize,
+               (b2->arraysize - oldsize) * sizeof(uint64_t));
+    }
+    return true;
+}
+
+size_t
+bitset_minimum(const bitset_t* bitset)
+{
+    for (size_t k = 0; k < bitset->arraysize; k++)
+    {
+        uint64_t w = bitset->array[k];
+        if (w != 0)
+        {
+            return __builtin_ctzll(w) + k * 64;
+        }
+    }
+    return 0;
+}
+
+size_t
+bitset_maximum(const bitset_t* bitset)
+{
+    for (size_t k = bitset->arraysize; k > 0; k--)
+    {
+        uint64_t w = bitset->array[k - 1];
+        if (w != 0)
+        {
+            return 63 - __builtin_clzll(w) + (k - 1) * 64;
+        }
+    }
+    return 0;
+}
+
+size_t
+bitset_union_count(const bitset_t* b1, const bitset_t* b2)
+{
+    size_t answer = 0;
+    size_t minlength =
+        b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
+    size_t k = 0;
+    for (; k + 3 < minlength; k += 4)
+    {
+        answer += __builtin_popcountll(b1->array[k] | b2->array[k]);
+        answer += __builtin_popcountll(b1->array[k + 1] | b2->array[k + 1]);
+        answer += __builtin_popcountll(b1->array[k + 2] | b2->array[k + 2]);
+        answer += __builtin_popcountll(b1->array[k + 3] | b2->array[k + 3]);
+    }
+    for (; k < minlength; ++k)
+    {
+        answer += __builtin_popcountll(b1->array[k] | b2->array[k]);
+    }
+    if (b2->arraysize > b1->arraysize)
+    {
+        // k = b1->arraysize;
+        for (; k + 3 < b2->arraysize; k += 4)
+        {
+            answer += __builtin_popcountll(b2->array[k]);
+            answer += __builtin_popcountll(b2->array[k + 1]);
+            answer += __builtin_popcountll(b2->array[k + 2]);
+            answer += __builtin_popcountll(b2->array[k + 3]);
+        }
+        for (; k < b2->arraysize; ++k)
+        {
+            answer += __builtin_popcountll(b2->array[k]);
+        }
+    }
+    else
+    {
+        // k = b2->arraysize;
+        for (; k + 3 < b1->arraysize; k += 4)
+        {
+            answer += __builtin_popcountll(b1->array[k]);
+            answer += __builtin_popcountll(b1->array[k + 1]);
+            answer += __builtin_popcountll(b1->array[k + 2]);
+            answer += __builtin_popcountll(b1->array[k + 3]);
+        }
+        for (; k < b1->arraysize; ++k)
+        {
+            answer += __builtin_popcountll(b1->array[k]);
+        }
+    }
+    return answer;
+}
+
+void
+bitset_inplace_intersection(bitset_t* b1, const bitset_t* b2)
+{
+    size_t minlength =
+        b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
+    size_t k = 0;
+    for (; k < minlength; ++k)
+    {
+        b1->array[k] &= b2->array[k];
+    }
+    for (; k < b1->arraysize; ++k)
+    {
+        b1->array[k] = 0; // memset could, maybe, be a tiny bit faster
+    }
+}
+
+void
+bitset_inplace_difference(bitset_t* b1, const bitset_t* b2)
+{
+    size_t minlength =
+        b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
+    size_t k = 0;
+    for (; k < minlength; ++k)
+    {
+        b1->array[k] &= ~(b2->array[k]);
+    }
+}
+
+size_t
+bitset_difference_count(const bitset_t* b1, const bitset_t* b2)
+{
+    size_t minlength =
+        b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
+    size_t k = 0;
+    size_t answer = 0;
+    for (; k < minlength; ++k)
+    {
+        answer += __builtin_popcountll(b1->array[k] & ~(b2->array[k]));
+    }
+    for (; k < b1->arraysize; ++k)
+    {
+        answer += __builtin_popcountll(b1->array[k]);
+    }
+    return answer;
+}
+
+bool
+bitset_inplace_symmetric_difference(bitset_t* b1, const bitset_t* b2)
+{
+    size_t minlength =
+        b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
+    size_t k = 0;
+    for (; k < minlength; ++k)
+    {
+        b1->array[k] ^= b2->array[k];
+    }
+    if (b2->arraysize > b1->arraysize)
+    {
+        size_t oldsize = b1->arraysize;
+        if (!bitset_resize(b1, b2->arraysize, false))
+            return false;
+        memcpy(b1->array + oldsize, b2->array + oldsize,
+               (b2->arraysize - oldsize) * sizeof(uint64_t));
+    }
+    return true;
+}
+
+size_t
+bitset_symmetric_difference_count(const bitset_t* b1, const bitset_t* b2)
+{
+    size_t minlength =
+        b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
+    size_t k = 0;
+    size_t answer = 0;
+    for (; k < minlength; ++k)
+    {
+        answer += __builtin_popcountll(b1->array[k] ^ b2->array[k]);
+    }
+    if (b2->arraysize > b1->arraysize)
+    {
+        for (; k < b2->arraysize; ++k)
+        {
+            answer += __builtin_popcountll(b2->array[k]);
+        }
+    }
+    else
+    {
+        for (; k < b1->arraysize; ++k)
+        {
+            answer += __builtin_popcountll(b1->array[k]);
+        }
+    }
+    return answer;
+}
+
+bool
+bitset_equal(const bitset_t* b1, const bitset_t* b2)
+{
+    size_t minlength =
+        b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
+    for (size_t k = 0; k < minlength; ++k)
+    {
+        if (b1->array[k] != b2->array[k])
+            return false;
+    }
+    return true;
+}
+
+bool
+bitset_subseteq(const bitset_t* b1, const bitset_t* b2)
+{
+    size_t minlength =
+        b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
+    for (size_t k = 0; k < minlength; ++k)
+    {
+        if ((b1->array[k] & b2->array[k]) != b1->array[k])
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool
+bitset_trim(bitset_t* bitset)
+{
+    size_t newsize = bitset->arraysize;
+    while (newsize > 0)
+    {
+        if (bitset->array[newsize - 1] == 0)
+            newsize -= 1;
+        else
+            break;
+    }
+    if (bitset->capacity == newsize)
+        return true; // nothing to do
+    bitset->capacity = newsize;
+    bitset->arraysize = newsize;
+    uint64_t* newarray;
+    if ((newarray = (uint64_t*)realloc(
+             bitset->array, sizeof(uint64_t) * bitset->capacity)) == NULL)
+    {
+        free(bitset->array);
+        abort();
+    }
+    bitset->array = newarray;
+    return true;
+}

--- a/source/scpp/lib/util/cbitset.h
+++ b/source/scpp/lib/util/cbitset.h
@@ -1,0 +1,319 @@
+#pragma once
+
+// Initial code copyright 2016-2019 Daniel Lemire (lemire@gmail.com). Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root of
+// this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Subsequent changes copyright 2019 Stellar Development Foundation and
+// contributors. Licensed under the Apache License, Version 2.0. See the COPYING
+// file at the root of this distribution or at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cbitset_portability.h"
+
+struct bitset_s
+{
+    uint64_t* array;
+    size_t arraysize;
+    size_t capacity;
+};
+
+typedef struct bitset_s bitset_t;
+
+/* Create a new bitset. Return NULL in case of failure. */
+bitset_t* bitset_create(void);
+
+/* Create a new bitset able to contain size bits. Return NULL in case of
+ * failure. */
+bitset_t* bitset_create_with_capacity(size_t size);
+
+/* Free memory. */
+void bitset_free(bitset_t* bitset);
+
+/* Set all bits to zero. */
+void bitset_clear(bitset_t* bitset);
+
+/* Create a copy */
+bitset_t* bitset_copy(const bitset_t* bitset);
+
+/* Resize the bitset. Return true in case of success, false for failure. Pad
+ * with zeroes new buffer areas if requested. */
+bool bitset_resize(bitset_t* bitset, size_t newarraysize, bool padwithzeroes);
+
+/* returns how many bytes of memory the backend buffer uses */
+static inline size_t
+bitset_size_in_bytes(const bitset_t* bitset)
+{
+    return bitset->arraysize * sizeof(uint64_t);
+}
+
+/* returns how many bits can be accessed */
+static inline size_t
+bitset_size_in_bits(const bitset_t* bitset)
+{
+    return bitset->arraysize * 64;
+}
+
+/* returns how many words (64-bit) of memory the backend buffer uses */
+static inline size_t
+bitset_size_in_words(const bitset_t* bitset)
+{
+    return bitset->arraysize;
+}
+
+/* Grow the bitset so that it can support newarraysize * 64 bits with padding.
+ * Return true in case of success, false for failure. */
+static inline bool
+bitset_grow(bitset_t* bitset, size_t newarraysize)
+{
+    if (bitset->capacity < newarraysize)
+    {
+        uint64_t* newarray;
+        bitset->capacity = newarraysize * 2;
+        if ((newarray = (uint64_t*)realloc(
+                 bitset->array, sizeof(uint64_t) * bitset->capacity)) == NULL)
+        {
+            free(bitset->array);
+            return false;
+        }
+        bitset->array = newarray;
+    }
+    memset(bitset->array + bitset->arraysize, 0,
+           sizeof(uint64_t) * (newarraysize - bitset->arraysize));
+    bitset->arraysize = newarraysize;
+    return true; // success!
+}
+
+/* attempts to recover unused memory, return false in case of reallocation
+ * failure */
+bool bitset_trim(bitset_t* bitset);
+
+/* shifts all bits by 's' positions so that the bitset representing values
+ * 1,2,10 would represent values 1+s, 2+s, 10+s */
+void bitset_shift_left(bitset_t* bitset, size_t s);
+
+/* shifts all bits by 's' positions so that the bitset representing values
+ * 1,2,10 would represent values 1-s, 2-s, 10-s, negative values are deleted */
+void bitset_shift_right(bitset_t* bitset, size_t s);
+
+/* Set the ith bit. Attempts to resize the bitset if needed (may abort on OOM)
+ */
+static inline void
+bitset_set(bitset_t* bitset, size_t i)
+{
+    size_t shiftedi = i >> 6;
+    if (shiftedi >= bitset->arraysize)
+    {
+        if (!bitset_grow(bitset, shiftedi + 1))
+        {
+            abort();
+        }
+    }
+    bitset->array[shiftedi] |= ((uint64_t)1) << (i % 64);
+}
+
+/* Set the ith bit to zero. Avoids resizing array since if it's not
+ * already set, there's nothing to do.
+ */
+static inline void
+bitset_unset(bitset_t* bitset, size_t i)
+{
+    size_t shiftedi = i >> 6;
+    if (shiftedi >= bitset->arraysize)
+    {
+        return;
+    }
+    bitset->array[shiftedi] &= ~(((uint64_t)1) << (i % 64));
+}
+
+/* Get the value of the ith bit.  */
+static inline bool
+bitset_get(const bitset_t* bitset, size_t i)
+{
+    size_t shiftedi = i >> 6;
+    if (shiftedi >= bitset->arraysize)
+    {
+        return false;
+    }
+    return (bitset->array[shiftedi] & (((uint64_t)1) << (i % 64))) != 0;
+}
+
+/* Count number of bit sets.  */
+size_t bitset_count(const bitset_t* bitset);
+
+/* Find the index of the first bit set.  */
+size_t bitset_minimum(const bitset_t* bitset);
+
+/* Find the index of the last bit set.  */
+size_t bitset_maximum(const bitset_t* bitset);
+
+/* compute the union in-place (to b1), returns true if successful, to generate a
+ * new bitset first call bitset_copy */
+bool bitset_inplace_union(bitset_t* b1, const bitset_t* b2);
+
+/* report the size of the union (without materializing it) */
+size_t bitset_union_count(const bitset_t* b1, const bitset_t* b2);
+
+/* compute the intersection in-place (to b1), to generate a new bitset first
+ * call bitset_copy */
+void bitset_inplace_intersection(bitset_t* b1, const bitset_t* b2);
+
+/* report the size of the intersection (without materializing it) */
+static inline size_t
+bitset_intersection_count(const bitset_t* b1, const bitset_t* b2)
+{
+    size_t answer = 0;
+    size_t minlength = b1->arraysize < b2->arraysize ? b1->arraysize : b2->arraysize;
+    for (size_t k = 0; k < minlength; ++k)
+    {
+        answer += __builtin_popcountll(b1->array[k] & b2->array[k]);
+    }
+    return answer;
+}
+
+/* compute the difference in-place (to b1), to generate a new bitset first call
+ * bitset_copy */
+void bitset_inplace_difference(bitset_t* b1, const bitset_t* b2);
+
+/* compute the size of the difference */
+size_t bitset_difference_count(const bitset_t* b1, const bitset_t* b2);
+
+/* compute the symmetric difference in-place (to b1), return true if successful,
+ * to generate a new bitset first call bitset_copy */
+bool bitset_inplace_symmetric_difference(bitset_t* b1, const bitset_t* b2);
+
+/* compute the size of the symmetric difference  */
+size_t bitset_symmetric_difference_count(const bitset_t* b1,
+                                         const bitset_t* b2);
+
+/* compute whether b1 == b2 */
+bool bitset_equal(const bitset_t* b1, const bitset_t* b2);
+
+/* compute whether b1 ⊆ b2 */
+bool bitset_subseteq(const bitset_t* b1, const bitset_t* b2);
+
+/* iterate over the set bits
+ like so :
+  for(size_t i = 0; nextSetBit(b,&i) ; i++) {
+    //.....
+  }
+  */
+static inline bool
+nextSetBit(const bitset_t* bitset, size_t* i)
+{
+    size_t x = *i >> 6;
+    if (x >= bitset->arraysize)
+    {
+        return false;
+    }
+    uint64_t w = bitset->array[x];
+    w >>= (*i & 63);
+    if (w != 0)
+    {
+        *i += __builtin_ctzll(w);
+        return true;
+    }
+    x++;
+    while (x < bitset->arraysize)
+    {
+        w = bitset->array[x];
+        if (w != 0)
+        {
+            *i = x * 64 + __builtin_ctzll(w);
+            return true;
+        }
+        x++;
+    }
+    return false;
+}
+
+/* iterate over the set bits
+ like so :
+   size_t buffer[256];
+   size_t howmany = 0;
+  for(size_t startfrom = 0; (howmany = nextSetBits(b,buffer,256, &startfrom)) >
+ 0 ; startfrom++) {
+    //.....
+  }
+  */
+static inline size_t
+nextSetBits(const bitset_t* bitset, size_t* buffer, size_t capacity,
+            size_t* startfrom)
+{
+    if (capacity == 0)
+        return 0; // sanity check
+    size_t x = *startfrom >> 6;
+    if (x >= bitset->arraysize)
+    {
+        return 0; // nothing more to iterate over
+    }
+    uint64_t w = bitset->array[x];
+    w >>= (*startfrom & 63);
+    size_t howmany = 0;
+    size_t base = x << 6;
+    while (howmany < capacity)
+    {
+        while (w != 0)
+        {
+            uint64_t t = w & (~w + 1);
+            int r = __builtin_ctzll(w);
+            buffer[howmany++] = r + base;
+            if (howmany == capacity)
+                goto end;
+            w ^= t;
+        }
+        x += 1;
+        if (x == bitset->arraysize)
+        {
+            break;
+        }
+        base += 64;
+        w = bitset->array[x];
+    }
+end:
+    if (howmany > 0)
+    {
+        *startfrom = buffer[howmany - 1];
+    }
+    return howmany;
+}
+
+typedef bool (*bitset_iterator)(size_t value, void* param);
+
+// return true if uninterrupted
+static inline bool
+bitset_for_each(const bitset_t* b, bitset_iterator iterator, void* ptr)
+{
+    size_t base = 0;
+    for (size_t i = 0; i < b->arraysize; ++i)
+    {
+        uint64_t w = b->array[i];
+        while (w != 0)
+        {
+            uint64_t t = w & (~w + 1);
+            int r = __builtin_ctzll(w);
+            if (!iterator(r + base, ptr))
+                return false;
+            w ^= t;
+        }
+        base += 64;
+    }
+    return true;
+}
+
+static inline void
+bitset_print(const bitset_t* b)
+{
+    printf("{");
+    for (size_t i = 0; nextSetBit(b, &i); i++)
+    {
+        printf("%zu, ", i);
+    }
+    printf("}");
+}

--- a/source/scpp/lib/util/cbitset_portability.h
+++ b/source/scpp/lib/util/cbitset_portability.h
@@ -1,0 +1,93 @@
+#pragma once
+
+// Initial code copyright 2016-2019 Daniel Lemire (lemire@gmail.com). Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root of
+// this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Subsequent changes copyright 2019 Stellar Development Foundation and
+// contributors. Licensed under the Apache License, Version 2.0. See the COPYING
+// file at the root of this distribution or at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#include <stdint.h>
+
+#ifdef _MSC_VER
+/* Microsoft C/C++-compatible compiler */
+#include <intrin.h>
+
+#ifndef __clang__ // if one compiles with MSVC *with* clang, then these
+                  // intrinsics are defined!!!
+// sadly there is no way to check whether we are missing these intrinsics
+// specifically.
+
+/* wrappers for Visual Studio built-ins that look like gcc built-ins */
+/* result might be undefined when input_num is zero */
+static inline int
+__builtin_ctzll(unsigned long long input_num)
+{
+    unsigned long index;
+#ifdef _WIN64 // highly recommended!!!
+    _BitScanForward64(&index, input_num);
+#else // if we must support 32-bit Windows
+    if ((uint32_t)input_num != 0)
+    {
+        _BitScanForward(&index, (uint32_t)input_num);
+    }
+    else
+    {
+        _BitScanForward(&index, (uint32_t)(input_num >> 32));
+        index += 32;
+    }
+#endif
+    return index;
+}
+
+/* result might be undefined when input_num is zero */
+static inline int
+__builtin_clzll(unsigned long long input_num)
+{
+    unsigned long index;
+#ifdef _WIN64 // highly recommended!!!
+    _BitScanReverse64(&index, input_num);
+#else // if we must support 32-bit Windows
+    if (input_num > 0xFFFFFFF)
+    {
+        _BitScanReverse(&index, (uint32_t)(input_num >> 32));
+    }
+    else
+    {
+        _BitScanReverse(&index, (uint32_t)(input_num));
+        index += 32;
+    }
+#endif
+    return 63 - index;
+}
+
+/* result might be undefined when input_num is zero */
+static inline int
+__builtin_clz(int input_num)
+{
+    unsigned long index;
+    _BitScanReverse(&index, input_num);
+    return 31 - index;
+}
+
+/* result might be undefined when input_num is zero */
+static inline int
+__builtin_popcountll(unsigned long long input_num)
+{
+#ifdef _WIN64 // highly recommended!!!
+    return (int)__popcnt64(input_num);
+#else // if we must support 32-bit Windows
+    return (int)(__popcnt((uint32_t)input_num) +
+                 __popcnt((uint32_t)(input_num >> 32)));
+#endif
+}
+
+static inline void
+__builtin_unreachable()
+{
+    __assume(0);
+}
+#endif
+#endif

--- a/source/scpp/src/util/BitSet.h
+++ b/source/scpp/src/util/BitSet.h
@@ -1,0 +1,257 @@
+#pragma once
+
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+// C++ value-semantic / convenience wrapper around C bitset_t
+
+#include <functional>
+#include <memory>
+#include <ostream>
+#include <set>
+
+#include "util/cbitset.h"
+
+class BitSet
+{
+    mutable bool mCountDirty = {true};
+    mutable size_t mCount = {0};
+    std::unique_ptr<bitset_t, decltype(&bitset_free)> mPtr;
+
+  public:
+    BitSet() : mPtr(bitset_create(), &bitset_free)
+    {
+    }
+    BitSet(size_t n) : mPtr(bitset_create_with_capacity(n), &bitset_free)
+    {
+    }
+    BitSet(std::set<size_t> const& s)
+        : mPtr(bitset_create_with_capacity(s.empty() ? 0 : *s.rbegin()),
+               &bitset_free)
+    {
+        for (auto i : s)
+            set(i);
+    }
+    BitSet(BitSet const& other)
+        : mPtr(bitset_copy(other.mPtr.get()), &bitset_free)
+    {
+    }
+    BitSet&
+    operator=(BitSet const& other)
+    {
+        mPtr = decltype(mPtr)(bitset_copy(other.mPtr.get()), &bitset_free);
+        mCount = other.mCount;
+        mCountDirty = other.mCountDirty;
+        return *this;
+    }
+    BitSet(BitSet&& other) = default;
+    BitSet& operator=(BitSet&& other) = default;
+
+    bool
+    operator==(BitSet const& other) const
+    {
+        return bitset_equal(mPtr.get(), other.mPtr.get());
+    }
+
+    bool
+    isSubsetEq(BitSet const& other) const
+    {
+        return bitset_subseteq(mPtr.get(), other.mPtr.get());
+    }
+
+    bool
+    operator<=(BitSet const& other) const
+    {
+        return isSubsetEq(other);
+    }
+
+    size_t
+    size() const
+    {
+        return bitset_size_in_bits(mPtr.get());
+    }
+    void
+    set(size_t i)
+    {
+        bitset_set(mPtr.get(), i);
+        mCountDirty = true;
+    }
+    void
+    unset(size_t i)
+    {
+        bitset_unset(mPtr.get(), i);
+        mCountDirty = true;
+    }
+    bool
+    get(size_t i) const
+    {
+        return bitset_get(mPtr.get(), i);
+    }
+    void
+    clear()
+    {
+        bitset_clear(mPtr.get());
+        mCount = 0;
+        mCountDirty = false;
+    }
+
+    size_t
+    count() const
+    {
+        if (mCountDirty)
+        {
+            mCount = bitset_count(mPtr.get());
+            mCountDirty = false;
+        }
+        return mCount;
+    }
+    bool
+    empty() const
+    {
+        size_t tmp = 0;
+        return !nextSet(tmp);
+    }
+    operator bool() const
+    {
+        return !empty();
+    }
+    size_t
+    min() const
+    {
+        return bitset_minimum(mPtr.get());
+    }
+    size_t
+    max() const
+    {
+        return bitset_maximum(mPtr.get());
+    }
+
+    void
+    inplaceUnion(BitSet const& other)
+    {
+        bitset_inplace_union(mPtr.get(), other.mPtr.get());
+        mCountDirty = true;
+    }
+    BitSet
+    operator|(BitSet const& other) const
+    {
+        BitSet tmp(*this);
+        tmp.inplaceUnion(other);
+        return tmp;
+    }
+    void
+    operator|=(BitSet const& other)
+    {
+        inplaceUnion(other);
+    }
+
+    void
+    inplaceIntersection(BitSet const& other)
+    {
+        bitset_inplace_intersection(mPtr.get(), other.mPtr.get());
+        mCountDirty = true;
+    }
+    BitSet operator&(BitSet const& other) const
+    {
+        BitSet tmp(*this);
+        tmp.inplaceIntersection(other);
+        return tmp;
+    }
+    void
+    operator&=(BitSet const& other)
+    {
+        inplaceIntersection(other);
+    }
+
+    void
+    inplaceDifference(BitSet const& other)
+    {
+        bitset_inplace_difference(mPtr.get(), other.mPtr.get());
+        mCountDirty = true;
+    }
+    BitSet
+    operator-(BitSet const& other) const
+    {
+        BitSet tmp(*this);
+        tmp.inplaceDifference(other);
+        return tmp;
+    }
+    void
+    operator-=(BitSet const& other)
+    {
+        inplaceDifference(other);
+    }
+
+    void
+    inplaceSymmetricDifference(BitSet const& other)
+    {
+        bitset_inplace_symmetric_difference(mPtr.get(), other.mPtr.get());
+        mCountDirty = true;
+    }
+    BitSet
+    symmetricDifference(BitSet const& other) const
+    {
+        BitSet tmp(*this);
+        tmp.inplaceSymmetricDifference(other);
+        return tmp;
+    }
+
+    size_t
+    unionCount(BitSet const& other) const
+    {
+        return bitset_union_count(mPtr.get(), other.mPtr.get());
+    }
+    size_t
+    intersectionCount(BitSet const& other) const
+    {
+        return bitset_intersection_count(mPtr.get(), other.mPtr.get());
+    }
+    size_t
+    differenceCount(BitSet const& other) const
+    {
+        return bitset_difference_count(mPtr.get(), other.mPtr.get());
+    }
+    size_t
+    symmetricDifferenceCount(BitSet const& other) const
+    {
+        return bitset_symmetric_difference_count(mPtr.get(), other.mPtr.get());
+    }
+    bool
+    nextSet(size_t& i) const
+    {
+        return nextSetBit(mPtr.get(), &i);
+    }
+    void
+    streamWith(std::ostream& out,
+               std::function<void(std::ostream&, size_t)> item) const
+    {
+        out << '{';
+        bool first = true;
+        for (size_t i = 0; nextSet(i); ++i)
+        {
+            if (first)
+            {
+                first = false;
+            }
+            else
+            {
+                out << ", ";
+            }
+            item(out, i);
+        }
+        out << '}';
+    }
+    void
+    stream(std::ostream& out) const
+    {
+        streamWith(out, [](std::ostream& out, size_t i) { out << i; });
+    }
+};
+
+inline std::ostream&
+operator<<(std::ostream& out, BitSet const& b)
+{
+    b.stream(out);
+    return out;
+}


### PR DESCRIPTION
This is used by the quorum intersection checker code. We won't actually bind to it.