### PR TITLE
Add the function restoring validators' information

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -18,6 +18,7 @@ import agora.common.crypto.Key;
 import agora.common.crypto.Schnorr;
 import agora.common.Hash;
 import agora.common.Serializer;
+import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.PreimageInfo;
 import agora.consensus.data.UTXOSet;
@@ -530,6 +531,23 @@ public class EnrollmentManager
         ulong next_height = this.getNextRevealHeight();
         if (this.next_reveal_height < ulong.max)
             this.setNextRevealHeight(next_height + PreimageRevealPeriod);
+    }
+
+    /***************************************************************************
+
+        Restore validators' information from block
+
+        Params:
+            last_height = the latest block height
+            block = the block to update the validator set with
+            finder = the delegate to find UTXOs with
+
+    ***************************************************************************/
+
+    public void restoreValidators (ulong last_height, const ref Block block,
+        scope UTXOFinder finder) @safe nothrow
+    {
+        this.validator_set.restoreValidators(last_height, block, finder);
     }
 
     /***************************************************************************

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -26,6 +26,7 @@ import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
 import agora.consensus.data.UTXOSet;
 import agora.consensus.EnrollmentManager;
+import agora.consensus.ValidatorSet;
 import agora.consensus.Genesis;
 import agora.consensus.Validation;
 import agora.node.BlockStorage;
@@ -97,6 +98,21 @@ public class Ledger
             {
                 this.storage.readBlock(block, height);
                 this.updateUTXOSet(block);
+            }
+        }
+
+        // restore validator set from lastest blocks
+        if (this.last_block.header.height > 0)
+        {
+            foreach (i; 0 .. ValidatorSet.ValidatorCycle)
+            {
+                if (i >= this.last_block.header.height)
+                    break;
+
+                Block block;
+                this.storage.readBlock(block, this.last_block.header.height - i);
+                this.enroll_man.restoreValidators(this.last_block.header.height,
+                    block, this.utxo_set.getUTXOFinder());
             }
         }
     }


### PR DESCRIPTION
In abnormal situations, the validator set must restore the information from blocks which have Enrollment objects and enrolled heights in their headers. This PR adds the `restoreValidators` function for that.