### PR TITLE
Fix issue #668: Github CI should have a timeout

### DIFF
--- a/.github/workflows/github_pr.yml
+++ b/.github/workflows/github_pr.yml
@@ -10,6 +10,7 @@ jobs:
         # LDC testing is disabled for the time being due to random failures
         dc: [dmd-2.090.1]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v1
       with:
@@ -38,6 +39,7 @@ jobs:
         os: [ubuntu-latest]
         dc: [dmd-2.090.1, ldc-1.20.0]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/github_push.yaml
+++ b/.github/workflows/github_push.yaml
@@ -9,6 +9,7 @@ jobs:
         os: [macOS-latest]
         dc: [dmd-master, ldc-master]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v1
       with:
@@ -41,6 +42,7 @@ jobs:
         os: [ubuntu-latest]
         dc: [dmd-master, ldc-master]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v1
       with:


### PR DESCRIPTION
Setting it to 30 minutes in a conservative estimate.