### PR TITLE
Make the C++ build script cross platform

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -11,7 +11,7 @@
     "targetType": "executable",
     "targetPath": "build",
     "excludedSourceFiles": [ "source/scpp/*.d" ],
-    "preGenerateCommands": [ "source/scpp/build.d" ],
+    "preGenerateCommands": [ "$DUB source/scpp/build.d" ],
     "sourceFiles": [
         "source/scpp/build/BallotProtocol.o",
         "source/scpp/build/ByteSliceHasher.o",

--- a/source/scpp/build.d
+++ b/source/scpp/build.d
@@ -1,4 +1,10 @@
-#!/usr/bin/env rdmd
+#!/usr/bin/env dub
+/+
+ dub.json:
+ {
+     "name": "cpp_build"
+ }
+ +/
 /*******************************************************************************
 
     Build the SCP library


### PR DESCRIPTION
Use a dub receipt and run it via DUB, so we can later add packages as dependency,
and it is cross platform (works on Windows).

In support of #624 