### PR TITLE
Make a node register as a listener with a valid address

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -72,21 +72,6 @@ public interface API
 
     /***************************************************************************
 
-        Register the given address to listen for gossiping messages.
-
-        Params:
-            address = the address of the node to register
-
-        API:
-            PUT /register_listener
-
-    ***************************************************************************/
-
-    @method(HTTPMethod.PUT)
-    public void registerListener (Address address);
-
-    /***************************************************************************
-
         Returns:
             The peer information on this node
 

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -145,7 +145,7 @@ public class NetworkManager
 
         private void connect ()
         {
-            auto client = new NetworkClient(this.outer.taskman,
+            auto client = this.outer.getNetworkClient(this.outer.taskman,
                 this.outer.banman, this.address,
                 this.outer.getClient(this.address,
                     this.outer.node_config.timeout),
@@ -403,8 +403,13 @@ public class NetworkManager
         this.known_addresses.put(node.address);
         this.connection_tasks.remove(node.address);
 
-        // todo: this should keep re-trying.
-        node.client.registerListener();
+        this.registerAsListener(node.client);
+    }
+
+    /// Overridable for LocalRest which uses public keys
+    protected void registerAsListener (NetworkClient client)
+    {
+        client.registerListener();
     }
 
     /// Discover the network, connect to all required peers
@@ -710,6 +715,25 @@ public class NetworkManager
         settings.httpClientSettings.readTimeout = timeout;
 
         return new RestInterfaceClient!API(settings);
+    }
+
+    /***************************************************************************
+
+        Instantiates a networking client to be used with the given API instance.
+
+        Overridable in unittests.
+
+        Returns:
+            a NetworkClient
+
+    ***************************************************************************/
+
+    public NetworkClient getNetworkClient (TaskManager taskman,
+        BanManager banman, Address address, API api, Duration retry,
+        size_t max_retries)
+    {
+        return new NetworkClient(taskman, banman, address, api, retry,
+            max_retries);
     }
 
     /***************************************************************************

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -404,7 +404,7 @@ public class NetworkManager
         this.connection_tasks.remove(node.address);
 
         // todo: this should keep re-trying.
-        node.client.registerListener(this.getAddress());
+        node.client.registerListener();
     }
 
     /// Discover the network, connect to all required peers

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -231,8 +231,18 @@ public class FullNode : API
         this.enroll_man = null;
     }
 
-    /// PUT /register_listener
-    public override void registerListener (Address address) @trusted
+    /***************************************************************************
+
+        Register the given address as a listener for gossip / consensus messages.
+
+        This register the given address into the `NetworkManager`.
+
+        Params:
+            address = the address of node to register
+
+    ***************************************************************************/
+
+    public void registerListener (Address address) @trusted
     {
         this.network.registerListener(address);
     }

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -27,6 +27,7 @@ import vibe.http.router;
 import vibe.web.rest;
 
 import std.file;
+import std.format;
 
 mixin AddLogger!();
 
@@ -69,6 +70,17 @@ public FullNode runNode (Config config)
         node = new FullNode(config);
         router.registerRestInterface!(agora.api.FullNode.API)(node);
     }
+
+    // Register a path for `register_listener` adding client's address.
+    router.route("/register_listener")
+        .post((scope HTTPServerRequest req, scope HTTPServerResponse res)
+        {
+            string addr = format("http://%s:%d",
+                req.clientAddress.toAddressString(), req.clientAddress.port());
+            node.registerListener(addr);
+            res.statusCode = 200;
+            res.writeVoidBody();
+        });
 
     node.start();  // asynchronous
 


### PR DESCRIPTION
This is the first PR for the #1051 issue and does not contain code making sure we keep the connection alive yet, which will be submitted with another PR. With the code @AndrejMitrovic suggested, I registered a path manually in vibe.d for registering a listener address.

With the talk with @Geod24 a few days ago, we share the thought that we need to abstract the implementation so it works with LocalRest too.

I applied abstraction for the LocalRest with the support of @AndrejMitrovic.

Relates #1051 