### PR TITLE
Fix syntax error in documentation actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Prepare compiler
       uses: mihails-strasuns/setup-dlang@v0.5.0
       with:
-          compiler: ${{ dmd-2.090.1 }}
+          compiler: [dmd-2.090.1]
           gh_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install dependencies
       run: |


### PR DESCRIPTION
It's an array of value, not the name of a variable.