### PR TITLE
CI: Implement a script-side timeout and retry mechanism

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
     - name: '[OSX] Install dependencies & setup environment'
       if: runner.os == 'macOS'
       run: |
-        brew install pkg-config
+        brew install coreutils pkg-config
         ./ci/ci_osx_setup.sh
         echo ::set-env name=LIBRARY_PATH::${LD_LIBRARY_PATH-}:/usr/local/lib/
         echo ::set-env name=PKG_CONFIG_PATH::/usr/local/opt/sqlite/lib/pkgconfig:/usr/local/opt/openssl@1.1/lib/pkgconfig/

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -3,7 +3,15 @@
 set -xeu
 set -o pipefail
 
-dchatty=1 dub test -b unittest-cov --skip-registry=all --compiler=${DC}
+# Only build the unittest binary, but don't run it
+# We want to run it ourselves to catch any bug / set timeout, etc...
+dub build -b unittest-cov -c unittest --skip-registry=all --compiler=${DC}
+
+dchatty=1
+# A run currently (2020-07-21) takes < 6 minutes on Linux
+# Try a total of three times
+timeout -s SEGV 8m ./build/agora-unittests || timeout -s SEGV 8m ./build/agora-unittests || timeout -s SEGV 8m ./build/agora-unittests
+
 rdmd --compiler=${DC} ./tests/runner.d --compiler=${DC} -cov
 dub build --skip-registry=all --compiler=${DC}
 dub build -c client --skip-registry=all --compiler=${DC}


### PR DESCRIPTION
Currently the CI is extremely flakey and that affects development speed.
This is a band-aid in an attempt to reduce the failures.