### PR TITLE
Work around hashmap invalidation issue (+ small race condition fix)

### DIFF
--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -114,6 +114,16 @@ public class NetworkManager
             this.address = address;
             this.onHandshakeComplete = onHandshakeComplete;
             this.onFailedRequest = onFailedRequest;
+        }
+
+        /***********************************************************************
+
+            Start the connection task
+
+        ***********************************************************************/
+
+        public void start ()
+        {
             this.outer.taskman.runTask(&this.connect);
         }
 
@@ -432,6 +442,7 @@ public class NetworkManager
                 this.todo_addresses.remove(address);
                 this.connection_tasks[address] = new ConnectionTask(
                     address, &onHandshakeComplete, &onFailedRequest);
+                this.connection_tasks[address].start();
             }
         }
     }


### PR DESCRIPTION
A better fix would be to use the `schedule` primitive as @Geod24 mentioned. But it's not implemented in vibe.d. We'll have to properly fix this later.

-----

Also I caught the second bug (fixed by second commit) by chance. The only bad side of the second bug is that the connection task would remain in the hashmap because `map.remove` could be called before `map[key] =`, so it is of no consequence really.
