### PR TITLE
[RFC] Drop support for DMD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,11 @@ jobs:
             git submodule sync
             git submodule update --init
       - run:
-          name: Install DMD
+          name: Install LDC
           command: |
             mkdir -p $HOME/dlang && wget https://dlang.org/install.sh -O $HOME/dlang/install.sh
             chmod +x $HOME/dlang/install.sh
-            $HOME/dlang/install.sh install dmd-2.090.1
+            $HOME/dlang/install.sh install ldc-1.20.1
       - run:
           name: Install libsodium
           command: |
@@ -44,7 +44,7 @@ jobs:
       - run:
           name: Build & test docker image
           command: |
-            source $HOME/dlang/dmd-2.090.1/activate
+            source $HOME/dlang/ldc-1.20.1/activate
             ci/system_integration_test.d
             # Work around druntime setting the permissions to 600..
             sudo chmod 644 tests/system/node/*/*.lst

--- a/.github/workflows/github_pr.yml
+++ b/.github/workflows/github_pr.yml
@@ -20,9 +20,7 @@ jobs:
       # fail-fast: false
       matrix:
         os: [ ubuntu-18.04, macOS-10.15, windows-2019 ]
-        dc: [ dmd-2.091.0, ldc-1.20.1, ldc-1.19.0 ]
-        exclude:
-          - { os: windows-2019, dc: dmd-2.091.0 }
+        dc: [ ldc-1.20.1, ldc-1.19.0 ]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/github_push.yaml
+++ b/.github/workflows/github_push.yaml
@@ -28,14 +28,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-18.04, macOS-10.15, windows-2019 ]
-        dc: [ dmd-master, ldc-master, dmd-latest ]
+        dc: [ ldc-master, ldc-latest ]
         exclude:
           # Not supported yet
           - os: windows-2019
           # We only build documentation on Linux
-          # Just use the latest release of DMD here, don't pin the version
-          - { os: macOS-10.15,  dc: dmd-latest }
-          - { os: windows-2019, dc: dmd-latest }
+          # Just use the latest release of LDC here, don't pin the version
+          - { os: macOS-10.15,  dc: ldc-master }
+          - { os: windows-2019, dc: ldc-master }
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -84,7 +84,7 @@ jobs:
 
     # Documentation: Note that this will push documentation to your fork, too!
     - name: Build and deploy documentation
-      if: matrix.dc == 'dmd-latest'
+      if: matrix.dc == 'ldc-latest'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: d
 dist: xenial
 
 d:
-  - dmd-2.090.1,dub
-  - ldc-1.20.0,dub
-  - dmd-nightly   # Nightlies at the end so that `fast_finish` is useful
+  - ldc-1.20.1,dub
   - ldc-latest-ci # The freshest LDC
 
 os:
@@ -14,7 +12,6 @@ os:
 
 matrix:
   allow_failures:
-    - d: dmd-nightly
     - d: ldc-latest-ci
   fast_finish: true
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and make the port locally accessible (See http://127.0.0.1:4000/) .
 
 ## Dependencies
 
-You need a recent C++ compiler (g++ with N4387 fixed), a recent D compiler, and `dub`.
+You need a recent C++ compiler (g++ with N4387 fixed), a recent (>=1.19.0) version of the LDC compiler, and `dub`.
 On Linux, we recommend gcc-9. On OSX, the latest `llvm` package available on Homebrew.
 
 Additionally, the following are dependencies:
@@ -54,8 +54,10 @@ and add it to your `.bashrc`, `.zshrc`, etc...
 ## Build instructions
 
 ```console
-# Install the latest DMD compiler
-curl https://dlang.org/install.sh | bash -s
+# Install the LDC compiler (you might want to use a newer version)
+curl https://dlang.org/install.sh | bash -s ldc-1.20.0
+# Add LDC to the $PATH
+source ~/dlang/ldc-1.20.0/activate
 # Clone this repository
 git clone https://github.com/bpfkorea/agora.git
 # Use the git root as working directory

--- a/dub.json
+++ b/dub.json
@@ -68,6 +68,12 @@
     "lflags-windows": [  "sqlite3.lib", "/nodefaultlib:msvcetd.lib" ],
     "buildRequirements": [ "allowWarnings" ],
 
+	"toolchainRequirements": {
+		"dmd": "no",
+		"gdc": "no",
+		"ldc": "~>1.19"
+	},
+
     "configurations": [
         {
             "name": "server",

--- a/dub.settings.json
+++ b/dub.settings.json
@@ -1,0 +1,3 @@
+{
+    "defaultCompiler": "ldc"
+}


### PR DESCRIPTION
```
DMD backend has proven to be a constant source of issues.
It produces suboptimal code, and behaves differently from other compilers,
e.g. causing unwarranted and unpreventable moves which would be detrimental
to our usage of `std::string`.
Last but not least, it provides completely broken debug infos on OSX.
```

@bpfkorea/core : Opinions ?