### PR TITLE
unittests: link Phobos with debugging symbols

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
         echo "::set-env name=INCLUDE::${{ github.workspace }}\lib\libsodium\include\;$INCLUDE"
 
     # Add whatever debugging information can be useful in the long run here
-    - name: Print system informations
+    - name: Print system information
       shell: bash
       run: |
         ${DC} --version

--- a/dub.json
+++ b/dub.json
@@ -114,7 +114,8 @@
             "sourceFiles-windows": [
                 "source/scpp/build/DSizeChecks.obj",
                 "source/scpp/build/DLayoutChecks.obj"
-            ]
+            ],
+            "dflags": [ "-extern-std=c++14", "--link-defaultlib-debug" ],
         },
         {
             "name": "multi",


### PR DESCRIPTION
I couldn't find a way to append to `dflags`, so it's copy-pasting the C++ flag here too.