### PR TITLE
[Fix] the delegate does not compile on X64

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -91,7 +91,7 @@ public class BanManager
             return;  // nothing to load
 
         auto ban_file = File(this.banfile_path, "r");
-        scope DeserializeDg dg = (size) @safe
+        scope DeserializeDg dg = (size) @trusted
         {
             ubyte[] res;
             res.length = size;
@@ -111,7 +111,7 @@ public class BanManager
     public void dump ()
     {
         auto ban_file = File(this.banfile_path, "w");
-        this.serialize((scope bytes) => ban_file.rawWrite(bytes));
+        this.serialize((scope bytes) @trusted => ban_file.rawWrite(bytes));
     }
 
     /***************************************************************************

--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -166,7 +166,8 @@ public class BanManager
     public void banFor (Address address, long ban_seconds) @safe nothrow
     {
         const ban_until = this.getCurTime() + ban_seconds;
-        this.banUntil(address, ban_until);
+        // TODO: cast to time_t for the time being
+        this.banUntil(address, cast(time_t)ban_until);
     }
 
     /***************************************************************************

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -33,6 +33,7 @@ import std.getopt;
 import std.range;
 import std.traits;
 
+import core.stdc.time;
 
 /// Command-line arguments
 public struct CommandLine
@@ -335,7 +336,7 @@ private BanManager.Config parseBanManagerConfig (Node* node, const ref CommandLi
 {
     BanManager.Config conf;
     conf.max_failed_requests = get!(size_t, "banman", "max_failed_requests")(cmdln, node);
-    conf.ban_duration = get!(size_t, "banman", "ban_duration")(cmdln, node);
+    conf.ban_duration = cast(time_t)get!(size_t, "banman", "ban_duration")(cmdln, node);
     return conf;
 }
 


### PR DESCRIPTION
This is the corrected PR for errors compiled by X64 & MSVC

Change deserialize delegate to be @trusted

On Windows the call to `rawRead` / `rawWrite` is not @safe

Cast to time_t for the time being (Related to  #665 )

Related to  #264 
