### PR TITLE
automerge: Add update method and reduce triggers

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -5,11 +5,9 @@ on:
   pull_request:
     types:
       - labeled
-      - unlabeled
       - synchronize
       - opened
       - edited
-      - ready_for_review
       - reopened
       - unlocked
   pull_request_review:
@@ -29,3 +27,4 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_METHOD: 'rebase'
+          UPDATE_METHOD: 'rebase'


### PR DESCRIPTION
The two removed triggers are not so useful, and the update method is necessary to enable some Github option