### PR TITLE
Move required peers into discovery() method

### DIFF
--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -98,15 +98,13 @@ public class NetworkManager
 
     /// Ctor
     public this (in NodeConfig node_config, in BanManager.Config banman_conf,
-        in string[] peers, Set!PublicKey required_peer_keys,
-        in string[] dns_seeds, Metadata metadata,
+        in string[] peers, in string[] dns_seeds, Metadata metadata,
         TaskManager taskman)
     {
         this.taskman = taskman;
         this.node_config = node_config;
         this.metadata = metadata;
         this.seed_peers = peers;
-        this.required_peer_keys = required_peer_keys;
         this.dns_seeds = dns_seeds;
         this.banman = this.getBanManager(banman_conf, node_config.data_dir);
     }
@@ -157,10 +155,15 @@ public class NetworkManager
         and keep discovering more full nodes nodes in the network
         until maxPeersConnected() returns true.
 
+        Params:
+            required_peer_keys = a set of any required keys the node should
+                connect to (e.g. quorum nodes) before discovery will be complete
+
     ***************************************************************************/
 
-    public void discover ()
+    public void discover (Set!PublicKey required_peer_keys = Set!PublicKey.init)
     {
+        this.required_peer_keys = required_peer_keys;
         this.banman.load();
 
         // add our own address to the list of banned addresses to avoid

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -110,13 +110,10 @@ public class FullNode : API
 
         Params:
             config = Config instance
-            required_peer_keys = if not empty, the set of public keys for which
-                to find the associated nodes in the network and to connect to
 
     ***************************************************************************/
 
-    public this (const Config config,
-        Set!PublicKey required_peer_keys = Set!PublicKey.init)
+    public this (const Config config)
     {
         // custom genesis block provided
         if (config.node.genesis_block.length > 0)
@@ -136,8 +133,7 @@ public class FullNode : API
         this.config = config;
         this.taskman = this.getTaskManager();
         this.network = this.getNetworkManager(config.node, config.banman,
-            config.network, required_peer_keys, config.dns_seeds, this.metadata,
-            this.taskman);
+            config.network, config.dns_seeds, this.metadata, this.taskman);
         this.storage = this.getBlockStorage(config.node.data_dir);
         this.pool = this.getPool(config.node.data_dir);
         scope (failure) this.pool.shutdown();
@@ -263,7 +259,6 @@ public class FullNode : API
             node_config = the node config
             banman_conf = the ban manager config
             peers = the peers to connect to
-            required_peer_keys = required peers with the given keys to connect to
             dns_seeds = the DNS seeds to retrieve peers from
             metadata = metadata containing known peers and other meta info
             taskman = task manager
@@ -275,11 +270,10 @@ public class FullNode : API
 
     protected NetworkManager getNetworkManager (in NodeConfig node_config,
         in BanManager.Config banman_conf, in string[] peers,
-        Set!PublicKey required_peer_keys,
         in string[] dns_seeds, Metadata metadata, TaskManager taskman)
     {
         return new NetworkManager(node_config, banman_conf, peers,
-            required_peer_keys, dns_seeds, metadata, taskman);
+            dns_seeds, metadata, taskman);
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -53,12 +53,7 @@ public class Validator : FullNode, API
     public this (const Config config)
     {
         assert(config.node.is_validator);
-
-        // build the list of required quorum peers to connect to
-        Set!PublicKey required_peer_keys;
-        buildRequiredKeys(config, config.quorum, required_peer_keys);
-
-        super(config, required_peer_keys);
+        super(config);
 
         // instantiating Nominator can fail if the quorum configuration
         // fails the checkSanity() test, and we must release resources.
@@ -79,8 +74,13 @@ public class Validator : FullNode, API
     {
         this.taskman.runTask(
         {
+            // build the list of required quorum peers to connect to
+            Set!PublicKey required_peer_keys;
+            buildRequiredKeys(this.config, this.config.quorum,
+                required_peer_keys);
+
             log.info("Doing network discovery..");
-            this.network.discover();
+            this.network.discover(required_peer_keys);
             this.network.startPeriodicCatchup(this.ledger, &this.nominator.isNominating);
         });
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -428,13 +428,11 @@ public class TestNetworkManager : NetworkManager
 
     /// Constructor
     public this (NodeConfig config, BanManager.Config ban_conf,
-        in string[] peers, Set!PublicKey required_peer_keys,
-        in string[] dns_seeds, Metadata metadata, TaskManager taskman,
-        Registry* reg)
+        in string[] peers, in string[] dns_seeds, Metadata metadata,
+        TaskManager taskman, Registry* reg)
     {
         this.registry = reg;
-        super(config, ban_conf, peers, required_peer_keys, dns_seeds, metadata,
-            taskman);
+        super(config, ban_conf, peers, dns_seeds, metadata, taskman);
     }
 
     /// We don't use IPs in tests
@@ -552,12 +550,12 @@ private mixin template TestNodeMixin ()
     /// Return an instance of the custom TestNetworkManager
     protected override NetworkManager getNetworkManager (
         in NodeConfig node_config, in BanManager.Config banman_conf,
-        in string[] peers, Set!PublicKey required_peer_keys,
-        in string[] dns_seeds, Metadata metadata, TaskManager taskman)
+        in string[] peers, in string[] dns_seeds, Metadata metadata,
+        TaskManager taskman)
     {
         assert(taskman !is null);
         return new TestNetworkManager(node_config, banman_conf, peers,
-            required_peer_keys, dns_seeds, metadata, taskman, this.registry);
+            dns_seeds, metadata, taskman, this.registry);
     }
 
     /// Return an enrollment manager backed by an in-memory SQLite db


### PR DESCRIPTION
This removes the dependency inversion that was introduced in #756, and simplifies code
for the implementation of #785.