### PR TITLE
Bug fix: get pre-image based on height

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -406,8 +406,6 @@ public class EnrollmentManager
     public bool getNextPreimage (out PreimageInfo preimage) @safe
     {
         auto height = this.next_reveal_height + PreimageRevealPeriod * 2;
-        if (height > ValidatorSet.ValidatorCycle - 1)
-            height = ValidatorSet.ValidatorCycle - 1;
         return getPreimage(height, preimage);
     }
 
@@ -872,6 +870,11 @@ unittest
     assert(man.needRevealPreimage(10));
     man.increaseNextRevealHeight();
     assert(man.needRevealPreimage(16));
+
+    // If the height of the requested preimage exceeds the height of the end of
+    // the validator cycle, the `getNextPreimage` must return `false`.
+    man.next_reveal_height = 10 + ValidatorSet.ValidatorCycle;
+    assert(!man.getNextPreimage(preimage));
 
     // test for getting validators
     Enrollment[] validators;


### PR DESCRIPTION
The recent commits related to getting a preimage, the height had been supposed to be used for getting a preimage, but the code using the old way using a round of cycle as an index for getting a preimage had not changed. So I have corrected the wrong code.

This bug was found in doing peer programming with Mathias.