### PR TITLE
Add randomness to leader selection

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -518,6 +518,31 @@ public class Ledger
             return null;
         return block.getMerklePath(index);
     }
+
+    /***************************************************************************
+
+        Generate the random seed reduced from the preimages for the provided
+        block height.
+
+        Params:
+            height = the desired block height to look up the images for
+
+        Returns:
+            the random seed
+
+    ***************************************************************************/
+
+    public Hash getValidatorRandomSeed (Height height) nothrow
+    {
+        Hash[] keys;
+        if (!this.enroll_man.getEnrolledUTXOs(keys) || keys.length == 0)
+        {
+            log.fatal("Could not retrieve enrollments / no enrollments found");
+            assert(0);
+        }
+
+        return this.enroll_man.getRandomSeed(keys, height);
+    }
 }
 
 /// Note: these unittests historically assume a block always contains

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -566,6 +566,42 @@ public class TestAPIManager
 
     /***************************************************************************
 
+        Checks the needed pre-images are revealed, sets the clock time to the
+        expected clock time to produce a block at the given height, and verifies
+        that the nodes have generated a block at the given block height.
+
+        The overload allows passing a subset of nodes to verify the block
+        heights for only these nodes. Note that the clock time is adjusted
+        for all nodes (this is what most tests expect).
+
+        Params:
+            height = the expected block height
+            enroll_header = the header which contains enrollment information
+            timeout = the request timeout to each node
+
+    ***************************************************************************/
+
+    public void expectBlock (Height height, const(BlockHeader) enroll_header,
+        Duration timeout, string file = __FILE__, int line = __LINE__)
+    {
+        this.expectBlock(this.clients, height, enroll_header, timeout, file,
+            line);
+    }
+
+    /// Ditto
+    public void expectBlock (Clients)(Clients clients, Height height,
+        const(BlockHeader) enroll_header, Duration timeout,
+        string file = __FILE__, int line = __LINE__) if (isInputRange!Clients)
+    {
+        assert(height > enroll_header.height);
+        auto distance = cast(ushort)(height - enroll_header.height - 1);
+        waitForPreimages(clients, enroll_header.enrollments, distance,
+            timeout);
+        this.expectBlock(clients, height, timeout, file, line);
+    }
+
+    /***************************************************************************
+
         Checks if all the nodes contain the given distance of pre-images for
         the given enrollments.
 

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -57,7 +57,7 @@ unittest
 
         // send it to one node
         txs.each!(tx => node_1.putTransaction(tx));
-        network.expectBlock(Height(block_idx + 1), 4.seconds);
+        network.expectBlock(Height(block_idx + 1), blocks[0].header, 4.seconds);
 
         blocks ~= node_1.getBlocksFrom(block_idx + 1, 1);
         block_txes ~= txs.sort.array;
@@ -185,6 +185,10 @@ unittest
 
     auto txs = network.blocks[0].spendable.map!(txb => txb.sign()).array();
     txs.each!(tx => node_1.putTransaction(tx));
+
+    // wait for preimages to be revealed before making blocks
+    network.waitForPreimages(network.blocks[0].header.enrollments, 6, 5.seconds);
+
     network.expectBlock(Height(1), 3.seconds);
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -54,7 +54,8 @@ unittest
 
     nodes[0].clearFilter();
     nodes[1].clearFilter();
-    network.expectBlock(Height(1), 2.seconds);
+    const b0 = nodes[0].getBlocksFrom(0, 2)[0];
+    network.expectBlock(Height(1), b0.header, 2.seconds);
 }
 
 /// test behavior when a node sends bad block data
@@ -170,6 +171,10 @@ unittest
     auto node_validators = nodes[0 .. 4];  // validators, create blocks
     auto node_test = nodes[4];  // full node, does not create blocks
     auto node_bad = nodes[5];  // full node, returns bad blocks in getBlocksFrom()
+
+    // wait for preimages to be revealed before making blocks
+    network.waitForPreimages(network.blocks[0].header.enrollments, 6,
+        5.seconds);
 
     // enable filtering first
     node_validators.each!(node => node.filter!(API.getBlocksFrom));

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -52,7 +52,8 @@ unittest
     network.waitForDiscovery();
 
     auto nodes = network.clients;
-    network.expectBlock(Height(8), 10.seconds);
+    const b0 = nodes[0].getBlocksFrom(0, 2)[0];
+    network.expectBlock(Height(8), b0.header, 10.seconds);
 
     enum quorums_1 = [
         // 0
@@ -146,7 +147,7 @@ unittest
     txs.each!(tx => nodes[0].putTransaction(tx));
 
     // at block height 9 the freeze txs are available
-    network.expectBlock(Height(9), 10.seconds);
+    network.expectBlock(Height(9), b0.header, 10.seconds);
 
     // now we re-enroll existing validators (extension),
     // and enroll 2 new validators.
@@ -175,7 +176,7 @@ unittest
     makeBlock();
 
     // at block height 10 the validator set has changed
-    network.expectBlock(Height(10), 3.seconds);
+    network.expectBlock(Height(10), b0.header, 3.seconds);
 
     // check if the needed pre-images are revealed timely
     enrolls.each!(enroll =>
@@ -276,12 +277,13 @@ unittest
                 idx, node.getQuorumConfig(), quorums_2[idx])));
 
     // create 9 blocks (1 short of all enrollments expiring)
+    const b10 = nodes[0].getBlocksFrom(10, 2)[0];
     foreach (idx; 0 .. 9)
     {
         makeBlock();
 
         // at block height 10 the validator set has changed
-        network.expectBlock(Height(10 + idx + 1), 3.seconds);
+        network.expectBlock(Height(10 + idx + 1), b10.header, 3.seconds);
     }
 
     // re-enroll all validators before they expire
@@ -298,7 +300,7 @@ unittest
     makeBlock();
 
     // at block height 20 the validator set has changed
-    network.expectBlock(Height(20), 10.seconds);
+    network.expectBlock(Height(20), b10.header, 10.seconds);
 
     // these changed compared to quorums_2 due to the new enrollments
     // which use a different preimage

--- a/source/agora/test/TimeBlockInterval.d
+++ b/source/agora/test/TimeBlockInterval.d
@@ -53,15 +53,20 @@ unittest
     ));
 
     // time updated, block height 1
+    const b0 = nodes[0].getBlocksFrom(0, 2)[0];
     network.setTimeFor(Height(1));
+    network.waitForPreimages(b0.header.enrollments, 1, 2.seconds);
     ensureConsistency(nodes, 1);
 
     network.setTimeFor(Height(2));
+    network.waitForPreimages(b0.header.enrollments, 2, 2.seconds);
     ensureConsistency(nodes, 2);
 
     network.setTimeFor(Height(3));
+    network.waitForPreimages(b0.header.enrollments, 3, 2.seconds);
     ensureConsistency(nodes, 3);
 
     network.setTimeFor(Height(4));
+    network.waitForPreimages(b0.header.enrollments, 4, 2.seconds);
     ensureConsistency(nodes, 4);
 }

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -48,7 +48,7 @@ unittest
     auto nodes = network.clients;
     auto set_a = network.clients[0 .. 4];
     auto set_b = network.clients[4 .. $];
-    network.expectBlock(Height(7), 5.seconds);
+    network.expectBlock(Height(7), network.blocks[0].header, 5.seconds);
 
     auto spendable = network.blocks[$ - 1].spendable().array;
 
@@ -64,7 +64,7 @@ unittest
 
     // Block 8
     txs.each!(tx => set_a[0].putTransaction(tx));
-    network.expectBlock(Height(8), 5.seconds);
+    network.expectBlock(Height(8), network.blocks[0].header, 5.seconds);
 
     // Freeze builders
     auto freezable = txs[$ - 3]
@@ -83,7 +83,7 @@ unittest
 
     // Block 9
     freeze_txs.each!(tx => set_a[0].putTransaction(tx));
-    network.expectBlock(Height(9), 5.seconds);
+    network.expectBlock(Height(9), network.blocks[0].header, 5.seconds);
 
     // Now we enroll four new validators. After this, the already enrolled
     // validators will be expired.
@@ -103,10 +103,10 @@ unittest
         .takeExactly(8)
         .map!(txb => txb.refund(WK.Keys.Genesis.address).sign()).array;
     new_txs.each!(tx => set_a[0].putTransaction(tx));
-    network.expectBlock(Height(10), 5.seconds);
+    network.expectBlock(Height(10), network.blocks[0].header, 5.seconds);
 
     // Sanity check
-    auto b10 = set_a[0].getBlocksFrom(0, 2)[0];
+    auto b10 = set_a[0].getBlocksFrom(10, 2)[0];
     assert(b10.header.enrollments.length == 4);
 
     // Now restarting the validators in the set B, all the data of those
@@ -139,7 +139,7 @@ unittest
         .takeExactly(8)
         .map!(txb => txb.refund(WK.Keys.Genesis.address).sign()).array;
     new_txs.each!(tx => set_b[0].putTransaction(tx));
-    network.expectBlock(set_b, Height(11), 5.seconds);
+    network.expectBlock(set_b, Height(11), b10.header, 5.seconds);
 }
 
 /// Situation: A validator is stopped and wiped clean after the block height

--- a/source/agora/test/ValidatorCount.d
+++ b/source/agora/test/ValidatorCount.d
@@ -58,7 +58,7 @@ unittest
 
         // send it to one node
         txs.each!(tx => node_1.putTransaction(tx));
-        network.expectBlock(Height(block_idx), 5.seconds);
+        network.expectBlock(Height(block_idx), blocks[0].header, 5.seconds);
 
         // add next block
          blocks ~= node_1.getBlocksFrom(block_idx, 1);

--- a/source/agora/test/VariableBlockSize.d
+++ b/source/agora/test/VariableBlockSize.d
@@ -46,7 +46,8 @@ unittest
     foreach (block_idx, block_txs; txs.chunks(txs_to_nominate).enumerate)
     {
         block_txs.each!(tx => nodes[0].putTransaction(tx));
-        network.expectBlock(Height(block_idx + 1), 5.seconds);
+        network.expectBlock(Height(block_idx + 1), network.blocks[0].header,
+            5.seconds);
     }
 
     // 8 txs will create 4 blocks if we nominate 2 per block


### PR DESCRIPTION
By adding the `random seed` for all the validators in calculating the hash value of nodes, we can add additional randomness when doing leader selection for each round. This PR has the implementation of that algorithm.

Fixes #1079