### PR TITLE
Report the test file and line number when failure in Network unit test

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -478,19 +478,18 @@ public class TestAPIManager
 
     ***************************************************************************/
 
-    public void createNewNode (Config conf )
+    public void createNewNode (Config conf, string file = __FILE__, int line = __LINE__)
     {
         RemoteAPI!TestAPI api;
-
         if (conf.node.is_validator)
         {
             api = RemoteAPI!TestAPI.spawn!TestValidatorNode(conf, &this.reg,
-                this.blocks, this.test_conf.txs_to_nominate, conf.node.timeout);
+                this.blocks, this.test_conf.txs_to_nominate, conf.node.timeout, file, line);
         }
         else
         {
             api = RemoteAPI!TestAPI.spawn!TestFullNode(conf, &this.reg,
-                this.blocks, conf.node.timeout);
+                this.blocks, conf.node.timeout, file, line);
         }
 
         this.reg.register(conf.node.address, api.tid());
@@ -1116,7 +1115,7 @@ public struct TestConf
 
 *******************************************************************************/
 
-public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)(
+public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager, string file = __FILE__, int line = __LINE__)(
     in TestConf test_conf)
 {
     import agora.common.Serializer;
@@ -1253,7 +1252,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
 
     auto net = new APIManager(blocks, test_conf);
     foreach (ref conf; main_configs)
-        net.createNewNode(conf);
+        net.createNewNode(conf, file, line);
 
     return net;
 }

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -240,7 +240,7 @@ unittest
         }
 
         /// see base class
-        public override void createNewNode (Config conf)
+        public override void createNewNode (Config conf, string file, int line)
         {
             if (this.nodes.length == 0)
             {
@@ -252,7 +252,7 @@ unittest
                 this.nodes ~= NodePair(conf.node.address, node);
             }
             else
-                super.createNewNode(conf);
+                super.createNewNode(conf, file, line);
         }
     }
 
@@ -362,7 +362,7 @@ unittest
         }
 
         /// see base class
-        public override void createNewNode (Config conf)
+        public override void createNewNode (Config conf, string file, int line)
         {
             if (this.nodes.length == 0)
             {
@@ -373,7 +373,7 @@ unittest
                 this.nodes ~= NodePair(conf.node.address, api);
             }
             else
-                super.createNewNode(conf);
+                super.createNewNode(conf, file, line);
         }
     }
 

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -102,7 +102,7 @@ unittest
         }
 
         /// see base class
-        public override void createNewNode (Config conf)
+        public override void createNewNode (Config conf, string file, int line)
         {
             RemoteAPI!TestAPI api;
 


### PR DESCRIPTION
This is just adding info about the test file and line number which caused an assertion failure during a Network Unit test run.