### PR TITLE
Workaround operation according to C++ mangling mismatch on Windows

### DIFF
--- a/ci/run.bat
+++ b/ci/run.bat
@@ -1,7 +1,8 @@
-call dub test --skip-registry=all --compiler=%DC%
-::if %errorlevel% neq 0 exit /b %errorlevel%
-call rdmd --compiler=%DC% ./tests/runner.d --compiler=%DC% -cov
-::if %errorlevel% neq 0 exit /b %errorlevel%
+rem call dub test --skip-registry=all --compiler=%DC%
+call dub build --skip-registry=all --compiler=%DC% -c unittest -b unittest
+if %errorlevel% neq 0 exit /b %errorlevel%
+call rdmd --build-only --compiler=%DC% ./tests/runner.d --compiler=%DC% -cov
+if %errorlevel% neq 0 exit /b %errorlevel%
 call dub build --skip-registry=all --compiler=%DC%
 if %errorlevel% neq 0 exit /b %errorlevel%
 call dub build -c client --skip-registry=all --compiler=%DC%

--- a/source/scpd/Cpp.d
+++ b/source/scpd/Cpp.d
@@ -373,9 +373,27 @@ extern(C++, (StdNamespace)) extern(C++, class) struct vector (T, Alloc = allocat
             foreach (idx; 0 .. len)
             {
                 auto entry = deserializeFull!(QT.ElementType)(data, opts);
-                push_back(cast() ret, entry);
+                ret.push_back(entry);
             }
             return () @trusted { return cast(QT) ret; }();
+        }
+
+        public void push_back (ref T value) @trusted pure nothrow @nogc
+        {
+            import Utils = scpd.types.Utils;
+
+            // Workaround for Dlang issue #20805
+            static if (is(T == ubyte))
+            {
+                version (Windows)
+                    Utils.push_back_vec(&this, &value);
+                else
+                    Utils.push_back(this, value);
+            }
+            else
+            {
+                Utils.push_back(this, value);
+            }
         }
     }
 }

--- a/source/scpd/types/Utils.d
+++ b/source/scpd/types/Utils.d
@@ -57,4 +57,6 @@ public SCPQuorumSet dup (ref const(SCPQuorumSet) orig)
 extern(C++):
 
 public void push_back(T, VectorT) (ref VectorT this_, ref T value) @safe pure nothrow @nogc;
+// Workaround for Dlang issue #20805
+public void push_back_vec (void*, const(void)*) @safe pure nothrow @nogc;
 public VectorT duplicate(VectorT)(ref const VectorT this_) @safe pure nothrow @nogc;

--- a/source/scpp/extra/DUtils.cpp
+++ b/source/scpp/extra/DUtils.cpp
@@ -37,7 +37,18 @@ PUSHBACKINST3(xvector<unsigned char>, std::vector)
 PUSHBACKINST3(unsigned char, std::vector)
 
 PUSHBACKINST1(unsigned char)
+// Workaround for Dlang issue #20805
+#if MSVC
+void push_back_vec (void *this_, void const *value_)
+{
+    auto value = (xvector<unsigned char>*)value_;
+    auto this_obj = (xvector<xvector<unsigned char> >*)this_;
+    (*this_obj).push_back(*value);
+}
 PUSHBACKINST1(xvector<unsigned char>)
+#else // !MSVC
+PUSHBACKINST1(xvector<unsigned char>)
+#endif // !MSVC
 
 PUSHBACKINST1(PublicKey)
 PUSHBACKINST1(SCPQuorumSet)


### PR DESCRIPTION
This is an issue upstrem D 20805 - C++ mining mismatch with templates and namespaces.
https://issues.dlang.org/show_bug.cgi?id=20805
Currently, a link error occurs in the windows due to this issue.
It is a workaround to the cause of the linker error on windows.

Relates to #739 