### PR TITLE
Re-enable BlockStorageChecksum test

### DIFF
--- a/tests/unit/BlockStorageChecksum.d
+++ b/tests/unit/BlockStorageChecksum.d
@@ -38,7 +38,15 @@ private void main ()
     scope (exit) storage.release();
 
     Block block;
-    // storage.readBlock(block, 0);  // will halt due to checksum failure
+    try
+    {
+        storage.readBlock(block, 0);
+        assert(0); // Failed to detect checksum error
+    }
+    catch (Exception ex)
+    {
+        // Normal due to checksum error
+    }
 }
 
 /// Write the block data to disk


### PR DESCRIPTION
Activate the code that caused the forced error for the checksum test.
If the checksum test is not detected, an error occurs.

Relates to  #650