### PR TITLE
SQlite: Use single quotes for string literals

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -799,7 +799,7 @@ public class EnrollmentManager
         try
         {
             auto results = this.db.execute(
-                `SELECT val FROM node_enroll_data WHERE key = "cycle_index"`);
+                `SELECT val FROM node_enroll_data WHERE key = 'cycle_index'`);
             if (results.empty)
                 return 0;
 


### PR DESCRIPTION
As explained in the SQLite documentation [1] double-quotes are for identifiers,
and single quotes are for literals.
SQLite was previously accepting them in an effort to mirror MySQL's behavior,
but their usage generates a warning / is disabled at runtime depending on the version.

[1]: https://www.sqlite.org/quirks.html (8. Double-quoted String Literals Are Accepted).