### PR TITLE
Make BlockStorage.load accept a genesis block as input

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -112,7 +112,7 @@ public class Ledger
         this.enroll_man = enroll_man;
         this.pool = pool;
         this.onValidatorsChanged = onValidatorsChanged;
-        if (!this.storage.load())
+        if (!this.storage.load(GenesisBlock))
             assert(0);
 
         // ensure latest checksum can be read

--- a/tests/unit/BlockStorage.d
+++ b/tests/unit/BlockStorage.d
@@ -40,7 +40,7 @@ private void main ()
     Hash[] block_hashes;
 
     blocks ~= GenesisBlock;
-    assert(storage.load());
+    assert(storage.load(GenesisBlock));
 
     const Transaction last_tx = blocks[$ - 1].txs[$-1];
     Hash gen_tx_hash = hashFull(last_tx);
@@ -99,7 +99,7 @@ private void main ()
 
     //  Verify index data that is already stored.
     BlockStorage other = new BlockStorage(path);
-    other.load();
+    other.load(GenesisBlock);
 
     foreach (height; iota(count).randomCover(rnd))
     {

--- a/tests/unit/BlockStorageMultiTx.d
+++ b/tests/unit/BlockStorageMultiTx.d
@@ -41,7 +41,7 @@ private void main ()
     auto path = makeCleanTempDir();
 
     BlockStorage storage = new BlockStorage(path);
-    storage.load();
+    storage.load(GenesisBlock);
     const(Block)[] blocks;
     blocks ~= GenesisBlock;
 


### PR DESCRIPTION
This remove the dependency on the global 'GenesisBlock' function.