### PR TITLE
Check the offset of virtual method in `vtable`

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -98,7 +98,8 @@
             "excludedSourceFiles": ["source/agora/cli/*/main.d"],
             "sourceFiles-posix": [
                 "source/scpp/build/DSizeChecks.o",
-                "source/scpp/build/DLayoutChecks.o"
+                "source/scpp/build/DLayoutChecks.o",
+                "source/scpp/build/DVMTestTypes.o"
             ],
             "sourceFiles-windows": [
                 "source/scpp/build/DSizeChecks.obj",

--- a/source/scpd/tests/VTableTest.d
+++ b/source/scpd/tests/VTableTest.d
@@ -1,0 +1,75 @@
+/*******************************************************************************
+
+    Contains checking if the virtual methods are in the same order
+    using vtable.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module scpd.tests.VTableTest;
+
+version (Windows) {} else:
+
+/// In case the virtual methods are in the correct order.
+unittest
+{
+    // abstract class, this is in the correct order.
+    extern (C++) class TestA
+    {
+    public:
+        ~this()
+        {
+        }
+        abstract void vfunc1();
+        abstract void vfunc2();
+    }
+
+    extern (C++) class BonTestA : TestA
+    {
+    public:
+        override void vfunc1() {}
+        override void vfunc2() {}
+    }
+
+    auto n = new BonTestA();
+    // The point of the method is the same as the expected value.
+    assert(n.__vptr[2] is &BonTestA.vfunc1);
+    assert(n.__vptr[3] is &BonTestA.vfunc2);
+}
+
+/// In case the virtual methods are in the incorrect order.
+unittest
+{
+    // abstract class, this is in the incorrect order.
+    extern (C++) class TestB
+    {
+    public:
+        ~this()
+        {
+        }
+        // The order of the two methods has changed.
+        abstract void vfunc2();
+        abstract void vfunc1();
+    }
+
+    extern (C++) class BonTestB : TestB
+    {
+    public:
+        override void vfunc1() {}
+        override void vfunc2() {}
+    }
+
+    auto n = new BonTestB();
+    // The method's point differs from the expected value.
+    assert(n.__vptr[2] !is &BonTestB.vfunc1);
+    assert(n.__vptr[3] !is &BonTestB.vfunc2);
+
+    assert(n.__vptr[2] is &BonTestB.vfunc2);
+    assert(n.__vptr[3] is &BonTestB.vfunc1);
+}

--- a/source/scpp/extra/DVMTestTypes.cpp
+++ b/source/scpp/extra/DVMTestTypes.cpp
@@ -1,0 +1,20 @@
+/*******************************************************************************
+
+    Contains classes to check the offset of virtual methods.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+#include "DVMTestTypes.h"
+
+void export_classes ()
+{
+    auto pF1A = &TestA::vfunc1;
+    auto pF1B = &TestB::vfunc1;
+}

--- a/source/scpp/extra/DVMTestTypes.h
+++ b/source/scpp/extra/DVMTestTypes.h
@@ -1,0 +1,30 @@
+/*******************************************************************************
+
+    Contains classes to check the offset of virtual methods.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+#pragma once
+
+class TestA
+{
+public:
+    virtual ~TestA() {}
+    virtual void vfunc1() = 0;
+    virtual void vfunc2() = 0;
+};
+
+class TestB
+{
+public:
+    virtual ~TestB() {}
+    virtual void vfunc1() = 0;
+    virtual void vfunc2() = 0;
+};


### PR DESCRIPTION
I checked the offset change in `vtable` according to the virtual method declaration order of C++ side and D side
1. I added the ability to check the offset of the virtual method.
 
The next PR is #710 #711 

Relates to #323