### PR TITLE
Remove retry timeout

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -8,9 +8,7 @@ set -o pipefail
 dub build -b unittest-cov -c unittest --skip-registry=all --compiler=${DC}
 
 export dchatty=1
-# A run currently (2020-07-21) takes < 6 minutes on Linux
-# Try a total of three times
-timeout -s SEGV 8m ./build/agora-unittests || timeout -s SEGV 8m ./build/agora-unittests || timeout -s SEGV 8m ./build/agora-unittests
+./build/agora-unittests
 
 rdmd --compiler=${DC} ./tests/runner.d --compiler=${DC} -cov
 dub build --skip-registry=all --compiler=${DC}


### PR DESCRIPTION
```
This was put in place to deal with the frequent infinite loop we were seeing.
Remove it now that those have been fixed so they don't creep back.
```

This will probably fail, let's see what the CI says.