### PR TITLE
Fix incorrectly described API documentation

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -210,7 +210,7 @@ public interface API
         Get validator's pre-image inforamtion
 
         API:
-            GET /get_preimage
+            GET /preimage
 
         Params:
             enroll_key = The key for the enrollment in which the pre-image is

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -526,7 +526,7 @@ public class Node : API
             this.network.sendPreimage(preimage);
     }
 
-    /// GET: /get_preimage
+    /// GET: /preimage
     public override PreImageInfo getPreimage (Hash enroll_key)
     {
         PreImageInfo preimage;


### PR DESCRIPTION
the method and URI parts will be inferred from the method name by looking for a known prefix
No get is required before the function name of the interface endpoint.