### PR TITLE
[RFC] Implement a per-node request queue for gossiping

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	url = https://github.com/Geod24/libsodiumd.git
 [submodule "localrest"]
 	path = submodules/localrest
-	url = https://github.com/Geod24/localrest.git
+	url = https://github.com/AndrejMitrovic/localrest.git
 [submodule "mir-linux-kernel"]
 	path = submodules/mir-linux-kernel
 	url = https://github.com/libmir/mir-linux-kernel.git

--- a/dub.json
+++ b/dub.json
@@ -100,7 +100,8 @@
                 "source/agora/consensus/protocol/*",
                 "source/agora/cli/checkvtable/*",
                 "source/agora/cli/multi/*",
-                "source/agora/cli/vanity/*"
+                "source/agora/cli/vanity/*",
+                "source/agora/test/*"
             ]
         },
         {

--- a/source/agora/common/Task.d
+++ b/source/agora/common/Task.d
@@ -33,6 +33,9 @@ public enum Periodic : bool
 /// Exposes primitives to run tasks through Vibe.d
 public class TaskManager
 {
+    /// stats: total number of task started
+    protected ulong tasks_started;
+
     /***************************************************************************
 
         Run an asynchronous task in vibe.d's event loop
@@ -45,6 +48,7 @@ public class TaskManager
     public void runTask (void delegate() dg) nothrow
     {
         static import vibe.core.core;
+        this.tasks_started++;
         vibe.core.core.runTask(dg);
     }
 
@@ -92,9 +96,21 @@ public class TaskManager
     public ITimer setTimer (Duration timeout, void delegate() dg,
         Periodic periodic = Periodic.No) nothrow
     {
+        this.tasks_started++;
         assert(dg !is null, "Cannot call this delegate if null");
         static import vibe.core.core;
         return new VibedTimer(vibe.core.core.setTimer(timeout, dg, periodic));
+    }
+
+    /***************************************************************************
+
+        Log out the request stats
+
+    ***************************************************************************/
+
+    public void logStats () @safe nothrow
+    {
+        log.info("Tasks started: {}", this.tasks_started);
     }
 }
 

--- a/source/agora/network/NetworkClient.d
+++ b/source/agora/network/NetworkClient.d
@@ -204,7 +204,7 @@ class NetworkClient
         this.taskman.runTask(
         {
             // if the node already has this tx, don't send it
-            if (this.attemptRequest!(API.hasTransactionHash, Throw.Yes,
+            if (this.attemptRequest!(API.hasTransactionHash, Throw.No,
                 LogLevel.Trace)(this.api, tx_hash))
                 return;
 

--- a/source/agora/network/NetworkClient.d
+++ b/source/agora/network/NetworkClient.d
@@ -201,15 +201,12 @@ class NetworkClient
         import agora.common.Hash;
         const tx_hash = tx.hashFull();
 
-        this.taskman.runTask(
-        {
-            // if the node already has this tx, don't send it
-            if (this.attemptRequest!(API.hasTransactionHash, Throw.No,
-                LogLevel.Trace)(this.api, tx_hash))
-                return;
+        // if the node already has this tx, don't send it
+        if (this.attemptRequest!(API.hasTransactionHash, Throw.No,
+            LogLevel.Trace)(this.api, tx_hash))
+            return;
 
-            this.attemptRequest!(API.putTransaction, Throw.No)(this.api, tx);
-        });
+        this.attemptRequest!(API.putTransaction, Throw.No)(this.api, tx);
     }
 
 
@@ -224,11 +221,8 @@ class NetworkClient
 
     public void sendEnvelope (SCPEnvelope envelope) nothrow
     {
-        this.taskman.runTask(
-        {
-            this.attemptRequest!(API.receiveEnvelope, Throw.No)(this.api,
-                envelope);
-        });
+        this.attemptRequest!(API.receiveEnvelope, Throw.No)(this.api,
+            envelope);
     }
 
     /***************************************************************************
@@ -288,11 +282,8 @@ class NetworkClient
 
     public void sendEnrollment (Enrollment enroll) @trusted nothrow
     {
-        this.taskman.runTask(
-        {
-            this.attemptRequest!(API.enrollValidator, Throw.No)(this.api,
-                enroll);
-        });
+        this.attemptRequest!(API.enrollValidator, Throw.No)(this.api,
+            enroll);
     }
 
     /***************************************************************************
@@ -310,11 +301,8 @@ class NetworkClient
 
     public void sendPreimage (PreImageInfo preimage) @trusted nothrow
     {
-        this.taskman.runTask(
-        {
-            this.attemptRequest!(API.receivePreimage, Throw.No)(this.api,
-                preimage);
-        });
+        this.attemptRequest!(API.receivePreimage, Throw.No)(this.api,
+            preimage);
     }
 
     /***************************************************************************

--- a/source/agora/network/NetworkClient.d
+++ b/source/agora/network/NetworkClient.d
@@ -219,7 +219,7 @@ class NetworkClient
 
     ***************************************************************************/
 
-    public void sendEnvelope (SCPEnvelope envelope) nothrow
+    public void sendEnvelope (SCPEnvelope envelope) @trusted nothrow
     {
         this.attemptRequest!(API.receiveEnvelope, Throw.No)(this.api,
             envelope);

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -215,8 +215,6 @@ public class NetworkManager
 
     private class AddressDiscoveryTask
     {
-        import std.container : DList;
-
         /// A queue of clients. Each client is contacted, and pushed back to the
         /// queue (unless they were banned)
         private DList!NetworkClient clients;

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -336,6 +336,9 @@ public class NetworkManager
     /// Easy lookup of currently connected peers
     protected Set!Address connected_peers;
 
+    /// Keeps track of Validator keys we're already connected to
+    private Set!PublicKey connected_validator_keys;
+
     /// All known addresses so far (used for getNodeInfo())
     protected Set!Address known_addresses;
 
@@ -398,6 +401,7 @@ public class NetworkManager
         {
             this.validators.insertBack(node.client);
             this.required_peer_keys.remove(node.key);
+            this.connected_validator_keys.put(node.key);
         }
 
         this.discovery_task.add(node.client);
@@ -421,6 +425,8 @@ public class NetworkManager
         log.info("Doing network discovery..");
 
         this.required_peer_keys = required_peer_keys;
+        foreach (key; this.connected_validator_keys)
+            this.required_peer_keys.remove(key);
 
         // actually just runs it once, but we need the scheduler to run first
         // and it doesn't run in the constructor yet (LocalRest)

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -475,7 +475,7 @@ public class NetworkManager
     private Metadata metadata;
 
     /// Maximum connection tasks to run in parallel
-    private enum MaxConnectionTasks = 10;
+    private enum MaxConnectionTasks = 64;
 
     /// Ctor
     public this (in NodeConfig node_config, in BanManager.Config banman_conf,

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -222,6 +222,7 @@ public class FullNode : API
     public void shutdown ()
     {
         log.info("Shutting down..");
+        this.taskman.logStats();
         this.network.dumpMetadata();
         this.pool = null;
         this.utxo_set = null;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -264,6 +264,7 @@ public class LocalRestTaskManager : TaskManager
 
     public override void runTask (void delegate() dg) nothrow
     {
+        this.tasks_started++;
         geod24.LocalRest.runTask(dg);
     }
 
@@ -303,6 +304,7 @@ public class LocalRestTaskManager : TaskManager
     public override ITimer setTimer (Duration timeout, void delegate() dg,
         Periodic periodic = Periodic.No) nothrow
     {
+        this.tasks_started++;
         return new LocalRestTimer(geod24.LocalRest.setTimer(timeout, dg,
             periodic));
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -538,8 +538,8 @@ public class TestAPIManager
         /// Private functions used for `shutdown`
         static void shutdownWithLogs (TestAPI node)
         {
-            node.printLog();
             (cast(FullNode)node).shutdown();
+            node.printLog();
         }
         static void shutdownSilent (TestAPI node)
         {

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -13,10 +13,6 @@
 
 module agora.test.ManyValidators;
 
-// temporarily disabled until failures are resolved
-// see #1145
-version (none):
-
 import agora.api.Validator;
 import agora.common.Amount;
 import agora.common.Config;

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -113,11 +113,11 @@ unittest
             .map!(txb => txb.refund(WK.Keys.Genesis.address).sign()).array;
         txs.each!(tx => nodes[0].putTransaction(tx));
 
-    network.expectBlock(Height(11), 3.seconds);
+    network.expectBlock(Height(11), 10.seconds);
 
     // sanity check
     nodes.enumerate.each!((idx, node) =>
-        retryFor(node.getValidatorCount() == 16, 3.seconds,
+        retryFor(node.getValidatorCount() == 16, 10.seconds,
             format("Node %s has validator count %s. Expected: %s",
                 idx, node.getValidatorCount(), 16)));
 
@@ -132,7 +132,7 @@ unittest
     txs.each!(tx => nodes[0].putTransaction(tx));
 
     // consensus check
-    network.expectBlock(Height(12), 3.seconds);
+    network.expectBlock(Height(12), 10.seconds);
 }
 
 /// 32 nodes


### PR DESCRIPTION
Also includes a bugfix.

This does not solve the issue of having too many requests to begin with. Our gossiping in the network is quadratic. Given N nodes there will be N to the power of 2 total messages propagated for every gossiping message. We need to make this smarter.

Fixes #1149