### PR TITLE
Fix segfault in `sendPreimage` function

### DIFF
--- a/source/agora/network/NetworkClient.d
+++ b/source/agora/network/NetworkClient.d
@@ -318,7 +318,7 @@ class NetworkClient
 
     ***************************************************************************/
 
-    public void sendPreimage (ref PreImageInfo preimage) @trusted
+    public void sendPreimage (PreImageInfo preimage) @trusted
     {
         this.taskman.runTask(
         {


### PR DESCRIPTION
The original code causes a segfault error because the `preimage` parameter has a `ref` modifier and the D compiler does not allocate memory for the parameter. So the `preimage` is corrupted after the fiber having called the delegate terminates. So the `ref` modifier must be removed at the moment.