### PR TITLE
Implement stake-based quorum balancer

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -522,6 +522,26 @@ public class EnrollmentManager
         return PublicKey(this.key_pair.V[]);
     }
 
+    /// Returns: true if this validator is currently enrolled
+    public bool isEnrolled (UTXOFinder finder) nothrow @safe
+    {
+        Hash[] utxo_keys;
+        assert(this.validator_set.getEnrolledUTXOs(utxo_keys));
+
+        const PublicKey key = this.getEnrollmentPublicKey();
+        foreach (utxo_key; utxo_keys)
+        {
+            UTXOSetValue value;
+            if (!finder(utxo_key, size_t.max, value))
+                assert(0, "UTXO for validator not found!");  // should never happen
+
+            if (value.output.address == key)
+                return true;
+        }
+
+        return false;
+    }
+
     /***************************************************************************
 
         Get the key for the enrollment data for this node

--- a/source/agora/consensus/Quorum.d
+++ b/source/agora/consensus/Quorum.d
@@ -13,161 +13,418 @@
 
 module agora.consensus.Quorum;
 
+import agora.common.Amount;
+import agora.common.BitField;
 import agora.common.Config;
 import agora.common.crypto.Key;
+import agora.common.Hash;
 import agora.common.Set;
 import agora.common.Types;
 import agora.consensus.data.Enrollment;
+import agora.consensus.data.Transaction;
 import agora.consensus.data.UTXOSetValue;
+import agora.consensus.EnrollmentManager;
+
+import scpd.Cpp;
+import scpd.types.Stellar_SCP;
+import scpd.types.Stellar_types : uint256, NodeID;
+import scpd.types.Utils;
+import scpd.types.XDRBase;
+import scpd.quorum.QuorumTracker;
+
+import ocean.core.Test;
 
 import std.algorithm;
 import std.array;
+import std.conv;
 import std.exception;
 import std.format;
 import std.math;
+import std.random;
 import std.range;
 import std.string;
+import std.typecons;
+
+version (unittest)
+{
+    import agora.utils.Test;
+    import std.stdio;
+}
+
+/// Maximum number of nodes to include in a quorum.
+private enum MAX_NODES_IN_QUORUM = 7;
+
+/// Threshold to use for the quorum configuration (e.g. 0.80 = 80%)
+private enum double THRESHOLD = 0.80;
 
 /*******************************************************************************
 
-    Build the quorum configuration for the given public key and the staked
-    enrollments.
+    Build the quorum configuration for the given public key and the registered
+    enrollment keys.
 
     Params:
-        node_key = the key of the node for which to generate the quorum
-        keys = the array of registered enrollment UTXO keys
+        key = the key of the node for which to generate the quorum
+        utxo_keys = the list of UTXO keys of all the active enrollments
         finder = UTXO finder delegate
-
-    Returns:
-        the generated quorum config
 
 *******************************************************************************/
 
-public QuorumConfig buildQuorumConfig ( const ref PublicKey node_key,
-    in Hash[] keys, in UTXOFinder finder )
+public QuorumConfig buildQuorumConfig ( const ref PublicKey key,
+    in Hash[] utxo_keys, UTXOFinder finder )
 {
-    Set!PublicKey all_nodes = getPublicKeys(keys, finder);
+    // special-case: only 1 validator is active
+    if (utxo_keys.length == 1)
+        return QuorumConfig(1, [key]);
+
+    // not including our own
+    NodeStake[] stakes = buildStakesDescending(key, utxo_keys, finder);
 
     QuorumConfig quorum;
-    all_nodes.each!(node => quorum.nodes ~= node);
-    quorum.nodes.sort();
-    quorum.threshold = quorum.nodes.length;
+    quorum.nodes ~= key;  // add ourself first
 
+    // for filtering duplicates from dice()
+    auto added = BitField!uint(stakes.length);
+    auto RNG_gen = getGenerator(key);
+    auto stake_amounts = stakes.map!(stake => stake.amount.integral);
+
+    // +1 as we already added ourself
+    const MaxNodes = min(stakes.length + 1, MAX_NODES_IN_QUORUM);
+    while (quorum.nodes.length < MaxNodes)
+    {
+        auto idx = dice(RNG_gen, stake_amounts);
+        if (added[idx])  // skip duplicate
+            continue;
+
+        quorum.nodes ~= stakes[idx].key;
+        added[idx] = true;  // mark used
+    }
+
+    quorum.nodes.sort;
+    quorum.threshold = max(1, cast(size_t)ceil(THRESHOLD * quorum.nodes.length));
     return quorum;
+}
+
+/// 1 node
+unittest
+{
+    auto keys = getKeys(1);
+    auto quorums = buildTestQuorums(Amount.MinFreezeAmount.only, keys);
+    verifyQuorumsSanity(quorums);
+    verifyQuorumsIntersect(quorums);
+    test!"=="(countNodeInclusions(quorums, keys), [1]);
+}
+
+// 2 nodes
+unittest
+{
+    auto keys = getKeys(2);
+    auto quorums = buildTestQuorums(Amount.MinFreezeAmount.repeat(2), keys);
+    verifyQuorumsSanity(quorums);
+    verifyQuorumsIntersect(quorums);
+    test!"=="(countNodeInclusions(quorums, keys), [2, 2]);
+}
+
+// 3 nodes with equal stakes
+unittest
+{
+    auto keys = getKeys(3);
+    auto quorums = buildTestQuorums(Amount.MinFreezeAmount.repeat(3), keys);
+    verifyQuorumsSanity(quorums);
+    verifyQuorumsIntersect(quorums);
+    test!"=="(countNodeInclusions(quorums, keys), [3, 3, 3]);
+}
+
+// 4 nodes with equal stakes
+unittest
+{
+    auto keys = getKeys(4);
+    auto quorums = buildTestQuorums(Amount.MinFreezeAmount.repeat(4), keys);
+    verifyQuorumsSanity(quorums);
+    verifyQuorumsIntersect(quorums);
+    test!"=="(countNodeInclusions(quorums, keys), [4, 4, 4, 4]);
+}
+
+// 8 nodes with equal stakes
+unittest
+{
+
+    auto keys = getKeys(8);
+    auto quorums = buildTestQuorums(Amount.MinFreezeAmount.repeat(8), keys);
+    verifyQuorumsSanity(quorums);
+    verifyQuorumsIntersect(quorums);
+    test!"=="(countNodeInclusions(quorums, keys), [8, 5, 8, 8, 8, 8, 7, 4]);
+}
+
+// 16 nodes with equal stakes
+unittest
+{
+    auto keys = getKeys(16);
+    auto quorums = buildTestQuorums(Amount.MinFreezeAmount.repeat(16), keys);
+    verifyQuorumsSanity(quorums);
+    verifyQuorumsIntersect(quorums);
+    test!"=="(countNodeInclusions(quorums, keys),
+        [6, 7, 10, 8, 6, 6, 5, 7, 9, 7, 7, 6, 7, 5, 6, 10]);
+}
+
+// 16 nodes with linearly ascending stakes
+unittest
+{
+    auto amounts = iota(16)
+        .map!(idx => Amount(400000000000uL + (100000000000uL * idx)));
+    auto keys = getKeys(16);
+    auto quorums = buildTestQuorums(amounts, keys);
+    verifyQuorumsSanity(quorums);
+    verifyQuorumsIntersect(quorums);
+    test!"=="(countNodeInclusions(quorums, keys),
+        [2, 3, 8, 3, 7, 6, 4, 10, 6, 8, 8, 9, 8, 9, 13, 8]);
+}
+
+// 16 nodes where two nodes own 66% of the stake
+unittest
+{
+    auto keys = getKeys(16);
+    auto amounts = Amount(400000000000uL).repeat(16).array;
+    amounts[0] = amounts[$ - 1] = Amount(400000000000uL * 14);
+    auto quorums = buildTestQuorums(amounts, keys);
+    verifyQuorumsSanity(quorums);
+    verifyQuorumsIntersect(quorums);
+    test!"=="(countNodeInclusions(quorums, keys),
+        [16, 7, 6, 7, 4, 4, 4, 10, 4, 7, 2, 9, 5, 5, 6, 16]);
+}
+
+// 32 nodes where two nodes own 66% of the stake
+unittest
+{
+    auto keys = getKeys(32);
+    auto amounts = Amount(400000000000uL).repeat(32).array;
+    amounts[0] = amounts[$ - 1] = Amount(400000000000uL * 30);
+    auto quorums = buildTestQuorums(amounts, keys);
+    verifyQuorumsSanity(quorums);
+    // verified to work but disabled because it runs slow with a
+    // non-max threshold (~20 seconds)
+    //verifyQuorumsIntersect(quorums);
+    test!"=="(countNodeInclusions(quorums, keys),
+        [32, 6, 6, 6, 5, 4, 7, 4, 3, 7, 7, 5, 6, 3, 4, 7, 4, 7, 6, 3, 3, 6, 7,
+        4, 3, 5, 6, 7, 5, 11, 3, 32]);
+}
+
+// 64 nodes where two nodes own 66% of the stake
+unittest
+{
+    auto keys = getKeys(64);
+    auto amounts = Amount(400000000000uL).repeat(64).array;
+    amounts[0] = amounts[$ - 1] = Amount(400000000000uL * 62);
+    auto quorums = buildTestQuorums(amounts, keys);
+    verifyQuorumsSanity(quorums);
+    // verified to work but disabled because it runs slow with a
+    // non-max threshold (~20 minutes)
+    //verifyQuorumsIntersect(quorums);
+    test!"=="(countNodeInclusions(quorums, keys),
+        [64, 7, 5, 3, 7, 6, 6, 4, 6, 6, 6, 6, 2, 4, 9, 5, 6, 1, 5, 5, 5, 8, 8,
+        3, 2, 9, 8, 6, 7, 4, 4, 6, 4, 4, 7, 3, 3, 5, 5, 7, 6, 6, 6, 6, 7, 8, 5,
+        4, 4, 4, 5, 2, 2, 6, 3, 6, 5, 5, 7, 3, 3, 7, 4, 63]);
+}
+
+// 128 nodes where two nodes own 66% of the stake
+unittest
+{
+    auto keys = getKeys(128);
+    auto amounts = Amount(400000000000uL).repeat(128).array;
+    amounts[0] = amounts[$ - 1] = Amount(400000000000uL * 126);
+    auto quorums = buildTestQuorums(amounts, keys);
+    verifyQuorumsSanity(quorums);
+    // not verified to work.
+    //verifyQuorumsIntersect(quorums);
+    test!"=="(countNodeInclusions(quorums, keys),
+        [123, 5, 5, 4, 7, 5, 5, 5, 7, 6, 6, 6, 1, 4, 2, 4, 4, 6, 3, 5, 6, 5, 3,
+        6, 6, 3, 3, 7, 8, 5, 5, 10, 4, 6, 5, 4, 7, 5, 5, 6, 6, 3, 4, 8, 6, 3, 6,
+        7, 8, 8, 8, 5, 6, 2, 8, 5, 4, 4, 7, 7, 8, 5, 7, 4, 4, 4, 4, 4, 5, 2, 4,
+        5, 2, 4, 4, 5, 4, 5, 9, 4, 2, 5, 7, 8, 5, 6, 4, 4, 3, 5, 7, 4, 7, 4, 3,
+        3, 6, 6, 8, 5, 4, 6, 8, 5, 3, 6, 4, 8, 5, 6, 4, 6, 7, 2, 7, 4, 5, 6, 7,
+        4, 4, 2, 3, 9, 3, 5, 4, 127]);
+}
+
+version (unittest)
+private const(PublicKey)[] getKeys (size_t count)
+{
+    return WK.Keys.byRange.take(count).map!(kp => kp.address).array;
+}
+
+/// Create a shorthash from a 64-byte blob for RNG initialization
+private ulong toShortHash (const ref PublicKey key) @trusted
+{
+    import libsodium.crypto_shorthash;
+    import std.bitmanip;
+
+    // using a once-generated initialization vector
+    static immutable ubyte[crypto_shorthash_KEYBYTES] IV =
+        [111, 165, 189, 80, 37, 5, 16, 194, 39, 214, 156, 169, 235, 221, 21, 126];
+    ubyte[ulong.sizeof] short_hash;
+    crypto_shorthash(short_hash.ptr, key[].ptr, key[].length, IV.ptr);
+
+    // assume a specific endianess for consistency in how we convert to ulong
+    return littleEndianToNative!ulong(short_hash[]);
 }
 
 ///
 unittest
 {
-    // test various node counts up to 1000 (hard limit)
-    foreach (num_nodes; iota(1, 11).map!(n => min(1000, 2 ^^ n)))
-    {
-        auto data = genTestEnrolls(num_nodes);
-        foreach (key; data.keys)
-        {
-            auto quorum = buildQuorumConfig(key,
-                data.enrolls.map!(enr => enr.utxo_key).array, data.finder);
-            verifyQuorumSanity(quorum);
-            const expected = QuorumConfig(num_nodes, data.keys);
-            assert(quorum == expected,
-                format("Expected: %s. Got: %s", expected, quorum));
-        }
-    }
+    test!"=="(toShortHash(WK.Keys.A.address), 13323068528962985137uL);
+    test!"=="(toShortHash(WK.Keys.B.address), 7384142154118289865uL);
 }
 
 /*******************************************************************************
 
-    For each enrollment find the associated public key,
-    and return the set of keys.
+    Create a random number generator which uses the node's public key as an
+    initializer for the RNG engine.
+
+    Using the Mersene Twister 19937 64-bit random number generator.
+    The public key is reduced to a short hash of 8 bytes which is then
+    used to initialize the RNG generator.
 
     Params
-        utxo_keys = the list of enrollments' UTXO keys
-        finder = UTXO finder delegate
+        key = the public key of a node
 
     Returns:
-        a set of all enrolled public keys
+        a Mersenne Twister 64bit random generator
 
 *******************************************************************************/
 
-private Set!PublicKey getPublicKeys (in Hash[] utxo_keys, in UTXOFinder finder)
+private auto getGenerator (PublicKey key)
 {
-    Set!PublicKey keys;
-    foreach (utxo_key; utxo_keys)
-    {
-        UTXOSetValue value;
-        if (!finder(utxo_key, size_t.max, value))
-            assert(0, "UTXO for validator not found!");  // should never happen
+    Mt19937_64 gen;
+    gen.seed(toShortHash(key));
+    return gen;
+}
 
-        if (value.output.address in keys)  // should never happen
-            assert(0, "Cannot have multiple enrollments for one validator!");
+/// The pair of (key, stake) for each node
+private struct NodeStake
+{
+    /// the node key
+    private PublicKey key;
 
-        keys.put(value.output.address);
-    }
-
-    return keys;
+    /// the node stake
+    private Amount amount;
 }
 
 /*******************************************************************************
 
-    Params:
-        num_enrollments = the number of enrollments to create
+    Build a list of NodeStake's in descending stake order
+
+    Params
+        filter = the node's own key should be filtered here
+        utxo_keys = the list of enrollments' UTXO keys
+        finder = delegate to find the public key & stake of each UTXO key
 
     Returns:
-        a tuple of (Enrollment[], UTXOFinder)
+        the list of stakes in descending stake order
+
+*******************************************************************************/
+
+private NodeStake[] buildStakesDescending (const ref PublicKey filter,
+    in Hash[] utxo_keys, UTXOFinder finder) nothrow
+{
+    static NodeStake[] stakes;
+    stakes.length = 0;
+    assumeSafeAppend(stakes);
+
+    foreach (utxo_key; utxo_keys)
+    {
+        UTXOSetValue value;
+        assert(finder(utxo_key, size_t.max, value),
+            "UTXO for validator not found!");
+
+        if (value.output.address != filter)
+            stakes ~= NodeStake(value.output.address, value.output.value);
+    }
+
+    stakes.sort!((a, b) => a.amount > b.amount);
+    return stakes;
+}
+
+/*******************************************************************************
+
+    Build the quorum configs for the given enrollments and range of seeds,
+    and return a map of the number of times each node was included in
+    another node's quorum set.
+
+    Returns:
+        the map of generated quorum configs
 
 *******************************************************************************/
 
 version (unittest)
-private auto genTestEnrolls (size_t num_enrollments)
+private QuorumConfig[PublicKey] buildTestQuorums (Range)(Range amounts,
+    const(PublicKey)[] keys)
 {
-    struct Result
-    {
-        PublicKey[] keys;
-        Enrollment[] enrolls;
-        UTXOFinder finder;
-    }
-
-    import agora.common.Amount;
-    import agora.consensus.data.Transaction;
-
+    assert(amounts.length == keys.length);
+    QuorumConfig[PublicKey] quorums;
     TestUTXOSet storage = new TestUTXOSet;
-    KeyPair[] key_pairs = num_enrollments.iota.map!(x => KeyPair.random()).array;
-
-    foreach (idx; 0 .. num_enrollments)
+    foreach (idx, const ref amount; amounts.save.enumerate)
     {
         Transaction tx =
         {
             type : TxType.Freeze,
-            outputs: [Output(Amount.MinFreezeAmount, key_pairs[idx].address)]
+            outputs: [Output(amount, keys[idx])]
         };
 
         storage.put(tx);
     }
 
-    Enrollment[] enrolls;
-    foreach (utxo; storage.keys)
+    Hash[] utxos = storage.keys;
+    foreach (idx, _; amounts.enumerate)
     {
-        const Enrollment enroll =
-        {
-            utxo_key : utxo,
-            cycle_length : 1008
-        };
-
-        enrolls ~= enroll;
+        quorums[keys[idx]] = buildQuorumConfig(
+            keys[idx], utxos, &storage.findUTXO);
     }
 
-    // cast: we need a mutable so we can sort
-    PublicKey[] keys = key_pairs.map!(k => cast()k.address).array;
-    keys.sort();
-    return Result(keys, enrolls, &storage.findUTXO);
+    return quorums;
 }
 
 /*******************************************************************************
 
-    Verify that the provided quorum configuration is considered sane by SCP.
+    For each node count the number of times it has been included in
+    each quorum configuration.
 
     Params:
-        quorum = the quorum config
+        quorums = the generated quorums
+        keys = the keys we want to look up. Used separately from the ones in
+            'quorums' to make it easy to test assumed key positions
+            [WK.Keys.A, WK.Keys.B], etc.
+
+    Returns:
+        the count of each node's inclusion in quorum sets,
+        where the index matches the 'keys' array.
+
+*******************************************************************************/
+
+version (unittest)
+private size_t[] countNodeInclusions (QuorumConfig[PublicKey] quorums,
+    const ref PublicKey[] keys)
+{
+    size_t[const(PublicKey)] counts;
+    foreach (_, const ref qc; quorums)
+        qc.nodes.each!(node => counts[node]++);
+
+    size_t[] results;
+    foreach (key; keys)
+    {
+        assert(key in counts);
+        results ~= counts[key];
+    }
+
+    return results;
+}
+
+/*******************************************************************************
+
+    Verify that the provided quorum sets are considered sane by SCP.
+
+    The quorums are checked both pre and post-normalization,
+    with extra safety checks enabled.
+
+    Params:
+        quorums = the quorum maps to verify
 
     Throws:
         an Exception if the quorum is not considered sane by SCP.
@@ -175,19 +432,59 @@ private auto genTestEnrolls (size_t num_enrollments)
 *******************************************************************************/
 
 version (unittest)
-private void verifyQuorumSanity (const ref QuorumConfig quorum)
+private void verifyQuorumsSanity (const ref QuorumConfig[PublicKey] quorums)
 {
     import scpd.scp.QuorumSetUtils;
-    auto scp_quorum = toSCPQuorumSet(quorum);
 
-    const bool ExtraChecks = true;
-    const(char)* fail_reason;
-    enforce(isQuorumSetSane(scp_quorum, ExtraChecks, &fail_reason),
-        format("Quorum %s fails sanity check before normalization: %s",
-                quorum, fail_reason.fromStringz));
+    foreach (key, quorum; quorums)
+    {
+        auto scp_quorum = toSCPQuorumSet(quorum);
+        const bool ExtraChecks = true;
+        const(char)* fail_reason;
+        enforce(isQuorumSetSane(scp_quorum, ExtraChecks, &fail_reason),
+            format("Quorum %s fails sanity check before normalization: %s",
+                    quorum, fail_reason.fromStringz));
 
-    normalizeQSet(scp_quorum);
-    enforce(isQuorumSetSane(scp_quorum, ExtraChecks, &fail_reason),
-        format("Quorum %s fails sanity check after normalization: %s",
-                quorum, fail_reason.fromStringz));
+        normalizeQSet(scp_quorum);
+        enforce(isQuorumSetSane(scp_quorum, ExtraChecks, &fail_reason),
+            format("Quorum %s fails sanity check after normalization: %s",
+                    quorum, fail_reason.fromStringz));
+    }
+}
+
+/*******************************************************************************
+
+    Verify that all the quorums intersect according to the quorum checker
+    routines designed by Stellar
+
+    Params:
+        quorums = the quorums to check
+
+*******************************************************************************/
+
+version (unittest):
+version (Windows)
+private void verifyQuorumsIntersect (QuorumConfig[PublicKey] quorums)
+{
+    // @bug@: Need to fix linking issues with QuorumIntersectionChecker.create()
+}
+else
+private void verifyQuorumsIntersect (QuorumConfig[PublicKey] quorums)
+{
+    import scpd.quorum.QuorumIntersectionChecker;
+
+    auto qm = QuorumTracker.QuorumMap.create();
+    foreach (key, quorum; quorums)
+    {
+        auto scp = toSCPQuorumSet(quorum);
+        auto scp_quorum = makeSharedSCPQuorumSet(scp);
+        auto scp_key = NodeID(uint256(key));
+        qm[scp_key] = scp_quorum;
+    }
+
+    auto qic = QuorumIntersectionChecker.create(qm);
+    assert(qic.networkEnjoysQuorumIntersection());
+
+    auto splits = qic.getPotentialSplit();
+    assert(splits.first.length == 0 && splits.second.length == 0);
 }

--- a/source/agora/consensus/Quorum.d
+++ b/source/agora/consensus/Quorum.d
@@ -77,35 +77,6 @@ unittest
 
 /*******************************************************************************
 
-    Verify that the provided quorum configuration is considered sane by SCP.
-
-    Params:
-        quorum = the quorum config
-
-    Throws:
-        an Exception if the quorum is not considered sane by SCP.
-
-*******************************************************************************/
-
-private void verifyQuorumSanity (const ref QuorumConfig quorum)
-{
-    import scpd.scp.QuorumSetUtils;
-    auto scp_quorum = toSCPQuorumSet(quorum);
-
-    const bool ExtraChecks = true;
-    const(char)* fail_reason;
-    enforce(isQuorumSetSane(scp_quorum, ExtraChecks, &fail_reason),
-        format("Quorum %s fails sanity check before normalization: %s",
-                quorum, fail_reason.fromStringz));
-
-    normalizeQSet(scp_quorum);
-    enforce(isQuorumSetSane(scp_quorum, ExtraChecks, &fail_reason),
-        format("Quorum %s fails sanity check after normalization: %s",
-                quorum, fail_reason.fromStringz));
-}
-
-/*******************************************************************************
-
     For each enrollment find the associated public key,
     and return the set of keys.
 
@@ -189,4 +160,34 @@ private auto genTestEnrolls (size_t num_enrollments)
     PublicKey[] keys = key_pairs.map!(k => cast()k.address).array;
     keys.sort();
     return Result(keys, enrolls, &storage.findUTXO);
+}
+
+/*******************************************************************************
+
+    Verify that the provided quorum configuration is considered sane by SCP.
+
+    Params:
+        quorum = the quorum config
+
+    Throws:
+        an Exception if the quorum is not considered sane by SCP.
+
+*******************************************************************************/
+
+version (unittest)
+private void verifyQuorumSanity (const ref QuorumConfig quorum)
+{
+    import scpd.scp.QuorumSetUtils;
+    auto scp_quorum = toSCPQuorumSet(quorum);
+
+    const bool ExtraChecks = true;
+    const(char)* fail_reason;
+    enforce(isQuorumSetSane(scp_quorum, ExtraChecks, &fail_reason),
+        format("Quorum %s fails sanity check before normalization: %s",
+                quorum, fail_reason.fromStringz));
+
+    normalizeQSet(scp_quorum);
+    enforce(isQuorumSetSane(scp_quorum, ExtraChecks, &fail_reason),
+        format("Quorum %s fails sanity check after normalization: %s",
+                quorum, fail_reason.fromStringz));
 }

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -91,6 +91,9 @@ public class Validator : FullNode, API
     {
         try
         {
+            if (!this.enroll_man.isEnrolled(this.utxo_set.getUTXOFinder()))
+                return;
+
             this.qc = this.rebuildQuorumConfig();
             this.nominator.setQuorumConfig(this.qc);
             buildRequiredKeys(this.config.node.key_pair.address, this.qc,
@@ -212,6 +215,9 @@ public class Validator : FullNode, API
 
     protected final override void onAcceptedTransaction () @safe
     {
+        if (!this.enroll_man.isEnrolled(this.utxo_set.getUTXOFinder()))
+            return;  // nothing to do, we're not an active validator
+
         // check if there's enough txs in the pool, and start nominating
         this.nominator.tryNominate();
     }

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -1,7 +1,7 @@
 /*******************************************************************************
 
-    Verify that expired enrollments and newly added enrollments change
-    the quorum set configuration of a node.
+    Contains various quorum tests, adding and expiring enrollments,
+    making a network with many validators, etc.
 
     Copyright:
         Copyright (c) 2020 BOS Platform Foundation Korea
@@ -156,4 +156,46 @@ unittest
         retryFor(node.getBlockHeight() == 11, 10.seconds,
             format("Node %s has block height %s. Expected: %s",
                 idx, node.getBlockHeight(), 11)));
+}
+
+/// 16 nodes
+version (none)  // disabled due to scaling issues
+unittest
+{
+    TestConf conf = { nodes : 16, timeout : 10_000 };
+    auto network = makeTestNetwork(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[0];
+
+    auto txes = makeChainedTransactions(WK.Keys.Genesis, null, 1);
+    txes.each!(tx => node_1.putTransaction(tx));
+
+    nodes.all!(node => node.getBlockHeight() == 1)
+        .retryFor(4.seconds);
+}
+
+/// 32 nodes
+version (none)  // disabled due to scaling issues
+unittest
+{
+    TestConf conf = { nodes : 32, timeout : 10_000 };
+    auto network = makeTestNetwork(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[0];
+
+    auto txes = makeChainedTransactions(WK.Keys.Genesis, null, 1);
+    txes.each!(tx => node_1.putTransaction(tx));
+
+    nodes.all!(node => node.getBlockHeight() == 1)
+        .retryFor(8.seconds);
 }


### PR DESCRIPTION
This is the second part of #240, and it implements #963.

There may be further plans to refine the algorithm:

- Take the preimages into account. This should be fairly simple, we will just add it as a second parameter to `getGenerator()`. However there are no mechanisms in place right now to retrieve preimages of all validators at a specific height.
- Take the history of the validator's performance into account. This could be a form of "score", a combination of the node's stake + historical voting data in the blockchain.

Fixes #963