### PR TITLE
Check the result of `Ledger.prepareNominatingSet`

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -179,6 +179,14 @@ extern(D):
         if (data.tx_set.length == 0)
             return;  // not ready yet
 
+        // check whether the consensus data is valid before nominating it.
+        if (auto msg = this.ledger.validateConsensusData(data))
+        {
+            log.fatal("tryNominate(): Invalid consensus data: {}. Data: {}",
+                    msg, data);
+            return;
+        }
+
         // note: we are not passing the previous tx set as we don't really
         // need it at this point (might later be necessary for chain upgrades)
         auto slot_idx = this.ledger.getBlockHeight() + 1;


### PR DESCRIPTION
This checks the validity of a `ConsensusData` before nominating it. It should never happen, so we make this a `log.fatal` call.

Fixes #900 