### PR TITLE
EnrollmentManager: Remove buggy call to setEnrollmentKey

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -271,8 +271,6 @@ public class EnrollmentManager
     public bool createEnrollment (Hash frozen_utxo_hash, Height height,
         out Enrollment enroll) @trusted nothrow
     {
-        static ubyte[] buffer;
-
         // K, frozen UTXO hash
         this.data.utxo_key = frozen_utxo_hash;
         this.enroll_key = frozen_utxo_hash;


### PR DESCRIPTION
```
This call is obviously wrong: it uses 'enroll' as a parameter,
which at this point is default-initialized.
So if an enrollment exists, the update would overwrite valid data
with all default-initialized data (most likely all 0).
After removing this wrong call, the 'setEnrollmentKey' function
is left unused, and thus was removed, without any effect on the tests.
```

Packed a small commit with it as will to avoid the double CI time.