### PR TITLE
Add bindings to updateLocalQuorumSet()

### DIFF
--- a/source/scpd/scp/NominationProtocol.d
+++ b/source/scpd/scp/NominationProtocol.d
@@ -113,6 +113,9 @@ nothrow:
     // stops the nomination protocol
     void stopNomination();
 
+    // Local QuorumSet interface (can be dynamically updated)
+    void updateLocalQuorumSet(const ref SCPQuorumSet qSet);
+
     void setStateFromEnvelope(const ref SCPEnvelope e);
 
     vector!SCPEnvelope getCurrentState() const;


### PR DESCRIPTION
I was surprised to see this exists in SCP.

However, it is actually unused in stellar-core. So whether it actually works as designed I am not completely sure yet.

In theory all that's needed to hot-swap a node's quorum settings is to cancel all SCP timers and then call this function with the new quorum set.

Needed for: #240 