### PR TITLE
Remove `hasEnrollment` API in the FullNode

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -189,21 +189,21 @@ public interface API
 
     /***************************************************************************
 
-        Check if an enrollment data exists in the validator set
+        Get an enrollment data if the data exists in the validator set
 
         API:
-            GET /has_enrollment
+            GET /enrollment
 
         Params:
             enroll_hash = key for an enrollment data which is hash of frozen UTXO
 
         Returns:
-            true if the validator set has the enrollment data
+            the enrollment data if exists, otherwise Enrollment.init
 
     ***************************************************************************/
 
     @method(HTTPMethod.GET)
-    public bool hasEnrollment (Hash enroll_hash);
+    public Enrollment getEnrollment (Hash enroll_hash);
 
     /***************************************************************************
 

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -296,7 +296,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public bool hasEnrollment (const ref Hash enroll_hash) @trusted
+    private bool hasEnrollment (const ref Hash enroll_hash) @trusted
     {
         return this.validator_set.hasEnrollment(enroll_hash);
     }

--- a/source/agora/network/NetworkClient.d
+++ b/source/agora/network/NetworkClient.d
@@ -303,11 +303,6 @@ class NetworkClient
     {
         this.taskman.runTask(
         {
-            // if the node already has this enrollment, don't send it
-            if (this.attemptRequest!(LogLevel.Trace)(
-                this.api.hasEnrollment(enroll.utxo_key), null))
-                    return;
-
             this.attemptRequest(this.api.enrollValidator(enroll), null);
         });
     }

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -1046,9 +1046,13 @@ unittest
     assert(enroll_man.add(findUTXO, enroll_1));
     assert(enroll_man.add(findUTXO, enroll_2));
     assert(enroll_man.add(findUTXO, enroll_3));
-    assert(enroll_man.hasEnrollment(utxo_hash_1));
-    assert(enroll_man.hasEnrollment(utxo_hash_2));
-    assert(enroll_man.hasEnrollment(utxo_hash_3));
+    Enrollment stored_enroll;
+    enroll_man.getEnrollment(utxo_hash_1, stored_enroll);
+    assert(stored_enroll == enroll_1);
+    enroll_man.getEnrollment(utxo_hash_2, stored_enroll);
+    assert(stored_enroll == enroll_2);
+    enroll_man.getEnrollment(utxo_hash_3, stored_enroll);
+    assert(stored_enroll == enroll_3);
     genNormalBlockTransactions(1);
     assert(ledger.getBlockHeight() == 4);
 

--- a/source/agora/node/Node.d
+++ b/source/agora/node/Node.d
@@ -511,10 +511,12 @@ public class Node : API
         }
     }
 
-    /// GET: /has_enrollment
-    public override bool hasEnrollment (Hash enroll_hash) @safe
+    /// GET: /enrollment
+    public override Enrollment getEnrollment (Hash enroll_hash) @safe
     {
-        return this.enroll_man.hasEnrollment(enroll_hash);
+        Enrollment enroll;
+        this.enroll_man.getEnrollment(enroll_hash, enroll);
+        return enroll;
     }
 
     /// PUT: /receive_preimage

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -74,7 +74,7 @@ unittest
 
     // check if nodes contains enrollment data previously sent.
     nodes.each!(node =>
-        retryFor(node.hasEnrollment(enroll.utxo_key) == true, 5.seconds));
+        retryFor(node.getEnrollment(enroll.utxo_key) == enroll, 5.seconds));
 
     // check if nodes don't have a pre-image yet
     nodes.each!(node =>


### PR DESCRIPTION
The `hasEnrollment` function is kind of useless if it's used to check if an enrollment data exists before sending an enrollment. It makes unnecessary communication between nodes. So it's simple to just send enrollment information. And we add the `getEnrollment` API to replace the use of the hasEnrollment.

Additionally, the `hasEnrollment` function became private because the `hasEnrollment` API doesn't exist anymore.

Mathias and I discussed removing the API in the pair programming session.