### PR TITLE
Make Genesis keypair well-know, remove getGenesisKeyPair()

### DIFF
--- a/source/agora/common/TransactionPool.d
+++ b/source/agora/common/TransactionPool.d
@@ -322,7 +322,7 @@ unittest
     import agora.consensus.Genesis;
 
     auto pool = new TransactionPool(":memory:");
-    auto gen_key = getGenesisKeyPair();
+    auto gen_key = WK.Keys.Genesis;
     auto txs = makeChainedTransactions(gen_key, null, 1);
 
     txs.each!(tx => pool.add(tx));
@@ -360,7 +360,7 @@ unittest
     import std.exception;
 
     auto pool = new TransactionPool(":memory:");
-    auto gen_key = getGenesisKeyPair();
+    auto gen_key = WK.Keys.Genesis;
     auto txs = makeChainedTransactions(gen_key, null, 1);
 
     txs.each!(tx => pool.add(tx));
@@ -391,7 +391,7 @@ unittest
     import core.memory;
 
     auto pool = new TransactionPool(":memory:");
-    auto gen_key = getGenesisKeyPair();
+    auto gen_key = WK.Keys.Genesis;
     auto txs = makeChainedTransactions(gen_key, null, 1);
 
     txs.each!(tx => pool.add(tx));

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -63,6 +63,7 @@ import agora.consensus.PreImage;
 import agora.consensus.validation;
 import agora.consensus.ValidatorSet;
 import agora.utils.Log;
+version (unittest) import agora.utils.Test;
 
 import d2sqlite3.library;
 import d2sqlite3.results;
@@ -687,7 +688,7 @@ unittest
 
     scope storage = new TestUTXOSet;
 
-    auto gen_key_pair = getGenesisKeyPair();
+    auto gen_key_pair = WK.Keys.Genesis;
     KeyPair key_pair = KeyPair.random();
 
     foreach (idx; 0 .. 8)
@@ -852,7 +853,7 @@ unittest
     import std.conv;
 
     scope storage = new TestUTXOSet;
-    auto gen_key_pair = getGenesisKeyPair();
+    auto gen_key_pair = WK.Keys.Genesis;
     KeyPair key_pair = KeyPair.random();
 
     foreach (idx; 0 .. 8)
@@ -966,7 +967,7 @@ unittest
 
     scope storage = new TestUTXOSet;
 
-    auto gen_key_pair = getGenesisKeyPair();
+    auto gen_key_pair = WK.Keys.Genesis;
     KeyPair key_pair = KeyPair.random();
 
     foreach (idx; 0 .. 8)

--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -28,6 +28,7 @@ import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.UTXOSetValue;
 import agora.consensus.validation;
 import agora.utils.Log;
+version (unittest) import agora.utils.Test;
 
 import d2sqlite3.library;
 import d2sqlite3.results;
@@ -304,7 +305,7 @@ unittest
 
     scope storage = new TestUTXOSet;
 
-    auto gen_key_pair = getGenesisKeyPair();
+    auto gen_key_pair = WK.Keys.Genesis;
     KeyPair key_pair = KeyPair.random();
 
     foreach (idx; 0 .. 8)

--- a/source/agora/consensus/Genesis.d
+++ b/source/agora/consensus/Genesis.d
@@ -144,37 +144,6 @@ unittest
     testSymmetry(UnitTestGenesisBlock);
 }
 
-version (unittest)
-{
-    /***************************************************************************
-
-        Get the key-pair which can spend the UTXO in the genesis transaction.
-
-        In unittests, we need the genesis key pair to be known for us to be
-        able to test anything. Hence the genesis block has a different value.
-
-        Seed:    SCT4KKJNYLTQO4TVDPVJQZEONTVVW66YLRWAINWI3FZDY7U4JS4JJEI4
-        Address: GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ
-
-        Returns:
-            the key pair which can spend the UTXO in the genesis transaction
-
-    ***************************************************************************/
-
-    public KeyPair getGenesisKeyPair ()
-    {
-        return KeyPair.fromSeed(
-            Seed.fromString(
-                "SCT4KKJNYLTQO4TVDPVJQZEONTVVW66YLRWAINWI3FZDY7U4JS4JJEI4"));
-    }
-
-    // Check that the public key matches, temporarily
-    unittest
-    {
-        assert(getGenesisKeyPair().address == UnitTestGenesisOutputAddress);
-    }
-}
-
 /// The genesis block as defined by CoinNet
 private immutable Block CoinNetGenesisBlock =
 {

--- a/source/agora/consensus/ValidatorSet.d
+++ b/source/agora/consensus/ValidatorSet.d
@@ -30,6 +30,7 @@ import agora.consensus.data.UTXOSetValue;
 import agora.consensus.PreImage;
 import agora.consensus.validation;
 import agora.utils.Log;
+version (unittest) import agora.utils.Test;
 
 import d2sqlite3.library;
 import d2sqlite3.results;
@@ -511,7 +512,7 @@ unittest
 
     scope storage = new TestUTXOSet;
 
-    auto gen_key_pair = getGenesisKeyPair();
+    auto gen_key_pair = WK.Keys.Genesis;
     KeyPair[5] kp = [ KeyPair.random(), KeyPair.random(), KeyPair.random(),
                       KeyPair.random(), KeyPair.random() ];
     Hash[5] utxos;
@@ -662,7 +663,7 @@ unittest
     import std.format;
 
     scope storage = new TestUTXOSet;
-    auto key_pair = getGenesisKeyPair();
+    auto key_pair = WK.Keys.Genesis;
     foreach (uint idx; 0 .. 8)
     {
         auto input = Input(hashFull(GenesisTransaction), idx);

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -397,7 +397,7 @@ unittest
     scope utxos = new TestUTXOSet();
     scope findUTXO = &utxos.findUTXO;
 
-    auto gen_key = getGenesisKeyPair();
+    auto gen_key = WK.Keys.Genesis;
     assert(GenesisBlock.isGenesisBlockValid());
     auto gen_hash = GenesisBlock.header.hashFull();
 
@@ -561,7 +561,7 @@ unittest
     scope utxo_set = new TestUTXOSet();
     UTXOFinder findUTXO = utxo_set.getUTXOFinder();
 
-    auto gen_key = getGenesisKeyPair();
+    auto gen_key = WK.Keys.Genesis;
     assert(GenesisBlock.isGenesisBlockValid());
     auto gen_hash = GenesisBlock.header.hashFull();
     foreach (ref tx; GenesisBlock.txs)

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -1066,7 +1066,7 @@ unittest
     const(Block)[] blocks;
     Hash[] block_hashes;
 
-    auto gen_key_pair = getGenesisKeyPair();
+    auto gen_key_pair = WK.Keys.Genesis;
     blocks ~= GenesisBlock;
     storage.saveBlock(GenesisBlock);
     block_hashes ~= hashFull(GenesisBlock.header);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -500,7 +500,7 @@ unittest
 {
     NodeConfig config = {
         is_validator: true,
-        key_pair:     getGenesisKeyPair(),
+        key_pair:     WK.Keys.Genesis,
     };
     scope ledger = new TestLedger(config);
 
@@ -581,7 +581,7 @@ unittest
 {
     NodeConfig config = {
         is_validator: true,
-        key_pair:     getGenesisKeyPair(),
+        key_pair:     WK.Keys.Genesis,
     };
     scope ledger = new TestLedger(config);
 
@@ -612,7 +612,7 @@ unittest
 {
     NodeConfig config = {
         is_validator: true,
-        key_pair:     getGenesisKeyPair(),
+        key_pair:     WK.Keys.Genesis,
     };
     scope ledger = new TestLedger(config);
 
@@ -630,7 +630,7 @@ unittest
 {
     NodeConfig config = {
         is_validator: true,
-        key_pair:     getGenesisKeyPair(),
+        key_pair:     WK.Keys.Genesis,
     };
     scope ledger = new TestLedger(config);
 
@@ -694,7 +694,7 @@ unittest
     // TODO: Make this more than one block (e.g. 5)
     //       Currently due to the design of `makeChainedTransactions`,
     //       we can't do that.
-    auto txs = makeChainedTransactions(getGenesisKeyPair(), null, 1);
+    auto txs = makeChainedTransactions(WK.Keys.Genesis, null, 1);
     // Cannot use literals: https://issues.dlang.org/show_bug.cgi?id=20938
     const(Block)[] blocks = [ GenesisBlock() ];
     blocks ~= makeNewBlock(GenesisBlock, txs);
@@ -702,7 +702,7 @@ unittest
     // And provide it to the ledger
     NodeConfig config = {
         is_validator: true,
-        key_pair:     getGenesisKeyPair(),
+        key_pair:     WK.Keys.Genesis,
     };
     scope ledger = new TestLedger(config, blocks);
 
@@ -727,7 +727,7 @@ unittest
 
 version (unittest)
 private Transaction[] makeTransactionForFreezing (
-    KeyPair[] in_key_pair,
+    const(KeyPair)[] in_key_pair,
     KeyPair[] out_key_pair,
     TxType tx_type,
     Transaction[] prev_txs,
@@ -791,12 +791,12 @@ unittest
 {
     NodeConfig config = {
         is_validator: true,
-        key_pair:     getGenesisKeyPair(),
+        key_pair:     WK.Keys.Genesis,
     };
     scope ledger = new TestLedger(config);
 
-    KeyPair[] in_key_pairs =
-        iota(Block.TxsInBlock).map!(_ => getGenesisKeyPair()).array();
+    const(KeyPair)[] in_key_pairs =
+        iota(Block.TxsInBlock).map!(_ => WK.Keys.Genesis).array();
     KeyPair[] out_key_pairs;
     Transaction[] last_txs;
 
@@ -852,7 +852,7 @@ unittest
     auto params = new immutable(ConsensusParams)(validator_cycle);
     NodeConfig config = {
         is_validator: true,
-        key_pair:     getGenesisKeyPair(),
+        key_pair:     WK.Keys.Genesis,
     };
     scope ledger = new TestLedger(config, null, params);
 
@@ -1046,7 +1046,7 @@ private Transaction[] splitGenesisTransaction (
         foreach (idx2; 0 .. Block.TxsInBlock)
             tx.outputs ~= Output(amount, out_key[idx].address);
 
-        auto signature = getGenesisKeyPair().secret.sign(hashFull(tx)[]);
+        auto signature = WK.Keys.Genesis.secret.sign(hashFull(tx)[]);
         tx.inputs[0].signature = signature;
         txes ~= tx;
     }
@@ -1072,7 +1072,7 @@ unittest
 {
     NodeConfig config = {
         is_validator: true,
-        key_pair:     getGenesisKeyPair(),
+        key_pair:     WK.Keys.Genesis,
     };
     scope ledger = new TestLedger(config);
 
@@ -1359,7 +1359,7 @@ unittest
         const(Transaction)[] prev_txs;
         foreach (_; 0 .. count)
         {
-            auto txs = makeChainedTransactions(getGenesisKeyPair(),
+            auto txs = makeChainedTransactions(WK.Keys.Genesis,
                 prev_txs, 1);
 
             const NoEnrollments = null;

--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -48,7 +48,7 @@ unittest
     auto node_2 = network.nodes[1].client;
     auto node_3 = network.nodes[2].client;  // non-validator
     auto nodes = [node_1, node_2, node_3];
-    auto gen_key = getGenesisKeyPair();
+    auto gen_key = WK.Keys.Genesis;
 
     Transaction[] all_txs;
     Transaction[] last_txs;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1191,7 +1191,7 @@ private immutable(Block)[] generateBlocks (
     foreach (_; 0 .. count)
     {
         // 10x more than MinFreezeAmount so we can split it to multiple freezes later
-        auto txs = makeChainedTransactions(getGenesisKeyPair(),
+        auto txs = makeChainedTransactions(WK.Keys.Genesis,
             prev_txs, 1, 4_000_000_000_000 * Block.TxsInBlock);
 
         const NoEnrollments = null;

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -69,7 +69,7 @@ unittest
                  node.getEnrollment(enroll_3.utxo_key) == enroll_3,
             5.seconds));
 
-    auto txs = makeChainedTransactions(getGenesisKeyPair(),
+    auto txs = makeChainedTransactions(WK.Keys.Genesis,
         network.blocks[$ - 1].txs, 1);
     txs.each!(tx => nodes[0].putTransaction(tx));
 
@@ -79,7 +79,7 @@ unittest
                 idx, node.getBlockHeight(), validator_cycle)));
 
     // verify that consensus can still be reached
-    txs = makeChainedTransactions(getGenesisKeyPair(), txs, 1);
+    txs = makeChainedTransactions(WK.Keys.Genesis, txs, 1);
     txs.each!(tx => nodes[0].putTransaction(tx));
 
     nodes.enumerate.each!((idx, node) =>

--- a/source/agora/test/GenesisBlock.d
+++ b/source/agora/test/GenesisBlock.d
@@ -37,7 +37,7 @@ unittest
     nodes.all!(node => node.getBlocksFrom(0, 1)[0] == network.blocks[0])
         .retryFor(2.seconds);
 
-    auto txes = makeChainedTransactions(getGenesisKeyPair(), null, 1);
+    auto txes = makeChainedTransactions(WK.Keys.Genesis, null, 1);
     txes.each!(tx => node_1.putTransaction(tx));
 
     nodes.all!(node => node.getBlockHeight() == 1)

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -39,7 +39,7 @@ unittest
 
     Transaction[] last_txs;
     // create enough tx's for a single block
-    auto txs = makeChainedTransactions(getGenesisKeyPair(), last_txs, 1);
+    auto txs = makeChainedTransactions(WK.Keys.Genesis, last_txs, 1);
 
     auto send_txs = txs[0..$-1];
     // send it to tx to node
@@ -82,7 +82,7 @@ unittest
     auto nodes = network.clients;
     auto node_1 = nodes[0];
 
-    auto txs = makeChainedTransactions(getGenesisKeyPair(), null, 1);
+    auto txs = makeChainedTransactions(WK.Keys.Genesis, null, 1);
 
     auto send_txs = txs[0 .. $ - 1];  // 1 short of making a block (don't start consensus)
     send_txs.each!(tx => node_1.putTransaction(tx));

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -48,7 +48,7 @@ unittest
     foreach (block_idx; 0 .. 10)  // create 10 blocks
     {
         // create enough tx's for a single block
-        auto txs = makeChainedTransactions(getGenesisKeyPair(), last_txs, 1);
+        auto txs = makeChainedTransactions(WK.Keys.Genesis, last_txs, 1);
 
         // send it to one node
         txs.each!(tx => node_1.putTransaction(tx));
@@ -103,7 +103,7 @@ unittest
     // ignore transaction propagation and periodically retrieve blocks via getBlocksFrom
     nodes[1 .. $].each!(node => node.filter!(node.putTransaction));
 
-    auto txs = makeChainedTransactions(getGenesisKeyPair(), null, 2);
+    auto txs = makeChainedTransactions(WK.Keys.Genesis, null, 2);
     txs.each!(tx => node_1.putTransaction(tx));
     containSameBlocks(nodes, 2).retryFor(8.seconds);
 }
@@ -120,7 +120,7 @@ unittest
     auto nodes = network.clients;
     auto node_1 = nodes[0];
 
-    auto gen_key_pair = getGenesisKeyPair();
+    auto gen_key_pair = WK.Keys.Genesis;
     auto txs = makeChainedTransactions(gen_key_pair, null, 1);
     txs.each!(tx => node_1.putTransaction(tx));
 
@@ -182,15 +182,15 @@ unittest
     auto nodes = network.clients;
     auto node_1 = nodes[0];
 
-    auto txs = makeChainedTransactions(getGenesisKeyPair(), null, 1);
+    auto txs = makeChainedTransactions(WK.Keys.Genesis, null, 1);
     txs.each!(tx => node_1.putTransaction(tx));
     containSameBlocks(nodes, 1).retryFor(3.seconds);
 
-    txs = makeChainedTransactions(getGenesisKeyPair(), txs, 1);
+    txs = makeChainedTransactions(WK.Keys.Genesis, txs, 1);
     txs.each!(tx => node_1.putTransaction(tx));
     containSameBlocks(nodes, 2).retryFor(3.seconds);
 
-    txs = makeChainedTransactions(getGenesisKeyPair(), txs, 1);
+    txs = makeChainedTransactions(WK.Keys.Genesis, txs, 1);
 
     // create a deep-copy of the first tx
     auto backup_tx = deserializeFull!Transaction(serializeFull(txs[0]));
@@ -198,7 +198,7 @@ unittest
     // create a double-spend tx
     txs[0].inputs[0] = txs[1].inputs[0];
     txs[0].outputs[0].value = Amount(100);
-    auto signature = getGenesisKeyPair().secret.sign(hashFull(txs[0])[]);
+    auto signature = WK.Keys.Genesis.secret.sign(hashFull(txs[0])[]);
     txs[0].inputs[0].signature = signature;
 
     // make sure the transaction is still authentic (signature is correct),

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -43,7 +43,7 @@ unittest
     // reject inbound requests
     nodes[1 .. $].each!(node => node.filter!(node.putTransaction));
 
-    auto txes = makeChainedTransactions(getGenesisKeyPair(), null, 1);
+    auto txes = makeChainedTransactions(WK.Keys.Genesis, null, 1);
 
     // node 1 will keep trying to send transactions up to
     // (max_retries * retry_delay) seconds (see Base.d)
@@ -76,7 +76,7 @@ unittest
     const DropRequests = true;
     nodes[1 .. $].each!(node => node.sleep(100.msecs, DropRequests));
 
-    auto txes = makeChainedTransactions(getGenesisKeyPair(), null, 1);
+    auto txes = makeChainedTransactions(WK.Keys.Genesis, null, 1);
 
     txes.each!(tx => node_1.putTransaction(tx));
 

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -46,7 +46,7 @@ unittest
     nodes[0].filter!(API.getBlockHeight);
     nodes[1].filter!(API.getBlockHeight);
 
-    auto txes = makeChainedTransactions(getGenesisKeyPair(), null, 1);
+    auto txes = makeChainedTransactions(WK.Keys.Genesis, null, 1);
     txes.each!(tx => node_1.putTransaction(tx));
 
     nodes[0].clearFilter();
@@ -158,7 +158,7 @@ unittest
     foreach (block_idx; 0 .. 10)  // create 10 blocks
     {
         // create enough tx's for a single block
-        auto txs = makeChainedTransactions(getGenesisKeyPair(), last_txs, 1);
+        auto txs = makeChainedTransactions(WK.Keys.Genesis, last_txs, 1);
 
         // send it to one node
         txs.each!(tx => node_validator.putTransaction(tx));

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -65,7 +65,7 @@ unittest
             addresses.map!(addr => Output(Amount.MinFreezeAmount, addr)).array
         };
 
-        auto signature = getGenesisKeyPair().secret.sign(hashFull(tx)[]);
+        auto signature = WK.Keys.Genesis.secret.sign(hashFull(tx)[]);
         tx.inputs[0].signature = signature;
         return tx;
     }
@@ -81,20 +81,20 @@ unittest
             [Output(Amount.MinFreezeAmount, address)]
         };
 
-        auto signature = getGenesisKeyPair().secret.sign(hashFull(tx)[]);
+        auto signature = WK.Keys.Genesis.secret.sign(hashFull(tx)[]);
         tx.inputs[0].signature = signature;
         return tx;
     }
 
     // create block with 6 payment and 2 freeze tx's
-    auto txs = makeChainedTransactions(getGenesisKeyPair(),
+    auto txs = makeChainedTransactions(WK.Keys.Genesis,
         network.blocks[$ - 1].txs, 1);
 
     // rewrite 3rd to last tx to multiple outputs so we can create 8 spend tx's
     // in next block
     txs[$ - 3] = makePayTx(network.blocks[$ - 1].txs[$ - 3],
-        [getGenesisKeyPair.address, getGenesisKeyPair.address,
-        getGenesisKeyPair.address]);
+        [WK.Keys.Genesis.address, WK.Keys.Genesis.address,
+        WK.Keys.Genesis.address]);
 
     // rewrite the last two tx's to be freeze tx's for our outsider validator nodes
     txs[$ - 2] = makeFreezeTransaction(network.blocks[$ - 1].txs[$ - 2],
@@ -121,11 +121,11 @@ unittest
                  node.getEnrollment(enroll_1.utxo_key) == enroll_1,
             5.seconds));
 
-    auto new_txs = makeChainedTransactions(getGenesisKeyPair(), txs, 1);
+    auto new_txs = makeChainedTransactions(WK.Keys.Genesis, txs, 1);
     // the last 3 tx's must refer to the outputs in txs[$ - 3] before
-    new_txs[$ - 3] = makePayTx(txs[$ - 3], [getGenesisKeyPair.address], 0);
-    new_txs[$ - 2] = makePayTx(txs[$ - 3], [getGenesisKeyPair.address], 1);
-    new_txs[$ - 1] = makePayTx(txs[$ - 3], [getGenesisKeyPair.address], 2);
+    new_txs[$ - 3] = makePayTx(txs[$ - 3], [WK.Keys.Genesis.address], 0);
+    new_txs[$ - 2] = makePayTx(txs[$ - 3], [WK.Keys.Genesis.address], 1);
+    new_txs[$ - 1] = makePayTx(txs[$ - 3], [WK.Keys.Genesis.address], 2);
     new_txs.each!(tx => nodes[0].putTransaction(tx));
 
     // at block height 1008 the validator set has changed
@@ -138,7 +138,7 @@ unittest
     nodes[0 .. $ - 2].each!(node => node.sleep(10.minutes, true));
 
     // verify that consensus can still be reached by the leftover validators
-    txs = makeChainedTransactions(getGenesisKeyPair(), new_txs, 1);
+    txs = makeChainedTransactions(WK.Keys.Genesis, new_txs, 1);
     txs.each!(tx => nodes[$ - 2].putTransaction(tx));
 
     nodes[$ - 2 .. $].enumerate.each!((idx, node) =>

--- a/source/agora/test/Simple.d
+++ b/source/agora/test/Simple.d
@@ -38,7 +38,7 @@ unittest
     auto nodes = network.clients;
     auto node_1 = nodes[0];
 
-    auto txes = makeChainedTransactions(getGenesisKeyPair(), null, 1);
+    auto txes = makeChainedTransactions(WK.Keys.Genesis, null, 1);
     txes.each!(tx => node_1.putTransaction(tx));
 
     nodes.all!(node => node.getBlockHeight() == 1)
@@ -58,7 +58,7 @@ unittest
     auto nodes = network.clients;
     auto node_1 = nodes[0];
 
-    auto txes = makeChainedTransactions(getGenesisKeyPair(), null, 1);
+    auto txes = makeChainedTransactions(WK.Keys.Genesis, null, 1);
     txes.each!(tx => node_1.putTransaction(tx));
 
     nodes.all!(node => node.getBlockHeight() == 1)

--- a/tests/system/source/main.d
+++ b/tests/system/source/main.d
@@ -72,7 +72,7 @@ int main (string[] args)
             assert(height == 0);
         }
 
-        auto kp = getGenesisKeyPair();
+        auto kp = WK.Keys.Genesis;
 
         foreach (idx; 0 .. Block.TxsInBlock)
         {


### PR DESCRIPTION
It is quite obvious in hindsight that the genesis keypair was the first well-known key,
and should be accessible through the same mean.
This will also allow unified lookup for the testing utilities being developed.