### PR TITLE
dub.json: Add correct extern-std definition

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -37,6 +37,8 @@
         "source/scpp/build/numeric.o",
         "source/scpp/build/uint128_t.o"
     ],
+
+    "dflags": [ "-extern-std=c++14" ],
     "lflags": [ "-lsodium", "-lstdc++", "-lsqlite3" ],
     "buildRequirements": [ "allowWarnings" ],
 


### PR DESCRIPTION
To avoid any mismatch with the C++ code, this needs to be in sync with build.d

Note that upstream  compiles with C++17 already. We should probably upgrade but there's a bit of work needed on the bindings first.