### PR TITLE
Tests: Move 'ValidatorCycle' argument to TestConf

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -847,6 +847,9 @@ public struct TestConf
     /// Number of nodes to instantiate
     size_t nodes = 4;
 
+    /// The value to give the `ValidatorCycle` of nodes
+    uint validator_cycle = 1008;
+
     /// whether to set up the peers in the config
     bool configure_network = true;
 
@@ -888,7 +891,7 @@ public struct TestConf
 *******************************************************************************/
 
 public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)(
-    in TestConf test_conf, immutable(ConsensusParams) params = null)
+    in TestConf test_conf)
 {
     import agora.common.Serializer;
     import std.digest;
@@ -900,9 +903,6 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
     std.concurrency.scheduler = null;
 
     assert(test_conf.nodes >= 2, "Creating a network require at least 2 nodes");
-
-    immutable cons_params =
-        (params !is null) ? params : new immutable(ConsensusParams)();
 
     size_t full_node_idx;
     size_t validator_idx;
@@ -925,7 +925,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             retry_delay : test_conf.retry_delay, // msecs
             max_retries : test_conf.max_retries,
             timeout : test_conf.timeout,
-            validator_cycle : cons_params.ValidatorCycle,
+            validator_cycle : test_conf.validator_cycle,
             min_listeners : test_conf.min_listeners == 0
                 ? test_conf.nodes - 1 : test_conf.min_listeners,
             max_listeners : (test_conf.max_listeners == 0)
@@ -1048,7 +1048,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
         node_configs
             .filter!(conf => conf.is_validator)
             .map!(conf => conf.key_pair)
-            .array, cons_params.ValidatorCycle);
+            .array, test_conf.validator_cycle);
 
     immutable string gen_block_hex = gen_block
         .serializeFull()

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -33,7 +33,7 @@ import core.time;
 /// test for enrollment process & revealing a pre-image periodically
 unittest
 {
-    // generate 1007 blocks, 1 short of the enrollments expiring.
+    // generate 9 blocks, 1 short of the enrollments expiring.
     immutable validator_cycle = 10;
     TestConf conf = {
         validator_cycle : validator_cycle,

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -34,10 +34,12 @@ import core.time;
 unittest
 {
     // generate 1007 blocks, 1 short of the enrollments expiring.
-    auto validator_cycle = 10;
-    auto params = new immutable(ConsensusParams)(validator_cycle);
-    TestConf conf = { extra_blocks : validator_cycle - 1 };
-    auto network = makeTestNetwork(conf, params);
+    immutable validator_cycle = 10;
+    TestConf conf = {
+        validator_cycle : validator_cycle,
+        extra_blocks : validator_cycle - 1,
+    };
+    auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
@@ -100,12 +102,13 @@ unittest
 // Test for re-enroll before the validator cycle ends
 unittest
 {
-    // Boilerplate
-    const validator_cycle = 20;
-    const current_height = validator_cycle - 5;
-    auto params = new immutable(ConsensusParams)(validator_cycle);
-    TestConf conf = { extra_blocks : current_height };
-    auto network = makeTestNetwork(conf, params);
+    immutable validator_cycle = 20;
+    immutable current_height = validator_cycle - 5;
+    TestConf conf = {
+        validator_cycle : validator_cycle,
+        extra_blocks : current_height,
+    };
+    auto network = makeTestNetwork(conf);
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
     network.start();

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -39,11 +39,14 @@ import core.time;
 ///
 unittest
 {
-    auto validator_cycle = 10;
-    auto params = new immutable(ConsensusParams)(validator_cycle);
-    TestConf conf = { nodes : 4, max_listeners : 5,
-        topology : NetworkTopology.TwoOutsiderValidators, validator_cycle - 2 };
-    auto network = makeTestNetwork(conf, params);
+    TestConf conf = {
+        nodes : 4,
+        max_listeners : 5,
+        topology : NetworkTopology.TwoOutsiderValidators,
+        validator_cycle : 10,
+        extra_blocks: 10 - 2,
+    };
+    auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();

--- a/source/agora/test/ValidatorCount.d
+++ b/source/agora/test/ValidatorCount.d
@@ -31,10 +31,11 @@ import core.thread;
 /// ditto
 unittest
 {
-    auto validator_cycle = 20;
-    auto params = new immutable(ConsensusParams)(validator_cycle);
-
-    auto network = makeTestNetwork(TestConf.init, params);
+    immutable validator_cycle = 20;
+    const TestConf conf = {
+        validator_cycle : validator_cycle,
+    };
+    auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();


### PR DESCRIPTION
This allows the configuration to be much more seamless,
and consistent accross the tests.