### PR TITLE
Remove unused quorum_conf from NetworkManager

### DIFF
--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -99,7 +99,7 @@ public class NetworkManager
     /// Ctor
     public this (in NodeConfig node_config, in BanManager.Config banman_conf,
         in string[] peers, Set!PublicKey required_peer_keys,
-        in QuorumConfig quorum_conf, in string[] dns_seeds, Metadata metadata,
+        in string[] dns_seeds, Metadata metadata,
         TaskManager taskman)
     {
         this.taskman = taskman;

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -136,8 +136,8 @@ public class FullNode : API
         this.config = config;
         this.taskman = this.getTaskManager();
         this.network = this.getNetworkManager(config.node, config.banman,
-            config.network, required_peer_keys, config.quorum, config.dns_seeds,
-            this.metadata, this.taskman);
+            config.network, required_peer_keys, config.dns_seeds, this.metadata,
+            this.taskman);
         this.storage = this.getBlockStorage(config.node.data_dir);
         this.pool = this.getPool(config.node.data_dir);
         scope (failure) this.pool.shutdown();
@@ -264,7 +264,6 @@ public class FullNode : API
             banman_conf = the ban manager config
             peers = the peers to connect to
             required_peer_keys = required peers with the given keys to connect to
-            quorum_conf = the quorum config
             dns_seeds = the DNS seeds to retrieve peers from
             metadata = metadata containing known peers and other meta info
             taskman = task manager
@@ -276,11 +275,11 @@ public class FullNode : API
 
     protected NetworkManager getNetworkManager (in NodeConfig node_config,
         in BanManager.Config banman_conf, in string[] peers,
-        Set!PublicKey required_peer_keys, in QuorumConfig quorum_conf,
+        Set!PublicKey required_peer_keys,
         in string[] dns_seeds, Metadata metadata, TaskManager taskman)
     {
         return new NetworkManager(node_config, banman_conf, peers,
-            required_peer_keys, quorum_conf, dns_seeds, metadata, taskman);
+            required_peer_keys, dns_seeds, metadata, taskman);
     }
 
     /***************************************************************************

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -429,12 +429,12 @@ public class TestNetworkManager : NetworkManager
     /// Constructor
     public this (NodeConfig config, BanManager.Config ban_conf,
         in string[] peers, Set!PublicKey required_peer_keys,
-        in QuorumConfig quorum_conf, in string[] dns_seeds,
-        Metadata metadata, TaskManager taskman, Registry* reg)
+        in string[] dns_seeds, Metadata metadata, TaskManager taskman,
+        Registry* reg)
     {
         this.registry = reg;
-        super(config, ban_conf, peers, required_peer_keys, quorum_conf,
-            dns_seeds, metadata, taskman);
+        super(config, ban_conf, peers, required_peer_keys, dns_seeds, metadata,
+            taskman);
     }
 
     /// We don't use IPs in tests
@@ -553,13 +553,11 @@ private mixin template TestNodeMixin ()
     protected override NetworkManager getNetworkManager (
         in NodeConfig node_config, in BanManager.Config banman_conf,
         in string[] peers, Set!PublicKey required_peer_keys,
-        in QuorumConfig quorum_conf, in string[] dns_seeds, Metadata metadata,
-        TaskManager taskman)
+        in string[] dns_seeds, Metadata metadata, TaskManager taskman)
     {
         assert(taskman !is null);
         return new TestNetworkManager(node_config, banman_conf, peers,
-            required_peer_keys, quorum_conf, dns_seeds, metadata, taskman,
-            this.registry);
+            required_peer_keys, dns_seeds, metadata, taskman, this.registry);
     }
 
     /// Return an enrollment manager backed by an in-memory SQLite db


### PR DESCRIPTION
The required_peer_keys already has this role, the quorum_conf parameter was never used.