### PR TITLE
Add `opSlice` to the `Point` structure

### DIFF
--- a/source/agora/common/crypto/ECC.d
+++ b/source/agora/common/crypto/ECC.d
@@ -268,6 +268,12 @@ public struct Point
         return result;
     }
 
+    /// Convenience overload to allow this to be converted to a `PublicKey`
+    public const(ubyte)[] opSlice () const @safe pure nothrow @nogc
+    {
+        return this.data[];
+    }
+
     /// Support for comparison
     public int opCmp (ref const typeof(this) s) const
     {

--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -430,3 +430,13 @@ unittest
     Point point_Address = Point(kp.address);
     assert(verify(point_Address, enroll_sig, "BOSAGORA"));
 }
+
+/// Test for converting from `Point` to `PublicKey`
+unittest
+{
+    import agora.common.crypto.Schnorr;
+
+    Pair pair = Pair.random();
+    auto pubkey = PublicKey(pair.V[]);
+    assert(pubkey.data == pair.V.data);
+}


### PR DESCRIPTION
There is a need to convert a `Point` value into a `PublicKey` value. The need for the function is related to PR #798 
