### PR TITLE
Fix pre-image handling & issue 847

### DIFF
--- a/source/agora/common/Hash.d
+++ b/source/agora/common/Hash.d
@@ -478,10 +478,6 @@ unittest
             assert(cache.data.length == 1);
             assert(cache.data[0] == data[0]);
             break;
-        case 0:
-            assert(cache.data.length == 32);
-            assert(cache.data[] == data[]);
-            break;
 
         default:
             assert(0);

--- a/source/agora/common/Hash.d
+++ b/source/agora/common/Hash.d
@@ -426,6 +426,9 @@ public struct PreImageCache
         return value;
     }
 
+    /// Alias to the underlying data, useful when dealing with multiple levels
+    public const(Hash)[] byStride () const pure @nogc { return this.data; }
+
     /// Returns: The number of preimages this cache can represent
     public size_t length () const pure nothrow @nogc @safe
     {

--- a/source/agora/common/Hash.d
+++ b/source/agora/common/Hash.d
@@ -505,7 +505,7 @@ unittest
         entry = hashFull(data[idx]);
 
     // First case and last two are degenerate
-    immutable intervals = [2, 4, 8, 16];
+    immutable intervals = [1, 2, 4, 8, 16];
     foreach (interval; intervals)
     {
         auto cache = PreImageCache(data.length / interval, interval);

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -203,7 +203,7 @@ public class EnrollmentManager
             // not the number of round, hence why we use `byStrides`
             // The alternative would be:
             // [$ - (this.index + 1) * this.preimages.length]
-            const ret = this.preimages.reset(this.seeds.byStride[$ - 1 - this.index]);
+            this.preimages.reset(this.seeds.byStride[$ - 1 - this.index]);
 
             // Increment index if there are rounds left in this cycle
             this.index += 1;
@@ -213,7 +213,7 @@ public class EnrollmentManager
                 this.nonce += 1;
             }
 
-            return ret;
+            return this.preimages[$ - 1];
         }
     }
 


### PR DESCRIPTION
This is quite embarrassing... The way the `Cycle` structure work is that it contains a two-layers cache, and the first layer is the seed of every enrollment, while the second layer contains the pre-images for the current cycle.

```
L1: [0, 1008, 2016, 3024, 4032, ..., 10800]
L2: [0 .. 1007] or [1008 .. 2015] or [2016 .. 3023], etc...
```

The were multiple problems with the code:
- First and foremost, while cycling through the L1, we would first reveal [0 .. 1007], then [1008 .. 2015], etc... Those are the last that should be revealed, we should start with [9798 .. 10800] !
- When resetting the cycle (once all enrollments are exhausted) there was an OB1 error leading to a `RangeError`;
- The way things were stored was overly complicated and not very usable (see #847). This has been refactored.
- There was no proper test of the behavior;

So all of those are fixed in those commits. In addition, I added a `toString`, which proved to be a valuable debugging utility. It should unblock some of @linked0 's PRs too.