### PR TITLE
Change the mechanism of creating preimages

### DIFF
--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -467,7 +467,8 @@ public class Node : API
     protected Enrollment createEnrollment (Hash frozen_utxo_hash) @safe
     {
         Enrollment enroll;
-        this.enroll_man.createEnrollment(frozen_utxo_hash, enroll);
+        this.enroll_man.createEnrollment(frozen_utxo_hash,
+            this.ledger.getBlockHeight(), enroll);
 
         return enroll;
     }


### PR DESCRIPTION
Previously, we create only 1008 number of preimages from a random value for the enrollment process. But there is the case when the random value is lost and we can't restore pre-images in  abnormal situations like database crashes. So we need the way to restore the pre-images. we have decided to change the mechanism of creating pre-images into generating a great number of pre-images like a hundred of thousand from the private key of a node.

This PR includes the code re-creating pre-images when all the pre-images have been used in case of the block height is above 100800, or`ValidatorCycle` x 100. If the re-creation of pre-images is needed, the enrollment manager creates new bulk of pre-images with a salt hash. A salt hash is derived from a bulk index which is an order of a series of a bulk of pre-images like 0, 1, 2, ... N.

Fixes #651 