### PR TITLE
Make TxBuilder.sign and PublicKey.toString nothrow

### DIFF
--- a/source/agora/common/crypto/Crc16.d
+++ b/source/agora/common/crypto/Crc16.d
@@ -88,6 +88,7 @@ private immutable ushort[256] crc16tab = [
 /// Checksum returns the 2-byte checksum for the provided data
 /// Data returned is in little endian
 ubyte[2] checksum(scope const(ubyte)[] data)
+    @safe pure nothrow @nogc
 {
     ushort crc;
     foreach (elem; data)
@@ -102,6 +103,7 @@ ubyte[2] checksum(scope const(ubyte)[] data)
 /// Validate returns an error if the provided checksum does not match
 /// the calculated checksum of the provided data
 bool validate(scope const ubyte[] data, scope const ubyte[] expected)
+    @safe pure nothrow @nogc
 {
     assert(expected.length == 2);
     const actual = checksum(data);

--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -120,7 +120,7 @@ public struct PublicKey
     }
 
     /// Uses Stellar's representation instead of hex
-    public string toString () const @trusted
+    public string toString () const @trusted nothrow
     {
         ubyte[1 + PublicKey.Width + 2] bin;
         bin[0] = VersionByte.AccountID;

--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -590,7 +590,7 @@ public struct TxBuilder
 
     ***************************************************************************/
 
-    public Transaction sign (TxType type = TxType.Payment) @safe
+    public Transaction sign (TxType type = TxType.Payment) @safe nothrow
     {
         assert(this.inputs.length, "Cannot sign input-less transaction");
         assert(this.data.outputs.length || this.leftover.value > Amount(0),


### PR DESCRIPTION
So that we can call `makeNewBlock` using a `map` that uses `TxBuilder` in a predicate.