### PR TITLE
Check the validity of a pre-image based on random seed

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -253,6 +253,7 @@ public class EnrollmentManager
 
         // X, final seed data and preimages of hashes
         this.data.random_seed = this.generatePreimages(height);
+        this.data.random_seed_height = height;
 
         // R, signature noise
         this.signature_noise = this.createSignatureNoise(height);

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -938,19 +938,19 @@ unittest
 
     auto utxo_hash = utxo_hashes[0];
     Enrollment enroll;
-    assert(man.createEnrollment(utxo_hash, 1, enroll));
+    assert(man.createEnrollment(utxo_hash, 100, enroll));
     assert(man.add(0, &storage.findUTXO, enroll));
     assert(man.hasEnrollment(utxo_hash));
 
     PreimageInfo result_image;
     assert(man.getValidatorPreimage(utxo_hash, result_image));
     assert(result_image == PreimageInfo.init);
-    auto preimage = PreimageInfo(utxo_hash, man.cycle_preimages[100], 1100);
+    auto preimage = PreimageInfo(utxo_hash, man.cycle_preimages[110], 110);
     assert(man.addPreimage(preimage));
     assert(man.getValidatorPreimage(utxo_hash, result_image));
     assert(result_image.enroll_key == utxo_hash);
-    assert(result_image.hash == man.cycle_preimages[100]);
-    assert(result_image.height == 1100);
+    assert(result_image.hash == man.cycle_preimages[110]);
+    assert(result_image.height == 110);
 }
 
 // test for generating pre-images

--- a/source/agora/consensus/data/Enrollment.d
+++ b/source/agora/consensus/data/Enrollment.d
@@ -41,6 +41,9 @@ public struct Enrollment
     /// X: random seed, The nth image of random value
     public Hash random_seed;
 
+    /// the block height where the random seed belongs to
+    public ulong random_seed_height;
+
     /// n: cycle length, the number of rounds a validator will participate in
     /// (currently fixed to (freezing period / 2)
     public uint cycle_length;


### PR DESCRIPTION
If there is no pre-image revealed, the validator set must check the validity of the pre-image based on the temporary pre-image made from the random seed. 

Fixes #694 