### PR TITLE
Fixup documentation following PR 776

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -187,7 +187,7 @@ public class EnrollmentManager
         Add a validator to the validator set or update the enrolled height.
 
         Params:
-            enroll_hash = enrollment blockheight to update enroll hash
+            enroll = Enrollment structure to add to the validator set
             finder = the delegate to find UTXOs with
             block_height = enrolled blockheight
 


### PR DESCRIPTION
The parameter name, type and purpose changed in PR https://github.com/bpfkorea/agora/pull/776,
but we forgot to update the method's documentation.