### PR TITLE
Remove GenesisTransaction function

### DIFF
--- a/source/agora/consensus/Genesis.d
+++ b/source/agora/consensus/Genesis.d
@@ -66,19 +66,6 @@ public void setGenesisBlock (immutable Block* block)
 
 /*******************************************************************************
 
-    Returns:
-        a reference to the genesis transaction
-
-*******************************************************************************/
-
-pragma(inline, true)
-public ref immutable(Transaction) GenesisTransaction () nothrow @safe @nogc
-{
-    return gen_block.txs[1];
-}
-
-/*******************************************************************************
-
     The genesis block as used by most unittests
 
     Note that this is more of a 'test' block than a 'unittest' block,

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -862,7 +862,7 @@ unittest
                 out_key_pairs,
                 tx_type,
                 last_txs,
-                GenesisTransaction);
+                GenesisBlock.txs[1]);
 
             txes.each!((tx)
                 {
@@ -1061,10 +1061,11 @@ private Transaction[] splitGenesisTransaction (
     KeyPair[] out_key, Amount amount = Amount.MinFreezeAmount)
 {
     Transaction[] txes;
+    const gen_tx_hash = GenesisBlock.txs[1].hashFull();
     foreach (idx; 0 .. Block.TxsInBlock)
     {
         Transaction tx = {TxType.Payment, [], []};
-        tx.inputs ~= Input(hashFull(GenesisTransaction), idx);
+        tx.inputs ~= Input(gen_tx_hash, idx);
         foreach (idx2; 0 .. Block.TxsInBlock)
             tx.outputs ~= Output(amount, out_key[idx].address);
 
@@ -1085,7 +1086,7 @@ private const(Block)[] genBlocksToIndex (
     // 1 payment and 1 freeze tx (must be a power of 2 due to #797)
     Transaction[] gen_txs;
     // need mutable
-    gen_txs ~= GenesisTransaction().serializeFull.deserializeFull!Transaction;
+    gen_txs ~= GenesisBlock.txs[1].serializeFull.deserializeFull!Transaction;
 
     Transaction freeze_tx =
     {

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -213,7 +213,7 @@ unittest
             UTXOSetValue(
                 0,
                 TxType.Payment,
-                GenesisTransaction.outputs[0]
+                GenesisBlock.txs[1].outputs[0]
             );
             return true;
         }, Height(0)));


### PR DESCRIPTION
```
Because we can have different kind of genesis blocks, we cannot offer an unified 'GenesisTransaction' API.
This function originally meant 'the only transaction in the genesis block',
and its meaning recently changed to 'the spendable output of genesis'.
But for this, using a more programmatic approach, such as what 'genesisSpendable'
is doing makes much more sense and is more robust.
Since make of the places which use GenesisTransaction are actually duplicating
what genesisSpendable is doing, this is a simple replacement.
This step is required to allow splitting the genesis block in multiple modules (821).
```