### PR TITLE
Change the name from NetworkInfo to NodeInfo

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -33,8 +33,8 @@ public enum NetworkState : ubyte
     Complete
 }
 
-/// Contains the network info (state & addresses)
-public struct NetworkInfo
+/// Contains the node info (state & addresses & isValidator)
+public struct NodeInfo
 {
     /// Whether the node knows about the IPs of all its quorum set nodes
     public NetworkState state;
@@ -88,14 +88,14 @@ public interface API
     /***************************************************************************
 
         Returns:
-            The peer network of this node
+            The peer information on this node
 
         API:
-            GET /network_info
+            GET /node_info
 
     ***************************************************************************/
 
-    public NetworkInfo getNetworkInfo ();
+    public NodeInfo getNodeInfo ();
 
     /***************************************************************************
 

--- a/source/agora/network/NetworkClient.d
+++ b/source/agora/network/NetworkClient.d
@@ -128,19 +128,19 @@ class NetworkClient
     /***************************************************************************
 
         Get the network info of the node, stored in the
-        `net_info` parameter if the request succeeded.
+        `node_info` parameter if the request succeeded.
 
         Returns:
-            `NetworkInfo` if successful
+            `NodeInfo` if successful
 
         Throws:
             `Exception` if the request failed.
 
     ***************************************************************************/
 
-    public NetworkInfo getNetworkInfo ()
+    public NodeInfo getNodeInfo ()
     {
-        return this.attemptRequest(this.api.getNetworkInfo(), this.exception);
+        return this.attemptRequest(this.api.getNodeInfo(), this.exception);
     }
 
     /***************************************************************************

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -417,9 +417,9 @@ public class NetworkManager
         {
             try
             {
-                auto net_info = node.getNetworkInfo();
-                this.addAddresses(net_info.addresses);
-                if (net_info.state == NetworkState.Complete)
+                auto node_info = node.getNodeInfo();
+                this.addAddresses(node_info.addresses);
+                if (node_info.state == NetworkState.Complete)
                     return;  // done
 
                 // if it's incomplete give the client some time to connect
@@ -502,9 +502,9 @@ public class NetworkManager
     }
 
     /// Returns: the list of node IPs this node is connected to
-    public NetworkInfo getNetworkInfo () pure nothrow @safe @nogc
+    public NodeInfo getNetworkInfo () pure nothrow @safe @nogc
     {
-        return NetworkInfo(
+        return NodeInfo(
             this.minPeersConnected()
                 ? NetworkState.Complete : NetworkState.Incomplete,
             this.known_addresses);

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -223,8 +223,8 @@ public class Node : API
         return this.config.node.key_pair.address;
     }
 
-    /// GET: /network_info
-    public override NetworkInfo getNetworkInfo () pure nothrow @safe @nogc
+    /// GET: /node_info
+    public override NodeInfo getNodeInfo () pure nothrow @safe @nogc
     {
         return this.network.getNetworkInfo();
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -378,7 +378,7 @@ public class TestAPIManager
         {
             const timeout = 5.seconds;
             this.nodes.each!(node =>
-                retryFor(node.client.getNetworkInfo().ifThrown(NetworkInfo.init)
+                retryFor(node.client.getNodeInfo().ifThrown(NodeInfo.init)
                     .state == NetworkState.Complete,
                     timeout,
                     format("Node %s has not completed discovery after %s.",

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -32,13 +32,13 @@ unittest
 
     foreach (key, node; network.nodes)
     {
-        auto addresses = node.client.getNetworkInfo().addresses.keys;
+        auto addresses = node.client.getNodeInfo().addresses.keys;
         assert(addresses.sort.uniq.count == conf.nodes - 1,
                format("Node %s has %d peers: %s", key, addresses.length, addresses));
     }
 }
 
-/// test network discovery through the getNetworkInfo() API
+/// test network discovery through the getNodeInfo() API
 unittest
 {
     import std.algorithm;
@@ -59,7 +59,7 @@ unittest
 
     foreach (key, node; network.nodes)
     {
-        auto addresses = node.client.getNetworkInfo().addresses.keys;
+        auto addresses = node.client.getNodeInfo().addresses.keys;
         assert(addresses.sort.uniq.count == 3,
                format("Node %s has %d peers: %s", key, addresses.length, addresses));
     }
@@ -85,7 +85,7 @@ unittest
 
     foreach (key, node; network.nodes)
     {
-        auto addresses = node.client.getNetworkInfo().addresses.keys;
+        auto addresses = node.client.getNodeInfo().addresses.keys;
         assert(addresses.sort.uniq.count == 3,
                format("Node %s has %d peers: %s", key, addresses.length, addresses));
     }

--- a/tests/system/source/main.d
+++ b/tests/system/source/main.d
@@ -37,7 +37,7 @@ import core.time;
 private void waitForDiscovery (API[] clients, Duration timeout)
 {
     clients.enumerate.each!((idx, api) =>
-        retryFor(api.getNetworkInfo().ifThrown(NetworkInfo.init)
+        retryFor(api.getNodeInfo().ifThrown(NodeInfo.init)
             .state == NetworkState.Complete,
             timeout,
             format("Node %s has not completed discovery after %s.",
@@ -65,7 +65,7 @@ int main (string[] args)
 
         foreach (idx, ref client; clients)
         {
-            writefln("[%s] getNetworkInfo: %s", idx, client.getNetworkInfo());
+            writefln("[%s] getNodeInfo: %s", idx, client.getNodeInfo());
             const height = client.getBlockHeight();
             writefln("[%s] getBlockHeight: %s", idx, height);
             writeln("----------------------------------------");


### PR DESCRIPTION
The existing struct `networkInfo` had only network information.
We need to know whether the node is `Validator` or not in order to distinguish between `FullNode` and `Validator`.
This is the first work of the work.

Relates #586 