### PR TITLE
Tests: Use more public import, hoist imports

### DIFF
--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -23,16 +23,11 @@ import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
 import agora.consensus.Genesis;
 import agora.test.Base;
+import core.thread;
 
 /// test node banning after putTransaction fails a number of times
 unittest
 {
-    import core.thread;
-    import std.algorithm;
-    import std.conv;
-    import std.format;
-    import std.range;
-
     TestConf conf =
     {
         topology : NetworkTopology.OneNonValidator,

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -45,7 +45,6 @@ import agora.node.Ledger;
 import agora.node.Validator;
 import agora.utils.Log;
 import agora.utils.PrettyPrinter;
-public import agora.utils.Test;  // frequently needed in tests
 import agora.api.FullNode : NodeInfo, NetworkState;
 import agora.api.Validator : ValidatorAPI = API;
 
@@ -56,19 +55,31 @@ import ocean.util.log.Logger;
 static import geod24.LocalRest;
 import geod24.Registry;
 
-import core.stdc.time;
 import std.array;
-import std.algorithm;
 import std.exception;
-import std.format;
-import std.stdio;
 
 import core.runtime;
-import core.time;
+import core.stdc.time;
+
+/* The following imports are frequently needed in tests */
+
+ // Contains utilities for testing, e.g. `retryFor`
+public import agora.utils.Test;
+// `core.time` provides duration-related utilities, used e.g. for `retryFor`
+public import core.time;
+// Useful to express complex pipeline simply
+public import std.algorithm;
+// Provides `to`, a template to convert anything to anything else
+public import std.conv;
+// `format` is often used to provide useful error messages
+public import std.format;
+// Range utilities are often used in combination with `std.algorithm`
+public import std.range;
+// To print messages to the screen while debugging a test
+public import std.stdio;
 
 shared static this()
 {
-    import core.runtime;
     Runtime.extendedModuleUnitTester = &customModuleUnitTester;
 }
 
@@ -79,7 +90,6 @@ shared static this()
 /// Workaround: Don't run ocean submodule unittests
 private UnitTestResult customModuleUnitTester ()
 {
-    import std.algorithm;
     import std.parallelism;
     import std.process;
     import std.string;
@@ -176,7 +186,6 @@ private UnitTestResult customModuleUnitTester ()
 public struct Serializer
 {
     import agora.common.Serializer;
-    import std.stdio;
 
     static immutable(ubyte)[] serialize (T) (auto ref T value) @trusted nothrow
     {
@@ -300,9 +309,6 @@ public struct NodePair
 
 public class TestAPIManager
 {
-    import core.time;
-    import core.stdc.time;
-
     /// Used by the unittests in order to directly interact with the nodes,
     /// without trying to handshake or do any automatic network discovery.
     /// Also kept here to avoid any eager garbage collection.
@@ -790,11 +796,8 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
     in TestConf test_conf)
 {
     import agora.common.Serializer;
-    import std.algorithm;
-    import std.array;
     import std.digest;
     import std.range;
-    import ocean.util.log.Logger;
 
     // We know we're in the main thread
     // Vibe.d messes with the scheduler - reset it

--- a/source/agora/test/Consensus.d
+++ b/source/agora/test/Consensus.d
@@ -28,10 +28,6 @@ import agora.test.Base;
 /// test cyclic quorum config
 unittest
 {
-    import std.algorithm;
-    import std.range;
-    import core.time;
-
     TestConf conf = { nodes : 6, topology : NetworkTopology.Cyclic, };
     auto network = makeTestNetwork(conf);
     network.start();

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -26,10 +26,6 @@ import agora.consensus.EnrollmentManager;
 import agora.consensus.Genesis;
 import agora.test.Base;
 
-import std.algorithm;
-import std.conv;
-import core.time;
-
 /// test for  enrollment process & revealing a pre-image periodically
 unittest
 {

--- a/source/agora/test/GenesisBlock.d
+++ b/source/agora/test/GenesisBlock.d
@@ -23,6 +23,7 @@ import agora.common.Hash;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
+import agora.consensus.Genesis;
 import agora.test.Base;
 
 import std.exception : assumeUnique;
@@ -74,14 +75,11 @@ private auto makeCustomGenesisBlock (in KeyPair key_pair)
 /// ditto
 unittest
 {
-    import std.algorithm;
-    import std.range;
     import core.thread;
 
     auto kp = KeyPair.random();
     auto genesis = makeCustomGenesisBlock(kp);
 
-    import agora.consensus.Genesis;
     TestConf conf = { gen_block : genesis[0] };
     auto network = makeTestNetwork(conf);
     network.start();

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -26,12 +26,6 @@ import agora.test.Base;
 ///
 unittest
 {
-    import std.algorithm;
-    import std.conv;
-    import std.format;
-    import std.range;
-    import core.time;
-
     auto network = makeTestNetwork(TestConf.init);
     network.start();
     scope(exit) network.shutdown();
@@ -73,12 +67,6 @@ unittest
 /// test gossiping behavior for an outsider node
 unittest
 {
-    import std.algorithm;
-    import std.conv;
-    import std.format;
-    import std.range;
-    import core.time;
-
     // node #5 is the outsider, so actually 5 total nodes
     TestConf conf = { nodes : 4, max_listeners : 5,
         topology : NetworkTopology.OneOutsider };

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -19,22 +19,21 @@ version (unittest):
 import agora.common.Amount;
 import agora.common.crypto.Key;
 import agora.common.Hash;
+import agora.common.Serializer;
 import agora.common.Types;
 import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
 import agora.consensus.data.UTXOSet;
 import agora.consensus.Genesis;
+import agora.consensus.Validation;
 import agora.test.Base;
+
+import core.thread;
+
 
 ///
 unittest
 {
-    import std.algorithm;
-    import std.conv;
-    import std.format;
-    import std.range;
-    import core.time;
-
     auto network = makeTestNetwork(TestConf.init);
     network.start();
     scope(exit) network.shutdown();
@@ -90,10 +89,6 @@ unittest
 /// test catch-up phase after initial booting (periodic catch-up)
 unittest
 {
-    import std.algorithm;
-    import std.range;
-    import core.time;
-
     TestConf conf = { topology : NetworkTopology.OneValidator };
     auto network = makeTestNetwork(conf);
     network.start();
@@ -116,9 +111,6 @@ unittest
 /// Merkle Proof
 unittest
 {
-    import core.time;
-    import std.algorithm;
-
     auto network = makeTestNetwork(TestConf.init);
     network.start();
     scope(exit) network.shutdown();
@@ -189,13 +181,6 @@ unittest
 /// test behavior of receiving double-spend transactions
 unittest
 {
-    import agora.common.Serializer;
-    import agora.consensus.Validation;
-
-    import std.algorithm;
-    import core.time;
-    import core.thread;
-
     TestConf conf = { nodes : 2 };
     auto network = makeTestNetwork(conf);
     network.start();

--- a/source/agora/test/Metadata.d
+++ b/source/agora/test/Metadata.d
@@ -15,16 +15,7 @@ module agora.test.Metadata;
 
 version (unittest):
 
-import agora.common.BanManager;
-import agora.common.Config;
-import agora.common.crypto.Key;
-import agora.common.Types;
-import agora.common.Metadata;
-import agora.common.Set;
 import agora.test.Base;
-
-import std.array;
-import std.algorithm;
 
 ///
 unittest

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -23,13 +23,11 @@ import agora.consensus.data.Transaction;
 import agora.consensus.Genesis;
 import agora.test.Base;
 
+import core.thread;
+
 /// test retrying requests after failure
 unittest
 {
-    import std.algorithm;
-    import std.range;
-    import core.thread;
-
     auto network = makeTestNetwork(TestConf.init);
     network.start();
     scope(exit) network.shutdown();
@@ -61,10 +59,6 @@ unittest
 /// test request timeouts
 unittest
 {
-    import std.algorithm;
-    import std.range;
-    import core.thread;
-
     auto network = makeTestNetwork(TestConf.init);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -20,9 +20,6 @@ import agora.test.Base;
 ///
 unittest
 {
-    import std.algorithm;
-    import std.format;
-
     TestConf conf = { nodes : 4 };
     auto network = makeTestNetwork(conf);
     network.start();
@@ -41,9 +38,6 @@ unittest
 /// test network discovery through the getNodeInfo() API
 unittest
 {
-    import std.algorithm;
-    import std.format;
-
     TestConf conf =
     {
         topology : NetworkTopology.FindNetwork,
@@ -68,9 +62,6 @@ unittest
 /// test finding all quorum nodes before network discovery is complete
 unittest
 {
-    import std.algorithm;
-    import std.format;
-
     TestConf conf =
     {
         topology : NetworkTopology.FindQuorums,

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -16,18 +16,22 @@ module agora.test.NetworkManager;
 version (unittest):
 
 import agora.api.Validator;
+import agora.common.BanManager;
+import agora.common.Config;
+import agora.common.crypto.Key;
+import agora.common.Metadata;
 import agora.common.Types;
+import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
 import agora.consensus.Genesis;
 import agora.test.Base;
 
+import geod24.Registry;
+import std.array;
+
 /// test behavior when getBlockHeight() call fails
 unittest
 {
-    import std.algorithm;
-    import std.range;
-    import core.thread;
-
     auto network = makeTestNetwork(TestConf.init);
     network.start();
     scope(exit) network.shutdown();
@@ -54,19 +58,6 @@ unittest
 /// test behavior when a node sends bad block data
 unittest
 {
-    import agora.common.BanManager;
-    import agora.consensus.data.Block;
-    import agora.common.Config;
-    import agora.common.Metadata;
-    import agora.common.crypto.Key;
-    import core.time;
-    import geod24.Registry;
-    import std.algorithm;
-    import std.array;
-    import std.conv;
-    import std.format;
-    import std.range;
-
     /// node which returns bad blocks
     static class BadNode : TestFullNode
     {

--- a/source/agora/test/Simple.d
+++ b/source/agora/test/Simple.d
@@ -28,10 +28,6 @@ import agora.test.Base;
 /// Simple test
 unittest
 {
-    import std.algorithm;
-    import std.range;
-    import core.thread;
-
     auto network = makeTestNetwork(TestConf.init);
     network.start();
     scope(exit) network.shutdown();


### PR DESCRIPTION
Some imports, such as std.algorithm, are ubiquitous in the test code.
Instead of copy-pasting a large list of import everywhere, we should make it easier to write test cases.
Simplifying the dependency is a first step in that direction.