### PR TITLE
getBlocksFrom() should return a mutable array

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -152,7 +152,7 @@ public interface API
 
     ***************************************************************************/
 
-    public const(Block)[] getBlocksFrom (ulong block_height, uint max_blocks);
+    public Block[] getBlocksFrom (ulong block_height, uint max_blocks);
 
 
     /***************************************************************************

--- a/source/agora/network/NetworkClient.d
+++ b/source/agora/network/NetworkClient.d
@@ -232,7 +232,7 @@ class NetworkClient
 
     ***************************************************************************/
 
-    public const(Block)[] getBlocksFrom (ulong block_height, uint max_blocks)
+    public Block[] getBlocksFrom (ulong block_height, uint max_blocks)
     {
         return this.attemptRequest(
             this.api.getBlocksFrom(block_height, max_blocks), this.exception);

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -573,7 +573,7 @@ public class NetworkManager
     ***************************************************************************/
 
     private void getBlocksFrom (ulong block_height,
-        scope bool delegate(const(Block)[]) @safe onReceivedBlocks) nothrow
+        scope bool delegate(Block[]) @safe onReceivedBlocks) nothrow
     {
         struct Pair { size_t height; NetworkClient client; }
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -252,7 +252,7 @@ public class FullNode : API
     }
 
     /// GET: /blocks_from
-    public override const(Block)[] getBlocksFrom (ulong block_height,
+    public override Block[] getBlocksFrom (ulong block_height,
         uint max_blocks)  @safe
     {
         return this.ledger.getBlocksFrom(block_height)

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -161,7 +161,7 @@ public class Ledger
 
     ***************************************************************************/
 
-    public bool acceptBlock (const ref Block block) @safe
+    public bool acceptBlock (ref Block block) @safe
     {
         if (auto fail_reason = this.validateBlock(block))
         {
@@ -219,7 +219,7 @@ public class Ledger
 
     ***************************************************************************/
 
-    private void addValidatedBlock (const ref Block block) @safe
+    private void addValidatedBlock (ref Block block) @safe
     {
         this.updateUTXOSet(block);
         if (!this.storage.saveBlock(block))
@@ -237,9 +237,7 @@ public class Ledger
                 assert(0);
             }
 
-        // read back and cache the last block
-        if (!this.storage.readLastBlock(this.last_block))
-            assert(0);
+        this.last_block = block;
     }
 
     /***************************************************************************
@@ -394,7 +392,7 @@ public class Ledger
     {
         start_height = min(start_height, this.getBlockHeight() + 1);
 
-        const(Block) readBlock (size_t height)
+        Block readBlock (size_t height)
         {
             Block block;
             if (!this.storage.tryReadBlock(block, height))
@@ -484,7 +482,7 @@ unittest
     assert(ledger.getBlockHeight() == 0);
 
     auto blocks = ledger.getBlocksFrom(0).take(10);
-    assert(blocks[$ - 1] == GenesisBlock);
+    assert(blocks[$ - 1] == cast()GenesisBlock);
 
     Transaction[] last_txs;
 
@@ -506,7 +504,7 @@ unittest
 
     genBlockTransactions(2);
     blocks = ledger.getBlocksFrom(0).take(10);
-    assert(blocks[0] == GenesisBlock);
+    assert(blocks[0] == cast()GenesisBlock);
     assert(blocks[0].header.height == 0);
     assert(blocks.length == 3);  // two blocks + genesis block
 
@@ -515,13 +513,13 @@ unittest
     assert(ledger.getBlockHeight() == 100);
 
     blocks = ledger.getBlocksFrom(0).takeExactly(10);
-    assert(blocks[0] == GenesisBlock);
+    assert(blocks[0] == cast()GenesisBlock);
     assert(blocks[0].header.height == 0);
     assert(blocks.length == 10);
 
     /// lower limit
     blocks = ledger.getBlocksFrom(0).takeExactly(5);
-    assert(blocks[0] == GenesisBlock);
+    assert(blocks[0] == cast()GenesisBlock);
     assert(blocks[0].header.height == 0);
     assert(blocks.length == 5);
 

--- a/source/agora/test/GenesisBlock.d
+++ b/source/agora/test/GenesisBlock.d
@@ -34,7 +34,7 @@ unittest
     auto nodes = network.clients;
     auto node_1 = nodes[0];
 
-    nodes.all!(node => node.getBlocksFrom(0, 1)[0] == network.blocks[0])
+    nodes.all!(node => node.getBlocksFrom(0, 1)[0] == cast()network.blocks[0])
         .retryFor(2.seconds);
 
     auto txes = makeChainedTransactions(getGenesisKeyPair(), null, 1);

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -66,7 +66,7 @@ unittest
     // get all the blocks (including genesis block)
     auto blocks = node_1.getBlocksFrom(0, 101);
 
-    assert(blocks[0] == network.blocks[0]);
+    assert(blocks[0] == cast()network.blocks[0]);
 
     // exclude genesis block
     assert(blocks[1 .. $].enumerate.each!((idx, block) =>
@@ -74,7 +74,7 @@ unittest
     ));
 
     blocks = node_1.getBlocksFrom(0, 1);
-    assert(blocks.length == 1 && blocks[0] == network.blocks[0]);
+    assert(blocks.length == 1 && blocks[0] == cast()network.blocks[0]);
 
     blocks = node_1.getBlocksFrom(10, 1);
     assert(blocks.length == 1 && blocks[0].txs == block_txes[9]);  // -1 as genesis block not included

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -68,7 +68,7 @@ unittest
         }
 
         /// return phony blocks
-        public override const(Block)[] getBlocksFrom (ulong block_height,
+        public override Block[] getBlocksFrom (ulong block_height,
             uint max_blocks)
         {
             Block[] blocks;


### PR DESCRIPTION
Commit explains it.

@Geod24 is there a way I can avoid doing the `cast()` here? Otherwise I'm getting the mutable/immutable array compare mismatch error:

> source/agora/test/Ledger.d(69,12): Error: array equality comparison type mismatch, Transaction[] vs immutable(Transaction[])

Maybe we just need to implement opEquals manually?