### PR TITLE
Trivial: Remove double semicolon in test

### DIFF
--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -749,7 +749,7 @@ unittest
         {
             tx.type = TxType.Payment;
             foreach (_; 0 .. Block.TxsInBlock)
-                tx.outputs ~= Output(Amount(100), keypair.address);;
+                tx.outputs ~= Output(Amount(100), keypair.address);
         }
 
         tx.inputs[0].signature = gen_key.secret.sign(hashFull(tx)[]);


### PR DESCRIPTION
This triggers a deprecation message