### PR TITLE
MemBlockStorage: Detect when blocks failed to load

### DIFF
--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -934,13 +934,11 @@ public class MemBlockStorage : IBlockStorage
     public override bool load ()
     {
         if (this._to_load.length == 0)
-            this.saveBlock(GenesisBlock);
-        else
-        {
-            foreach (const ref block; this._to_load)
-                this.saveBlock(block);
-        }
+            return this.saveBlock(GenesisBlock);
 
+        foreach (const ref block; this._to_load)
+            if (!this.saveBlock(block))
+                return false;
         return true;
     }
 


### PR DESCRIPTION
saveBlock can return false, and if ignored, the error might not be detected until much later.
This can easily happen when one provides a block at the wrong height
(builds a block on top of Genesis and forget to pass Genesis in blocks).