### PR TITLE
Change ConsensusData to take an array of Transaction

### DIFF
--- a/source/agora/consensus/data/ConsensusData.d
+++ b/source/agora/consensus/data/ConsensusData.d
@@ -13,7 +13,6 @@
 
 module agora.consensus.data.ConsensusData;
 
-import agora.common.Set;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
 
@@ -21,7 +20,7 @@ import agora.consensus.data.Transaction;
 public struct ConsensusData
 {
     /// The transaction set that is being nominated / voted on
-    public Set!Transaction tx_set;
+    public Transaction[] tx_set;
 
     /// The enrollments that are being nominated / voted on
     public Enrollment[] enrolls;
@@ -45,23 +44,17 @@ unittest
     Signature sig = Signature("0x000000000000000000016f605ea9638d7bff58d2c0c" ~
                               "c2467c18e38b36367be78000000000000000000016f60" ~
                               "5ea9638d7bff58d2c0cc2467c18e38b36367be78");
-    Enrollment record = {
+    const Enrollment record = {
         utxo_key: key,
         random_seed: seed,
         cycle_length: 1008,
         enroll_sig: sig,
     };
 
-    Enrollment[] enrollments;
-    enrollments ~= record;
-    enrollments ~= record;
-
-    auto tx_set = Set!Transaction.from([cast(Transaction)GenesisTransaction]);
-
-    ConsensusData data =
+    const(ConsensusData) data =
     {
-        tx_set: tx_set,
-        enrolls: enrollments,
+        tx_set:  GenesisBlock.txs,
+        enrolls: [ record, record, ],
     };
 
     testSymmetry(data);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -167,8 +167,7 @@ public class Ledger
     public bool onExternalized (ConsensusData data)
         @trusted
     {
-        auto block = makeNewBlock(this.last_block, data.tx_set.byKey(),
-            data.enrolls);
+        auto block = makeNewBlock(this.last_block, data.tx_set, data.enrolls);
         return this.acceptBlock(block);
     }
 
@@ -343,10 +342,13 @@ public class Ledger
             if (auto reason = tx.isInvalidReason(utxo_finder, next_height))
                 log.trace("Rejected invalid ('{}') tx: {}", reason, tx);
             else
-                data.tx_set.put(tx);
+                data.tx_set ~= tx;
 
             if (data.tx_set.length >= Block.TxsInBlock)
+            {
+                data.tx_set.sort();
                 return;
+            }
         }
 
         // not enough txs were found

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -450,7 +450,7 @@ private struct ConsensusDataFmt
         try
         {
             formattedWrite(sink, "{ tx_set: %s, enrolls: %s }",
-                this.data.tx_set.byKey().map!(tx => TransactionFmt(tx)),
+                this.data.tx_set.map!(tx => TransactionFmt(tx)),
                 this.data.enrolls.map!(enroll => EnrollmentFmt(enroll)));
         }
         catch (Exception ex)
@@ -480,7 +480,7 @@ unittest
     Signature sig = Signature("0x000000000000000000016f605ea9638d7bff58d2c0c" ~
                               "c2467c18e38b36367be78000000000000000000016f60" ~
                               "5ea9638d7bff58d2c0cc2467c18e38b36367be78");
-    Enrollment record =
+    const Enrollment record =
     {
         utxo_key: key,
         random_seed: seed,
@@ -488,19 +488,15 @@ unittest
         enroll_sig: sig,
     };
 
-    Enrollment[] enrollments;
-    enrollments ~= record;
-    enrollments ~= record;
-
-    auto tx_set = Set!Transaction.from([cast(Transaction)GenesisTransaction]);
-
-    ConsensusData cd =
+    const(ConsensusData) cd =
     {
-        tx_set: tx_set,
-        enrolls: enrollments,
+        tx_set: GenesisBlock.txs,
+        enrolls: [ record, record, ],
     };
 
-    static immutable Res1 = `{ tx_set: [Type : Payment, Inputs: None
+    static immutable Res1 = `{ tx_set: [Type : Freeze, Inputs: None
+Outputs (6): GDNO...LVHQ(2,000,000), GDNO...EACM(2,000,000), GDNO...OSNY(2,000,000),
+GDNO...JQC2(2,000,000), GDNO...T6GH(2,000,000), GDNO...IX2U(2,000,000), Type : Payment, Inputs: None
 Outputs (8): GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000),
 GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000),
 GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000)], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }] }`;

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -389,7 +389,7 @@ unittest
     Signature sig = Signature("0x000000000000000000016f605ea9638d7bff58d2c0c" ~
                               "c2467c18e38b36367be78000000000000000000016f60" ~
                               "5ea9638d7bff58d2c0cc2467c18e38b36367be78");
-    Enrollment record =
+    const Enrollment record =
     {
         utxo_key: key,
         random_seed: seed,
@@ -397,16 +397,10 @@ unittest
         enroll_sig: sig,
     };
 
-    Enrollment[] enrollments;
-    enrollments ~= record;
-    enrollments ~= record;
-
-    auto tx_set = Set!Transaction.from([cast(Transaction)GenesisTransaction]);
-
-    ConsensusData cd =
+    const(ConsensusData) cd =
     {
-        tx_set: tx_set,
-        enrolls: enrollments,
+        tx_set:  GenesisBlock.txs[1 .. $],
+        enrolls: [ record, record, ],
     };
 
     SCPBallot ballot;


### PR DESCRIPTION
Using a set was a bit surprising, and didn't compose well with qualifiers,
e.g. we had to cast away constness and immutability.
Using an array is a bit more natural and ensures that `ConsensusData`
can be qualified.