### PR TITLE
Replace more makeChainedTransactions with TxBuilder

### DIFF
--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -584,9 +584,9 @@ unittest
         findUTXO, Enrollment.MinValidatorCount));
     const last_root = block.header.merkle_root;
 
-    // txs with a different amount
-    block = GenesisBlock.makeNewBlock(
-        makeChainedTransactions(gen_key, prev_txs, 1, 20_000_000));
+    block = GenesisBlock.makeNewBlock(prev_txs.enumerate.map!(en =>
+        TxBuilder(en.value).split(WK.Keys.byRange().take(en.index + 1).map!(k => k.address)).sign()));
+
     assert(block.isValid(GenesisBlock.header.height, GenesisBlock.header.hashFull(),
         findUTXO, Enrollment.MinValidatorCount));
 
@@ -615,8 +615,7 @@ unittest
     foreach (ref tx; GenesisBlock.txs)
         utxo_set.put(tx);
 
-    auto txs_1 = makeChainedTransactions(gen_key, null, 1,
-        400_000_000_000 * 8).sort.array;
+    auto txs_1 = genesisSpendable().map!(txb => txb.sign()).array();
 
     auto block1 = makeNewBlock(GenesisBlock, txs_1);
     assert(block1.isValid(GenesisBlock.header.height, gen_hash, findUTXO,
@@ -737,8 +736,7 @@ unittest
     foreach (ref tx; GenesisBlock.txs)
         utxo_set.put(tx);
 
-    auto txs_1 = makeChainedTransactions(gen_key, null, 1,
-        400_000_000_000 * 10 * 8).sort.array;
+    auto txs_1 = genesisSpendable().map!(txb => txb.sign()).array();
 
     auto block1 = makeNewBlock(GenesisBlock, txs_1);
     assert(block1.isValid(GenesisBlock.header.height, gen_hash, findUTXO,

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1429,16 +1429,12 @@ private immutable(Block)[] generateBlocks (
     if (count == 0)
         return blocks.assumeUnique;  // just the genesis block
 
-    const(Transaction)[] prev_txs;
     foreach (_; 0 .. count)
     {
-        // see `agora.consensus.data.genesis.Test` for the magic amount
-        auto txs = makeChainedTransactions(WK.Keys.Genesis,
-            prev_txs, 1, 61_000_000uL * 10_000_000uL * 8);
+        auto txs = blocks[$ - 1].spendable().map!(txb => txb.sign());
 
         const NoEnrollments = null;
         blocks ~= makeNewBlock(blocks[$ - 1], txs, NoEnrollments);
-        prev_txs = txs;
     }
 
     return blocks.assumeUnique;


### PR DESCRIPTION
`makeChainedTransactions` has `key_pair` and `spend_amount` as parameters, but `TxBuilder` does not. It also does not allow invalid transactions to be created. As a result, some of the unit tests were not doing what they were supposed to do.

Below are some of the improvements:
1. Replace one transaction with a different amount, in order to get a different merkle root
2. Modify valid transactions by replacing and signing with a `foreach` loop
3. Delete unnecessary declaration of `Transaction` arrays

Improvement in `Base.d` developed with @AndrejMitrovic 

Relates #1107 