### PR TITLE
Add an overload of 'sign' which accepts a signature noise

### DIFF
--- a/source/agora/common/crypto/Schnorr.d
+++ b/source/agora/common/crypto/Schnorr.d
@@ -175,6 +175,12 @@ public Signature sign (T) (const ref Scalar privateKey, T data)
     return sign!T(privateKey, privateKey.toPoint(), R.V, R.v, data);
 }
 
+/// Sign with a given `r` (warning: `r` should never be reused with `x`)
+public Signature sign (T) (const ref Pair kp, const ref Pair r, auto ref T data)
+{
+    return sign!T(kp.v, kp.V, r.V, r.v, data);
+}
+
 /// Complex API, allow multisig
 public Signature sign (T) (
     const ref Scalar x, const ref Point X,

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -295,8 +295,7 @@ public class EnrollmentManager
         }
 
         // signature
-        data.enroll_sig = sign(this.key_pair.v, this.key_pair.V, this.signature_noise.V,
-            this.signature_noise.v, this.data);
+        data.enroll_sig = sign(this.key_pair, this.signature_noise, this.data);
 
         enroll = this.data;
 
@@ -716,8 +715,7 @@ unittest
     fail_enroll.utxo_key = utxo_hash;
     fail_enroll.random_seed = hashFull(Scalar.random());
     fail_enroll.cycle_length = 1008;
-    fail_enroll.enroll_sig = sign(fail_enroll_key_pair.v, fail_enroll_key_pair.V,
-        signature_noise.V, signature_noise.v, fail_enroll);
+    fail_enroll.enroll_sig = sign(fail_enroll_key_pair, signature_noise, fail_enroll);
 
     assert(man.createEnrollment(utxo_hash, 1, enroll));
     assert(!man.pool.add(fail_enroll, &storage.findUTXO));

--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -300,8 +300,7 @@ private Enrollment createEnrollment(const ref Hash utxo_key,
         preimages ~= hashFull(preimages[i]);
     reverse(preimages);
     enroll.random_seed = preimages[0];
-    enroll.enroll_sig = sign(pair.v, pair.V, signature_noise.V,
-        signature_noise.v, enroll);
+    enroll.enroll_sig = sign(pair, signature_noise, enroll);
     return enroll;
 }
 

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -144,8 +144,7 @@ unittest
     enroll1.utxo_key = utxo_hash1;
     enroll1.random_seed = hashFull(Scalar.random());
     enroll1.cycle_length = 1008;
-    enroll1.enroll_sig = sign(node_key_pair_1.v, node_key_pair_1.V, signature_noise.V,
-        signature_noise.v, enroll1);
+    enroll1.enroll_sig = sign(node_key_pair_1, signature_noise, enroll1);
 
     Pair node_key_pair_2;
     node_key_pair_2.v = secretKeyToCurveScalar(key_pairs[1].secret);
@@ -155,8 +154,7 @@ unittest
     enroll2.utxo_key = utxo_hash2;
     enroll2.random_seed = hashFull(Scalar.random());
     enroll2.cycle_length = 1008;
-    enroll2.enroll_sig = sign(node_key_pair_2.v, node_key_pair_2.V, signature_noise.V,
-        signature_noise.v, enroll2);
+    enroll2.enroll_sig = sign(node_key_pair_2, signature_noise, enroll2);
 
     Pair node_key_pair_3;
     node_key_pair_3.v = secretKeyToCurveScalar(key_pairs[2].secret);
@@ -166,8 +164,7 @@ unittest
     enroll3.utxo_key = utxo_hash3;
     enroll3.random_seed = hashFull(Scalar.random());
     enroll3.cycle_length = 1008;
-    enroll3.enroll_sig = sign(node_key_pair_3.v, node_key_pair_3.V, signature_noise.V,
-        signature_noise.v, enroll3);
+    enroll3.enroll_sig = sign(node_key_pair_3, signature_noise, enroll3);
 
     Pair node_key_pair_4;
     // Invalid secret key
@@ -178,8 +175,7 @@ unittest
     enroll4.utxo_key = utxo_hash4;
     enroll4.random_seed = hashFull(Scalar.random());
     enroll4.cycle_length = 1008;
-    enroll4.enroll_sig = sign(node_key_pair_4.v, node_key_pair_4.V, signature_noise.V,
-        signature_noise.v, enroll4);
+    enroll4.enroll_sig = sign(node_key_pair_4, signature_noise, enroll4);
 
     assert(!enroll1.isValid(utxoFinder));
     assert(!enroll2.isValid(utxoFinder));

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -1034,22 +1034,19 @@ unittest
     enroll_1.utxo_key = utxo_hash_1;
     enroll_1.random_seed = hashFull(Scalar.random());
     enroll_1.cycle_length = 1008;
-    enroll_1.enroll_sig = sign(node_key_pair_1.v, node_key_pair_1.V, signature_noise.V,
-        signature_noise.v, enroll_1);
+    enroll_1.enroll_sig = sign(node_key_pair_1, signature_noise, enroll_1);
 
     Enrollment enroll_2;
     enroll_2.utxo_key = utxo_hash_2;
     enroll_2.random_seed = hashFull(Scalar.random());
     enroll_2.cycle_length = 1008;
-    enroll_2.enroll_sig = sign(node_key_pair_2.v, node_key_pair_2.V, signature_noise.V,
-        signature_noise.v, enroll_2);
+    enroll_2.enroll_sig = sign(node_key_pair_2, signature_noise, enroll_2);
 
     Enrollment enroll_3;
     enroll_3.utxo_key = utxo_hash_3;
     enroll_3.random_seed = hashFull(Scalar.random());
     enroll_3.cycle_length = 1008;
-    enroll_3.enroll_sig = sign(node_key_pair_3.v, node_key_pair_3.V, signature_noise.V,
-        signature_noise.v, enroll_3);
+    enroll_3.enroll_sig = sign(node_key_pair_3, signature_noise, enroll_3);
 
     Enrollment[] enrollments ;
     enrollments ~= enroll_1;


### PR DESCRIPTION
Using a signature noise might be frequent enough to warrant an overload.
This needs to be used with care, as reusing `R` would be deadly to the node.