### PR TITLE
prettify: Ocean does not support `scope` in toString()

### DIFF
--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -79,7 +79,7 @@ private struct AmountFmt
 {
     private Amount value;
 
-    public void toString (scope void delegate(scope const(char)[]) @safe sink) @safe nothrow
+    public void toString (scope void delegate (in char[]) @safe sink) @safe nothrow
     {
         try
         {
@@ -119,7 +119,7 @@ private struct HashFmt
 {
     private const(Hash) value;
 
-    public void toString (scope void delegate(scope const(char)[]) @safe sink) @safe nothrow
+    public void toString (scope void delegate (in char[]) @safe sink) @safe nothrow
     {
         try
         {
@@ -127,7 +127,7 @@ private struct HashFmt
             enum StartUntil = 6;
             enum EndFrom    = Hash.StringBufferSize - 4;
             size_t count;
-            scope void delegate(scope const(char)[]) @safe wrapper = (scope data) @safe {
+            scope void delegate (in char[]) @safe wrapper = (scope data) @safe {
                     if (count < StartUntil)
                     {
                         sink(data);
@@ -160,7 +160,7 @@ private struct PubKeyFmt
 {
     private const(PublicKey) value;
 
-    public void toString (scope void delegate(scope const(char)[]) @safe sink) @safe nothrow
+    public void toString (scope void delegate (in char[]) @safe sink) @safe nothrow
     {
         try
         {
@@ -169,7 +169,7 @@ private struct PubKeyFmt
             enum StartUntil = 4;
             enum EndFrom    = 56 - 4;
             size_t count;
-            scope void delegate(scope const(char)[]) @safe wrapper = (scope data) @safe {
+            scope void delegate (in char[]) @safe wrapper = (scope data) @safe {
                     if (count < StartUntil)
                     {
                         sink(data);
@@ -206,7 +206,7 @@ private struct InputFmt
         this.value = r;
     }
 
-    public void toString (scope void delegate(scope const(char)[]) @safe sink) @safe nothrow
+    public void toString (scope void delegate (in char[]) @safe sink) @safe nothrow
     {
         try
         {
@@ -237,7 +237,7 @@ private struct OutputFmt
         this.value = r;
     }
 
-    public void toString (scope void delegate(scope const(char)[]) @safe sink) @safe nothrow
+    public void toString (scope void delegate (in char[]) @safe sink) @safe nothrow
     {
         try
         {
@@ -267,7 +267,7 @@ private struct TransactionFmt
         this.value = r;
     }
 
-    public void toString (scope void delegate(scope const(char)[]) @safe sink)
+    public void toString (scope void delegate (in char[]) @safe sink)
         @safe nothrow
     {
         try
@@ -320,7 +320,7 @@ private struct BlockHeaderFmt
         this.value = r;
     }
 
-    public void toString (scope void delegate(scope const(char)[]) @safe sink) nothrow
+    public void toString (scope void delegate (in char[]) @safe sink) nothrow
         @safe
     {
         try
@@ -353,7 +353,7 @@ private struct BlockFmt
         this.value = r;
     }
 
-    public void toString (scope void delegate(scope const(char)[]) @safe sink)
+    public void toString (scope void delegate (in char[]) @safe sink)
         @safe nothrow
     {
         try
@@ -388,7 +388,7 @@ private struct EnrollmentFmt
 {
     private const(Enrollment) enroll;
 
-    public void toString (scope void delegate(scope const(char)[]) @safe sink)
+    public void toString (scope void delegate (in char[]) @safe sink)
         @safe nothrow
     {
         try
@@ -438,7 +438,7 @@ private struct ConsensusDataFmt
 {
     private const(ConsensusData) data;
 
-    public void toString (scope void delegate(scope const(char)[]) @safe sink)
+    public void toString (scope void delegate (in char[]) @safe sink)
         @safe nothrow
     {
         try
@@ -501,7 +501,7 @@ private struct QuorumConfigFmt
 {
     private const(QuorumConfig) data;
 
-    public void toString (scope void delegate(scope const(char)[]) @safe sink)
+    public void toString (scope void delegate (in char[]) @safe sink)
         @safe nothrow
     {
         try


### PR DESCRIPTION
E.g. before:

```
-----
2020-08-04 11:38:06,359 Trace [agora.node.FullNode] - Received Enrollment: { enroll: { utxo_key: 0xb82cb96710af2e9804c59d1f1e1679f8b8b69f4c0f6cd79c8c12f365dd766c09aaa4febcc18b3665d33301cb248ac7afd343ac7b98b27beaf246ad12d3b3219a, random_seed: 0xabb640e7c36df355074971ae3dc98759b5a80ee0270f98973b9045c9000f6c583ebf425ffb08e5c84466a1a4521c004141268c34aa34f6c224759d66b9b69251, cycle_length: 10, enroll_sig: 0x09cf6c4c3722aee7c83e4bbeba99bc3233574433f90b759ef3308d8e06b43762ec335415eb1064e6fcaf43ef02dcd1132e50e0948951463f28e4d82b4308cb37 } }
-----

After:

-----
2020-08-04 11:39:19,677 Trace [agora.node.FullNode] - Received Enrollment: { utxo: 0x81a3...7497, seed: 0x166e...29a4, cycles: 10, sig: 0x012c...05a4 }
-----
```