### PR TITLE
Remove unused protobuf-d submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,9 +43,6 @@
 [submodule "d2sqlite3"]
 	path = submodules/d2sqlite3
 	url = https://github.com/biozic/d2sqlite3.git
-[submodule "protobuf-d"]
-	path = submodules/protobuf-d
-	url = https://github.com/dcarp/protobuf-d.git
 [submodule "ocean"]
 	path = submodules/ocean
 	url = https://github.com/bpfkorea/ocean.git

--- a/dub.json
+++ b/dub.json
@@ -92,7 +92,6 @@
         "libsodiumd":       { "path": "submodules/libsodiumd/", "version": "*" },
         "localrest":        { "path": "submodules/localrest/", "version": "*" },
         "ocean":            { "path": "submodules/ocean/", "version": "*" },
-        "protobuf":         { "path": "submodules/protobuf-d/", "version": "*" },
         "vibe-d":           { "path": "submodules/vibe.d/", "version": "*" }
     }
 }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -15,7 +15,6 @@
 		"localrest": { "path": "submodules/localrest/" },
 		"mir-linux-kernel": { "path": "submodules/mir-linux-kernel/" },
 		"openssl": { "path": "submodules/openssl/" },
-		"protobuf": { "path": "submodules/protobuf-d/" },
 		"stdx-allocator": { "path": "submodules/stdx-allocator/" },
 		"taggedalgebraic": { "path": "submodules/taggedalgebraic/" },
 		"tinyendian": { "path": "submodules/tinyendian/" },

--- a/submodules/README.md
+++ b/submodules/README.md
@@ -17,7 +17,6 @@ This data can also be gathered by running `git submodules`.
 | localrest        | 6da1455      | 2020-02-14  | Yes (Owned)  |
 | mir-linux-kernel | 1.0.1        | 2018-09-17  |     No       |
 | openssl          | 1.1.6+1.0.1g | 2017-11-06  |     No       |
-| protobuf-d       | a89aa09      | 2019-10-08  |     No       |
 | stdx-allocator   | 2.77.5       | 2000-00-00  |     No       |
 | taggedalgebraic  | 0.11.9       | 2020-02-20  |     No       |
 | tinyendian       | 0.2.0        | 2018-06-10  |     No       |


### PR DESCRIPTION
The idea was to use it for the TCP communication,
but in order to deal with C++ data type we'll have to take another route.