### PR TITLE
Remove `ConsensusParams` when invoking 'runNode'

### DIFF
--- a/source/agora/cli/multi/main.d
+++ b/source/agora/cli/multi/main.d
@@ -107,9 +107,7 @@ private int main (string[] args)
     FullNode[] nodes;
     foreach (const ref config; configs)
     {
-        auto params = new immutable(ConsensusParams)(
-            config.node.validator_cycle);
-        nodes ~= runNode(config, params);
+        nodes ~= runNode(config);
     }
 
     scope (exit)


### PR DESCRIPTION
Changes to function `runNode` were not reflected in `agora-multi`