### PR TITLE
Apply the ability to check the number of active validators

### DIFF
--- a/source/agora/consensus/data/Enrollment.d
+++ b/source/agora/consensus/data/Enrollment.d
@@ -48,6 +48,9 @@ public struct Enrollment
     /// S: A signature for the message H(K, X, n, R) and the key K, using R
     public Signature enroll_sig;
 
+    /// The minimum number of validators required to create a block
+    public static immutable uint MinValidatorCount = 1;
+
     /***************************************************************************
 
         Implements hashing support

--- a/source/agora/test/ValidatorCount.d
+++ b/source/agora/test/ValidatorCount.d
@@ -1,0 +1,73 @@
+/*******************************************************************************
+
+    The creation of a block must stop immediately just before all the
+    active validators is expired.
+    This is to allow additional enrollment of validators.
+    Enrollment's cycle is `ConsensusParams.validator_cycle`,
+    If none of the active validators exist at height `validator_cycle`,
+    block generation must stop at height `validator_cycle`-1.
+
+    This code tests these.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.ValidatorCount;
+
+version (unittest):
+
+import agora.consensus.data.ConsensusParams;
+import agora.consensus.data.Transaction;
+import agora.consensus.Genesis;
+import agora.test.Base;
+
+import core.thread;
+
+/// ditto
+unittest
+{
+    auto validator_cycle = 20;
+    auto params = new immutable(ConsensusParams)(validator_cycle);
+
+    auto network = makeTestNetwork(TestConf.init, params);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[0];
+
+    auto gen_key_pair = WK.Keys.Genesis;
+
+    Transaction[] txs;
+
+    // create validator_cycle - 1 blocks
+    foreach (block_idx; 1 .. validator_cycle)
+    {
+        // create enough tx's for a single block
+        txs = makeChainedTransactions(gen_key_pair, txs, 1);
+
+        // send it to one node
+        txs.each!(tx => node_1.putTransaction(tx));
+
+        containSameBlocks(nodes, block_idx).retryFor(5.seconds);
+    }
+
+    // Block will not be created because otherwise there would be no active validators
+    {
+        txs = makeChainedTransactions(gen_key_pair, txs, 1);
+        txs.each!(tx => node_1.putTransaction(tx));
+    }
+
+    Thread.sleep(2.seconds);  // wait for propagation
+
+    // New block was not created because all validators would expire
+    containSameBlocks(nodes, validator_cycle - 1).retryFor(5.seconds);
+}


### PR DESCRIPTION
Consider this case:

- Genesis block begins with 2 validators
- Their expiration block is at height 1008
- Block height 1008 is reached, and the validators are now expired.

When the height 1008 block is being created, I developed so that the block is not created without any active validators.

The creation of a block must stop immediately just before all the enrollment data expire.
This is to allow additional enrollment of validators.
If enrollment's cycle is 1008,
If none of the active validators exist at height 1008, block generation must stop at height 1007.
If the number of additionally enrolled validators at height 1007 is satisfied, a block of 1008 can be created.

The optimal number of active validators is 3 or 4.
I will increase the value of the minimum active validator from 1 to 3.
If I make a lot of changes at once, suddenly there are more test codes to modify, and the solutions are complicated.
So I will change it little by little and reach the goal.

Related to #822 