### PR TITLE
Cherry-pick commits from 798: Restore a node's Enrollment data

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -145,6 +145,9 @@ public class Ledger
             block_count >= this.params.ValidatorCycle
             ? Height(block_count - this.params.ValidatorCycle) : Height(0);
 
+        PublicKey pubkey = this.enroll_man.getEnrollmentPublicKey();
+        UTXOSetValue[Hash] utxos = this.utxo_set.getUTXOs(pubkey);
+
         // restore validator set from the blockchain.
         // using block_count, as the range is inclusive
         foreach (block_idx; min_height .. block_count)
@@ -152,7 +155,7 @@ public class Ledger
             Block block;
             this.storage.readBlock(block, block_idx);
             this.enroll_man.restoreValidators(this.last_block.header.height,
-                block, this.utxo_set.getUTXOFinder());
+                block, this.utxo_set.getUTXOFinder(), utxos);
         }
     }
 
@@ -310,8 +313,10 @@ public class Ledger
         {
             this.enroll_man.removeEnrollment(enrollment.utxo_key);
 
+            PublicKey pubkey = this.enroll_man.getEnrollmentPublicKey();
+            UTXOSetValue[Hash] utxos = this.utxo_set.getUTXOs(pubkey);
             if (auto r = this.enroll_man.addValidator(enrollment,
-                block.header.height, this.utxo_set.getUTXOFinder()))
+                block.header.height, this.utxo_set.getUTXOFinder(), utxos))
             {
                 log.fatal("Error while adding a new validator: {}", r);
                 log.fatal("Enrollment #{}: {}", idx, enrollment);

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1117,6 +1117,19 @@ public bool containSameBlocks (APIS)(APIS nodes, size_t height)
     return true;
 }
 
+/// Asserts that all nodes in the range are at height `expected`
+public void ensureConsistency (APIS)(
+    APIS nodes, ulong expected, Duration timeout = 2.seconds)
+    if (isInputRange!APIS)
+{
+    foreach (idx, node; nodes.enumerate())
+    {
+        retryFor(node.getBlockHeight() == expected, timeout,
+                 format("Node #%d was at height %d (expected: %d)",
+                        idx, node.getBlockHeight(), expected));
+    }
+}
+
 
 /*******************************************************************************
 


### PR DESCRIPTION
This merges a few commit together. Changes are:
- Style fixes (doc / ordering);
- Splitting the refactoring off the main commit;
- Merged the test with the actual fix;
- Remove default parameter for `populate`;