### PR TITLE
Print logs when constructor / start() fails

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -61,6 +61,7 @@ import std.array;
 import std.algorithm;
 import std.exception;
 import std.format;
+import std.stdio;
 
 import core.runtime;
 import core.time;
@@ -81,7 +82,6 @@ private UnitTestResult customModuleUnitTester ()
     import std.algorithm;
     import std.parallelism;
     import std.process;
-    import std.stdio;
     import std.string;
     import std.uni;
     import core.atomic;
@@ -353,15 +353,9 @@ public class TestAPIManager
     {
         synchronized  // make sure logging output is not interleaved
         {
-            import std.stdio;
             writefln("%s(%s): Node logs:\n", file, line);
             foreach (node; this.nodes)
-            {
-                writefln("Log for node %s:", node.address);
-                writeln("======================================================================");
                 node.client.printLog();
-                writeln("======================================================================\n");
-            }
         }
     }
 
@@ -515,7 +509,10 @@ private mixin template TestNodeMixin ()
     /// Prints out the log contents for this node
     public void printLog ()
     {
+        writefln("Log for node: %s", this.config.node.address);
+        writeln("======================================================================");
         CircularAppender().printConsole();
+        writeln("======================================================================\n");
     }
 
     /// Used by the node
@@ -577,6 +574,7 @@ public class TestFullNode : FullNode, TestAPI
     public this (Config config, Registry* reg)
     {
         assert(!config.node.is_validator);
+        scope (failure) this.printLog();
         this.registry = reg;
         super(config);
     }
@@ -618,6 +616,7 @@ public class TestValidatorNode : Validator, TestAPI
     public this (Config config, Registry* reg)
     {
         assert(config.node.is_validator);
+        scope (failure) this.printLog();
         this.registry = reg;
         super(config);
     }


### PR DESCRIPTION
Currently when a single node fails in either its constructor call or when start() is called, its logs will not be emitted.