### PR TITLE
Print logs of worker threads when unittests fail & fix interleaved output

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -137,6 +137,7 @@ private UnitTestResult customModuleUnitTester ()
         {
             writefln("Module tests failed: %s", mod.name);
             writeln(ex);
+            CircularAppender().printConsole();  // print logs of the work thread
         }
     }
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -123,10 +123,10 @@ private UnitTestResult customModuleUnitTester ()
 
     shared size_t executed;
     shared size_t passed;
-    foreach (mod; parallel(mod_tests))
+
+    void runTest (ModTest mod)
     {
         atomicOp!"+="(executed, 1);
-
         try
         {
             //writefln("Unittesting %s..", mod.name);
@@ -139,24 +139,13 @@ private UnitTestResult customModuleUnitTester ()
             writeln(ex);
         }
     }
+
+    foreach (mod; parallel(mod_tests))
+        runTest(mod);
 
     // Run single-threaded tests
     foreach (mod; single_threaded)
-    {
-        atomicOp!"+="(executed, 1);
-        try
-        {
-            //writefln("Unittesting %s..", mod.name);
-            mod.test();
-            atomicOp!"+="(passed, 1);
-        }
-        catch (Throwable ex)
-        {
-            writefln("Module tests failed: %s", mod.name);
-            writeln(ex);
-        }
-    }
-
+        runTest(mod);
 
     UnitTestResult result = { executed : executed, passed : passed };
     if (filtered > 0)

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -80,6 +80,7 @@ private UnitTestResult customModuleUnitTester ()
     import std.string;
     import std.uni;
     import core.atomic;
+    import core.sync.mutex;
 
     //
     auto filter = environment.get("dtest").toLower();
@@ -123,6 +124,7 @@ private UnitTestResult customModuleUnitTester ()
 
     shared size_t executed;
     shared size_t passed;
+    shared Mutex print_lock = new shared Mutex();
 
     void runTest (ModTest mod)
     {
@@ -135,9 +137,12 @@ private UnitTestResult customModuleUnitTester ()
         }
         catch (Throwable ex)
         {
-            writefln("Module tests failed: %s", mod.name);
-            writeln(ex);
-            CircularAppender().printConsole();  // print logs of the work thread
+            synchronized (print_lock)
+            {
+                writefln("Module tests failed: %s", mod.name);
+                writeln(ex);
+                CircularAppender().printConsole();  // print logs of the work thread
+            }
         }
     }
 

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -100,6 +100,6 @@ unittest
     send_txs.each!(tx => node_1.putTransaction(tx));
     nodes.each!(node =>
        send_txs.each!(tx =>
-           node.hasTransactionHash(hashFull(tx)).retryFor(3.seconds)
+           node.hasTransactionHash(hashFull(tx)).retryFor(5.seconds)
     ));
 }

--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -98,6 +98,7 @@ public template AddLogger (string moduleName = __MODULE__)
     {
         import core.memory;
         log = Logger(Ocean.Log.lookup(moduleName));
+        log.logger.buffer(new char[](16384));
         GC.addRoot(cast(void*)log.logger);
     }
 


### PR DESCRIPTION
For example if a test like `assert(ledger.acceptTransaction(tx));` in `agora.node.Ledger` fails then we currently can't tell why it fails. All of the diagnostics are logged to the logger.