### PR TITLE
Improve Ledger testability and reorder constructors arguments

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -146,8 +146,8 @@ public class FullNode : API
         this.utxo_set = this.getUtxoSet(config.node.data_dir);
         this.enroll_man = this.getEnrollmentManager(config.node.data_dir,
             config.node, params);
-        this.ledger = new Ledger(this.pool, this.utxo_set, this.storage,
-            this.enroll_man, config.node, params, onValidatorsChanged);
+        this.ledger = new Ledger(config.node, params, this.utxo_set,
+            this.storage, this.enroll_man, this.pool, onValidatorsChanged);
         this.exception = new RestException(
             400, Json("The query was incorrect"), string.init, int.init);
     }


### PR DESCRIPTION
```
Re-order the constructor arguments so that it is more sensible.
The most important arguments are the one the ledger cannot do without,
namely the configuration, consensus parameter, and various utilities
to handle consensus rules.
Things like TransactionPool could actually be optional
(even though they currently aren't).

Secondly, the Ledger unittests are actually very repetitive,
and there is little need to change e.g. the TransactionPool used,
or the `EnrollmentManager`. So we provide a unittest-only subclass
that has all the sensible defaults.
```

Side note: Some places were left with the old copy-pasta because they were doing a bit more (e.g. pre-generating blocks). I will refactor them later to do things using `MemBlockStorage`, but since the initial intent was simply to re-order the ctor arguments, I didn't want this diff to grow to large or become too involved.