### PR TITLE
Make a constructor of Scalar trusted

### DIFF
--- a/source/agora/common/crypto/ECC.d
+++ b/source/agora/common/crypto/ECC.d
@@ -80,8 +80,10 @@ public struct Scalar
     }
 
     /// Reduce the hash to a scalar
-    public this (Hash param) nothrow @nogc
+    public this (Hash param) @trusted nothrow @nogc
     {
+        static assert(typeof(data).sizeof == 32);
+        static assert(Hash.sizeof == 64);
         crypto_core_ed25519_scalar_reduce(this.data[].ptr, param[].ptr);
     }
 


### PR DESCRIPTION
We know the call is safe because the C library under the hood accept fixed-size values.
Two static assert were added both to verify this and to make it clearer to the reader.