### PR TITLE
Remove unused threshold parameter

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -816,9 +816,6 @@ public struct TestConf
 
     /// max listener nodes. If set to 0, set to this.nodes - 1
     size_t max_listeners;
-
-    /// The threshold. If not set, it will default to the number of nodes
-    size_t threshold;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
It was part of the quorum configuration.