### PR TITLE
Deserializer: Rise the default limit for length

### DIFF
--- a/source/agora/common/Serializer.d
+++ b/source/agora/common/Serializer.d
@@ -516,7 +516,7 @@ public struct DeserializerOptions
 
 *******************************************************************************/
 
-public enum DefaultMaxLength = 0x09D0;
+public enum DefaultMaxLength = 0x39D0;
 
 /*******************************************************************************
 
@@ -740,7 +740,7 @@ unittest
     import std.exception;
 
     static struct Bomb { ubyte[] data; }
-    ushort length = 0x2000;
+    ushort length = 0xFF_00;
     ubyte[16192] bomb;
     bomb[0] = 0xFD;
     bomb[1 .. 3] = (cast(ubyte*)&length)[0 .. ushort.sizeof];


### PR DESCRIPTION
We are starting to hit this limit quite often.
It's not a good limit anyway, as it's the length (in items), not the size in bytes,
so anyone could just set all arrays to this value and it'd still be a pretty big read.