### PR TITLE
Use setTimer on Nominator.setupTimer

### DIFF
--- a/source/agora/common/Task.d
+++ b/source/agora/common/Task.d
@@ -73,14 +73,57 @@ public class TaskManager
             dg = This delegate will be called when the timer fires.
             periodic = Specifies if the timer fires repeatedly or only once.
 
+        Returns:
+            An `ITimer` interface with the ability to control the timer
+
     ***************************************************************************/
 
-    public void setTimer (Duration timeout, void delegate() dg,
+    public ITimer setTimer (Duration timeout, void delegate() dg,
         Periodic periodic = Periodic.No)
     {
         assert(dg !is null, "Cannot call this delegate if null");
-
         static import vibe.core.core;
-        vibe.core.core.setTimer(timeout, dg, periodic);
+        return new VibedTimer(vibe.core.core.setTimer(timeout, dg, periodic));
+    }
+}
+
+/*******************************************************************************
+
+    Defines an abstraction over the timer implementation
+
+*******************************************************************************/
+
+public interface ITimer
+{
+    /***************************************************************************
+
+        Stop or cancel this timer
+
+    ***************************************************************************/
+
+    public void stop ();
+}
+
+/*******************************************************************************
+
+    Vibe.d timer
+
+*******************************************************************************/
+
+private final class VibedTimer : ITimer
+{
+    static import Vibe = vibe.core.core;
+
+    private Vibe.Timer timer;
+
+    public this (Vibe.Timer timer) @safe nothrow
+    {
+        this.timer = timer;
+    }
+
+    /// Ditto
+    public override void stop () @safe nothrow
+    {
+        this.timer.stop();
     }
 }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -277,12 +277,40 @@ public class LocalRestTaskManager : TaskManager
             dg = This delegate will be called when the timer fires.
             periodic = Specifies if the timer fires repeatedly or only once.
 
+        Return:
+           An `ITimer` interface with the ability to control the timer
+
     ***************************************************************************/
 
-    public override void setTimer (Duration timeout, void delegate() dg,
+    public override ITimer setTimer (Duration timeout, void delegate() dg,
         Periodic periodic = Periodic.No)
     {
-        geod24.LocalRest.setTimer(timeout, dg, periodic);
+        return new LocalRestTimer(geod24.LocalRest.setTimer(timeout, dg,
+            periodic));
+    }
+}
+
+/*******************************************************************************
+
+    LocalRest only timer (for unittests)
+
+*******************************************************************************/
+
+private final class LocalRestTimer : ITimer
+{
+    import LocalRest = geod24.LocalRest;
+
+    private LocalRest.Timer timer;
+
+    public this (LocalRest.Timer timer)
+    {
+        this.timer = timer;
+    }
+
+    /// Ditto
+    public override void stop ()
+    {
+        this.timer.stop();
     }
 }
 


### PR DESCRIPTION
`ITimer` interface has been newly created and this is implemented as `VibeTimer` and `LocalRestTimer`.
Currently, it only defined a stop function in the `ITimer`, which can be expanded.
Also, the `Nominator.setupTimer` uses `TaskManager`'s `setTimer` new task which waits until a timer expires and call

Relates #872 