### PR TITLE
Rename updateEnrolledHeight to addValidator

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -212,8 +212,7 @@ public class Ledger
         Add a validated block to the Ledger,
         and add all of its outputs to the UTXO set.
         If there are any enrollments in the block,
-        update the enrollments' starting block heights
-        in the enrollment manager.
+        add enrollments to the validator set.
 
         Params:
             block = the block to add
@@ -229,8 +228,8 @@ public class Ledger
             assert(0);
 
         foreach (enrollment; block.header.enrollments)
-            if (!this.enroll_man.updateEnrolledHeight(enrollment.utxo_key,
-                block.header.height))
+            if (!this.enroll_man.addValidator(enrollment,
+                this.utxo_set.getUTXOFinder(), block.header.height))
                 assert(0);
 
         // read back and cache the last block

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -478,7 +478,7 @@ public interface TestAPI : API
     public abstract void broadcastPreimage (uint height);
 
     ///
-    public abstract void updateEnrolledHeight (Hash enroll_key, ulong height);
+    public abstract void addValidator (Enrollment enroll, ulong height);
 }
 
 /// Ditto
@@ -591,10 +591,11 @@ public class TestNode : Node, TestAPI
         this.receivePreimage(preimage);
     }
 
-    /// Set a enrolled height for the enrollment
-    public override void updateEnrolledHeight (Hash enroll_key, ulong height)
+    /// Add a validator to the validator set
+    public override void addValidator (Enrollment enroll, ulong height)
     {
-        this.enroll_man.updateEnrolledHeight(enroll_key, height);
+        this.enroll_man.addValidator(enroll, this.utxo_set.getUTXOFinder(),
+            height);
     }
 }
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -138,9 +138,9 @@ unittest
         retryFor(node.hasEnrollment(enroll.utxo_key) == true, 5.seconds));
 
     // set enrolled height to all nodes
-    // the updateEnrolledHeight function is actually called in the middle of
+    // the addValidator function is actually called in the middle of
     // making block but now the code is not merged so calling it is needed.
-    nodes.each!(node => node.updateEnrolledHeight(enroll.utxo_key, 1));
+    nodes.each!(node => node.addValidator(enroll, 1));
 
     // check if nodes don't have a validator's pre-image yet
     nodes.each!(node =>


### PR DESCRIPTION
As we are splitting the EnrollmentManager into EnrollmentPool and ValidatorSet, this function had to be renamed to fit its new purpose.
Before, enrollments that were not in the chain would have an enrolled height of 0, and when they appeared in the chain, the actual enrolled height would be set through this function.
Soon the storage will be separate, and instead, this function will just add new enrollments and clear up the pool.
Additionally, this fixes a bug, where catchup didn't work when an Enrollment seen in a block was not found in the Enrollment pool.