### PR TITLE
Simplify createNewNode()

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -349,11 +349,12 @@ public class TestAPIManager
 
     ***************************************************************************/
 
-    public void printLogs ()
+    public void printLogs (string file = __FILE__, size_t line = __LINE__)
     {
         synchronized  // make sure logging output is not interleaved
         {
             import std.stdio;
+            writefln("%s(%s): Node logs:\n", file, line);
             foreach (node; this.nodes)
             {
                 writefln("Log for node %s:", node.key);

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -16,6 +16,7 @@ module agora.test.NetworkManager;
 version (unittest):
 
 import agora.api.Validator;
+import agora.common.Types;
 import agora.consensus.data.Transaction;
 import agora.consensus.Genesis;
 import agora.test.Base;
@@ -107,7 +108,7 @@ unittest
     static class BadAPIManager : TestAPIManager
     {
         /// see base class
-        public override void createNewNode (PublicKey address, Config conf)
+        public override void createNewNode (Config conf)
         {
             RemoteAPI!TestAPI api;
 
@@ -131,8 +132,8 @@ unittest
                         &this.reg, conf.node.timeout.msecs);
             }
 
-            this.reg.register(address.toString(), api.tid());
-            this.nodes ~= NodePair(address, api);
+            this.reg.register(conf.node.address, api.tid());
+            this.nodes ~= NodePair(conf.node.address, api);
         }
     }
 


### PR DESCRIPTION
The address was already accessible through the public key.

Simplification as part of #785