### PR TITLE
Make the validator set to clear up expired validators

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -357,21 +357,19 @@ public class EnrollmentManager
 
     /***************************************************************************
 
-        Set current block height
+        Clear up expired validators whose cycle for a validator ends
 
-        The enrollment manager can weed out expired validators from the set
-        based on the block height. Validators are deleted if their enrolled
-        height is less than or equal to the value of the passed block height
-        minus the validator cycle.
+        The enrollment manager clears up expired validators from the set based
+        on the block height.
 
         Params:
             block_height = current block height
 
     ***************************************************************************/
 
-    public void setCurrentBlockHeight (ulong block_height) @safe nothrow
+    public void clearExpiredValidators (ulong block_height) @safe nothrow
     {
-        this.validator_set.setCurrentBlockHeight(block_height);
+        this.validator_set.clearExpiredValidators(block_height);
     }
 
     /***************************************************************************
@@ -882,24 +880,17 @@ unittest
     // validator B with the 'utxo_hash2' and the enrolled height of 11.
     // validator C with the 'utxo_hash3' and no enrolled height.
     assert(man.updateEnrolledHeight(utxo_hash2, 11));
-
-    // current block height is 1017
-    // So, valid validator are validator A and validator B
-    man.setCurrentBlockHeight(1017);
+    man.clearExpiredValidators(11);
     assert(man.getValidators(validators));
     assert(validators.length == 2);
-
-    // change the block height to 1018, which means validator A is expired.
-    man.setCurrentBlockHeight(1018);
-    assert(man.getValidators(validators));
-    assert(validators[0].utxo_key == utxo_hash2);
 
     // set an enrolled height for validator C
     // set the block height to 1019, which means validator B is expired.
     // there is only one validator in the middle of 1020th block being made.
-    assert(man.updateEnrolledHeight(utxo_hash3, 12));
-    man.setCurrentBlockHeight(1019);
+    assert(man.updateEnrolledHeight(utxo_hash3, 1019));
+    man.clearExpiredValidators(1019);
     assert(man.getValidators(validators));
+    assert(validators.length == 1);
     assert(validators[0].utxo_key == utxo_hash3);
 }
 

--- a/source/agora/consensus/ValidatorSet.d
+++ b/source/agora/consensus/ValidatorSet.d
@@ -330,19 +330,19 @@ public class ValidatorSet
 
     /***************************************************************************
 
-        Set current block height
+        Clear up expired validators whose cycle for a validator ends
 
-        The enrollment manager can weed out expired validators from the set
-        based on the block height. Validators are deleted if their enrolled
-        height is less than or equal to the value of the passed block height
-        minus the validator cycle.
+        The validator set clears up expired validators from the set based on
+        the block height. Validators are deleted if their enrolled height is
+        less than or equal to the value of the passed block height minus the
+        validator cycle.
 
         Params:
             block_height = current block height
 
     ***************************************************************************/
 
-    public void setCurrentBlockHeight (ulong block_height) @safe nothrow
+    public void clearExpiredValidators (ulong block_height) @safe nothrow
     {
         // the smallest enrolled height would be 1, so the passed block height
         // should be greater than the validator cycle for deleting validators.
@@ -746,6 +746,14 @@ unittest
     assert(result_image.enroll_key == preimage.enroll_key);
     assert(result_image.hash == preimage.hash);
     assert(result_image.height == preimage.height);
+
+    // test for clear up expired validators
+    assert(set.updateEnrolledHeight(utxo_hash2, 1017));
+    assert(set.getValidators(validators));
+    assert(validators.length == 2);
+    set.clearExpiredValidators(1017);
+    assert(set.getValidators(validators));
+    assert(validators[0].utxo_key == utxo_hash2);
 }
 
 /// test for restroing information about validators from blocks

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -236,6 +236,8 @@ public class Ledger
         // read back and cache the last block
         if (!this.storage.readLastBlock(this.last_block))
             assert(0);
+
+        this.enroll_man.clearExpiredValidators(this.last_block.header.height);
     }
 
     /***************************************************************************


### PR DESCRIPTION
This PR changes the name of the function which clears up an expired validator to a proper name and makes the ledger to call the function in adding a block.

The test code on the module of agora.test.EnrollmentManager will be added in other PR because it's a kind of big task for me. I'll make a PR for that on Thursday or Friday.