### PR TITLE
Remove restriction for 8-transaction blocks

### DIFF
--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -128,14 +128,17 @@ unittest
 
     The block which contains the block header and its body (the transactions).
 
-    In the current preliminary design a block contains a single transaction.
-
 *******************************************************************************/
 
 public struct Block
 {
-    /// number of transactions that constitutes a block
-    public enum TxsInBlock = 8;
+    // some unittests still assume a block contains 8 txs. Once they're fixed
+    // this constant should be removed.
+    version (unittest)
+    {
+        /// number of transactions that constitutes a block
+        public enum TxsInTestBlock = 8;
+    }
 
     ///
     public BlockHeader header;

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -170,8 +170,8 @@ extern(D):
 
     protected bool prepareNominatingSet (out ConsensusData data) @safe
     {
-        this.ledger.prepareNominatingSet(data, Block.TxsInBlock);
-        if (data.tx_set.length != Block.TxsInBlock)
+        this.ledger.prepareNominatingSet(data, 8);
+        if (data.tx_set.length != 8)
             return false;  // not ready to nominate yet
 
         // check whether the consensus data is valid before nominating it.

--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -27,13 +27,15 @@ import core.thread;
 /// test node banning after putTransaction fails a number of times
 unittest
 {
+    const txs_to_nominate = 8;
     TestConf conf =
     {
         validators : 2,
         full_nodes : 1,
         retry_delay : 10.msecs,
         max_retries : 10,
-        max_failed_requests : 4 * Block.TxsInBlock
+        txs_to_nominate : txs_to_nominate,
+        max_failed_requests : 4 * txs_to_nominate
     };
 
     auto network = makeTestNetwork(conf);
@@ -57,7 +59,7 @@ unittest
     {
         auto txes = makeChainedTransactions(gen_key, last_txs, count);
         // keep track of last tx's to chain them to
-        last_txs = txes[$ - Block.TxsInBlock .. $];
+        last_txs = txes[$ - 8 .. $];
         all_txs ~= txes;
         return txes;
     }

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -98,9 +98,9 @@ unittest
     static class BadAPIManager : TestAPIManager
     {
         ///
-        public this (immutable(Block)[] blocks)
+        public this (immutable(Block)[] blocks, TestConf test_conf)
         {
-            super(blocks);
+            super(blocks, test_conf);
         }
 
         /// see base class
@@ -116,7 +116,8 @@ unittest
             if (conf.node.is_validator)
             {
                 api = RemoteAPI!TestAPI.spawn!TestValidatorNode(
-                    conf, &this.reg, this.blocks, conf.node.timeout);
+                    conf, &this.reg, this.blocks, this.test_conf.txs_to_nominate,
+                    conf.node.timeout);
             }
             else
             {

--- a/source/agora/test/VariableBlockSize.d
+++ b/source/agora/test/VariableBlockSize.d
@@ -1,0 +1,59 @@
+/*******************************************************************************
+
+    Tests creating blocks of arbitrary transaction counts.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.VariableBlockSize;
+
+version (unittest):
+
+import agora.api.Validator;
+import agora.consensus.data.Transaction;
+import agora.test.Base;
+
+///
+unittest
+{
+    const txs_to_nominate = 2;
+    TestConf conf = { txs_to_nominate : txs_to_nominate };
+    auto network = makeTestNetwork(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[0];
+
+    auto spendable = network.blocks[0].txs
+        .filter!(tx => tx.type == TxType.Payment)
+        .map!(tx => iota(tx.outputs.length)
+            .map!(idx => TxBuilder(tx, cast(uint)idx)))
+        .joiner().take(8).array;
+
+    auto txs = spendable
+        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
+        .array;
+
+    foreach (block_idx, block_txs; txs.chunks(txs_to_nominate).enumerate)
+    {
+        block_txs.each!(tx => nodes[0].putTransaction(tx));
+
+        nodes.enumerate.each!((idx, node) =>
+            retryFor(node.getBlockHeight() == block_idx + 1, 5.seconds,
+                format("Node %s has block height %s. Expected: %s",
+                    idx, node.getBlockHeight(), block_idx + 1)));
+
+    }
+
+    // 8 txs will create 4 blocks if we nominate 2 per block
+    ensureConsistency(nodes, 4);
+}

--- a/tests/system/source/main.d
+++ b/tests/system/source/main.d
@@ -81,7 +81,7 @@ int main (string[] args)
 
         auto kp = WK.Keys.Genesis;
 
-        iota(Block.TxsInBlock)
+        iota(8)
             .map!(idx => TxBuilder(TestGenesis.GenesisBlock.txs[1], idx)
                   .refund(kp.address).sign())
             .each!(tx => clients[0].putTransaction(tx));

--- a/tests/unit/BlockStorageMultiTx.d
+++ b/tests/unit/BlockStorageMultiTx.d
@@ -46,7 +46,7 @@ private void main ()
     blocks ~= GenesisBlock;
 
     // For genesis, we need to use the outputs, not previous transactions
-    Transaction[] txs = iota(Block.TxsInBlock)
+    Transaction[] txs = iota(8)
         .map!(idx => TxBuilder(GenesisBlock.txs[1], idx).refund(WK.Keys.A.address).sign())
         .array();
     foreach (block_idx; 0 .. BlockCount)


### PR DESCRIPTION
Now there is a new TestConf option called `txs_to_nominate` which is passed to the `TestNominator`.

This does not change the nominating behavior of the production node yet.

Note also that this is **not** a consensus parameter because we don't want a transaction count consensus rule - we rather want a block size rule. However this is outside the scope of #1004.

This is the first part of the support code for #1004. In the next PRs I'll add a timer-based nominator.