### PR TITLE
Applying sliding window concept to managing pre-images

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -85,8 +85,8 @@ public class EnrollmentManager
     /// Enrollment pool managing enrollments waiting to be a validator
     private EnrollmentPool enroll_pool;
 
-    /// The count for generating pre-images
-    private immutable uint AllCountPreimages = Enrollment.ValidatorCycle * 100;
+    /// The number of cycles for a bulk of pre-images
+    private immutable uint NumberOfCycles = 100;
 
     /***************************************************************************
 
@@ -665,8 +665,10 @@ public class EnrollmentManager
         {
             // The value of `bulk_index` is zero-based. so we need to plus 1 to
             // the value to get the max height(`MaxHeight`) of this bulk.
-            ulong bulk_index = start_height / AllCountPreimages;
-            const ulong MaxHeight = (bulk_index + 1) * AllCountPreimages;
+            ulong bulk_index = start_height /
+                (NumberOfCycles * Enrollment.ValidatorCycle);
+            const ulong MaxHeight = (bulk_index + 1) *
+                (NumberOfCycles * Enrollment.ValidatorCycle);
             auto hash = hashMulti(this.key_pair.v, "consensus.preimages", bulk_index);
             ulong idx = MaxHeight;
             this.preimage_rounds[idx] = hash;

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -62,6 +62,9 @@ public class EnrollmentManager
     /// Pre-images for current validator cycle
     private Hash[ulong] cycle_preimages;
 
+    /// The current cycle index
+    private uint cycle_index;
+
     /// Random key for enrollment
     private Pair signature_noise;
 
@@ -285,6 +288,10 @@ public class EnrollmentManager
             this.signature_noise.v, this.data);
 
         enroll = this.data;
+
+        // increase current cycle index
+        this.cycle_index += 1;
+
         return true;
     }
 


### PR DESCRIPTION
The core of this PR is using a cycle index of pre-image for enrollment. The enrollment manager uses only one cycle of pre-images like 1008 for enrollment. We don't use a height for managing pre-images anymore.

Relates #767 