### PR TITLE
Ledger: Remove useless foreach in unittest

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -584,14 +584,6 @@ unittest
 
     // Valid case
     auto txs = makeChainedTransactions(gen_key_pair, null, 1);
-    foreach (ref tx; txs)
-    {
-        foreach (ref output; tx.outputs)
-            output.value = Amount(1_000_000L);
-        foreach (ref input; tx.inputs)
-            input.signature = gen_key_pair.secret.sign(hashFull(tx)[]);
-    }
-
     txs.each!(tx => assert(ledger.acceptTransaction(tx)));
     ledger.forceCreateBlock();
     auto blocks = ledger.getBlocksFrom(Height(0)).take(10);


### PR DESCRIPTION
There's no point in setting those values to 1_000_000 as the value isn't checked anyway.
To it just switches to one valid input to another valid input.