### PR TITLE
Check the distance of newly sent pre-image in the revealing unittest

### DIFF
--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -76,13 +76,13 @@ unittest
     txs.each!(tx => nodes[0].putTransaction(tx));
     network.expectBlock(Height(validator_cycle + 1), 2.seconds);
 
-    // check if nodes have a pre-image newly sent
-    // during creating transactions for the new block
+    // check if the distance of newly sent pre-image is greater than
+    // or equal to 1, during creating transactions for the new block
     nodes.each!(node =>
-        retryFor(node.getPreimage(enroll_0.utxo_key) != PreImageInfo.init &&
-                 node.getPreimage(enroll_1.utxo_key) != PreImageInfo.init &&
-                 node.getPreimage(enroll_2.utxo_key) != PreImageInfo.init &&
-                 node.getPreimage(enroll_3.utxo_key) != PreImageInfo.init,
+        retryFor(node.getPreimage(enroll_0.utxo_key).distance >= 1 &&
+                 node.getPreimage(enroll_1.utxo_key).distance >= 1 &&
+                 node.getPreimage(enroll_2.utxo_key).distance >= 1 &&
+                 node.getPreimage(enroll_3.utxo_key).distance >= 1,
             5.seconds));
 }
 


### PR DESCRIPTION
https://github.com/bpfkorea/agora/blob/9d0f3b9ea188e3d98e7c0b0cf337756812da052e/source/agora/test/EnrollmentManager.d#L92-L99
In this issue there were 2 problems:
1. The pre-images were revealed too slowly, so they could not be checked. The test checked the commitment (height = 0) and not the following pre-images.
2. Since`PreImageInfo.init` is 
```
PreImageInfo(0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, 0)
``` 
but we start with the commitment, the test is not effective.

The 1st problem is solved by the configurable timer in https://github.com/bpfkorea/agora/pull/1113 by @AndrejMitrovic 

Fixes #1071 