### PR TITLE
`EnrollmentManager` add an enrollment before the cycle

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -336,7 +336,8 @@ public class Ledger
         const next_height = Height(this.getBlockHeight() + 1);
         auto utxo_finder = this.utxo_set.getUTXOFinder();
 
-        this.enroll_man.pool.getEnrollments(data.enrolls);
+        this.enroll_man.getEnrollments(data.enrolls,
+            Height(this.getBlockHeight()));
         foreach (hash, tx; this.pool)
         {
             if (auto reason = tx.isInvalidReason(utxo_finder, next_height))
@@ -1046,7 +1047,8 @@ unittest
 
     // Check if there are any unregistered enrollments
     Enrollment[] unreg_enrollments;
-    assert(ledger.enroll_man.pool.getEnrollments(unreg_enrollments) is null);
+    assert(ledger.enroll_man.getEnrollments(unreg_enrollments,
+        ledger.getBlockHeight()) is null);
     auto block_4 = ledger.getBlocksFrom(Height(4));
     enrollments.sort!("a.utxo_key < b.utxo_key");
     assert(block_4[0].header.enrollments == enrollments);


### PR DESCRIPTION
The validator set should allow a node to re-enroll before the validator cycle ends. It's not for sure that an enrollment will be contained in the next new block, so the validator set must add the enrollment earlier before the cycle ends.

I also added the constant about the round where a node can re-enroll because unnecessary re-enrollments should be avoid. The value can be configurable in the issue #520 .

Relates #824