### PR TITLE
Simplify Logger implementation

### DIFF
--- a/source/agora/common/TransactionPool.d
+++ b/source/agora/common/TransactionPool.d
@@ -19,13 +19,12 @@ import agora.common.Hash;
 import agora.common.Serializer;
 import agora.common.Set;
 import agora.consensus.data.Transaction;
+import agora.utils.Log;
 
 import d2sqlite3.database;
 import d2sqlite3.library;
 import d2sqlite3.results;
 import d2sqlite3.sqlite3;
-
-import ocean.util.log.Logger;
 
 import std.algorithm;
 import std.conv : to;
@@ -51,8 +50,13 @@ version (unittest)
 
 static this ()
 {
-    log = Log.lookup(__MODULE__);
+    log = Logger(__MODULE__);
     TransactionPool.initialize();
+}
+
+static ~this ()
+{
+    destroy(log);
 }
 
 /// Logger instance
@@ -322,14 +326,7 @@ public class TransactionPool
     private static extern(C) void loggerCallback (void *arg, int code,
         const(char)* msg) nothrow
     {
-        try
-        {
-            log.error("SQLite error: ({}) {}", code, msg.fromStringz);
-        }
-        catch (Exception ex)
-        {
-            // should not propagate exceptions to C code
-        }
+        log.error("SQLite error: ({}) {}", code, msg.fromStringz);
     }
 }
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -47,8 +47,6 @@ import vibe.http.router;
 import vibe.http.server;
 import vibe.web.rest;
 
-import ocean.util.log.Logger;
-
 import std.algorithm;
 import std.exception;
 import std.file;

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -20,8 +20,6 @@ import agora.node.FullNode;
 import agora.node.Validator;
 import agora.utils.Log;
 
-import ocean.util.log.Logger;
-
 import vibe.http.server;
 import vibe.http.router;
 import vibe.web.rest;

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -37,8 +37,6 @@ import agora.utils.PrettyPrinter;
 
 import scpd.types.Stellar_SCP;
 
-import ocean.util.log.Logger;
-
 import core.stdc.stdlib : abort;
 import core.time;
 

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -25,7 +25,6 @@ import agora.node.Runner;
 import agora.utils.Log;
 
 import vibe.core.core;
-import ocean.util.log.Logger;
 
 import std.getopt;
 import std.stdio;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -52,8 +52,6 @@ import agora.api.Validator : ValidatorAPI = API;
 
 import scpd.types.Stellar_SCP;
 
-import ocean.util.log.Logger;
-
 static import geod24.LocalRest;
 import geod24.Registry;
 

--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -59,21 +59,6 @@ public struct Logger
         GC.removeRoot(cast(void*)this.logger);
     }
 
-    // workaround: weird CT bug in NetworkManager.d call:
-    // log.info("Discovery reached. {} peers connected.", this.peers.length);
-    // source/agora/network/NetworkManager.d(149,12): Error: no property info for type Logger
-    public void info (Args...) (Args args) @safe nothrow
-    {
-        try
-        {
-            this.logger.info(args);
-        }
-        catch (Exception ex)
-        {
-            assert(0, ex.msg);
-        }
-    }
-
     public void opDispatch (string call, Args...) (Args args) @safe nothrow
     {
         try

--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -59,7 +59,7 @@ public struct Logger
         GC.removeRoot(cast(void*)this.logger);
     }
 
-    public void opDispatch (string call, Args...) (Args args) @safe nothrow
+    public void opDispatch (string call, Args...) (Args args)
     {
         try
         {


### PR DESCRIPTION
At first I had a strange error where one module was complaining that `Logger` was implemented in multiple modules. There was an `AddLogger` mixin in both modules. Then I noticed the `mixed-in` Logger was public. Well, it could just be one symbol instead of having a separate instance per module.