### PR TITLE
build.d: Use g++ instead of gcc

### DIFF
--- a/source/scpp/build.d
+++ b/source/scpp/build.d
@@ -59,7 +59,7 @@ version (Posix)
         "-D_GLIBCXX_USE_CXX11_ABI=0",
         "-std=c++14",
     ];
-    immutable CppCmd = [ "gcc" ] ~ CppFlags;
+    immutable CppCmd = [ "g++" ] ~ CppFlags;
 }
 else version (Windows)
 {


### PR DESCRIPTION
It has been known (and experienced) to cause issues when using gcc to link C++ code.