### PR TITLE
Fix rawWrite of checksum test in Windows

### DIFF
--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -167,7 +167,7 @@ private immutable size_t MapSize = 640 * 1024;
 private immutable size_t DataSize = MapSize - ChecksumSize;
 
 /// The CRC32 checksum size
-private immutable size_t ChecksumSize = 4;
+public immutable size_t ChecksumSize = 4;
 
 private struct HeightPosition
 {

--- a/tests/unit/BlockStorageChecksum.d
+++ b/tests/unit/BlockStorageChecksum.d
@@ -79,6 +79,7 @@ private void corruptBlocks (string dir_path)
 
         // write a modified byte
         bytes[0]++;
+        block_file.seek(5, SEEK_SET);
         block_file.rawWrite(bytes);
     }
 }

--- a/tests/unit/BlockStorageChecksum.d
+++ b/tests/unit/BlockStorageChecksum.d
@@ -72,14 +72,14 @@ private void corruptBlocks (string dir_path)
         assert(path.isFile);
 
         auto block_file = File(path, "r+b");
-        block_file.seek(5, SEEK_SET);
+        block_file.seek(ChecksumSize + 1, SEEK_SET);
 
         ubyte[1] bytes;
         block_file.rawRead(bytes);
 
         // write a modified byte
         bytes[0]++;
-        block_file.seek(5, SEEK_SET);
+        block_file.seek(ChecksumSize + 1, SEEK_SET);
         block_file.rawWrite(bytes);
     }
 }


### PR DESCRIPTION
The setmode of the file is r+b.
However, when you switch between reading and writing, there must be an intervening fflush, fsetpos, fseek, or rewind operation
Only for windows.
But it works normally on Posix, too.
Relates to #739 