### PR TITLE
 Test & fix BanManager's serialization

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -127,7 +127,7 @@ public class BanManager
         if (!this.banfile_path.exists())
             return;  // nothing to load
 
-        auto ban_file = File(this.banfile_path, "r");
+        auto ban_file = File(this.banfile_path, "rb");
         scope DeserializeDg dg = (size) @trusted
         {
             ubyte[] res;
@@ -146,7 +146,7 @@ public class BanManager
 
     public void dump ()
     {
-        auto ban_file = File(this.banfile_path, "w");
+        auto ban_file = File(this.banfile_path, "wb");
         serializePart(this.ips, (scope bytes) @trusted => ban_file.rawWrite(bytes));
     }
 

--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -50,7 +50,7 @@ public class BanManager
 
         /// To set an IP as banned, we simply set its un-ban time in the future.
         /// By default it's set to the past (therefore un-banned)
-        private time_t banned_until = 0;
+        private time_t banned_until;
     }
 
     /// Container type to emulate an AA, with serialization routines


### PR DESCRIPTION
```
Before this change, the serialization symmetry wasn't tested at all,
since we don't have any test that restart a node yet,
and this type isn't passed around.
Being untested, it was, obviously, buggy: while the serialization
was serializing `{ length, keys[], values[] }`, the deserialization
expected `{ length, { keys[idx], values[idx] }[] }`.
The serialization part was changed to meet the deserialization's
reasonable expectations.
```