### PR TITLE
Replace most `makeChainedTransactions` with `TxBuilder`

### DIFF
--- a/source/agora/common/TransactionPool.d
+++ b/source/agora/common/TransactionPool.d
@@ -321,7 +321,7 @@ unittest
 {
     auto pool = new TransactionPool(":memory:");
     auto gen_key = WK.Keys.Genesis;
-    auto txs = makeChainedTransactions(gen_key, null, 1);
+    auto txs = genesisSpendable().map!(txb => txb.sign()).array();
 
     txs.each!(tx => pool.add(tx));
     assert(pool.length == txs.length);
@@ -358,7 +358,7 @@ unittest
 
     auto pool = new TransactionPool(":memory:");
     auto gen_key = WK.Keys.Genesis;
-    auto txs = makeChainedTransactions(gen_key, null, 1);
+    auto txs = genesisSpendable().map!(txb => txb.sign()).array();
 
     txs.each!(tx => pool.add(tx));
     assert(pool.length == txs.length);
@@ -388,7 +388,7 @@ unittest
 
     auto pool = new TransactionPool(":memory:");
     auto gen_key = WK.Keys.Genesis;
-    auto txs = makeChainedTransactions(gen_key, null, 1);
+    auto txs = genesisSpendable().map!(txb => txb.sign()).array();
 
     txs.each!(tx => pool.add(tx));
     assert(pool.length == txs.length);

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -435,7 +435,7 @@ unittest
     auto gen_hash = GenesisBlock.header.hashFull();
 
     GenesisBlock.txs.each!(tx => utxos.put(tx));
-    auto block = GenesisBlock.makeNewBlock(makeChainedTransactions(gen_key, null, 1));
+    auto block = GenesisBlock.makeNewBlock(genesisSpendable().map!(txb => txb.sign()));
 
     // height check
     assert(block.isValid(GenesisBlock.header.height, gen_hash, findUTXO,
@@ -498,7 +498,7 @@ unittest
     prev_txs.each!(tx => utxos.put(tx));  // these will be spent
 
     auto prev_block = block;
-    block = block.makeNewBlock(makeChainedTransactions(gen_key, prev_txs, 1));
+    block = block.makeNewBlock(prev_txs.map!(tx => TxBuilder(tx).sign()));
     assert(block.isValid(prev_block.header.height, prev_block.header.hashFull(),
         findUTXO, Enrollment.MinValidatorCount));
 
@@ -547,7 +547,7 @@ unittest
     };
 
     // consumed all utxo => fail
-    block = GenesisBlock.makeNewBlock(makeChainedTransactions(gen_key, null, 1));
+    block = GenesisBlock.makeNewBlock(genesisSpendable().map!(txb => txb.sign()));
     assert(block.isValid(GenesisBlock.header.height, GenesisBlock.header.hashFull(),
             findNonSpent, Enrollment.MinValidatorCount));
 
@@ -568,7 +568,7 @@ unittest
     // we stopped validation due to a double-spend
     assert(used_set.length == double_spend.length - 1);
 
-    block = GenesisBlock.makeNewBlock(makeChainedTransactions(gen_key, prev_txs, 1));
+    block = GenesisBlock.makeNewBlock(prev_txs.map!(tx => TxBuilder(tx).sign()));
     assert(block.isValid(GenesisBlock.header.height, GenesisBlock.header.hashFull(),
         findUTXO, Enrollment.MinValidatorCount));
 

--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -57,11 +57,25 @@ unittest
     // generate enough transactions to form 'count' blocks
     Transaction[] genBlockTransactions (size_t count)
     {
-        auto txes = makeChainedTransactions(gen_key, last_txs, count);
-        // keep track of last tx's to chain them to
-        last_txs = txes[$ - 8 .. $];
-        all_txs ~= txes;
-        return txes;
+        assert(count > 0);
+        Transaction[] txes;
+
+         if (!last_txs.length)
+         {
+             txes = genesisSpendable().map!(txb => txb.sign()).array();
+             last_txs = txes[$ - 8 .. $];
+             all_txs ~= last_txs;
+             count--;
+         }
+
+         foreach (idx; 0 .. count)
+         {
+             txes = last_txs.map!(tx => TxBuilder(tx).sign()).array();
+             // keep track of last tx's to chain them to
+             last_txs = txes[$ - 8 .. $];
+             all_txs ~= txes;
+         }
+         return txes;
     }
 
     genBlockTransactions(1).each!(tx => node_1.putTransaction(tx));

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -67,13 +67,12 @@ unittest
                  node.getEnrollment(enroll_3.utxo_key) == enroll_3,
             5.seconds));
 
-    auto txs = makeChainedTransactions(WK.Keys.Genesis,
-        network.blocks[$ - 1].txs, 1);
+    auto txs = network.blocks[$ - 1].spendable().map!(txb => txb.sign()).array();
     txs.each!(tx => nodes[0].putTransaction(tx));
     network.expectBlock(Height(validator_cycle), 2.seconds);
 
     // verify that consensus can still be reached
-    txs = makeChainedTransactions(WK.Keys.Genesis, txs, 1);
+    txs = txs.map!(tx => TxBuilder(tx).sign()).array();
     txs.each!(tx => nodes[0].putTransaction(tx));
     network.expectBlock(Height(validator_cycle + 1), 2.seconds);
 
@@ -115,7 +114,7 @@ unittest
     const(Transaction)[] prev_txs = network.blocks[$ - 1].txs;
     foreach (height; current_height .. validator_cycle)
     {
-        auto txs = makeChainedTransactions(WK.Keys.Genesis, prev_txs, 1);
+        auto txs = prev_txs.map!(tx => TxBuilder(tx).sign()).array();
         txs.each!(tx => nodes[0].putTransaction(tx));
         network.expectBlock(Height(height + 1), 2.seconds);
         prev_txs = txs;

--- a/source/agora/test/GenesisBlock.d
+++ b/source/agora/test/GenesisBlock.d
@@ -36,7 +36,7 @@ unittest
     nodes.all!(node => node.getBlocksFrom(0, 1)[0] == network.blocks[0])
         .retryFor(2.seconds);
 
-    auto txes = makeChainedTransactions(WK.Keys.Genesis, null, 1);
+    auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
     network.expectBlock(Height(1), 2.seconds);
 }

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -38,7 +38,7 @@ unittest
 
     Transaction[] last_txs;
     // create enough tx's for a single block
-    auto txs = makeChainedTransactions(WK.Keys.Genesis, last_txs, 1);
+    auto txs = genesisSpendable().map!(txb => txb.sign()).array();
 
     auto send_txs = txs[0..$-1];
     // send it to tx to node
@@ -74,7 +74,7 @@ unittest
     auto nodes = network.clients;
     auto node_1 = nodes[0];
 
-    auto txs = makeChainedTransactions(WK.Keys.Genesis, null, 1);
+    auto txs = genesisSpendable().map!(txb => txb.sign()).array();
 
     auto send_txs = txs[0 .. $ - 1];  // 1 short of making a block (don't start consensus)
     send_txs.each!(tx => node_1.putTransaction(tx));

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -42,7 +42,7 @@ unittest
     // reject inbound requests
     nodes[1 .. $].each!(node => node.filter!(node.putTransaction));
 
-    auto txes = makeChainedTransactions(WK.Keys.Genesis, null, 1);
+    auto txes = genesisSpendable().map!(txb => txb.sign()).array();
 
     // node 1 will keep trying to send transactions up to
     // (max_retries * retry_delay) seconds (see Base.d)
@@ -74,7 +74,7 @@ unittest
     const DropRequests = true;
     nodes[1 .. $].each!(node => node.sleep(100.msecs, DropRequests));
 
-    auto txes = makeChainedTransactions(WK.Keys.Genesis, null, 1);
+    auto txes = genesisSpendable().map!(txb => txb.sign()).array();
 
     txes.each!(tx => node_1.putTransaction(tx));
 

--- a/source/agora/test/Restart.d
+++ b/source/agora/test/Restart.d
@@ -31,7 +31,7 @@ unittest
     auto nodes = network.clients;
     auto node_1 = nodes[0];
 
-    auto txes = makeChainedTransactions(WK.Keys.Genesis, null, 1);
+    auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
     network.expectBlock(Height(1), 2.seconds);
 

--- a/source/agora/test/Simple.d
+++ b/source/agora/test/Simple.d
@@ -37,7 +37,7 @@ unittest
     auto nodes = network.clients;
     auto node_1 = nodes[0];
 
-    auto txes = makeChainedTransactions(WK.Keys.Genesis, null, 1);
+    auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
     network.expectBlock(Height(1), 2.seconds);
 }


### PR DESCRIPTION
`makeChainedTransactions` is an outdated function which assumes a block always contains exactly 8 transactions.
Since we have transitioned away from creating a block based on the number of transactions, we should use `TxBuilder` instead.

Relates #1107