### PR TITLE
Nominate enrollments using `avail_height` on the `enrollment_pool` table

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -428,7 +428,8 @@ public class FullNode : API
     {
         log.trace("Received Enrollment: {}", prettify(enroll));
 
-        if (this.enroll_man.pool.add(enroll, this.utxo_set.getUTXOFinder()))
+        if (this.enroll_man.addEnrollment(enroll, this.ledger.getBlockHeight(),
+            this.utxo_set.getUTXOFinder()))
         {
             this.network.sendEnrollment(enroll);
         }

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -438,9 +438,7 @@ public class FullNode : API
     /// GET: /enrollment
     public override Enrollment getEnrollment (Hash enroll_hash) @safe
     {
-        Enrollment enroll;
-        this.enroll_man.pool.getEnrollment(enroll_hash, enroll);
-        return enroll;
+        return this.enroll_man.getEnrollment(enroll_hash);
     }
 
     /// PUT: /receive_preimage

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -1025,7 +1025,7 @@ unittest
 
     auto findUTXO = ledger.utxo_set.getUTXOFinder();
     foreach (const ref e; enrollments)
-        assert(ledger.enroll_man.pool.add(e, findUTXO));
+        assert(ledger.enroll_man.pool.add(e, Height(3), findUTXO));
 
     Enrollment stored_enroll;
     foreach (idx, hash; utxo_hashes)

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -308,7 +308,7 @@ public class Ledger
 
         foreach (idx, ref enrollment; block.header.enrollments)
         {
-            this.enroll_man.pool.remove(enrollment.utxo_key);
+            this.enroll_man.removeEnrollment(enrollment.utxo_key);
 
             if (auto r = this.enroll_man.addValidator(enrollment,
                 block.header.height, this.utxo_set.getUTXOFinder()))
@@ -1025,12 +1025,12 @@ unittest
 
     auto findUTXO = ledger.utxo_set.getUTXOFinder();
     foreach (const ref e; enrollments)
-        assert(ledger.enroll_man.pool.add(e, Height(3), findUTXO));
+        assert(ledger.enroll_man.addEnrollment(e, Height(3), findUTXO));
 
     Enrollment stored_enroll;
     foreach (idx, hash; utxo_hashes)
     {
-        assert(ledger.enroll_man.pool.getEnrollment(hash, stored_enroll));
+        stored_enroll = ledger.enroll_man.getEnrollment(hash);
         assert(stored_enroll == enrollments[idx]);
     }
 


### PR DESCRIPTION
I added the `avail_height` column into the `EnrollmentPool` in order to check if an enrollment can be a validator. If even the enrollment had been promoted as a validator, it can be used as the request to be a validator in the next cycle. So the `getEnrollments` function can select the enrollments which can be a validator for the next block with the `avail_height` and the height passed in as a parameter.

When the `getEnrollments` is called, it uses the `avail_height` column to get the right enrollments at the current block height. The rule is as follows.
1) If the `enrolled_height` of an enrollment is greater than the `avail_height`, we do not return the enrollment.
2) If the current height(the height for which we are nominating minus 1) is smaller than the `avail_height`, we do not return the enrollment.

Relates to #900 