### PR TITLE
Remove Config.quorum in the `agora-multi`

### DIFF
--- a/source/agora/cli/multi/main.d
+++ b/source/agora/cli/multi/main.d
@@ -89,7 +89,6 @@ private int main (string[] args)
                 node : config.node,
                 network : assumeUnique(converted_network),
                 dns_seeds : config.dns_seeds,
-                quorum : config.quorum,
                 logging: config.logging,
                 admin: config.admin,
             };


### PR DESCRIPTION
Member `quorum` of `Config` was removed from the previous PR. So I apply this to agora-multi.