### PR TITLE
Restore a node's enrollment data from the Genesis block

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -390,7 +390,7 @@ public class EnrollmentManager
         // Generate the random seed to use
         auto cache = PreImageCache(PreImageCycle.NumberOfCycles, cycle_length);
         assert(offset < cache.length);
-        cache.reset(hashMulti(kp.v, "consensus.preimages", offset));
+        cache.reset(hashMulti(kp.v, "consensus.preimages", cast(uint)offset));
 
         return makeEnrollment(kp, utxo, cycle_length, cache[$ - offset - 1], offset);
     }

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -277,7 +277,7 @@ public class EnrollmentManager
 
     public string addValidator (const ref Enrollment enroll,
         Height block_height, scope UTXOFinder finder,
-        const UTXOSetValue[Hash] self_utxos) @safe
+        const UTXOSetValue[Hash] self_utxos) @safe nothrow
     {
         this.enroll_pool.remove(enroll.utxo_key);
 
@@ -641,7 +641,15 @@ public class EnrollmentManager
         scope UTXOFinder finder, const ref UTXOSetValue[Hash] self_utxos)
         @safe nothrow
     {
-        this.validator_set.restoreValidators(last_height, block, finder);
+        assert(last_height >= block.header.height);
+        if (last_height - block.header.height < this.params.ValidatorCycle)
+        {
+            foreach (const ref enroll; block.header.enrollments)
+            {
+                this.addValidator(enroll, block.header.height, finder,
+                    self_utxos);
+            }
+        }
     }
 
     /***************************************************************************


### PR DESCRIPTION
This PR is for restoring the enrollment data of a node from the `enrollments` field of the header of blocks. This is the first step to remove the `node_enroll_data` table in the `EnrollmentManager` class, which is to remove the `Enrollment` object from the table. The next step is to remove `next_reveal_height` from the table. Finally, the table will be removed.

(EDIT)
This PR has added two more items as follows
- Restoring the enrollment data when the `EnrollmentManager` adds an validator to the `ValidatorSet`.
- Restoring the pre-image data from blocks of the chain

Fixes #789 