### PR TITLE
Change the order of the enrollments in makeGenesisBlock

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1090,7 +1090,7 @@ private immutable(Block) makeGenesisBlock (in KeyPair[] key_pairs)
         enrolls ~= enroll;
     }
 
-    enrolls.sort!("a.utxo_key > b.utxo_key");
+    enrolls.sort!("a.utxo_key < b.utxo_key");
 
     txs.sort;
     Hash[] merkle_tree;


### PR DESCRIPTION
The enrollments of the blocks must be sorted in ascending order.

Relate to #890