### PR TITLE
The UTXOSet Refactoring and separated into UTXOSetValue and UTXOSet

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -54,6 +54,7 @@ import agora.common.Serializer;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.PreImageInfo;
+import agora.consensus.data.UTXOSetValue;
 import agora.consensus.UTXOSet;
 import agora.consensus.EnrollmentPool;
 import agora.consensus.PreImage;

--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -24,6 +24,7 @@ import agora.common.Serializer;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.PreImageInfo;
+import agora.consensus.data.UTXOSetValue;
 import agora.consensus.UTXOSet;
 import agora.consensus.validation;
 import agora.utils.Log;

--- a/source/agora/consensus/Quorum.d
+++ b/source/agora/consensus/Quorum.d
@@ -18,6 +18,7 @@ import agora.common.crypto.Key;
 import agora.common.Set;
 import agora.common.Types;
 import agora.consensus.data.Enrollment;
+import agora.consensus.data.UTXOSetValue;
 import agora.consensus.UTXOSet;
 
 import std.algorithm;

--- a/source/agora/consensus/ValidatorSet.d
+++ b/source/agora/consensus/ValidatorSet.d
@@ -23,6 +23,7 @@ import agora.common.Serializer;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.PreImageInfo;
+import agora.consensus.data.UTXOSetValue;
 import agora.consensus.UTXOSet;
 import agora.consensus.PreImage;
 import agora.consensus.validation;
@@ -578,6 +579,7 @@ unittest
 {
     import agora.common.Amount;
     import agora.consensus.data.Transaction;
+    import agora.consensus.data.UTXOSetValue;
     import agora.consensus.Genesis;
     import std.algorithm;
     import std.format;
@@ -604,7 +606,7 @@ unittest
         tx.inputs[0].signature = signature;
         storage.put(tx);
         // Store the hash of the UTXO as we need it to create enrollments
-        utxos[idx % $] = UTXOSet.getHash(thisHash, 0);
+        utxos[idx % $] = UTXOSetValue.getHash(thisHash, 0);
     }
     ValidatorSet set = new ValidatorSet(":memory:");
     scope (exit) set.shutdown();

--- a/source/agora/consensus/data/UTXOSetValue.d
+++ b/source/agora/consensus/data/UTXOSetValue.d
@@ -1,0 +1,153 @@
+/*******************************************************************************
+
+    Defines the UTXO transaction set struct,
+    contains the UTXOFinder delegate
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.consensus.data.UTXOSetValue;
+
+import agora.common.Hash;
+import agora.common.Serializer;
+import agora.common.Set;
+import agora.common.Types;
+import agora.consensus.data.Transaction;
+
+/// Delegate to find an unspent UTXO
+public alias UTXOFinder = scope bool delegate (Hash hash, size_t index,
+    out UTXOSetValue) @safe nothrow;
+
+/// The structure of spendable transaction output
+public struct UTXOSetValue
+{
+    /// Height of the block to be unlock
+    ulong unlock_height;
+
+    /// Transaction type
+    TxType type;
+
+    /// Unspend transaction output
+    Output output;
+
+    /***************************************************************************
+
+        Get the combined hash of the previous hash and index.
+        This makes sure the index is always of the same type,
+        as mixing different-sized uint/ulong would create different hashes.
+
+        Returns:
+            the combined hash of a previous hash and index
+
+    ***************************************************************************/
+
+    public static Hash getHash (Hash hash, ulong index) @safe nothrow
+    {
+        return hashMulti(hash, index);
+    }
+}
+
+/*******************************************************************************
+
+    This is a simple UTXOSet, used when the AA behavior is desired
+
+    Most unittestsdo not need a full-fledged UTXOSet with all the DB and
+    serialization that comes with it, instead relying on an associative array
+    and a delegate.
+
+    Since this pattern is so common, this class is offered as a mean to achieve
+    this without code duplication. See issue #501 for history.
+
+    Note that this should *NOT* be used to replace the above UTXOSet,
+    when for example doing integration tests with LocalRest.
+
+*******************************************************************************/
+
+version (unittest) public class TestUTXOSet
+{
+    ///
+    public UTXOSetValue[Hash] storage;
+
+    /// Keeps track of spent outputs
+    private Set!Hash used_utxos;
+
+    ///
+    alias storage this;
+
+    /// Similar to `UTXOSet.getUTXOFinder`
+    public UTXOFinder getUTXOFinder () @trusted nothrow
+    {
+        this.used_utxos.clear();
+        return &this.findUTXO_;
+    }
+
+    /// FIXME: Remove and make UTXO-sensible tests use either `peekUTXO`
+    /// or `getUTXOFinder`
+    public alias findUTXO = peekUTXO;
+
+    /// Get an UTXO, no double-spend protection
+    public bool peekUTXO (Hash hash, size_t index, out UTXOSetValue value)
+        nothrow @safe
+    {
+        // Note: Keep this in sync with `findUTXO`
+        Hash utxo_hash = (index == size_t.max) ?
+            hash : UTXOSetValue.getHash(hash, index);
+        if (auto ptr = utxo_hash in this.storage)
+        {
+            value = *ptr;
+            return true;
+        }
+        return false;
+    }
+
+    /// Short hand to add a transaction
+    public void put (const Transaction tx)
+    {
+        Hash txhash = hashFull(tx);
+        foreach (size_t idx, ref output_; tx.outputs)
+        {
+            Hash h = UTXOSetValue.getHash(txhash, idx);
+            UTXOSetValue v = {
+                type: tx.type,
+                output: output_
+            };
+            this.storage[h] = v;
+        }
+    }
+
+    /// Workaround 20559...
+    public void clear ()
+    {
+        this.storage.clear();
+    }
+
+    /// Get an UTXO, does not return double spend
+    private bool findUTXO_ (Hash hash, size_t index, out UTXOSetValue value)
+        nothrow @safe
+    {
+        // Note: Keep this in sync with the real `findUTXO`
+        Hash utxo_hash = (index == size_t.max) ?
+            hash : UTXOSetValue.getHash(hash, index);
+        // double-spend
+        if (utxo_hash in this.used_utxos)
+            return false;
+        if (auto ptr = utxo_hash in this.storage)
+        {
+            value = *ptr;
+            this.used_utxos.put(utxo_hash);
+            return true;
+        }
+        return false;
+    }
+}
+
+unittest
+{
+    testSymmetry!UTXOSetValue();
+}

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -16,6 +16,7 @@ module agora.consensus.validation.Block;
 import agora.common.Amount;
 import agora.common.Types;
 import agora.consensus.data.Block;
+import agora.consensus.data.UTXOSetValue;
 import agora.consensus.UTXOSet;
 import VEn = agora.consensus.validation.Enrollment;
 import VTx = agora.consensus.validation.Transaction;
@@ -193,7 +194,7 @@ unittest
     foreach (tx; prev_txs)
     {
         // one utxo missing from the set => fail
-        utxos.storage.remove(UTXOSet.getHash(tx.hashFull(), 0));
+        utxos.storage.remove(UTXOSetValue.getHash(tx.hashFull(), 0));
         assert(!block.isValid(prev_block.header.height, prev_block.header.hashFull(),
             findUTXO));
 
@@ -371,7 +372,7 @@ unittest
     node_key_pair.v = secretKeyToCurveScalar(keypair.secret);
     node_key_pair.V = node_key_pair.v.toPoint();
 
-    auto utxo_hash1 = UTXOSet.getHash(hashFull(txs_2[0]), 0);
+    auto utxo_hash1 = UTXOSetValue.getHash(hashFull(txs_2[0]), 0);
     Enrollment enroll1;
     enroll1.utxo_key = utxo_hash1;
     enroll1.random_seed = hashFull(Scalar.random());
@@ -379,7 +380,7 @@ unittest
     enroll1.enroll_sig = sign(node_key_pair.v, node_key_pair.V, signature_noise.V,
         signature_noise.v, enroll1);
 
-    auto utxo_hash2 = UTXOSet.getHash(hashFull(txs_2[1]), 0);
+    auto utxo_hash2 = UTXOSetValue.getHash(hashFull(txs_2[1]), 0);
     Enrollment enroll2;
     enroll2.utxo_key = utxo_hash2;
     enroll2.random_seed = hashFull(Scalar.random());

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -19,6 +19,7 @@ import agora.common.crypto.ECC;
 import agora.common.crypto.Key;
 import agora.common.crypto.Schnorr;
 import agora.consensus.data.Enrollment;
+import agora.consensus.data.UTXOSetValue;
 import agora.consensus.UTXOSet;
 
 import std.conv;
@@ -129,10 +130,10 @@ unittest
         [Output(Amount.MinFreezeAmount, key_pairs[3].address)]
     );
 
-    auto utxo_hash1 = UTXOSet.getHash(hashFull(tx1), 0);
-    auto utxo_hash2 = UTXOSet.getHash(hashFull(tx2), 0);
-    auto utxo_hash3 = UTXOSet.getHash(hashFull(tx3), 0);
-    auto utxo_hash4 = UTXOSet.getHash(hashFull(tx4), 0);
+    auto utxo_hash1 = UTXOSetValue.getHash(hashFull(tx1), 0);
+    auto utxo_hash2 = UTXOSetValue.getHash(hashFull(tx2), 0);
+    auto utxo_hash3 = UTXOSetValue.getHash(hashFull(tx3), 0);
+    auto utxo_hash4 = UTXOSetValue.getHash(hashFull(tx4), 0);
 
     Pair signature_noise = Pair.random;
 

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -16,6 +16,7 @@ module agora.consensus.validation.Transaction;
 import agora.common.Amount;
 import agora.common.Hash;
 import agora.consensus.data.Transaction;
+import agora.consensus.data.UTXOSetValue;
 import agora.consensus.UTXOSet;
 
 version (unittest)

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -24,6 +24,7 @@ import agora.consensus.data.Block;
 import agora.consensus.data.ConsensusData;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
+import agora.consensus.data.UTXOSetValue;
 import agora.consensus.UTXOSet;
 import agora.consensus.EnrollmentManager;
 import agora.consensus.Genesis;
@@ -742,7 +743,8 @@ unittest
 
     auto findUTXO = utxo_set.getUTXOFinder();
     Transaction find_tx = new_txs[0];
-    Hash utxo_hash = utxo_set.getHash(find_tx.inputs[0].previous, find_tx.inputs[0].index);
+    Hash utxo_hash = UTXOSetValue.getHash(find_tx.inputs[0].previous,
+        find_tx.inputs[0].index);
     UTXOSetValue value;
     assert(findUTXO(utxo_hash, size_t.max, value));
 }
@@ -1018,9 +1020,9 @@ unittest
             if (tx.outputs[0].address == key_pair.address)
                 enroll_key_pair ~= key_pair;
 
-    auto utxo_hash_1 = utxo_set.getHash(hashFull(blocks[3].txs[0]),0);
-    auto utxo_hash_2 = utxo_set.getHash(hashFull(blocks[3].txs[1]),0);
-    auto utxo_hash_3 = utxo_set.getHash(hashFull(blocks[3].txs[2]),0);
+    auto utxo_hash_1 = UTXOSetValue.getHash(hashFull(blocks[3].txs[0]),0);
+    auto utxo_hash_2 = UTXOSetValue.getHash(hashFull(blocks[3].txs[1]),0);
+    auto utxo_hash_3 = UTXOSetValue.getHash(hashFull(blocks[3].txs[2]),0);
 
     Pair signature_noise = Pair.random;
     Pair node_key_pair_1;
@@ -1395,7 +1397,7 @@ unittest
 
         gen_txs ~= freeze_tx;
         Hash txhash = hashFull(freeze_tx);
-        Hash utxo = UTXOSet.getHash(txhash, 0);
+        Hash utxo = UTXOSetValue.getHash(txhash, 0);
 
         Enrollment[] enrolls;
         Enrollment enroll;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -37,6 +37,7 @@ import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.Transaction;
+import agora.consensus.data.UTXOSetValue;
 import agora.consensus.UTXOSet;
 import agora.consensus.EnrollmentManager;
 import agora.consensus.Genesis;
@@ -1096,7 +1097,7 @@ private immutable(Block) makeGenesisBlock (in KeyPair[] key_pairs)
 
         txs ~= tx;
         Hash txhash = hashFull(tx);
-        Hash utxo = UTXOSet.getHash(txhash, 0);
+        Hash utxo = UTXOSetValue.getHash(txhash, 0);
         scope enr = new EnrollmentManager(":memory:", key_pair);
         scope (exit) enr.shutdown();
 

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -23,6 +23,7 @@ import agora.common.Serializer;
 import agora.common.Types;
 import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
+import agora.consensus.data.UTXOSetValue;
 import agora.consensus.UTXOSet;
 import agora.consensus.Genesis;
 import agora.consensus.validation;


### PR DESCRIPTION
D2sqlite does not need to be imported depending on the purpose of the use of UTXOSet.

Related to #945