### PR TITLE
runNode: Move type from parameter to body

### DIFF
--- a/source/agora/cli/multi/main.d
+++ b/source/agora/cli/multi/main.d
@@ -107,12 +107,7 @@ private int main (string[] args)
 
     FullNode[] nodes;
     foreach (const ref config; configs)
-    {
-        if (config.node.is_validator)
-            nodes ~= runNode!Validator(config);
-        else
-            nodes ~= runNode!FullNode(config);
-    }
+        nodes ~= runNode(config);
 
     scope (exit)
     {

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -73,10 +73,7 @@ private int main (string[] args)
             return 0;
         }
 
-        if (config.node.is_validator)
-            runTask(() => node = runNode!Validator(config));
-        else
-            runTask(() => node = runNode!FullNode(config));
+        runTask(() => node = runNode(config));
     }
     catch (Exception ex)
     {


### PR DESCRIPTION
This function was a bit weird, as it knew the inner details of the nodes,
and had assertion to protect from misuse.
Additionally, client code was already only dealing with FullNode.
Moving the 'if' inside instead of having it at the call site
simplify the code.