### PR TITLE
Introduce a ManagedDatabase class

### DIFF
--- a/source/agora/common/ManagedDatabase.d
+++ b/source/agora/common/ManagedDatabase.d
@@ -1,0 +1,81 @@
+/*******************************************************************************
+
+    Contains a managed wrapper around SQLite databases.
+
+    This class ensures that all D2SQLite databases handled by the thread
+    are cleanly destroyed after the thread shuts down.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.common.ManagedDatabase;
+
+import agora.utils.Log;
+
+import d2sqlite3.database;
+import d2sqlite3.sqlite3;
+
+mixin AddLogger!();
+
+/// Ditto
+public class ManagedDatabase
+{
+    /// ManagedDatabase managed by the current thread
+    private static Database*[] thread_dbs;
+
+    /// Close all database handles
+    static ~this ()
+    {
+        try
+        {
+            foreach (db; thread_dbs)
+                db.close();
+        }
+        catch (Exception ex)
+        {
+            log.error("Error closing database handles: {}", ex.message);
+            throw ex;
+        }
+    }
+
+    /// Pointer to the database handle
+    private Database* database;
+
+    /// Subtype
+    public alias getDatabase this;
+
+    /***************************************************************************
+
+        Constructs a managed database
+
+        Params:
+            path = path to the db on disk, or :memory: for an in-memory database
+            flags = SQLite read / write flags
+
+    ***************************************************************************/
+
+    public this (string path,
+        int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE)
+    {
+        this.database = new Database(path, flags);
+        thread_dbs ~= this.database;
+    }
+
+    /***************************************************************************
+
+        Returns:
+            the database handle (used via alias this)
+
+    ***************************************************************************/
+
+    public Database* getDatabase () pure nothrow @safe @nogc
+    {
+        return this.database;
+    }
+}

--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -20,6 +20,7 @@ import agora.common.crypto.ECC;
 import agora.common.crypto.Key;
 import agora.common.crypto.Schnorr;
 import agora.common.Hash;
+import agora.common.ManagedDatabase;
 import agora.common.Serializer;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
@@ -29,7 +30,6 @@ import agora.consensus.UTXOSet;
 import agora.consensus.validation;
 import agora.utils.Log;
 
-import d2sqlite3.database;
 import d2sqlite3.library;
 import d2sqlite3.results;
 import d2sqlite3.sqlite3;
@@ -40,7 +40,7 @@ mixin AddLogger!();
 public class EnrollmentPool
 {
     /// SQLite DB instance
-    private Database db;
+    private ManagedDatabase db;
 
     /***************************************************************************
 
@@ -54,25 +54,11 @@ public class EnrollmentPool
 
     public this (string db_path)
     {
-        this.db = Database(db_path);
+        this.db = new ManagedDatabase(db_path);
 
         // create the table for enrollment pool if it doesn't exist yet
         this.db.execute("CREATE TABLE IF NOT EXISTS enrollment_pool " ~
             "(key TEXT PRIMARY KEY, val BLOB NOT NULL)");
-    }
-
-    /***************************************************************************
-
-        Shut down the database
-
-        Note: this method must be called explicitly, and not inside of
-        a destructor.
-
-    ***************************************************************************/
-
-    public void shutdown ()
-    {
-        this.db.close();
     }
 
     /***************************************************************************
@@ -126,7 +112,7 @@ public class EnrollmentPool
         }
         catch (Exception ex)
         {
-            log.error("Database operation error: {}, Data was: {}", ex.msg, enroll);
+            log.error("ManagedDatabase operation error: {}, Data was: {}", ex.msg, enroll);
             return false;
         }
 
@@ -150,7 +136,7 @@ public class EnrollmentPool
         }
         catch (Exception ex)
         {
-            log.error("Database operation error on count");
+            log.error("ManagedDatabase operation error on count");
             return 0;
         }
     }
@@ -173,7 +159,7 @@ public class EnrollmentPool
         }
         catch (Exception ex)
         {
-            log.error("Database operation error on remove");
+            log.error("ManagedDatabase operation error on remove");
         }
     }
 
@@ -336,7 +322,6 @@ unittest
         storage.put(tx);
     }
     EnrollmentPool pool = new EnrollmentPool(":memory:");
-    scope (exit) pool.shutdown();
     Hash[] utxo_hashes = storage.keys;
 
     // add enrollments

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -137,11 +137,8 @@ public class FullNode : API
             config.network, config.dns_seeds, this.metadata, this.taskman);
         this.storage = this.getBlockStorage(config.node.data_dir);
         this.pool = this.getPool(config.node.data_dir);
-        scope (failure) this.pool.shutdown();
         this.utxo_set = this.getUtxoSet(config.node.data_dir);
-        scope (failure) this.utxo_set.shutdown();
         this.enroll_man = this.getEnrollmentManager(config.node.data_dir, config.node);
-        scope (failure) this.enroll_man.shutdown();
         this.ledger = new Ledger(this.pool, this.utxo_set, this.storage,
             this.enroll_man, config.node, onValidatorsChanged);
         this.exception = new RestException(
@@ -193,11 +190,8 @@ public class FullNode : API
     {
         log.info("Shutting down..");
         this.network.dumpMetadata();
-        this.pool.shutdown();
         this.pool = null;
-        this.utxo_set.shutdown();
         this.utxo_set = null;
-        this.enroll_man.shutdown();
         this.enroll_man = null;
     }
 

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -479,12 +479,9 @@ unittest
 
     auto storage = new MemBlockStorage();
     auto pool = new TransactionPool(":memory:");
-    scope(exit) pool.shutdown();
     auto utxo_set = new UTXOSet(":memory:");
-    scope (exit) utxo_set.shutdown();
     auto config = new Config();
     auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair);
-    scope (exit) enroll_man.shutdown();
     config.node.is_validator = true;
     scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
     assert(ledger.getBlockHeight() == 0);
@@ -568,12 +565,9 @@ unittest
 
     auto storage = new MemBlockStorage();
     auto pool = new TransactionPool(":memory:");
-    scope(exit) pool.shutdown();
     auto utxo_set = new UTXOSet(":memory:");
-    scope (exit) utxo_set.shutdown();
     auto config = new Config();
     auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair);
-    scope (exit) enroll_man.shutdown();
     config.node.is_validator = true;
     scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
 
@@ -618,12 +612,9 @@ unittest
 
     auto storage = new MemBlockStorage();
     auto pool = new TransactionPool(":memory:");
-    scope(exit) pool.shutdown();
     auto utxo_set = new UTXOSet(":memory:");
-    scope (exit) utxo_set.shutdown();
     auto config = new Config();
     auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair);
-    scope (exit) enroll_man.shutdown();
     config.node.is_validator = true;
     scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
 
@@ -645,12 +636,9 @@ unittest
 
     auto storage = new MemBlockStorage();
     auto pool = new TransactionPool(":memory:");
-    scope(exit) pool.shutdown();
     auto utxo_set = new UTXOSet(":memory:");
-    scope (exit) utxo_set.shutdown();
     auto config = new Config();
     auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair);
-    scope (exit) enroll_man.shutdown();
     config.node.is_validator = true;
     scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
 
@@ -723,12 +711,9 @@ unittest
     assert(storage.saveBlock(block));
 
     auto pool = new TransactionPool(":memory:");
-    scope(exit) pool.shutdown();
     auto utxo_set = new UTXOSet(":memory:");
-    scope (exit) utxo_set.shutdown();
     auto config = new Config();
     auto enroll_man = new EnrollmentManager(":memory:", gen_key);
-    scope (exit) enroll_man.shutdown();
     config.node.is_validator = true;
     scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
 
@@ -830,14 +815,9 @@ unittest
 
     auto storage = new MemBlockStorage();
     auto pool = new TransactionPool(":memory:");
-    scope(exit) pool.shutdown();
-
     auto utxo_set = new UTXOSet(":memory:");
-    scope (exit) utxo_set.shutdown();
-
     auto config = new Config();
     auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair);
-    scope (exit) enroll_man.shutdown();
     config.node.is_validator = true;
     scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
 
@@ -909,12 +889,9 @@ unittest
 
     auto storage = new MemBlockStorage();
     auto pool = new TransactionPool(":memory:");
-    scope(exit) pool.shutdown();
     auto utxo_set = new UTXOSet(":memory:");
-    scope (exit) utxo_set.shutdown();
     auto config = new Config();
     auto enroll_man = new EnrollmentManager(":memory:", gen_key);
-    scope (exit) enroll_man.shutdown();
     config.node.is_validator = true;
     scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
 
@@ -1133,14 +1110,9 @@ unittest
 
     auto storage = new MemBlockStorage();
     auto pool = new TransactionPool(":memory:");
-    scope(exit) pool.shutdown();
-
     auto utxo_set = new UTXOSet(":memory:");
-    scope (exit) utxo_set.shutdown();
-
     auto config = new Config();
     auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair);
-    scope (exit) enroll_man.shutdown();
     config.node.is_validator = true;
     scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
 
@@ -1442,13 +1414,10 @@ unittest
     {
         auto key_pair = KeyPair.random();
         scope enroll_man = new EnrollmentManager(":memory:", key_pair);
-        scope (exit) enroll_man.shutdown();
         const blocks = genBlocksToIndex(key_pair, enroll_man, 0);
         scope storage = new MemBlockStorage(blocks);
         scope pool = new TransactionPool(":memory:");
-        scope (exit) pool.shutdown();
         scope utxo_set = new UTXOSet(":memory:");
-        scope (exit) utxo_set.shutdown();
         scope config = new Config();
         scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
         Hash[] keys;
@@ -1460,13 +1429,10 @@ unittest
     {
         auto key_pair = KeyPair.random();
         scope enroll_man = new EnrollmentManager(":memory:", key_pair);
-        scope (exit) enroll_man.shutdown();
         const blocks = genBlocksToIndex(key_pair, enroll_man, 1007);
         scope storage = new MemBlockStorage(blocks);
         scope pool = new TransactionPool(":memory:");
-        scope (exit) pool.shutdown();
         scope utxo_set = new UTXOSet(":memory:");
-        scope (exit) utxo_set.shutdown();
         scope config = new Config();
         scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
         Hash[] keys;
@@ -1478,13 +1444,10 @@ unittest
     {
         auto key_pair = KeyPair.random();
         scope enroll_man = new EnrollmentManager(":memory:", key_pair);
-        scope (exit) enroll_man.shutdown();
         const blocks = genBlocksToIndex(key_pair, enroll_man, 1008);
         scope storage = new MemBlockStorage(blocks);
         scope pool = new TransactionPool(":memory:");
-        scope (exit) pool.shutdown();
         scope utxo_set = new UTXOSet(":memory:");
-        scope (exit) utxo_set.shutdown();
         scope config = new Config();
         scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
         Hash[] keys;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1099,7 +1099,6 @@ private immutable(Block) makeGenesisBlock (in KeyPair[] key_pairs)
         Hash txhash = hashFull(tx);
         Hash utxo = UTXOSetValue.getHash(txhash, 0);
         scope enr = new EnrollmentManager(":memory:", key_pair);
-        scope (exit) enr.shutdown();
 
         Enrollment enroll;
         const StartHeight = 1;


### PR DESCRIPTION
This finally resolves all of our issues with the D2SQLite destructor throwing Errors, and it removes the need for all of the .shutdown() routines and `scope (exit)` calls.

These benefits were actually incidental. I was designing a database manager class which exposed `batch / commit / rollback` SQLite routines on all its managed databases. But I soon ran into many issues with managing the `Database` D2SQLite struct instance, its internal RefCounted struct was a pain and kept causing issues.

Then I've realized that since we only have a small set of databases and we only want to destroy them at the very end, why not just destroy them when the thread is destroyed? This way even if an assert in a unittest fails, the static module destructor will *not* be detected as being ran in a "regular" destructor.

Part of #836.