### PR TITLE
Don't process SCP messages if we're not enrolled

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -215,6 +215,10 @@ public class Validator : FullNode, API
 
     public override void receiveEnvelope (SCPEnvelope envelope) @safe
     {
+        // we're not enrolled and don't care about messages
+        if (!this.enroll_man.isEnrolled(this.utxo_set.getUTXOFinder()))
+            return;
+
         this.nominator.receiveEnvelope(envelope);
     }
 


### PR DESCRIPTION
This would result in error logs with "Rejected invalid SCP envelope" because the hash of the message was unknown to the receiver as the receiver has not generated any quorum configs when they are not enrolled. 

See #1018 