### PR TITLE
Disable ManyValidators test as it frequently fails

### DIFF
--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -13,7 +13,9 @@
 
 module agora.test.ManyValidators;
 
-version (unittest):
+// temporarily disabled until failures are resolved
+// see #1145
+version (none):
 
 import agora.api.Validator;
 import agora.common.Amount;


### PR DESCRIPTION
`dchatty=1` revealed this is the test that's consistently causing Github CI failures.

The test is likely running into a performance problem. With 16 nodes the amount of messages being sent throughout the network seems to be quite large - it's something we need to fix. It would be good to take a look at how Stellar implements the `emitEnvelope` routine.