### PR TITLE
Some fix about docs and modifier

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -189,7 +189,7 @@ public interface API
 
     /***************************************************************************
 
-        Get an enrollment data if the data exists in the validator set
+        Get an enrollment data if the data exists in the enrollment pool
 
         API:
             GET /enrollment

--- a/source/agora/consensus/ValidatorSet.d
+++ b/source/agora/consensus/ValidatorSet.d
@@ -226,7 +226,7 @@ public class ValidatorSet
 
     ***************************************************************************/
 
-    public bool getEnrollment (const ref Hash enroll_hash,
+    private bool getEnrollment (const ref Hash enroll_hash,
         out Enrollment enroll) @trusted
     {
         auto results = this.db.execute("SELECT key, val FROM validator_set " ~


### PR DESCRIPTION
Simple changes for docs and the modifier of the `getEnrollment` of the `ValidatorSet` as follows.

- Fix the description of the` FullNode` API endpoint, or `getEnrollment`
- Make the `getEnrollment` of the `ValidatorSet` private