### PR TITLE
Ignore same height pre-image because validators will gossip them

### DIFF
--- a/source/agora/consensus/ValidatorSet.d
+++ b/source/agora/consensus/ValidatorSet.d
@@ -475,6 +475,10 @@ public class ValidatorSet
             return false;
         }
 
+        // Ignore same height pre-image because validators will gossip them
+        if (prev_preimage.distance == preimage.distance)
+            return false;
+
         if (auto reason = isInvalidReason(preimage, prev_preimage,
             this.params.ValidatorCycle))
         {


### PR DESCRIPTION
```console
node-7_1_7e2b1f0640fc | 2020-08-06T07:54:49.463088747Z 2020-08-06 07:54:49,461 Info [agora.consensus.ValidatorSet] - Invalid pre-image data: The height of new pre-image is not greater than that of the previous one. Pre-image: { enroll_key: 0xdb3931bd87d2cea097533d82be0a5e36c54fec8e5570790c3369bd8300c65a03d76d12a74aa38ec3e6866fd64ae56091ed3cbc3ca278ae0c8265ab699ffe2d85, hash: 0x033d75ea3cf5f2d3e6b4be76ca6cc66bac6c101b79614dabe930111b34396fa2a5445ca43d0225d96c49874264caaea87cbaee692f60a8aac1b586b231202fb3, distance: 11 }
```
This message was showing up in the system integration test. The node gossips the pre-image even though the receiving nodes already have the information. Gossiping is not a malicious behavior, so we can ignore it because it prints the same message several times.

~~This addition is a workaround for~~ 
Fixes issue [#1104](https://github.com/bpfkorea/agora/issues/1104)