### PR TITLE
Set the limit on the validator cycle

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -102,10 +102,6 @@ public class EnrollmentManager
     /// Next height for pre-image revelation
     private Height next_reveal_height;
 
-    /// The period for revealing a preimage
-    /// It is an hour interval if a block is made in every 10 minutes
-    public static immutable uint PreimageRevealPeriod = 6;
-
     /// Validator set managing validators' information such as Enrollment object
     /// enrolled height, and preimages.
     private ValidatorSet validator_set;
@@ -332,7 +328,8 @@ public class EnrollmentManager
 
     public bool getNextPreimage (out PreImageInfo preimage) @safe
     {
-        auto height = Height(this.next_reveal_height + PreimageRevealPeriod * 2);
+        auto height = Height(this.next_reveal_height +
+            ConsensusParams.PreimageRevealPeriod);
         return getPreimage(height, preimage);
     }
 
@@ -453,7 +450,8 @@ public class EnrollmentManager
     {
         auto next_height = this.getNextRevealHeight();
         if (this.next_reveal_height < ulong.max)
-            this.setNextRevealHeight(Height(next_height + PreimageRevealPeriod));
+            this.setNextRevealHeight(Height(next_height +
+                ConsensusParams.PreimageRevealPeriod));
     }
 
     /***************************************************************************

--- a/source/agora/consensus/data/ConsensusParams.d
+++ b/source/agora/consensus/data/ConsensusParams.d
@@ -19,11 +19,17 @@
 
 module agora.consensus.data.ConsensusParams;
 
+import std.format;
+
 /// Ditto
 public immutable class ConsensusParams
 {
     /// The cycle length for a validator
     public uint ValidatorCycle;
+
+    /// The period for revealing a preimage
+    /// It is an hour interval if a block is made in every about 10 minutes
+    public static immutable uint PreimageRevealPeriod = 6;
 
     /***************************************************************************
 
@@ -36,6 +42,9 @@ public immutable class ConsensusParams
 
     public this (uint validator_cycle = 1008)
     {
+        assert(validator_cycle >= PreimageRevealPeriod,
+            format("The validator cycle must be equal to or greater than " ~
+                "`PreimageRevalePeriod`(%d)", PreimageRevealPeriod));
         this.ValidatorCycle = validator_cycle;
     }
 }


### PR DESCRIPTION
We have made the consensus-critical constants set through a parameter in the last sprint. By the way, developers could set the validator cycle to a value smaller than the `RevealPreimagePeriod` value inadvertently, which make the developers not to be able to find the cause of failures about tests of revealing pre-images.

So I set the restriction that the value must be equal to or greater than the validator cycle.