### PR TITLE
Improved messages from unit test build in Windows

### DIFF
--- a/source/agora/cli/checkvtable/check.d
+++ b/source/agora/cli/checkvtable/check.d
@@ -19,7 +19,11 @@ import std.format;
 import std.stdio;
 import std.string;
 
-version (Windows) { pragma(msg, "This does not support Windows."); } else:
+version (Windows)
+{
+    pragma(msg, __MODULE__, " : This does not support Windows.");
+}
+else:
 
 version (unittest) { } else:
 

--- a/source/agora/cli/checkvtable/generate.d
+++ b/source/agora/cli/checkvtable/generate.d
@@ -19,7 +19,11 @@ import std.file;
 import std.format;
 import std.stdio;
 
-version (Windows) { pragma(msg, "This does not support Windows."); } else:
+version (Windows)
+{
+    pragma(msg, __MODULE__, " : This does not support Windows.");
+}
+else:
 
 version (unittest) { } else
 


### PR DESCRIPTION
Currently, This is the message that comes from the unit test build in the windows.

```
This does not support Windows.
This does not support Windows.
```

It makes it clearer where it's being printed.