### PR TITLE
Avoid nominating with duplicated Enrollments

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -422,6 +422,37 @@ public class EnrollmentManager
 
     /***************************************************************************
 
+        Check if an enrollment is a valid candidate for the proposed height
+
+        Params:
+            enroll = The enrollment of the target to be checked
+            height = the height of proposed block
+            findUTXO = delegate to find the referenced unspent UTXOs with
+
+        Returns:
+            `null` if the enrollment can be a validator at the proposed height,
+            otherwise a string explaining the reason it is invalid.
+
+    ***************************************************************************/
+
+    public string isInvalidCandidateReason (const ref Enrollment enroll,
+        Height height, scope UTXOFinder findUTXO) @safe nothrow
+    {
+        if (auto fail_reason = enroll.isInvalidReason(findUTXO))
+            return fail_reason;
+
+        const enrolled = this.validator_set.getEnrolledHeight(enroll.utxo_key);
+        if (enrolled != ulong.max &&
+            height < (enrolled + this.params.ValidatorCycle))
+        {
+            return "Enrollment: Duplicated enrollments";
+        }
+
+        return null;
+    }
+
+    /***************************************************************************
+
         Clear up expired validators whose cycle for a validator ends
 
         The enrollment manager clears up expired validators from the set based

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -231,7 +231,7 @@ extern(D):
 
     ***************************************************************************/
 
-    private void nominate (ulong slot_idx, ConsensusData next) @trusted
+    protected void nominate (ulong slot_idx, ConsensusData next) @trusted
     {
         log.info("{}(): Proposing tx set for slot {}", __FUNCTION__, slot_idx);
 

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -398,10 +398,9 @@ public class Ledger
 
         foreach (enroll; data.enrolls)
         {
-            if (auto fail_reason = enroll.isInvalidReason(utxo_finder))
-            {
+            if (auto fail_reason = this.enroll_man.isInvalidCandidateReason(
+                enroll, expect_height, utxo_finder))
                 return fail_reason;
-            }
         }
 
         return null;


### PR DESCRIPTION
If a block is nominated with duplicated Enrollments, we must reject the block with checking that the Enrollments are valid candidates for the proposed block. I create a bad nominator and make it create duplicated enrollments for a network test in this pull request, 

Next time, I will submit another PR checking the result of `Ledger.prepareNominatingSet`.

Relates #900 