### PR TITLE
Change SCP's Signature definition to be a fixed-size type

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -772,15 +772,12 @@ private struct SCPEnvelopeHash
         "4039907a44d671dbffe55ce9ae21f8eca7d218e6c87573c381ae20d96bf4a56"),
     getEnvHash().hashFull().to!string);
 
-    alias Sig = agora.common.Types.Signature;
-    Sig sig;
     () @trusted
     {
         auto seed = "SAI4SRN2U6UQ32FXNYZSXA5OIO6BYTJMBFHJKX774IGS2RHQ7DOEW5SJ";
         auto pair = KeyPair.fromSeed(Seed.fromString(seed));
         auto msg = getStHash().hashFull();
-        sig = pair.secret.sign(msg[]);
-        env.signature = sig;
+        env.signature = pair.secret.sign(msg[]);
     }();
 
     // with a signature

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -761,26 +761,26 @@ private struct SCPEnvelopeHash
     // empty envelope
     import std.conv;
     assert(getEnvHash().hashFull() == Hash.fromString(
-        "0xd3dc2318365e55ea3a62b403fcbe22d447402741a5151a703326dbf852350dcd0" ~
-        "e020a762ae12a871473aed80d82f51c1cd3942c0b2360c2d609279a2867fe68"),
+        "0xfd2ea2b85d2a315a9817e6661bc3c4378637de37649d2fdb9ca82d6e4172e9e46" ~
+        "af5a57113cfb7cb09d25eb7b4518eca9930c57231a29ffa396661822603c509"),
     getEnvHash().hashFull().to!string);
 
     // with a statement
     env.statement = st;
     assert(getEnvHash().hashFull() == Hash.fromString(
-        "0xbba4bdee0e083e6e5f56ddc2815afcd509f597f45d6ae5c83af747de2d568a26d" ~
-        "bc1f0792c8c6f990816bf9f2fc913ccc700c0a022644f8bd25835a6b439944c"),
+        "0x45d6b9adba8da9f2763f33960d7cd77b6c7e844fc11b0c7d793dfa47c99bc4377" ~
+        "4039907a44d671dbffe55ce9ae21f8eca7d218e6c87573c381ae20d96bf4a56"),
     getEnvHash().hashFull().to!string);
 
     alias Sig = agora.common.Types.Signature;
-    Sig sig;  // be warned: toVec() will point to stack-allocated memory
+    Sig sig;
     () @trusted
     {
         auto seed = "SAI4SRN2U6UQ32FXNYZSXA5OIO6BYTJMBFHJKX774IGS2RHQ7DOEW5SJ";
         auto pair = KeyPair.fromSeed(Seed.fromString(seed));
         auto msg = getStHash().hashFull();
         sig = pair.secret.sign(msg[]);
-        env.signature = sig[].toVec();
+        env.signature = sig;
     }();
 
     // with a signature

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -354,14 +354,10 @@ private struct SCPEnvelopeFmt
     {
         try
         {
-            Signature sig;
-            if (this.envelope.signature[].length == Signature.Width)
-                sig = Signature(this.envelope.signature[]);
-
             formattedWrite(sink,
                 "{ statement: %s, sig: %s }",
                 SCPStatementFmt(this.envelope.statement, this.getQSet),
-                prettify(sig));
+                prettify(this.envelope.signature));
         }
         catch (Exception ex)
         {

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -459,7 +459,7 @@ GCOQ...LRIJ(62,500,000), GCOQ...LRIJ(62,500,000)], enrolls: [{ utxo: 0x0000...e2
     assert(MissingSig == format("%s", scpPrettify(&env)),
                          format("%s", scpPrettify(&env)));
 
-    env.signature = pair.secret.sign(hashFull(0)[])[].toVec();
+    env.signature = pair.secret.sign(hashFull(0)[]);
 
     // null quorum (hash not found)
     static immutable PrepareRes1 = `{ statement: { node: GBUV...KOEK, slotIndex: 0, pledge: Prepare { qset: { hash: 0xc048...6205, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [Type : Payment, Inputs (1): 0x0000...0000[0]:0x0000...0000

--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -259,13 +259,14 @@ struct SCPStatement {
 }
 
 static assert(SCPStatement.sizeof == 176);
+static assert(Signature.sizeof == 64);
 
 struct SCPEnvelope {
   SCPStatement statement;
   Signature signature;
 }
 
-static assert(SCPEnvelope.sizeof == 200);
+static assert(SCPEnvelope.sizeof == 240);
 
 struct SCPQuorumSet {
     import agora.common.Hash;
@@ -342,4 +343,4 @@ public alias SCPQuorumSetPtr = shared_ptr!SCPQuorumSet;
 static assert(SCPBallot.sizeof == 32);
 static assert(Value.sizeof == 24);
 static assert(SCPQuorumSet.sizeof == 56);
-static assert(SCPEnvelope.sizeof == 200);
+static assert(SCPEnvelope.sizeof == 240);

--- a/source/scpd/types/Stellar_types.d
+++ b/source/scpd/types/Stellar_types.d
@@ -68,6 +68,6 @@ struct PublicKey {
     alias ed25519_ this;
 }
 
-alias Signature = opaque_vec!64;
+alias Signature = opaque_array!64;
 alias SignatureHint = opaque_array!4;
 alias NodeID = PublicKey;

--- a/source/scpp/extra/DSizeChecks.cpp
+++ b/source/scpp/extra/DSizeChecks.cpp
@@ -14,6 +14,7 @@
 *******************************************************************************/
 
 #include <vector>
+#include <type_traits>
 #include "xdrpp/marshal.h"
 #include "xdrpp/types.h"
 #include "xdr/Stellar-SCP.h"
@@ -46,7 +47,8 @@ CPPSIZEOF(CryptoKeyType)
 CPPSIZEOF(PublicKeyType)
 CPPSIZEOF(SignerKeyType)
 CPPSIZEOF(PublicKey)
-CPPSIZEOF(Signature)
+// Signature is removed because it is the same as Hash.
+static_assert(std::is_same<Signature, Hash>::value, "Signature and Hash must be the same type");
 CPPSIZEOF(SignatureHint)
 CPPSIZEOF(ByteSlice)
 

--- a/source/scpp/src/crypto/SecretKey.cpp
+++ b/source/scpp/src/crypto/SecretKey.cpp
@@ -26,6 +26,8 @@ SecretKey::SecretKey() : mKeyType(PUBLIC_KEY_TYPE_ED25519)
                   "Unexpected secret key length");
     static_assert(crypto_sign_BYTES == sizeof(uint512),
                   "Unexpected signature length");
+    static_assert(crypto_sign_BYTES == sizeof(Signature),
+                  "Unexpected signature length");
 }
 
 SecretKey::~SecretKey()
@@ -91,7 +93,7 @@ SecretKey::sign(ByteSlice const& bin) const
 {
     assert(mKeyType == PUBLIC_KEY_TYPE_ED25519);
 
-    Signature out(crypto_sign_BYTES, 0);
+    Signature out;
     if (crypto_sign_detached(out.data(), NULL, bin.data(), bin.size(),
                              mSecretKey.data()) != 0)
     {

--- a/source/scpp/src/xdr/Stellar-types.h
+++ b/source/scpp/src/xdr/Stellar-types.h
@@ -437,7 +437,7 @@ template<> struct xdr_traits<::stellar::SignerKey> : xdr_traits_base {
 };
 } namespace stellar {
 
-using Signature = xdr::opaque_vec<64>;
+using Signature = xdr::opaque_array<64>;
 using SignatureHint = xdr::opaque_array<4>;
 using NodeID = PublicKey;
 

--- a/source/scpp/src/xdr/Stellar-types.x
+++ b/source/scpp/src/xdr/Stellar-types.x
@@ -51,8 +51,8 @@ case SIGNER_KEY_TYPE_HASH_X:
     uint256 hashX;
 };
 
-// variable size as the size depends on the signature scheme used
-typedef opaque Signature<64>;
+// fixed size as we use a 64-byte Signature in Agora
+typedef opaque Signature[64];
 
 typedef opaque SignatureHint[4];
 


### PR DESCRIPTION
I changed `Signature` to fixed length array.

``` C++
using Signature = xdr::opaque_vec<64>;
```
I changed it as follows.
``` C++
using Signature = xdr::opaque_array<64>;
```

`Signature` is the data structure used by SCP.
This is declared vector in SCP because of compatibility between versions.
SCP has several versions. In some of the previous versions, Signature was 32 Byte and is now 64 Byte.

For this reason, I think there is no problem if we change to 64Byte fixed length.

And I tried to compile it after changing it in `stellar-core`.
There were some errors in the test codes, but there were no problems with the rest.
[

https://github.com/stellar/stellar-core/blob/69c75632ae903191a82c7b2b010cce4022a60870/src/crypto/SecretKey.cpp#L128

https://github.com/stellar/stellar-core/blob/69c75632ae903191a82c7b2b010cce4022a60870/src/transactions/test/TxEnvelopeTests.cpp#L83-L101

https://github.com/stellar/stellar-core/blob/69c75632ae903191a82c7b2b010cce4022a60870/src/herder/test/HerderTests.cpp#L1262-L1266
]
Relates to #744 