### PR TITLE
Add ability to create a merkle tree of arbitrary number of transactions

### DIFF
--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -497,6 +497,8 @@ unittest
 
     // transactions are ordered lexicographically by hash in the Merkle tree
     hashes.sort!("a < b");
+    foreach (idx, hash; hashes)
+        assert(block.findHashIndex(hash) == idx);
 
     const Hash ha = hashes[0];
     const Hash hb = hashes[1];

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -205,8 +205,8 @@ public struct Block
     {
         () @trusted { merkle_tree.assumeSafeAppend(); }();
 
-        // workaround for issue #127 with ldc2 on osx
         const MerkleLength = (txs.length * 2) - 1;
+        // 'new' instead of .length: workaround for issue #127 with ldc2 on osx
         merkle_tree = new Hash[](MerkleLength);
 
         return Block.buildMerkleTreeImpl(txs, merkle_tree);


### PR DESCRIPTION
As mentioned in https://github.com/bpfkorea/agora/issues/797#issuecomment-625054477, it's not blocking anything yet. But it probably will once we remove the limitation of 8 transactions per block.

Fixes #797