### PR TITLE
Check validity of pre-image with random seed

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -588,7 +588,7 @@ public class EnrollmentManager
 
         preimage.enroll_key = this.data.utxo_key;
         preimage.distance = index;
-        preimage.hash = this.cycle.preimages[index];
+        preimage.hash = this.cycle.preimages[$ - index - 1];
         return true;
     }
 
@@ -943,7 +943,9 @@ unittest
     assert(man.addValidator(enroll, 10, &storage.findUTXO));
     assert(!man.getPreimage(10, preimage));
     assert(man.getPreimage(11, preimage));
+    assert(preimage.hash == man.cycle.preimages[$ - 1]);
     assert(man.getPreimage(10 + Enrollment.ValidatorCycle, preimage));
+    assert(preimage.hash == man.cycle.preimages[0]);
     assert(!man.getPreimage(11 + Enrollment.ValidatorCycle, preimage));
 
     /// test for the functions about periodic revelation of a pre-image


### PR DESCRIPTION
If there is no pre-image revealed previously, the validity of a newly received pre-image should be checked with the random seed of an enrollment. All the operations for checking the validity are based on the distance of two pre-image hashes.

Last commit is about fixing an bug related to calculating distance in order to get pre-image, but the bug had been found when applying the new validity checking code. So I include the commit in this PR. If it's a problem, I will make another PR.

Fixes #694 