### PR TITLE
Properly silence SCP trace logs

### DIFF
--- a/source/scpp/src/util/Logging.cpp
+++ b/source/scpp/src/util/Logging.cpp
@@ -19,6 +19,9 @@ DLogger::DLogger(int level, std::string const& loggerName)
 
 DLogger::~DLogger()
 {
+    if (mLevel == TRACE && !Logging::logTrace("SCP"))
+        return;
+
     writeDLog(mLoggerName.c_str(), mLevel, mOutStream.str().c_str());
 }
 }


### PR DESCRIPTION
Only some of the SCPP code checks if (mLogTrace(...)),
in many routines this is not checked. For example in
Slot::recordStatement which unconditionally calls
CLOG(DEBUG, "SCP") << "new statement: " ..