### PR TITLE
Adds the ability to check if the offset in the `vtable` on C++ side and D side is the same.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -98,7 +98,8 @@
             "excludedSourceFiles": ["source/agora/cli/*/main.d"],
             "sourceFiles-posix": [
                 "source/scpp/build/DSizeChecks.o",
-                "source/scpp/build/DLayoutChecks.o"
+                "source/scpp/build/DLayoutChecks.o",
+                "source/scpp/build/DVMTestTypes.o"
             ],
             "sourceFiles-windows": [
                 "source/scpp/build/DSizeChecks.obj",

--- a/dub.json
+++ b/dub.json
@@ -99,7 +99,8 @@
             "sourceFiles-posix": [
                 "source/scpp/build/DSizeChecks.o",
                 "source/scpp/build/DLayoutChecks.o",
-                "source/scpp/build/DVMTestTypes.o"
+                "source/scpp/build/DVMTestTypes.o",
+                "source/scpp/build/DVMChecks.o"
             ],
             "sourceFiles-windows": [
                 "source/scpp/build/DSizeChecks.obj",

--- a/source/scpd/tests/VTableTest.d
+++ b/source/scpd/tests/VTableTest.d
@@ -1,0 +1,75 @@
+/*******************************************************************************
+
+    Contains checking if the virtual methods are in the same order
+    using vtable.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module scpd.tests.VTableTest;
+
+version (Windows) {} else:
+
+/// In case the virtual methods are in the correct order.
+unittest
+{
+    // abstract class, this is in the correct order.
+    extern (C++) class TestA
+    {
+    public:
+        ~this()
+        {
+        }
+        abstract void vfunc1();
+        abstract void vfunc2();
+    }
+
+    extern (C++) class BonTestA : TestA
+    {
+    public:
+        override void vfunc1() {}
+        override void vfunc2() {}
+    }
+
+    auto n = new BonTestA();
+    // The point of the method is the same as the expected value.
+    assert(n.__vptr[2] is &BonTestA.vfunc1);
+    assert(n.__vptr[3] is &BonTestA.vfunc2);
+}
+
+/// In case the virtual methods are in the incorrect order.
+unittest
+{
+    // abstract class, this is in the incorrect order.
+    extern (C++) class TestB
+    {
+    public:
+        ~this()
+        {
+        }
+        // The order of the two methods has changed.
+        abstract void vfunc2();
+        abstract void vfunc1();
+    }
+
+    extern (C++) class BonTestB : TestB
+    {
+    public:
+        override void vfunc1() {}
+        override void vfunc2() {}
+    }
+
+    auto n = new BonTestB();
+    // The method's point differs from the expected value.
+    assert(n.__vptr[2] !is &BonTestB.vfunc1);
+    assert(n.__vptr[3] !is &BonTestB.vfunc2);
+
+    assert(n.__vptr[2] is &BonTestB.vfunc2);
+    assert(n.__vptr[3] is &BonTestB.vfunc1);
+}

--- a/source/scpd/tests/VTableTypes.d
+++ b/source/scpd/tests/VTableTypes.d
@@ -1,0 +1,35 @@
+/*******************************************************************************
+
+    Contains types to check if the virtual methods are in the same order
+    using vtable.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module scpd.tests.VTableTypes;
+
+public import scpd.scp.SCPDriver;
+
+import std.meta;
+
+extern (C++) public class TestA
+{
+public:
+    ~this()
+    {
+    }
+    abstract void vfunc1();
+    abstract void vfunc2();
+}
+
+public immutable VTableCheckClasses =
+[
+    "TestA",
+    "SCPDriver"
+];

--- a/source/scpp/extra/DVMChecks.cpp
+++ b/source/scpp/extra/DVMChecks.cpp
@@ -1,0 +1,19 @@
+/*******************************************************************************
+
+    Contains checking the offset of virtual methods.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+#include "DVMChecks.h"
+
+int checkVMOffset (const char* classname, const char* offsets)
+{
+    return 0;
+}

--- a/source/scpp/extra/DVMChecks.h
+++ b/source/scpp/extra/DVMChecks.h
@@ -1,0 +1,19 @@
+/*******************************************************************************
+
+    Contains checking the offset of virtual methods.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+#pragma once
+
+#include "DVMTestTypes.h";
+#include "scp/SCPDriver.h";
+
+using namespace stellar;

--- a/source/scpp/extra/DVMTestTypes.cpp
+++ b/source/scpp/extra/DVMTestTypes.cpp
@@ -1,0 +1,20 @@
+/*******************************************************************************
+
+    Contains classes to check the offset of virtual methods.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+#include "DVMTestTypes.h"
+
+void export_classes ()
+{
+    auto pF1A = &TestA::vfunc1;
+    auto pF1B = &TestB::vfunc1;
+}

--- a/source/scpp/extra/DVMTestTypes.h
+++ b/source/scpp/extra/DVMTestTypes.h
@@ -1,0 +1,30 @@
+/*******************************************************************************
+
+    Contains classes to check the offset of virtual methods.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+#pragma once
+
+class TestA
+{
+public:
+    virtual ~TestA() {}
+    virtual void vfunc1() = 0;
+    virtual void vfunc2() = 0;
+};
+
+class TestB
+{
+public:
+    virtual ~TestB() {}
+    virtual void vfunc1() = 0;
+    virtual void vfunc2() = 0;
+};


### PR DESCRIPTION
It checks the offset of the virtual method for any class.

The previous PR is #689 

The next PR is #711 

Relates to #323 
