### PR TITLE
Minor modifications for MSVC mangling

### DIFF
--- a/source/scpd/scp/BallotProtocol.d
+++ b/source/scpd/scp/BallotProtocol.d
@@ -55,7 +55,7 @@ extern(C++, class) public struct BallotProtocol
         SCP_PHASE_NUM
     }
     // human readable names matching SCPPhase
-    static extern __gshared const(char*)[] phaseNames;
+    extern __gshared const(char*)[SCPPhase.max] phaseNames;
 
     unique_ptr!SCPBallot mCurrentBallot;      // b
     unique_ptr!SCPBallot mPrepared;           // p


### PR DESCRIPTION
This problem was found in the WindowsX64 MSVC test.

@Geod24 description
POSIX the type isn’t mangled
static and __gshared are redundant. 
Because static means “TLS global” when in an aggregate, while __gshared means “non-TLS global”
So they are both global, and __gshared wins over static (because TLS is the default)