### PR TITLE
Update LocalRest and wait on start() indefinitely

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -398,7 +398,15 @@ public class TestAPIManager
 
     public void start ()
     {
-        this.nodes.each!(a => a.client.start());
+        foreach (node; this.nodes)
+        {
+            // have to wait indefinitely as the constructor is
+            // currently a slow routine, stalling the call to start().
+            node.client.ctrl.withTimeout(0.msecs,
+                (scope TestAPI api) {
+                    api.start();
+                });
+        }
     }
 
     /***************************************************************************


### PR DESCRIPTION
The constructor is currently a slow routine
and take take a long time to finish, in particular
in the tests. This stalls the calls to start(),
and those requests would normally time-out.