### PR TITLE
Add BlockExternalized and PreImageReceived handler events to Agora

### DIFF
--- a/source/agora/api/handler/BlockExternalizedHandler.d
+++ b/source/agora/api/handler/BlockExternalizedHandler.d
@@ -1,0 +1,38 @@
+/*******************************************************************************
+
+    Definitions of the BlockExternalizedHandler
+
+    Copyright:
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.api.handler.BlockExternalizedHandler;
+
+import agora.consensus.data.Block;
+
+import vibe.web.rest;
+import vibe.http.common;
+
+public interface BlockExternalizedHandler
+{
+// The REST generator requires @safe methods
+@safe:
+
+    /***************************************************************************
+
+        Externalize block data in JSON format with HTTP POST
+
+        API:
+            See config.event_handlers.block_externalized_handler_addresses
+
+    ***************************************************************************/
+
+    @method(HTTPMethod.POST)
+    @path("/")
+    public void pushBlock (const Block block);
+}

--- a/source/agora/api/handler/PreImageReceivedHandler.d
+++ b/source/agora/api/handler/PreImageReceivedHandler.d
@@ -1,0 +1,38 @@
+/*******************************************************************************
+
+    Definitions of the PreImageReceivedHandler
+
+    Copyright:
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.api.handler.PreImageReceivedHandler;
+
+import agora.consensus.data.PreImageInfo;
+
+import vibe.web.rest;
+import vibe.http.common;
+
+public interface PreImageReceivedHandler
+{
+// The REST generator requires @safe methods
+@safe:
+
+    /***************************************************************************
+
+        Push a preImage in JSON format with HTTP POST
+
+        API:
+            See config.event_handlers.preimage_updated_handler_addresses
+
+    ***************************************************************************/
+
+    @method(HTTPMethod.POST)
+    @path("/")
+    public void pushPreImage (const PreImageInfo preimage);
+}

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -23,6 +23,8 @@
 module agora.network.NetworkManager;
 
 import agora.api.Validator;
+import agora.api.handler.BlockExternalizedHandler;
+import agora.api.handler.PreImageReceivedHandler;
 import agora.common.BanManager;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
@@ -823,6 +825,62 @@ public class NetworkManager
         // allocates, called infrequently though
         return format("http://%s:%s", this.node_config.address,
             this.node_config.port);
+    }
+
+    /***************************************************************************
+
+        Instantiates a client object implementing `BlockExternalizedHandler`
+
+        In the default implementation, this returns a `BlockExternalizedHandler`
+
+        Params:
+            address = The address (IPv4, IPv6, hostname) of target Server
+        Returns:
+            A BlockExternalizedHandler to communicate with the server
+            at `address`
+
+    ***************************************************************************/
+
+    public BlockExternalizedHandler getBlockExternalizedHandler
+        (Address address)
+    {
+        import vibe.http.client;
+
+        auto settings = new RestInterfaceSettings;
+        settings.baseURL = URL(address);
+        settings.httpClientSettings = new HTTPClientSettings;
+        settings.httpClientSettings.connectTimeout = this.node_config.timeout;
+        settings.httpClientSettings.readTimeout = this.node_config.timeout;
+
+        return new RestInterfaceClient!BlockExternalizedHandler(settings);
+    }
+
+    /***************************************************************************
+
+        Instantiates a client object implementing `PreImageReceivedHandler`
+
+        In the default implementation, this returns a `PreImageReceivedHandler`
+
+        Params:
+            address = The address (IPv4, IPv6, hostname) of target Server
+        Returns:
+            A PreImageReceivedHandler to communicate with the server
+            at `address`
+
+    ***************************************************************************/
+
+    public PreImageReceivedHandler getPreimageReceivedHandler
+        (Address address)
+    {
+        import vibe.http.client;
+
+        auto settings = new RestInterfaceSettings;
+        settings.baseURL = URL(address);
+        settings.httpClientSettings = new HTTPClientSettings;
+        settings.httpClientSettings.connectTimeout = this.node_config.timeout;
+        settings.httpClientSettings.readTimeout = this.node_config.timeout;
+
+        return new RestInterfaceClient!PreImageReceivedHandler(settings);
     }
 }
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -467,7 +467,10 @@ public class FullNode : API
         log.trace("Received Preimage: {}", prettify(preimage));
 
         if (this.enroll_man.addPreimage(preimage))
+        {
             this.network.sendPreimage(preimage);
+            this.pushPreImage(preimage);
+        }
     }
 
     /// GET: /preimage

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -154,7 +154,8 @@ public class FullNode : API
         this.enroll_man = this.getEnrollmentManager(config.node.data_dir,
             config.node, params);
         this.ledger = new Ledger(config.node, params, this.utxo_set,
-            this.storage, this.enroll_man, this.pool, onValidatorsChanged);
+            this.storage, this.enroll_man, this.pool, &this.pushBlock,
+            onValidatorsChanged);
         this.exception = new RestException(
             400, Json("The query was incorrect"), string.init, int.init);
 
@@ -169,6 +170,11 @@ public class FullNode : API
             config.event_handlers.preimage_updated_handler_addresses)
             this.preimage_handlers[address] = this.network
                 .getPreimageReceivedHandler(address);
+
+        // Special case
+        // Block externalized handler is set and push for Genesis block.
+        if (this.block_handlers.length > 0 && this.getBlockHeight() == 0)
+            this.pushBlock(GenesisBlock);
     }
 
     /***************************************************************************

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -563,6 +563,9 @@ public class TestAPIManager
 
 public class TestNetworkManager : NetworkManager
 {
+    import agora.api.handler.BlockExternalizedHandler;
+    import agora.api.handler.PreImageReceivedHandler;
+
     ///
     public Registry* registry;
 
@@ -606,6 +609,20 @@ public class TestNetworkManager : NetworkManager
         cstring _data_dir)
     {
         return new FakeClockBanManager(conf);
+    }
+
+    ///
+    protected final override BlockExternalizedHandler getBlockExternalizedHandler
+        (Address address)
+    {
+        assert(0, "Not supported");
+    }
+
+    ///
+    protected final override PreImageReceivedHandler getPreimageReceivedHandler
+        (Address address)
+    {
+        assert(0, "Not supported");
     }
 }
 


### PR DESCRIPTION
Add event handlers to be used when the block is externalized and when receiving the preimage.

Call `pushBlock` when the block is externalized.
When receiving a preImage, call `pushPreimage`.

Convert data into JSON format is sent to POST using RestInterfaceClient.

TestNetworkManager does not support it.

Related to #1033 