### PR TITLE
Move from checkout@v1 to checkout@v2

### DIFF
--- a/.github/workflows/github_pr.yml
+++ b/.github/workflows/github_pr.yml
@@ -12,9 +12,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: true
+        persist-credentials: false
     - name: Prepare compiler
       uses: mihails-strasuns/setup-dlang@v0.5.0
       with:
@@ -41,9 +42,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: true
+        persist-credentials: false
     - name: Prepare compiler
       uses: mihails-strasuns/setup-dlang@v0.5.0
       with:

--- a/.github/workflows/github_push.yaml
+++ b/.github/workflows/github_push.yaml
@@ -11,9 +11,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: true
+        persist-credentials: false
     - name: Prepare compiler
       uses: mihails-strasuns/setup-dlang@v0.5.0
       with:
@@ -44,9 +45,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: true
+        persist-credentials: false
     - name: Prepare compiler
       uses: mihails-strasuns/setup-dlang@v0.5.0
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: true
+        persist-credentials: false
     - name: Install D and Dub
       run: |
         DMD_VERSION=2.090.1


### PR DESCRIPTION
````
git checkout --progress --force 330e5b4befb6b6cca8c53840fda27670c6abae4c
##[error]fatal: `reference is not a tree`: 330e5b4befb6b6cca8c53840fda27670c6abae4c
Removed matchers: 'checkout-git'
##[error]Git checkout failed with exit code: 128
##[error]Exit code 1 returned from process: file name '/Users/runner/runners/2.165.2/bin/Runner.PluginHost', arguments 'action "GitHub.Runner.Plugins.Repository.v1_0.CheckoutTask, Runner.Plugins"'.
  Prepare compiler
````

When jobs are re-run, a race condition in checkout@v1 causes jobs to error with the message fatal: reference is not a tree.

https://github.com/actions/checkout/issues/23
This issue is discussed here and changed to V2 as a solution.