### PR TITLE
Use setTimer on Network.discover 

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -171,11 +171,9 @@ public class FullNode : API
         this.taskman.runTask(
         ()
         {
-            while (1)
-            {
-                this.network.discover();
-                this.taskman.wait(5.seconds);
-            }
+            void discover () { this.network.discover(); }
+            discover(); // avoid delay
+            this.taskman.setTimer(5.seconds, &discover, Periodic.Yes);
         });
     }
 

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -100,11 +100,9 @@ public class Validator : FullNode, API
             buildRequiredKeys(this.config.node.key_pair.address,
                 this.config.quorum, required_peer_keys);
 
-            while (1)
-            {
-                this.network.discover(required_peer_keys);
-                this.taskman.wait(5.seconds);
-            }
+            void discover () { this.network.discover(required_peer_keys); }
+            discover();  // avoid delay
+            this.taskman.setTimer(5.seconds, &discover, Periodic.Yes);
         });
     }
 


### PR DESCRIPTION
Two improvements are needed here.

`Taskmanager.setTimer` is `wait` and `call` action.

So I call first to eliminate the delay in the first run.

Currently, this kind of movement causes the error as below.

Second `Validator.startPeriodicDiscovery`
This is unnecessary repetitive behavior of `buildRequiredKeys`

Relates #872 