### PR TITLE
Make 'height' parameter strongly typed

### DIFF
--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -58,3 +58,13 @@ public struct QuorumConfig
     /// List of any sub-quorums
     public QuorumConfig[] quorums;
 }
+
+/// A type to ensure that height and other integer values aren't mixed
+public struct Height
+{
+    ///
+    public ulong value;
+
+    /// Provides implicit conversion to `ulong`
+    public alias value this;
+}

--- a/source/agora/consensus/Genesis.d
+++ b/source/agora/consensus/Genesis.d
@@ -15,6 +15,7 @@ module agora.consensus.Genesis;
 
 import agora.common.Amount;
 import agora.common.Hash;
+import agora.common.Types;
 import agora.common.crypto.Key;
 import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
@@ -80,7 +81,7 @@ private immutable Block UnitTestGenesisBlock =
     header:
     {
         prev_block:  Hash.init,
-        height:      0,
+        height:      Height(0),
         merkle_root: UnitTestGenesisMerkleRoot,
     },
     txs: [ UnitTestGenesisTransaction ],
@@ -91,7 +92,7 @@ private immutable Block UnitTestGenesisBlock =
 unittest
 {
     assert(UnitTestGenesisBlock.header.prev_block == Hash.init);
-    assert(UnitTestGenesisBlock.header.height == 0);
+    assert(UnitTestGenesisBlock.header.height == Height(0));
     assert(UnitTestGenesisBlock.header.merkle_root == UnitTestGenesisBlock.merkle_tree[0]);
     assert(UnitTestGenesisBlock.merkle_tree.length == 1);
     assert(UnitTestGenesisBlock.header.merkle_root == hashFull(UnitTestGenesisTransaction));
@@ -180,7 +181,7 @@ private immutable Block CoinNetGenesisBlock =
     header:
     {
         prev_block:  Hash.init,
-        height:      0,
+        height:      Height(0),
         merkle_root: CoinNetGenesisMerkleRoot,
     },
     txs: [ CoinNetGenesisTransaction ],

--- a/source/agora/consensus/UTXOSet.d
+++ b/source/agora/consensus/UTXOSet.d
@@ -74,12 +74,12 @@ public class UTXOSet
 
     ***************************************************************************/
 
-    public void updateUTXOCache (const ref Transaction tx, ulong height) @safe
+    public void updateUTXOCache (const ref Transaction tx, Height height) @safe
     {
         import std.algorithm : any;
 
         // defaults to next block
-        ulong unlock_height = height + 1;
+        Height unlock_height = Height(height + 1);
 
         // for payments of frozen transactions, it will melt after 2016 blocks
         if ((tx.type == TxType.Payment)
@@ -91,7 +91,7 @@ public class UTXOSet
             )
         )
         {
-            unlock_height = height + 2016;
+            unlock_height = Height(height + 2016);
         }
 
         foreach (const ref input; tx.inputs)
@@ -372,7 +372,7 @@ unittest
         [Input(Hash.init, 0)],
         [Output(Amount.MinFreezeAmount, key_pairs[0].address)]
     );
-    utxo_set.updateUTXOCache(tx1, 0);
+    utxo_set.updateUTXOCache(tx1, Height(0));
     Hash hash1 = hashFull(tx1);
     auto utxo_hash = UTXOSetValue.getHash(hash1, 0);
 
@@ -386,7 +386,7 @@ unittest
         [Input(Hash.init, 0)],
         [Output(Amount(100_000 * 10_000_000L), key_pairs[0].address)]
     );
-    utxo_set.updateUTXOCache(tx2, 0);
+    utxo_set.updateUTXOCache(tx2, Height(0));
 
     // create the third transaction
     Transaction tx3 = Transaction(
@@ -394,7 +394,7 @@ unittest
         [Input(Hash.init, 0)],
         [Output(Amount.MinFreezeAmount, key_pairs[1].address)]
     );
-    utxo_set.updateUTXOCache(tx3, 0);
+    utxo_set.updateUTXOCache(tx3, Height(0));
 
     // test for getting UTXOs for the first KeyPair
     utxos = utxo_set.getUTXOs(key_pairs[0].address);

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -46,7 +46,7 @@ public struct BlockHeader
     public Hash prev_block;
 
     /// Block height (genesis is #0)
-    public ulong height;
+    public Height height;
 
     /// The hash of the merkle root of the transactions
     public Hash merkle_root;
@@ -75,7 +75,7 @@ public struct BlockHeader
     public void computeHash (scope HashDg dg) const nothrow @safe @nogc
     {
         dg(this.prev_block[]);
-        hashPart(this.height, dg);
+        hashPart(this.height.value, dg);
         dg(this.merkle_root[]);
         foreach (enrollment; this.enrollments)
             hashPart(enrollment, dg);
@@ -93,7 +93,7 @@ public struct BlockHeader
     public void serialize (scope SerializeDg dg) const @safe
     {
         dg(this.prev_block[]);
-        serializePart(this.height, dg);
+        serializePart(this.height.value, dg);
         dg(this.merkle_root[]);
         serializePart(this.validators, dg);
         serializePart(this.signature, dg);
@@ -413,7 +413,7 @@ unittest
         header:
         {
             prev_block:  Hash.init,
-            height:      0,
+            height:      Height(0),
             merkle_root: merkle,
             validators:  validators,
             signature:   Signature(sig_data),
@@ -445,7 +445,7 @@ public Block makeNewBlock (Transactions)(const ref Block prev_block,
     Block block;
 
     block.header.prev_block = prev_block.header.hashFull();
-    block.header.height = prev_block.header.height + 1;
+    block.header.height.value = prev_block.header.height.value + 1;
     txs.each!(tx => block.txs ~= tx);
     block.txs.sort;
 
@@ -528,7 +528,7 @@ unittest
     Block block;
 
     block.header.prev_block = Hash.init;
-    block.header.height = 0;
+    block.header.height = Height(0);
     block.txs ~= txs;
     block.header.merkle_root = block.buildMerkleTree();
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -255,7 +255,7 @@ extern(D):
 
         auto pub_key = NodeID(uint256(this.key_pair.address));
 
-        foreach (block_idx, block; ledger.getBlocksFrom(0).enumerate)
+        foreach (block_idx, block; ledger.getBlocksFrom(Height(0)).enumerate)
         {
             SCPStatement statement =
             {

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -75,7 +75,7 @@ version (unittest)
 
 *******************************************************************************/
 
-public string isInvalidReason (const ref Block block, in ulong prev_height,
+public string isInvalidReason (const ref Block block, Height prev_height,
     in Hash prev_hash, UTXOFinder findUTXO) nothrow @safe
 {
     import std.algorithm;
@@ -239,7 +239,7 @@ unittest
     assert(block.isGenesisBlockValid());
 
     // don't accept block height 0 from the network
-    assert(!block.isValid(0, Hash.init, null));
+    assert(!block.isValid(Height(0), Hash.init, null));
 
     // height check
     block.header.height = 1;
@@ -382,7 +382,7 @@ public bool isGenesisBlockValid (const ref Block genesis_block)
 
 /// Ditto but returns `bool`, only usable in unittests
 version (unittest)
-public bool isValid (const ref Block block, ulong prev_height,
+public bool isValid (const ref Block block, Height prev_height,
     Hash prev_hash, UTXOFinder findUTXO) nothrow @safe
 {
     return isInvalidReason(block, prev_height, prev_hash, findUTXO) is null;

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -521,7 +521,7 @@ public class NetworkManager
                     return;
 
                 this.getBlocksFrom(
-                    ledger.getBlockHeight() + 1,
+                    Height(ledger.getBlockHeight() + 1),
                     blocks => blocks.all!(block =>
                         // do not alter the state of the ledger if
                         // we're currently nominating (Validator)
@@ -572,22 +572,22 @@ public class NetworkManager
 
     ***************************************************************************/
 
-    private void getBlocksFrom (ulong block_height,
+    private void getBlocksFrom (Height block_height,
         scope bool delegate(const(Block)[]) @safe onReceivedBlocks) nothrow
     {
-        struct Pair { size_t height; NetworkClient client; }
+        struct Pair { Height height; NetworkClient client; }
 
         static Pair[] node_pairs;
         node_pairs.length = 0;
         assumeSafeAppend(node_pairs);
 
-        // return size_t.max if getBlockHeight() fails
-        size_t getHeight (NetworkClient node)
+        // return ulong.max if getBlockHeight() fails
+        Height getHeight (NetworkClient node)
         {
             try
-                return node.getBlockHeight();
+                return Height(node.getBlockHeight());
             catch (Exception ex)
-                return size_t.max;
+                return Height(ulong.max);
         }
 
         auto node_pair = this.peers.byValue

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -258,7 +258,7 @@ public class FullNode : API
     public override const(Block)[] getBlocksFrom (ulong block_height,
         uint max_blocks)  @safe
     {
-        return this.ledger.getBlocksFrom(block_height)
+        return this.ledger.getBlocksFrom(Height(block_height))
             .take(min(max_blocks, MaxBatchBlocksSent)).array;
     }
 
@@ -421,7 +421,7 @@ public class FullNode : API
     /// GET: /merkle_path
     public override Hash[] getMerklePath (ulong block_height, Hash hash) @safe
     {
-        return this.ledger.getMerklePath(block_height, hash);
+        return this.ledger.getMerklePath(Height(block_height), hash);
     }
 
     /// PUT: /enroll_validator

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1112,7 +1112,7 @@ private immutable(Block) makeGenesisBlock (in KeyPair[] key_pairs,
         scope enr = new EnrollmentManager(":memory:", key_pair, params);
 
         Enrollment enroll;
-        const StartHeight = 1;
+        const StartHeight = Height(1);
         assert(enr.createEnrollment(utxo, StartHeight, enroll));
         enrolls ~= enroll;
     }
@@ -1127,7 +1127,7 @@ private immutable(Block) makeGenesisBlock (in KeyPair[] key_pairs,
     {
         return immutable(BlockHeader)(
             Hash.init,   // prev
-            0,           // height
+            Height(0),   // height
             merkle_root,
             BitField!uint.init,
             Signature.init,

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -212,7 +212,7 @@ unittest
                 GenesisTransaction.outputs[0]
             );
             return true;
-        }, 0));
+        }, Height(0)));
 
     txs.each!(tx => node_1.putTransaction(tx));
 

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -320,7 +320,8 @@ private struct BlockHeaderFmt
         try
         {
             formattedWrite(sink, "Height: %d, Prev: %s, Root: %s",
-                this.value.height, HashFmt(this.value.prev_block), HashFmt(this.value.merkle_root));
+                this.value.height.value, HashFmt(this.value.prev_block),
+                HashFmt(this.value.merkle_root));
         }
         catch (Exception ex)
         {
@@ -395,7 +396,7 @@ GCOQ...LRIJ(62,500,000), GCOQ...LRIJ(62,500,000)`;
     immutable Block block2tx = {
         header: {
             prev_block: hashFull(GenesisBlock.header),
-            height: 1,
+            height: Height(1),
             merkle_root: MerkleRoot,
         },
         txs: [ GenesisTransaction, GenesisTransaction ],

--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -32,6 +32,7 @@ module agora.utils.Test;
 import agora.common.Amount;
 import agora.common.crypto.Key;
 import agora.common.Hash;
+import agora.common.Types;
 import agora.consensus.data.Transaction;
 import agora.consensus.Genesis;
 
@@ -323,7 +324,7 @@ unittest
     {
         return immutable(BlockHeader)(
             Hash.init,   // prev
-            0,           // height
+            Height(0),   // height
             merkle_root,
             BitField!uint.init,
             Signature.init,

--- a/tests/unit/BlockStorage.d
+++ b/tests/unit/BlockStorage.d
@@ -71,7 +71,7 @@ private void main ()
     Block[] loaded_blocks;
     loaded_blocks.length = count;
     foreach (idx; 0 .. count)
-        storage.readBlock(loaded_blocks[idx], idx);
+        storage.readBlock(loaded_blocks[idx], Height(idx));
 
     // compare
     assert(equal(blocks, loaded_blocks));
@@ -85,7 +85,7 @@ private void main ()
     Block random_block;
     foreach (height; iota(count).randomCover(rnd))
     {
-        storage.readBlock(random_block, height);
+        storage.readBlock(random_block, Height(height));
         assert(random_block.header.height == height);
     }
 
@@ -103,7 +103,7 @@ private void main ()
 
     foreach (height; iota(count).randomCover(rnd))
     {
-        other.readBlock(random_block, height);
+        other.readBlock(random_block, Height(height));
         assert(random_block.header.height == height);
     }
 

--- a/tests/unit/BlockStorageChecksum.d
+++ b/tests/unit/BlockStorageChecksum.d
@@ -13,6 +13,7 @@
 
 module unit.BlockStorageChecksum;
 
+import agora.common.Types;
 import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
 import agora.consensus.Genesis;
@@ -41,7 +42,7 @@ private void main ()
     Block block;
 
     // Checksum detection test
-    assertThrown!Exception(storage.readBlock(block, 0));
+    assertThrown!Exception(storage.readBlock(block, Height(0)));
 }
 
 /// Write the block data to disk

--- a/tests/unit/BlockStorageMultiTx.d
+++ b/tests/unit/BlockStorageMultiTx.d
@@ -63,7 +63,7 @@ private void main ()
     Block[] loaded_blocks;
     loaded_blocks.length = BlockCount + 1;
     foreach (idx; 0 .. BlockCount + 1)
-        storage.readBlock(loaded_blocks[idx], idx);
+        storage.readBlock(loaded_blocks[idx], Height(idx));
     size_t idx;
 
     assert(loaded_blocks == blocks);


### PR DESCRIPTION
By using a `struct` which `alias this` to the underlying (ulong) type,
we can guarantee that callers of the functions accepting `Height`
will need to provide a `Height` (or build one), while allowing
most manipulation of `Height` as a regular `ulong`.