### PR TITLE
Fix setting the is_nominating flag

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -171,13 +171,12 @@ extern(D):
         if (this.is_nominating)
             return;
 
-        this.is_nominating = true;
-        scope (exit) this.is_nominating = false;
-
         ConsensusData data;
         this.ledger.prepareNominatingSet(data);
         if (data.tx_set.length == 0)
             return;  // not ready yet
+
+        this.is_nominating = true;
 
         // check whether the consensus data is valid before nominating it.
         if (auto msg = this.ledger.validateConsensusData(data))
@@ -383,6 +382,9 @@ extern(D):
         if (slot_idx <= this.ledger.getBlockHeight())
             return;  // slot was already externalized
 
+        // ready for nominating again
+        this.is_nominating = false;
+        this.scp.stopNomination(slot_idx);
         ConsensusData data = void;
         try
             data = deserializeFull!ConsensusData(value[]);


### PR DESCRIPTION
This is a bug which I've noticed while inspecting leader selection.

When originally writing the Nominator class I failed to realize that `scp.nominate` may actually return early. For example if the current node is not the leader then SCP will start a timer 1 second in the future to [run scp.nominate() again](https://github.com/bpfkorea/agora/blob/1af3731d063a8b52f1e114a4b31e5ac65ad70869/source/scpp/src/scp/NominationProtocol.cpp#L528) and increase the round number to 2. This goes on an on as the number of rounds continue to increase (if nomination failed at every round).

I will have more PRs incoming which add additional tests - and I'll also write up a few more issues about what's still missing in the consensus networking tests.