### PR TITLE
Add @safe to quorum conversion functions

### DIFF
--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -576,7 +576,7 @@ private T get (T, string section, string name) (const ref CommandLine cmdl, Node
 
 *******************************************************************************/
 
-public SCPQuorumSet toSCPQuorumSet ( in QuorumConfig quorum_conf )
+public SCPQuorumSet toSCPQuorumSet ( in QuorumConfig quorum_conf ) @safe
 {
     import std.conv;
     import scpd.types.Stellar_types : Hash, NodeID;
@@ -612,7 +612,7 @@ public SCPQuorumSet toSCPQuorumSet ( in QuorumConfig quorum_conf )
 
 *******************************************************************************/
 
-public QuorumConfig toQuorumConfig (const ref SCPQuorumSet scp_quorum)
+public QuorumConfig toQuorumConfig (const ref SCPQuorumSet scp_quorum) @safe
 {
     import std.conv;
     import scpd.types.Stellar_types : Hash, NodeID;


### PR DESCRIPTION
When QuorumConfig was moved out, I forgot to move these additional routines.