### PR TITLE
Use atomic transactions when altering databases

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -270,7 +270,7 @@ public class Ledger
 
     ***************************************************************************/
 
-    private void updateUTXOSet (const ref Block block) @safe
+    protected void updateUTXOSet (const ref Block block) @safe
     {
         const height = block.header.height;
         // add the new UTXOs

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -242,9 +242,10 @@ public class Ledger
 
     private void addValidatedBlock (const ref Block block) @safe
     {
-        this.updateUTXOSet(block);
         if (!this.storage.saveBlock(block))
             assert(0);
+
+        this.updateUTXOSet(block);
 
         auto old_count = this.enroll_man.validatorCount();
         this.enroll_man.clearExpiredValidators(block.header.height);


### PR DESCRIPTION
Although it includes unittests it doesn't include an integration test. I would like to test that crashing the node while it's busy in `addValidatedBlock` would ensure the Node's databases don't get corrupted. In theory this should just work, but a test would be nice..