### PR TITLE
Remove default configuration interface from integration tests

### DIFF
--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -30,14 +30,6 @@ banman:
   ban_duration: 86400
 
 ################################################################################
-##                          Administrative interface                          ##
-################################################################################
-admin:
-  enabled: false
-  address: 127.0.0.1
-  port:    2827
-
-################################################################################
 ##                               Node discovery                               ##
 ##                                                                            ##
 ## When the network first starts, we need to connect to some peers to learn   ##

--- a/tests/system/node/1/config.yaml
+++ b/tests/system/node/1/config.yaml
@@ -30,14 +30,6 @@ banman:
   ban_duration: 86400
 
 ################################################################################
-##                          Administrative interface                          ##
-################################################################################
-admin:
-  enabled: false
-  address: 127.0.0.1
-  port:    2827
-
-################################################################################
 ##                               Node discovery                               ##
 ##                                                                            ##
 ## When the network first starts, we need to connect to some peers to learn   ##

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -30,14 +30,6 @@ banman:
   ban_duration: 86400
 
 ################################################################################
-##                          Administrative interface                          ##
-################################################################################
-admin:
-  enabled: false
-  address: 127.0.0.1
-  port:    2827
-
-################################################################################
 ##                               Node discovery                               ##
 ##                                                                            ##
 ## When the network first starts, we need to connect to some peers to learn   ##

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -23,12 +23,6 @@ banman:
   ban_duration: 86400
 
 ################################################################################
-##                          Administrative interface                          ##
-################################################################################
-admin:
-  enabled: false
-
-################################################################################
 ##                               Node discovery                               ##
 ##                                                                            ##
 ## When the network first starts, we need to connect to some peers to learn   ##


### PR DESCRIPTION
We're already using the default value, so there's no need to specify it.