### PR TITLE
Check the validity of a preimage

### DIFF
--- a/source/agora/consensus/ValidatorSet.d
+++ b/source/agora/consensus/ValidatorSet.d
@@ -518,6 +518,20 @@ public class ValidatorSet
             return false;
         }
 
+        // check the validity of new pre-image based on the stored pre-image
+        PreimageInfo stored_image;
+        if (this.getPreimage(preimage.enroll_key, stored_image) &&
+            stored_image != PreimageInfo.init)
+        {
+            if (auto reason =
+                isInvalidPreimageReason(preimage, stored_image, ValidatorCycle))
+            {
+                log.info("Invalid preimage data: {}, Data was: ", reason,
+                    preimage);
+                return false;
+            }
+        }
+
         // insert the pre-image into the table
         try
         {


### PR DESCRIPTION
When new pre-image is revealed, it must be checked if it's the right pre-image for a current pre-image stored in the validator set. This PR adds the `isInvalidPreimageReason` function checking the validity of a preimage and makes the validator set use the function in the `addPreimage` function.

Relates #694 