### PR TITLE
[trivial] Properly set dchatty=1 when running tests

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -7,7 +7,7 @@ set -o pipefail
 # We want to run it ourselves to catch any bug / set timeout, etc...
 dub build -b unittest-cov -c unittest --skip-registry=all --compiler=${DC}
 
-dchatty=1
+export dchatty=1
 # A run currently (2020-07-21) takes < 6 minutes on Linux
 # Try a total of three times
 timeout -s SEGV 8m ./build/agora-unittests || timeout -s SEGV 8m ./build/agora-unittests || timeout -s SEGV 8m ./build/agora-unittests


### PR DESCRIPTION
The spawned unittest process did not receive the environment variable before.