### PR TITLE
Allow enrollments to be present in the same block as the freezing transaction

### DIFF
--- a/source/agora/consensus/data/UTXOSetValue.d
+++ b/source/agora/consensus/data/UTXOSetValue.d
@@ -107,7 +107,7 @@ version (unittest) public class TestUTXOSet
     }
 
     /// Short hand to add a transaction
-    public void put (const Transaction tx)
+    public void put (const Transaction tx) nothrow @safe
     {
         Hash txhash = hashFull(tx);
         foreach (size_t idx, ref output_; tx.outputs)

--- a/source/agora/consensus/data/UTXOSetValue.d
+++ b/source/agora/consensus/data/UTXOSetValue.d
@@ -69,7 +69,7 @@ public struct UTXOSetValue
 
 *******************************************************************************/
 
-version (unittest) public class TestUTXOSet
+public class TestUTXOSet
 {
     ///
     public UTXOSetValue[Hash] storage;


### PR DESCRIPTION
This was never really specified, but it makes sense to allow it considering our recent work.
Since it's needed to fix (along with another PR) #907 and there's little time left for the demo, the implementation isn't great but works well enough.