### PR TITLE
Move pre-image cache handling in inner struct, use PreImageCache for seeds

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -110,7 +110,7 @@ public class EnrollmentManager
     private EnrollmentPool enroll_pool;
 
     /// The number of cycles for a bulk of pre-images
-    private immutable uint NumberOfCycles = 100;
+    private static immutable uint NumberOfCycles = 100;
 
     /// This struct hold all the cycle data together for better readability
     private static struct PreImageCycle


### PR DESCRIPTION
Base on #838, only last 2 commits are part of this PR.

```
Like we did for `preimages`, switch `seeds` to use `PreImageCache`.
This is way more memory efficient and reduce the amount of duplication.
It allows to reduce `generatePreimage` to a very simple, 5 lines functions,
which can in turn be moved inside the inner struct,
to which we added proper handling of `nonce`.

The last thing left to do is to move the consume call to `addValidator`,
so that we only consume a round of pre-image when we are confirmed as
a validator. The `createEnrollment` code will have to generate the
next round's pre-image manually, which can be expensive if the next round
is in another cycle, but is another step towards decouple generating
an Enrollment and actually acting on this Enrollment.
```

Note that this is still lacking tests, but I need to eliminate the constant first.