### PR TITLE
Bug fix: Avoid calling receivePreimage endlessly

### DIFF
--- a/source/agora/consensus/validation/PreImage.d
+++ b/source/agora/consensus/validation/PreImage.d
@@ -53,8 +53,8 @@ public string isInvalidReason (const ref PreImageInfo new_image,
     if (new_image.enroll_key != prev_image.enroll_key)
         return "The pre-image's enrollment key differs from its descendant";
 
-    if (new_image.distance < prev_image.distance)
-        return "The height of new pre-image is smaller than that of previous one";
+    if (new_image.distance <= prev_image.distance)
+        return "The height of new pre-image is not greater than that of the previous one";
 
     if (new_image.distance > validator_cycle)
         return "The hashing count of two pre-images is above the validator cycle";


### PR DESCRIPTION
If a FullNode accept an pre-image although the distance is equal to that of
the previous one, it sends the pre-image to the network endlessly. You can
see the reason why it does in the following code of the `receivePreimage`
function of the `FullNode.d`.
```
if (this.enroll_man.addPreimage(preimage))
    this.network.sendPreimage(preimage);
```
So, I make FullNodes not accept the pre-image by returning the string of the
reason why the pre-image is invalid.

Commit & explanations by @linked0 , tests by @kchulj & @Geod24 .