### PR TITLE
Share consensus-critical constants through parameter

### DIFF
--- a/source/agora/cli/multi/main.d
+++ b/source/agora/cli/multi/main.d
@@ -106,7 +106,7 @@ private int main (string[] args)
 
     FullNode[] nodes;
     foreach (const ref config; configs)
-        nodes ~= runNode(config);
+        nodes ~= runNode(config, new immutable(ConsensusParams)());
 
     scope (exit)
     {

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -54,6 +54,7 @@ import agora.common.ManagedDatabase;
 import agora.common.Serializer;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
+import agora.consensus.data.ConsensusParams;
 import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.UTXOSetValue;
 import agora.consensus.EnrollmentPool;
@@ -113,6 +114,9 @@ public class EnrollmentManager
     /// Ditto
     private PreImageCycle cycle;
 
+    /// Parameters for consensus-critical constants
+    private immutable(ConsensusParams) params;
+
     /***************************************************************************
 
         Constructor
@@ -121,10 +125,12 @@ public class EnrollmentManager
             db_path = path to the database file, or in-memory storage if
                         :memory: was passed
             key_pair = the keypair of the owner node
+            params = the consensus-critical constants
 
     ***************************************************************************/
 
-    public this (string db_path, KeyPair key_pair)
+    public this (string db_path, KeyPair key_pair,
+        immutable(ConsensusParams) params)
     {
         this.cycle = PreImageCycle(
             /* nounce: */ 0,
@@ -135,7 +141,8 @@ public class EnrollmentManager
             /* preimages: */ PreImageCache(Enrollment.ValidatorCycle, 1)
         );
 
-        this.validator_set = new ValidatorSet(db_path);
+        this.params = params;
+        this.validator_set = new ValidatorSet(db_path, params);
         this.enroll_pool = new EnrollmentPool(db_path);
 
         this.db = new ManagedDatabase(db_path);
@@ -697,7 +704,8 @@ unittest
     }
 
     // create an EnrollmentManager object
-    auto man = new EnrollmentManager(":memory:", key_pair);
+    auto man = new EnrollmentManager(":memory:", key_pair,
+        new immutable(ConsensusParams)());
     Hash[] utxo_hashes = storage.keys;
 
     // check the return value of `getEnrollmentPublicKey`
@@ -860,7 +868,8 @@ unittest
         storage.put(tx);
     }
 
-    auto man = new EnrollmentManager(":memory:", key_pair);
+    auto man = new EnrollmentManager(":memory:", key_pair,
+        new immutable(ConsensusParams)());
     Hash[] utxo_hashes = storage.keys;
 
     auto utxo_hash = utxo_hashes[0];
@@ -971,7 +980,8 @@ unittest
     }
 
     // create an EnrollmentManager object
-    auto man = new EnrollmentManager(":memory:", key_pair);
+    auto man = new EnrollmentManager(":memory:", key_pair,
+        new immutable(ConsensusParams)());
     Hash[] utxo_hashes = storage.keys;
 
     Enrollment enrollment;

--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -266,7 +266,8 @@ public class EnrollmentPool
 
 version (unittest)
 private Enrollment createEnrollment(const ref Hash utxo_key,
-    const ref KeyPair key_pair, ref Scalar random_seed_src)
+    const ref KeyPair key_pair, ref Scalar random_seed_src,
+    uint validator_cycle)
 {
     import std.algorithm;
 
@@ -280,7 +281,7 @@ private Enrollment createEnrollment(const ref Hash utxo_key,
     auto signature_noise = Pair.random();
 
     enroll.utxo_key = utxo_key;
-    enroll.cycle_length = Enrollment.ValidatorCycle;
+    enroll.cycle_length = validator_cycle;
     preimages ~= hashFull(random_seed_src);
     foreach (i; 0 ..  enroll.cycle_length-1)
         preimages ~= hashFull(preimages[i]);
@@ -294,6 +295,7 @@ private Enrollment createEnrollment(const ref Hash utxo_key,
 unittest
 {
     import agora.common.Amount;
+    import agora.consensus.data.ConsensusParams;
     import agora.consensus.data.Transaction;
     import agora.consensus.Genesis;
     import std.algorithm;
@@ -324,10 +326,12 @@ unittest
     Hash[] utxo_hashes = storage.keys;
 
     // add enrollments
+    auto params = new immutable(ConsensusParams)();
     Scalar[Hash] seed_sources;
     auto utxo_hash = utxo_hashes[0];
     seed_sources[utxo_hash] = Scalar.random();
-    auto enroll = createEnrollment(utxo_hash, key_pair, seed_sources[utxo_hash]);
+    auto enroll = createEnrollment(utxo_hash, key_pair, seed_sources[utxo_hash],
+        params.ValidatorCycle);
     assert(pool.add(enroll, &storage.findUTXO));
     assert(pool.count() == 1);
     assert(pool.hasEnrollment(utxo_hash));
@@ -335,13 +339,15 @@ unittest
 
     auto utxo_hash2 = utxo_hashes[1];
     seed_sources[utxo_hash2] = Scalar.random();
-    auto enroll2 = createEnrollment(utxo_hash2, key_pair, seed_sources[utxo_hash2]);
+    auto enroll2 = createEnrollment(utxo_hash2, key_pair, seed_sources[utxo_hash2],
+        params.ValidatorCycle);
     assert(pool.add(enroll2, &storage.findUTXO));
     assert(pool.count() == 2);
 
     auto utxo_hash3 = utxo_hashes[2];
     seed_sources[utxo_hash3] = Scalar.random();
-    auto enroll3 = createEnrollment(utxo_hash3, key_pair, seed_sources[utxo_hash3]);
+    auto enroll3 = createEnrollment(utxo_hash3, key_pair, seed_sources[utxo_hash3],
+        params.ValidatorCycle);
     assert(pool.add(enroll3, &storage.findUTXO));
     assert(pool.count() == 3);
 

--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -320,7 +320,7 @@ unittest
         tx.inputs[0].signature = signature;
         storage.put(tx);
     }
-    EnrollmentPool pool = new EnrollmentPool(":memory:");
+    auto pool = new EnrollmentPool(":memory:");
     Hash[] utxo_hashes = storage.keys;
 
     // add enrollments

--- a/source/agora/consensus/ValidatorSet.d
+++ b/source/agora/consensus/ValidatorSet.d
@@ -23,6 +23,7 @@ import agora.common.ManagedDatabase;
 import agora.common.Serializer;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
+import agora.consensus.data.ConsensusParams;
 import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.UTXOSetValue;
 import agora.consensus.PreImage;
@@ -41,6 +42,9 @@ public class ValidatorSet
     /// SQLite db instance
     private ManagedDatabase db;
 
+    /// Parameters for consensus-critical constants
+    private immutable(ConsensusParams) params;
+
     /***************************************************************************
 
         Constructor
@@ -48,12 +52,14 @@ public class ValidatorSet
         Params:
             db_path = path to the database file, or in-memory storage if
                         :memory: was passed
+            params = the consensus-critical constants
 
     ***************************************************************************/
 
-    public this (string db_path)
+    public this (string db_path, immutable(ConsensusParams) params)
     {
         this.db = new ManagedDatabase(db_path);
+        this.params = params;
 
         // create the table for validator set if it doesn't exist yet
         this.db.execute("CREATE TABLE IF NOT EXISTS validator_set " ~
@@ -524,7 +530,7 @@ unittest
         // Store the hash of the UTXO as we need it to create enrollments
         utxos[idx % $] = UTXOSetValue.getHash(thisHash, 0);
     }
-    ValidatorSet set = new ValidatorSet(":memory:");
+    auto set = new ValidatorSet(":memory:", new immutable(ConsensusParams)());
 
     // add enrollments
     Scalar[Hash] seed_sources;
@@ -665,7 +671,7 @@ unittest
     }
     Hash[] utxos = storage.keys;
 
-    auto set = new ValidatorSet(":memory:");
+    auto set = new ValidatorSet(":memory:", new immutable(ConsensusParams)());
 
     // create enrollments
     Enrollment[] enrolls;

--- a/source/agora/consensus/data/ConsensusParams.d
+++ b/source/agora/consensus/data/ConsensusParams.d
@@ -1,0 +1,50 @@
+/*******************************************************************************
+
+    The set for consensus-critical constants
+
+    This defines the class for the consensus-critical constants. Only one
+    object should exist for a single node. The `class` is `immutable`, hence
+    the constants need to be set at the start of the process. The
+    consensus-critical constants are the protocol-level constants, so they
+    shouldn't be modified outside of test environments.
+
+    Copyright:
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.consensus.data.ConsensusParams;
+
+/// Ditto
+public immutable class ConsensusParams
+{
+    /// The cycle length for a validator
+    public uint ValidatorCycle;
+
+    /***************************************************************************
+
+        Constructor
+
+        Params:
+            validator_cycle = cycle length for a validator
+
+    ***************************************************************************/
+
+    public this (uint validator_cycle = 1008)
+    {
+        this.ValidatorCycle = validator_cycle;
+    }
+}
+
+unittest
+{
+    auto params = new immutable(ConsensusParams)(100);
+    assert(params.ValidatorCycle == 100);
+
+    auto params2 = new immutable(ConsensusParams)();
+    assert(params2.ValidatorCycle == 1008);
+}

--- a/source/agora/consensus/data/Enrollment.d
+++ b/source/agora/consensus/data/Enrollment.d
@@ -48,9 +48,6 @@ public struct Enrollment
     /// S: A signature for the message H(K, X, n, R) and the key K, using R
     public Signature enroll_sig;
 
-    /// The cycle length for a validator
-    public static immutable uint ValidatorCycle = 1008; // freezing period / 2
-
     /***************************************************************************
 
         Implements hashing support

--- a/source/agora/consensus/validation/PreImage.d
+++ b/source/agora/consensus/validation/PreImage.d
@@ -14,6 +14,7 @@
 module agora.consensus.validation.PreImage;
 
 import agora.common.Hash;
+import agora.consensus.data.ConsensusParams;
 import agora.consensus.data.PreImageInfo;
 
 version (unittest)
@@ -85,20 +86,21 @@ unittest
     reverse(preimages);
 
     PreImageInfo prev_image = PreImageInfo(hashFull("abc"), preimages[0], 1);
+    auto params = new immutable(ConsensusParams)();
 
     // valid pre-image
     PreImageInfo new_image = PreImageInfo(hashFull("abc"), preimages[100], 101);
-    assert(new_image.isValid(prev_image, Enrollment.ValidatorCycle));
+    assert(new_image.isValid(prev_image, params.ValidatorCycle));
 
     // invalid pre-image with wrong enrollment key
     new_image = PreImageInfo(hashFull("xyz"), preimages[100], 101);
-    assert(!new_image.isValid(prev_image, Enrollment.ValidatorCycle));
+    assert(!new_image.isValid(prev_image, params.ValidatorCycle));
 
     // invalid pre-image with wrong height number
     new_image = PreImageInfo(hashFull("abc"), preimages[1], 3);
-    assert(!new_image.isValid(prev_image, Enrollment.ValidatorCycle));
+    assert(!new_image.isValid(prev_image, params.ValidatorCycle));
 
     // invalid pre-image with wrong hash value
     new_image = PreImageInfo(hashFull("abc"), preimages[100], 100);
-    assert(!new_image.isValid(prev_image, Enrollment.ValidatorCycle));
+    assert(!new_image.isValid(prev_image, params.ValidatorCycle));
 }

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -23,6 +23,7 @@ import agora.common.Types;
 import agora.consensus.data.Block;
 import agora.consensus.data.ConsensusData;
 import agora.consensus.data.Enrollment;
+import agora.consensus.data.ConsensusParams;
 import agora.consensus.data.Transaction;
 import agora.consensus.data.UTXOSetValue;
 import agora.consensus.UTXOSet;
@@ -68,6 +69,9 @@ public class Ledger
     /// a block was externalized
     private void delegate () nothrow @safe onValidatorsChanged;
 
+    /// Parameters for consensus-critical constants
+    private immutable(ConsensusParams) params;
+
     /***************************************************************************
 
         Constructor
@@ -78,6 +82,7 @@ public class Ledger
             storage = the block storage
             enroll_man = the enrollmentManager
             node_config = the node config
+            params = the consensus-critical constants
             onValidatorsChanged = optional delegate to call after the validator
                                   set changes when a block was externalized
 
@@ -88,6 +93,7 @@ public class Ledger
         IBlockStorage storage,
         EnrollmentManager enroll_man,
         NodeConfig node_config,
+        immutable(ConsensusParams) params,
         void delegate () nothrow @safe onValidatorsChanged = null)
     {
         this.pool = pool;
@@ -96,6 +102,7 @@ public class Ledger
         this.enroll_man = enroll_man;
         this.node_config = node_config;
         this.onValidatorsChanged = onValidatorsChanged;
+        this.params = params;
         if (!this.storage.load())
             assert(0);
 
@@ -481,9 +488,11 @@ unittest
     auto pool = new TransactionPool(":memory:");
     auto utxo_set = new UTXOSet(":memory:");
     auto config = new Config();
-    auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair);
+    auto params = new immutable(ConsensusParams)();
+    auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair, params);
     config.node.is_validator = true;
-    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
+    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node,
+        params);
     assert(ledger.getBlockHeight() == 0);
 
     auto blocks = ledger.getBlocksFrom(0).take(10);
@@ -567,9 +576,11 @@ unittest
     auto pool = new TransactionPool(":memory:");
     auto utxo_set = new UTXOSet(":memory:");
     auto config = new Config();
-    auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair);
+    auto params = new immutable(ConsensusParams)();
+    auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair, params);
     config.node.is_validator = true;
-    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
+    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node,
+        params);
 
     // Valid case
     auto txs = makeChainedTransactions(gen_key_pair, null, 1);
@@ -614,9 +625,11 @@ unittest
     auto pool = new TransactionPool(":memory:");
     auto utxo_set = new UTXOSet(":memory:");
     auto config = new Config();
-    auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair);
+    auto params = new immutable(ConsensusParams)();
+    auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair, params);
     config.node.is_validator = true;
-    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
+    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node,
+        params);
 
     Block invalid_block;  // default-initialized should be invalid
     assert(!ledger.acceptBlock(invalid_block));
@@ -638,9 +651,11 @@ unittest
     auto pool = new TransactionPool(":memory:");
     auto utxo_set = new UTXOSet(":memory:");
     auto config = new Config();
-    auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair);
+    auto params = new immutable(ConsensusParams)();
+    auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair, params);
     config.node.is_validator = true;
-    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
+    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node,
+        params);
 
     auto txs = makeChainedTransactions(gen_key_pair, null, 1);
     txs.each!(tx => assert(ledger.acceptTransaction(tx)));
@@ -713,9 +728,11 @@ unittest
     auto pool = new TransactionPool(":memory:");
     auto utxo_set = new UTXOSet(":memory:");
     auto config = new Config();
-    auto enroll_man = new EnrollmentManager(":memory:", gen_key);
+    auto params = new immutable(ConsensusParams)();
+    auto enroll_man = new EnrollmentManager(":memory:", gen_key, params);
     config.node.is_validator = true;
-    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
+    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node,
+        params);
 
     assert(utxo_set.length == 8);
     auto finder = utxo_set.getUTXOFinder();
@@ -817,9 +834,11 @@ unittest
     auto pool = new TransactionPool(":memory:");
     auto utxo_set = new UTXOSet(":memory:");
     auto config = new Config();
-    auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair);
+    auto params = new immutable(ConsensusParams)();
+    auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair, params);
     config.node.is_validator = true;
-    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
+    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node,
+        params);
 
     KeyPair[] in_key_pairs;
     KeyPair[] out_key_pairs;
@@ -891,9 +910,11 @@ unittest
     auto pool = new TransactionPool(":memory:");
     auto utxo_set = new UTXOSet(":memory:");
     auto config = new Config();
-    auto enroll_man = new EnrollmentManager(":memory:", gen_key);
+    auto params = new immutable(ConsensusParams)();
+    auto enroll_man = new EnrollmentManager(":memory:", gen_key, params);
     config.node.is_validator = true;
-    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
+    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node,
+        params);
 
     Transaction[] splited_txex;
     // Divide 8 'Outputs' that are included in Genesis Block by 40,000
@@ -1112,9 +1133,11 @@ unittest
     auto pool = new TransactionPool(":memory:");
     auto utxo_set = new UTXOSet(":memory:");
     auto config = new Config();
-    auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair);
+    auto params = new immutable(ConsensusParams)();
+    auto enroll_man = new EnrollmentManager(":memory:", gen_key_pair, params);
     config.node.is_validator = true;
-    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
+    scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node,
+        params);
 
     KeyPair[] splited_keys = getRandomKeyPairs();
 
@@ -1413,13 +1436,15 @@ unittest
     // only genesis loaded: validator is active
     {
         auto key_pair = KeyPair.random();
-        scope enroll_man = new EnrollmentManager(":memory:", key_pair);
+        auto params = new immutable(ConsensusParams)();
+        scope enroll_man = new EnrollmentManager(":memory:", key_pair, params);
         const blocks = genBlocksToIndex(key_pair, enroll_man, 0);
         scope storage = new MemBlockStorage(blocks);
         scope pool = new TransactionPool(":memory:");
         scope utxo_set = new UTXOSet(":memory:");
         scope config = new Config();
-        scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
+        scope ledger = new Ledger(pool, utxo_set, storage, enroll_man,
+            config.node, params);
         Hash[] keys;
         assert(enroll_man.getEnrolledUTXOs(keys));
         assert(keys.length == 1);
@@ -1428,13 +1453,15 @@ unittest
     // block 1007 loaded: validator is still active
     {
         auto key_pair = KeyPair.random();
-        scope enroll_man = new EnrollmentManager(":memory:", key_pair);
+        auto params = new immutable(ConsensusParams)();
+        scope enroll_man = new EnrollmentManager(":memory:", key_pair, params);
         const blocks = genBlocksToIndex(key_pair, enroll_man, 1007);
         scope storage = new MemBlockStorage(blocks);
         scope pool = new TransactionPool(":memory:");
         scope utxo_set = new UTXOSet(":memory:");
         scope config = new Config();
-        scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
+        scope ledger = new Ledger(pool, utxo_set, storage, enroll_man,
+            config.node, params);
         Hash[] keys;
         assert(enroll_man.getEnrolledUTXOs(keys));
         assert(keys.length == 1);
@@ -1443,13 +1470,15 @@ unittest
     // block 1008 loaded: validator is inactive
     {
         auto key_pair = KeyPair.random();
-        scope enroll_man = new EnrollmentManager(":memory:", key_pair);
+        auto params = new immutable(ConsensusParams)();
+        scope enroll_man = new EnrollmentManager(":memory:", key_pair, params);
         const blocks = genBlocksToIndex(key_pair, enroll_man, 1008);
         scope storage = new MemBlockStorage(blocks);
         scope pool = new TransactionPool(":memory:");
         scope utxo_set = new UTXOSet(":memory:");
         scope config = new Config();
-        scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node);
+        scope ledger = new Ledger(pool, utxo_set, storage, enroll_man,
+            config.node, params);
         Hash[] keys;
         assert(enroll_man.getEnrolledUTXOs(keys));
         assert(keys.length == 0);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -906,11 +906,12 @@ unittest
     KeyPair[] out_key_pairs_freeze;
     Transaction[] last_txs_freeze;
 
+    auto validator_cycle = 10;
     auto storage = new MemBlockStorage();
     auto pool = new TransactionPool(":memory:");
     auto utxo_set = new UTXOSet(":memory:");
     auto config = new Config();
-    auto params = new immutable(ConsensusParams)();
+    auto params = new immutable(ConsensusParams)(validator_cycle);
     auto enroll_man = new EnrollmentManager(":memory:", gen_key, params);
     config.node.is_validator = true;
     scope ledger = new Ledger(pool, utxo_set, storage, enroll_man, config.node,
@@ -1038,19 +1039,19 @@ unittest
     Enrollment enroll_1;
     enroll_1.utxo_key = utxo_hash_1;
     enroll_1.random_seed = hashFull(Scalar.random());
-    enroll_1.cycle_length = 1008;
+    enroll_1.cycle_length = validator_cycle;
     enroll_1.enroll_sig = sign(node_key_pair_1, signature_noise, enroll_1);
 
     Enrollment enroll_2;
     enroll_2.utxo_key = utxo_hash_2;
     enroll_2.random_seed = hashFull(Scalar.random());
-    enroll_2.cycle_length = 1008;
+    enroll_2.cycle_length = validator_cycle;
     enroll_2.enroll_sig = sign(node_key_pair_2, signature_noise, enroll_2);
 
     Enrollment enroll_3;
     enroll_3.utxo_key = utxo_hash_3;
     enroll_3.random_seed = hashFull(Scalar.random());
-    enroll_3.cycle_length = 1008;
+    enroll_3.cycle_length = validator_cycle;
     enroll_3.enroll_sig = sign(node_key_pair_3, signature_noise, enroll_3);
 
     Enrollment[] enrollments ;
@@ -1079,11 +1080,11 @@ unittest
     enrollments.sort!("a.utxo_key < b.utxo_key");
     assert(block_4[0].header.enrollments == enrollments);
 
-    genNormalBlockTransactions(1008);
+    genNormalBlockTransactions(validator_cycle);
     Hash[] keys;
     assert(enroll_man.getEnrolledUTXOs(keys));
     assert(keys.length == 0);
-    assert(ledger.getBlockHeight() == 1012);
+    assert(ledger.getBlockHeight() == validator_cycle + 4);
 }
 
 version (unittest)
@@ -1452,10 +1453,12 @@ unittest
 
     // block 1007 loaded: validator is still active
     {
+        auto validator_cycle = 10;
         auto key_pair = KeyPair.random();
-        auto params = new immutable(ConsensusParams)();
+        auto params = new immutable(ConsensusParams)(validator_cycle);
         scope enroll_man = new EnrollmentManager(":memory:", key_pair, params);
-        const blocks = genBlocksToIndex(key_pair, enroll_man, 1007);
+        const blocks = genBlocksToIndex(key_pair, enroll_man,
+            validator_cycle - 1);
         scope storage = new MemBlockStorage(blocks);
         scope pool = new TransactionPool(":memory:");
         scope utxo_set = new UTXOSet(":memory:");
@@ -1469,10 +1472,11 @@ unittest
 
     // block 1008 loaded: validator is inactive
     {
+        auto validator_cycle = 20;
         auto key_pair = KeyPair.random();
-        auto params = new immutable(ConsensusParams)();
+        auto params = new immutable(ConsensusParams)(validator_cycle);
         scope enroll_man = new EnrollmentManager(":memory:", key_pair, params);
-        const blocks = genBlocksToIndex(key_pair, enroll_man, 1008);
+        const blocks = genBlocksToIndex(key_pair, enroll_man, validator_cycle);
         scope storage = new MemBlockStorage(blocks);
         scope pool = new TransactionPool(":memory:");
         scope utxo_set = new UTXOSet(":memory:");

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -127,8 +127,8 @@ public class Ledger
         // we are only interested in the last 1008 blocks,
         // because that is the maximum length of an enrollment.
         const ulong min_height =
-            block_count >= Enrollment.ValidatorCycle
-            ? block_count - Enrollment.ValidatorCycle : 0;
+            block_count >= this.params.ValidatorCycle
+            ? block_count - this.params.ValidatorCycle : 0;
 
         // restore validator set from the blockchain.
         // using block_count, as the range is inclusive

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -16,6 +16,7 @@ module agora.node.Runner;
 import agora.api.FullNode;
 import agora.api.Validator;
 import agora.common.Config;
+import agora.consensus.data.ConsensusParams;
 import agora.node.FullNode;
 import agora.node.Validator;
 import agora.utils.Log;
@@ -38,10 +39,11 @@ mixin AddLogger!();
 
     Params:
       config = A parsed and validated config file
+      params = the consensus-critical constants
 
 *******************************************************************************/
 
-public FullNode runNode (Config config)
+public FullNode runNode (Config config, immutable(ConsensusParams) params)
 {
     Log.root.level(config.logging.log_level, true);
     log.trace("Config is: {}", config);
@@ -56,14 +58,14 @@ public FullNode runNode (Config config)
     if (config.node.is_validator)
     {
         log.trace("Started Validator...");
-        auto inst = new Validator(config);
+        auto inst = new Validator(config, params);
         router.registerRestInterface!(agora.api.Validator.API)(inst);
         node = inst;
     }
     else
     {
         log.trace("Started FullNode...");
-        node = new FullNode(config);
+        node = new FullNode(config, params);
         router.registerRestInterface!(agora.api.FullNode.API)(node);
     }
 

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -21,6 +21,7 @@ import agora.common.Set;
 import agora.common.Task;
 import agora.common.TransactionPool;
 import agora.common.Types;
+import agora.consensus.data.ConsensusParams;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.Transaction;
@@ -62,10 +63,10 @@ public class Validator : FullNode, API
     protected Set!PublicKey required_peer_keys;
 
     /// Ctor
-    public this (const Config config)
+    public this (const Config config, immutable(ConsensusParams) params)
     {
         assert(config.node.is_validator);
-        super(config, &this.onValidatorsChanged);
+        super(config, params, &this.onValidatorsChanged);
 
         this.nominator = this.getNominator(this.network,
             this.config.node.key_pair, this.ledger, this.taskman);

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -19,6 +19,7 @@
 module agora.node.main;
 
 import agora.common.Config;
+import agora.consensus.data.ConsensusParams;
 import agora.node.FullNode;
 import agora.node.Validator;
 import agora.node.Runner;
@@ -72,7 +73,7 @@ private int main (string[] args)
             return 0;
         }
 
-        runTask(() => node = runNode(config));
+        runTask(() => node = runNode(config, new immutable(ConsensusParams)()));
     }
     catch (Exception ex)
     {

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -22,6 +22,7 @@ import agora.common.crypto.Key;
 import agora.common.Metadata;
 import agora.common.Types;
 import agora.consensus.data.Block;
+import agora.consensus.data.ConsensusParams;
 import agora.consensus.data.Transaction;
 import agora.consensus.Genesis;
 import agora.test.Base;
@@ -62,9 +63,10 @@ unittest
     static class BadNode : TestFullNode
     {
         ///
-        public this (Config config, Registry* reg, immutable(Block)[] blocks)
+        public this (Config config, Registry* reg, immutable(Block)[] blocks,
+            immutable(ConsensusParams) params)
         {
-            super(config, reg, blocks);
+            super(config, reg, blocks, params);
         }
 
         /// return phony blocks
@@ -98,9 +100,10 @@ unittest
     static class BadAPIManager : TestAPIManager
     {
         ///
-        public this (immutable(Block)[] blocks)
+        public this (immutable(Block)[] blocks,
+            immutable(ConsensusParams) params)
         {
-            super(blocks);
+            super(blocks, params);
         }
 
         /// see base class
@@ -116,16 +119,16 @@ unittest
             if (conf.node.is_validator)
             {
                 api = RemoteAPI!TestAPI.spawn!TestValidatorNode(
-                    conf, &this.reg, this.blocks, conf.node.timeout.msecs);
+                    conf, &this.reg, this.blocks, this.params, conf.node.timeout.msecs);
             }
             else
             {
                 if (this.nodes.length == 2)
                     api = RemoteAPI!TestAPI.spawn!BadNode(conf,
-                        &this.reg, this.blocks, conf.node.timeout.msecs);
+                        &this.reg, this.blocks, this.params, conf.node.timeout.msecs);
                 else
                     api = RemoteAPI!TestAPI.spawn!TestFullNode(conf,
-                        &this.reg, this.blocks, conf.node.timeout.msecs);
+                        &this.reg, this.blocks, this.params, conf.node.timeout.msecs);
             }
 
             this.reg.register(conf.node.address, api.tid());


### PR DESCRIPTION
For unit tests, we need to modify the protocol-level constants because running the network based on the defined constants like`ValidatorCycle`, or 1008 make unit tests very time-consuming and error-prone, so we need to make the contents variable in unit tests. 

I applied the concept of passing parameters to the code, so we can set the constants when calling the `runNode` function for the real environment or calling the `makeTestNetwork` function for test environments.

Relates to #894 