### PR TITLE
Add a function to restart a given node (and a test for it)

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -444,6 +444,24 @@ public class TestAPIManager
 
     /***************************************************************************
 
+        Restart a specific node
+
+        This routine restarts the given `client`, making sure it gracefully
+        shuts down then restart properly.
+
+        Params:
+          client = Reference to the client to restart
+
+    ***************************************************************************/
+
+    public void restart (scope RemoteAPI!TestAPI client)
+    {
+        client.ctrl.restart((TestAPI node) { (cast(FullNode)node).shutdown(); });
+        client.ctrl.withTimeout(0.msecs, (scope TestAPI api) { api.start(); });
+    }
+
+    /***************************************************************************
+
         Print out the logs for each node
 
     ***************************************************************************/

--- a/source/agora/test/Simple.d
+++ b/source/agora/test/Simple.d
@@ -44,3 +44,29 @@ unittest
     nodes.all!(node => node.getBlockHeight() == 1)
         .retryFor(2.seconds);
 }
+
+/// A test that stops and restarts a node
+unittest
+{
+    auto network = makeTestNetwork(TestConf.init);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[0];
+
+    auto txes = makeChainedTransactions(getGenesisKeyPair(), null, 1);
+    txes.each!(tx => node_1.putTransaction(tx));
+
+    nodes.all!(node => node.getBlockHeight() == 1)
+        .retryFor(2.seconds);
+
+    // Now shut down & restart one node
+    auto restartMe = nodes[$-1];
+    network.restart(restartMe);
+    network.waitForDiscovery();
+    nodes.all!(node => node.getBlockHeight() == 1)
+        .retryFor(5.seconds);
+}


### PR DESCRIPTION
```
Using `ctrl.restart` directly is not advised as the teardown / startup
code won't be run. Instead, this method is provided.
```