### PR TITLE
Split enrollments of the ValidatorSet into candidates and validators

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -83,7 +83,7 @@ public class EnrollmentManager
     private EnrollmentPool enroll_pool;
 
     /// The count for generating pre-images
-    private immutable uint AllCountPreimages = ValidatorSet.ValidatorCycle * 100;
+    private immutable uint AllCountPreimages = Enrollment.ValidatorCycle * 100;
 
     /***************************************************************************
 
@@ -242,7 +242,7 @@ public class EnrollmentManager
         this.enroll_key = frozen_utxo_hash;
 
         // N, cycle length
-        this.data.cycle_length = ValidatorSet.ValidatorCycle;
+        this.data.cycle_length = Enrollment.ValidatorCycle;
 
         // X, final seed data and preimages of hashes
         this.data.random_seed = this.generatePreimages(height);
@@ -417,7 +417,7 @@ public class EnrollmentManager
         if (height < start_height)
             return false;
         immutable index = (height - start_height);
-        if (index > ValidatorSet.ValidatorCycle - 1)
+        if (index > Enrollment.ValidatorCycle - 1)
             return false;
 
         if (height !in this.cycle_preimages)
@@ -620,12 +620,12 @@ public class EnrollmentManager
         // This determines which range of preimages must be generated.
         // In order to get hash values more than one cycle, the `start_height`
         // is to be the height of the last preimage of next cycle. The value of
-        // `height / ValidatorSet.ValidatorCycle` is the index of previous
+        // `height / Enrollment.ValidatorCycle` is the index of previous
         // cycle, so we need to plus 2 to the value in order to get the index
         // of the next cycle.
         ulong start_height =
-            ((height / ValidatorSet.ValidatorCycle) + 2) *
-                ValidatorSet.ValidatorCycle;
+            ((height / Enrollment.ValidatorCycle) + 2) *
+                Enrollment.ValidatorCycle;
 
         // Clear if recreating pre-images is needed
         if (this.preimage_rounds.byKey.maxElement(0) < start_height)
@@ -649,7 +649,7 @@ public class EnrollmentManager
             for (--idx; idx >= height; --idx)
             {
                 hash = hashFull(hash);
-                if (idx % ValidatorSet.ValidatorCycle == 0)
+                if (idx % Enrollment.ValidatorCycle == 0)
                     this.preimage_rounds[idx] = hash;
             }
         }
@@ -679,7 +679,7 @@ public class EnrollmentManager
         // Load first entry from the rounds
         this.cycle_preimages[height] = seed;
         // Fill the cache
-        foreach (idx; 1 .. ValidatorSet.ValidatorCycle * 2)
+        foreach (idx; 1 .. Enrollment.ValidatorCycle * 2)
         {
             seed = hashFull(seed);
             this.cycle_preimages[height - idx] = seed;
@@ -874,8 +874,8 @@ unittest
     assert(man.addValidator(enroll, 10, &storage.findUTXO));
     assert(!man.getPreimage(10, preimage));
     assert(man.getPreimage(11, preimage));
-    assert(man.getPreimage(10 + ValidatorSet.ValidatorCycle, preimage));
-    assert(!man.getPreimage(11 + ValidatorSet.ValidatorCycle, preimage));
+    assert(man.getPreimage(10 + Enrollment.ValidatorCycle, preimage));
+    assert(!man.getPreimage(11 + Enrollment.ValidatorCycle, preimage));
 
     /// test for the functions about periodic revelation of a pre-image
     assert(man.needRevealPreimage(10));
@@ -884,7 +884,7 @@ unittest
 
     // If the height of the requested preimage exceeds the height of the end of
     // the validator cycle, the `getNextPreimage` must return `false`.
-    man.next_reveal_height = 10 + ValidatorSet.ValidatorCycle;
+    man.next_reveal_height = 10 + Enrollment.ValidatorCycle;
     assert(!man.getNextPreimage(preimage));
 
     // test for getting validators

--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -1,0 +1,403 @@
+/*******************************************************************************
+
+    Contains supporting code for managing enrollments registered by nodes
+    on the network to be a validator, which means the enrollment information
+    needs to be confirmed on the consensus protocol to be a validator. The
+    information is stored in a table of SQLite.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.consensus.EnrollmentPool;
+
+import agora.common.crypto.ECC;
+import agora.common.crypto.Key;
+import agora.common.crypto.Schnorr;
+import agora.common.Hash;
+import agora.common.Serializer;
+import agora.consensus.data.Block;
+import agora.consensus.data.Enrollment;
+import agora.consensus.data.PreImageInfo;
+import agora.consensus.data.UTXOSet;
+import agora.consensus.Validation;
+import agora.utils.Log;
+
+import d2sqlite3.database;
+import d2sqlite3.library;
+import d2sqlite3.results;
+import d2sqlite3.sqlite3;
+
+mixin AddLogger!();
+
+/// Ditto
+public class EnrollmentPool
+{
+    /// SQLite DB instance
+    private Database db;
+
+    /***************************************************************************
+
+        Constructor
+
+        Params:
+            db_path = path to the database file, or in-memory storage if
+                        :memory: was passed
+
+    ***************************************************************************/
+
+    public this (string db_path)
+    {
+        this.db = Database(db_path);
+
+        // create the table for enrollment pool if it doesn't exist yet
+        this.db.execute("CREATE TABLE IF NOT EXISTS enrollment_pool " ~
+            "(key TEXT PRIMARY KEY, val BLOB NOT NULL)");
+    }
+
+    /***************************************************************************
+
+        Shut down the database
+
+        Note: this method must be called explicitly, and not inside of
+        a destructor.
+
+    ***************************************************************************/
+
+    public void shutdown ()
+    {
+        this.db.close();
+    }
+
+    /***************************************************************************
+
+        Add a enrollment data to the enrollment pool
+
+        Params:
+            enroll = the enrollment data to add
+            finder = the delegate to find UTXOs with
+
+        Returns:
+            true if the enrollment data has been added to the enrollment pool
+
+    ***************************************************************************/
+
+    public bool add (const ref Enrollment enroll, scope UTXOFinder finder)
+        @safe nothrow
+    {
+        // check validity of the enrollment data
+        if (auto reason = isInvalidEnrollmentReason(enroll, finder))
+        {
+            log.info("Invalid enrollment data: {}, Data was: {}", reason, enroll);
+            return false;
+        }
+
+        // check if already exists
+        if (this.hasEnrollment(enroll.utxo_key))
+        {
+            log.info("Rejected already existing enrollment, Data was: {}",
+                enroll);
+            return false;
+        }
+
+        static ubyte[] buffer;
+        try
+        {
+            serializeToBuffer(enroll, buffer);
+        }
+        catch (Exception ex)
+        {
+            log.error("Serialization error: {}, Data was: {}", ex.msg, enroll);
+            return false;
+        }
+
+        try
+        {
+            () @trusted {
+                this.db.execute("INSERT INTO enrollment_pool (key, val) VALUES (?, ?)",
+                    enroll.utxo_key.toString(), buffer);
+            }();
+        }
+        catch (Exception ex)
+        {
+            log.error("Database operation error: {}, Data was: {}", ex.msg, enroll);
+            return false;
+        }
+
+        return true;
+    }
+
+    /***************************************************************************
+
+        Returns:
+            the number of enrollments being managed by the enrollment pool,
+            which are un-registered enrollments.
+
+    ***************************************************************************/
+
+    public size_t count () @trusted nothrow
+    {
+        try
+        {
+            return this.db.execute("SELECT count(*) FROM enrollment_pool").
+                oneValue!size_t;
+        }
+        catch (Exception ex)
+        {
+            log.error("Database operation error on count");
+            return 0;
+        }
+    }
+
+    /***************************************************************************
+
+        Remove the enrollment data with the given key from the enrollment pool
+
+        Params:
+            enroll_hash = key for an enrollment data to remove
+
+    ***************************************************************************/
+
+    public void remove (const ref Hash enroll_hash) @trusted nothrow
+    {
+        try
+        {
+            this.db.execute("DELETE FROM enrollment_pool WHERE key = ?",
+                enroll_hash.toString());
+        }
+        catch (Exception ex)
+        {
+            log.error("Database operation error on remove");
+        }
+    }
+
+    /***************************************************************************
+
+        Check if a enrollment data exists in the enrollment pool.
+
+        Params:
+            enroll_hash = key for an enrollment data which is hash of frozen UTXO
+
+        Returns:
+            true if the validator set has the enrollment data
+
+    ***************************************************************************/
+
+    public bool hasEnrollment (const ref Hash enroll_hash) @trusted nothrow
+    {
+        try
+        {
+            auto results = this.db.execute("SELECT EXISTS(SELECT 1 FROM " ~
+                "enrollment_pool WHERE key = ?)", enroll_hash.toString());
+            return results.front().peek!bool(0);
+        }
+        catch (Exception ex)
+        {
+            log.error("Exception occured on hasEnrollment: {}, " ~
+                "Key for enrollment: {}", ex.msg, enroll_hash);
+            return false;
+        }
+    }
+
+    /***************************************************************************
+
+        Get the enrollment data with the key, and store it to 'enroll' if found
+
+        Params:
+            enroll_hash = key for an enrollment data which is a hash of a frozen
+                            UTXO
+            enroll = will contain the enrollment data if found
+
+        Returns:
+            Return true if the enrollment data was found
+
+    ***************************************************************************/
+
+    public bool getEnrollment (const ref Hash enroll_hash,
+        out Enrollment enroll) @trusted nothrow
+    {
+        try
+        {
+            auto results = this.db.execute("SELECT key, val FROM enrollment_pool " ~
+                "WHERE key = ?", enroll_hash.toString());
+
+            foreach (row; results)
+            {
+                enroll = deserializeFull!Enrollment(row.peek!(ubyte[])(1));
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            log.error("Exception occured on getEnrollment: {}, " ~
+                "Key for enrollment: {}", ex.msg, enroll_hash);
+            return false;
+        }
+
+        return false;
+    }
+
+    /***************************************************************************
+
+        Get the unregistered enrollments in the block
+        And this is arranged in ascending order with the utxo_key
+
+        Params:
+            enrolls = will contain the unregistered enrollments data if found
+
+        Returns:
+            The unregistered enrollments data
+
+    ***************************************************************************/
+
+    public Enrollment[] getEnrollments (ref Enrollment[] enrolls)
+        @trusted nothrow
+    {
+        enrolls.length = 0;
+        assumeSafeAppend(enrolls);
+
+        try
+        {
+            auto results = this.db.execute("SELECT val FROM enrollment_pool " ~
+                "ORDER BY key ASC");
+
+            foreach (row; results)
+                enrolls ~= deserializeFull!Enrollment(row.peek!(ubyte[])(0));
+        }
+        catch (Exception ex)
+        {
+            log.error("Exception occured on getEnrollments: {}", ex.msg);
+        }
+
+        return enrolls;
+    }
+}
+
+version (unittest)
+private Enrollment createEnrollment(const ref Hash utxo_key,
+    const ref KeyPair key_pair, ref Scalar random_seed_src)
+{
+    import std.algorithm;
+
+    Pair pair;
+    pair.v = secretKeyToCurveScalar(key_pair.secret);
+    pair.V = pair.v.toPoint();
+
+    Hash random_seed;
+    Hash[] preimages;
+    auto enroll = Enrollment();
+    auto signature_noise = Pair.random();
+
+    enroll.utxo_key = utxo_key;
+    enroll.cycle_length = Enrollment.ValidatorCycle;
+    preimages ~= hashFull(random_seed_src);
+    foreach (i; 0 ..  enroll.cycle_length-1)
+        preimages ~= hashFull(preimages[i]);
+    reverse(preimages);
+    enroll.random_seed = preimages[0];
+    enroll.enroll_sig = sign(pair.v, pair.V, signature_noise.V,
+        signature_noise.v, enroll);
+    return enroll;
+}
+
+/// test for function of EnrollmentPool
+unittest
+{
+    import agora.common.Amount;
+    import agora.consensus.data.Transaction;
+    import agora.consensus.Genesis;
+    import std.algorithm;
+    import std.format;
+    import std.conv;
+
+    scope storage = new TestUTXOSet;
+
+    auto gen_key_pair = getGenesisKeyPair();
+    KeyPair key_pair = KeyPair.random();
+
+    foreach (idx; 0 .. 8)
+    {
+        auto input = Input(hashFull(GenesisTransaction), idx.to!uint);
+
+        Transaction tx =
+        {
+            TxType.Freeze,
+            [input],
+            [Output(Amount.MinFreezeAmount, key_pair.address)]
+        };
+
+        auto signature = gen_key_pair.secret.sign(hashFull(tx)[]);
+        tx.inputs[0].signature = signature;
+        storage.put(tx);
+    }
+    EnrollmentPool pool = new EnrollmentPool(":memory:");
+    scope (exit) pool.shutdown();
+    Hash[] utxo_hashes = storage.keys;
+
+    // add enrollments
+    Scalar[Hash] seed_sources;
+    auto utxo_hash = utxo_hashes[0];
+    seed_sources[utxo_hash] = Scalar.random();
+    auto enroll = createEnrollment(utxo_hash, key_pair, seed_sources[utxo_hash]);
+    assert(pool.add(enroll, &storage.findUTXO));
+    assert(pool.count() == 1);
+    assert(pool.hasEnrollment(utxo_hash));
+    assert(!pool.add(enroll, &storage.findUTXO));
+
+    auto utxo_hash2 = utxo_hashes[1];
+    seed_sources[utxo_hash2] = Scalar.random();
+    auto enroll2 = createEnrollment(utxo_hash2, key_pair, seed_sources[utxo_hash2]);
+    assert(pool.add(enroll2, &storage.findUTXO));
+    assert(pool.count() == 2);
+
+    auto utxo_hash3 = utxo_hashes[2];
+    seed_sources[utxo_hash3] = Scalar.random();
+    auto enroll3 = createEnrollment(utxo_hash3, key_pair, seed_sources[utxo_hash3]);
+    assert(pool.add(enroll3, &storage.findUTXO));
+    assert(pool.count() == 3);
+
+    // check if enrolled heights are not set
+    Enrollment[] enrolls;
+    pool.getEnrollments(enrolls);
+    assert(enrolls.length == 3);
+    assert(enrolls.isStrictlyMonotonic!("a.utxo_key < b.utxo_key"));
+
+    // get a specific enrollment object
+    Enrollment stored_enroll;
+    assert(pool.getEnrollment(utxo_hash2, stored_enroll));
+    assert(stored_enroll == enroll2);
+
+    // remove an enrollment
+    pool.remove(utxo_hash2);
+    assert(pool.count() == 2);
+    assert(!pool.getEnrollment(utxo_hash2, stored_enroll));
+
+    // test for enrollment block height update
+    pool.getEnrollments(enrolls);
+    assert(enrolls.length == 2);
+
+    assert(pool.hasEnrollment(utxo_hash));
+    pool.remove(utxo_hash);
+    assert(!pool.hasEnrollment(utxo_hash));
+    pool.remove(utxo_hash2);
+    pool.remove(utxo_hash3);
+    assert(pool.getEnrollments(enrolls).length == 0);
+
+    Enrollment[] ordered_enrollments;
+    ordered_enrollments ~= enroll;
+    ordered_enrollments ~= enroll2;
+    ordered_enrollments ~= enroll3;
+
+    // Reverse ordering
+    ordered_enrollments.sort!("a.utxo_key > b.utxo_key");
+    foreach (ordered_enroll; ordered_enrollments)
+        assert(pool.add(ordered_enroll, &storage.findUTXO));
+    pool.getEnrollments(enrolls);
+    assert(enrolls.length == 3);
+    assert(enrolls.isStrictlyMonotonic!("a.utxo_key < b.utxo_key"));
+}

--- a/source/agora/consensus/Validation.d
+++ b/source/agora/consensus/Validation.d
@@ -1463,17 +1463,17 @@ unittest
 
     // valid pre-image
     PreImageInfo new_image = PreImageInfo(hashFull("abc"), preimages[100], 101);
-    assert(isValidPreimage(new_image, prev_image, ValidatorSet.ValidatorCycle));
+    assert(isValidPreimage(new_image, prev_image, Enrollment.ValidatorCycle));
 
     // invalid pre-image with wrong enrollment key
     new_image = PreImageInfo(hashFull("xyz"), preimages[100], 101);
-    assert(!isValidPreimage(new_image, prev_image, ValidatorSet.ValidatorCycle));
+    assert(!isValidPreimage(new_image, prev_image, Enrollment.ValidatorCycle));
 
     // invalid pre-image with wrong height number
     new_image = PreImageInfo(hashFull("abc"), preimages[1], 3);
-    assert(!isValidPreimage(new_image, prev_image, ValidatorSet.ValidatorCycle));
+    assert(!isValidPreimage(new_image, prev_image, Enrollment.ValidatorCycle));
 
     // invalid pre-image with wrong hash value
     new_image = PreImageInfo(hashFull("abc"), preimages[100], 100);
-    assert(!isValidPreimage(new_image, prev_image, ValidatorSet.ValidatorCycle));
+    assert(!isValidPreimage(new_image, prev_image, Enrollment.ValidatorCycle));
 }

--- a/source/agora/consensus/ValidatorSet.d
+++ b/source/agora/consensus/ValidatorSet.d
@@ -40,10 +40,6 @@ public class ValidatorSet
     /// SQLite db instance
     private Database db;
 
-    /// The cycle length for a validator
-    public static immutable uint ValidatorCycle = Enrollment.ValidatorCycle;
-
-
     /***************************************************************************
 
         Constructor
@@ -301,13 +297,14 @@ public class ValidatorSet
     {
         // the smallest enrolled height would be 1, so the passed block height
         // should be greater than the validator cycle for deleting validators.
-        if (block_height > ValidatorCycle)
+        if (block_height > Enrollment.ValidatorCycle)
         {
             try
             {
                 () @trusted {
                     this.db.execute("DELETE FROM validator_set WHERE " ~
-                        "enrolled_height <= ?", block_height - ValidatorCycle);
+                        "enrolled_height <= ?",
+                        block_height - Enrollment.ValidatorCycle);
 
                 }();
             }
@@ -453,7 +450,8 @@ public class ValidatorSet
             stored_image != PreImageInfo.init)
         {
             if (auto reason =
-                isInvalidPreimageReason(preimage, stored_image, ValidatorCycle))
+                isInvalidPreimageReason(preimage, stored_image,
+                    Enrollment.ValidatorCycle))
             {
                 log.info("Invalid preimage data: {}, Data was: ", reason,
                     preimage);
@@ -505,7 +503,7 @@ public class ValidatorSet
         scope UTXOFinder finder) @safe nothrow
     {
         assert(last_height >= block.header.height);
-        if (last_height - block.header.height < ValidatorCycle)
+        if (last_height - block.header.height < Enrollment.ValidatorCycle)
         {
             foreach (const ref enroll; block.header.enrollments)
             {
@@ -534,7 +532,7 @@ private Enrollment createEnrollment(const ref Hash utxo_key,
     auto signature_noise = Pair.random();
 
     enroll.utxo_key = utxo_key;
-    enroll.cycle_length = ValidatorSet.ValidatorCycle;
+    enroll.cycle_length = Enrollment.ValidatorCycle;
     preimages ~= hashFull(random_seed_src);
     foreach (i; 0 ..  enroll.cycle_length-1)
         preimages ~= hashFull(preimages[i]);
@@ -701,7 +699,7 @@ unittest
 
     // make test blocks used for restoring validator set
     Block[] blocks;
-    ulong last_height = ValidatorSet.ValidatorCycle;
+    ulong last_height = Enrollment.ValidatorCycle;
     foreach (ulong i; 0 .. last_height + 1)
     {
         Block block;

--- a/source/agora/consensus/data/Enrollment.d
+++ b/source/agora/consensus/data/Enrollment.d
@@ -48,6 +48,9 @@ public struct Enrollment
     /// S: A signature for the message H(K, X, n, R) and the key K, using R
     public Signature enroll_sig;
 
+    /// The cycle length for a validator
+    public static immutable uint ValidatorCycle = 1008; // freezing period / 2
+
     /***************************************************************************
 
         Implements hashing support

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -422,7 +422,7 @@ public class FullNode : API
     {
         log.trace("Received Enrollment: {}", prettify(enroll));
 
-        if (this.enroll_man.add(this.utxo_set.getUTXOFinder(), enroll))
+        if (this.enroll_man.add(enroll, this.utxo_set.getUTXOFinder()))
         {
             this.network.sendEnrollment(enroll);
         }

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -26,7 +26,6 @@ import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
 import agora.consensus.data.UTXOSet;
 import agora.consensus.EnrollmentManager;
-import agora.consensus.ValidatorSet;
 import agora.consensus.Genesis;
 import agora.consensus.Validation;
 import agora.node.BlockStorage;
@@ -109,7 +108,7 @@ public class Ledger
         // restore validator set from lastest blocks
         if (this.last_block.header.height > 0)
         {
-            foreach (i; 0 .. ValidatorSet.ValidatorCycle)
+            foreach (i; 0 .. Enrollment.ValidatorCycle)
             {
                 if (i >= this.last_block.header.height)
                     break;
@@ -229,7 +228,7 @@ public class Ledger
 
         foreach (enrollment; block.header.enrollments)
             if (!this.enroll_man.addValidator(enrollment,
-                this.utxo_set.getUTXOFinder(), block.header.height))
+                block.header.height, this.utxo_set.getUTXOFinder()))
                 assert(0);
 
         // read back and cache the last block
@@ -1043,9 +1042,9 @@ unittest
     enrollments ~= enroll_3;
 
     auto findUTXO = utxo_set.getUTXOFinder();
-    assert(enroll_man.add(findUTXO, enroll_1));
-    assert(enroll_man.add(findUTXO, enroll_2));
-    assert(enroll_man.add(findUTXO, enroll_3));
+    assert(enroll_man.add(enroll_1, findUTXO));
+    assert(enroll_man.add(enroll_2, findUTXO));
+    assert(enroll_man.add(enroll_3, findUTXO));
     Enrollment stored_enroll;
     enroll_man.getEnrollment(utxo_hash_1, stored_enroll);
     assert(stored_enroll == enroll_1);


### PR DESCRIPTION
The old `ValidatorSet` had an issue that it manages two kinds of enrollments which consist of the enrollments waiting to be a validator and the enrollments having already been a validator. This could cause an unexpected error, so we are splitting the class into the `EnrollmentPoo`l for the candidates of a validator and the `ValidatorSet` for the confirmed validators.

**In this PR, I have just split the ValidatorSet class into two classes, EnrollmentPool and ValidatorSet for smaller PR.** 

There will be other PRs having the following modifications.
1. Change unnecessary public into private in the `ValidatorSet`
2. Change function names in the `ValidatorSet` into proper names like `getEnrollment` into `getValidator`
3. Check abnormal situations in `add` of the `ValidatorSet` and `updateEnrolledHeight` of the EnrollmentManager.

Relates #735 