### PR TITLE
Fix the Enable Windows version unit test

### DIFF
--- a/ci/run.bat
+++ b/ci/run.bat
@@ -1,7 +1,6 @@
-rem call dub test --skip-registry=all --compiler=%DC%
-call dub build --skip-registry=all --compiler=%DC% -c unittest -b unittest
+call dub test --skip-registry=all --compiler=%DC%
 if %errorlevel% neq 0 exit /b %errorlevel%
-call rdmd --build-only --compiler=%DC% ./tests/runner.d --compiler=%DC% -cov
+call rdmd --compiler=%DC% ./tests/runner.d --compiler=%DC% -cov
 if %errorlevel% neq 0 exit /b %errorlevel%
 call dub build --skip-registry=all --compiler=%DC%
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -150,7 +150,12 @@ private UnitTestResult customModuleUnitTester ()
             else if (mod.name == "agora.test.ManyValidators")
                 heavy_tests ~= ModTest(mod.name, fp);
             else
-                parallel_tests ~= ModTest(mod.name, fp);
+                // due to problems with the parallelism test,
+                // the test is performed with single threads
+                version (Windows)
+                    single_threaded ~= ModTest(mod.name, fp);
+                else
+                    parallel_tests ~= ModTest(mod.name, fp);
         }
     }
 

--- a/source/scpd/Cpp.d
+++ b/source/scpd/Cpp.d
@@ -381,9 +381,10 @@ extern(C++, (StdNamespace)) extern(C++, class) struct vector (T, Alloc = allocat
         public void push_back (ref T value) @trusted pure nothrow @nogc
         {
             import Utils = scpd.types.Utils;
+            import scpd.types.XDRBase;
 
             // Workaround for Dlang issue #20805
-            static if (is(T == ubyte))
+            static if (is(T == xvector!ubyte))
             {
                 version (Windows)
                     Utils.push_back_vec(&this, &value);


### PR DESCRIPTION
This runs a unit test of the Windows version.
In the Windows version, due to problems with the parallelism test,
the test is performed with single threads.
And Fix the can't allocate of push_back

Related to #820 