### PR TITLE
Correct the Github actions CI Test to return the error level correctly

### DIFF
--- a/ci/run.bat
+++ b/ci/run.bat
@@ -1,4 +1,8 @@
 call dub test --skip-registry=all --compiler=%DC%
+::if %errorlevel% neq 0 exit /b %errorlevel%
 call rdmd --compiler=%DC% ./tests/runner.d --compiler=%DC% -cov
+::if %errorlevel% neq 0 exit /b %errorlevel%
 call dub build --skip-registry=all --compiler=%DC%
+if %errorlevel% neq 0 exit /b %errorlevel%
 call dub build -c client --skip-registry=all --compiler=%DC%
+if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
A build test error occurred in the window cmd environment, but the exit code is not returned.
Returns only the last run result.