### PR TITLE
System integration tests: Make the sleep time 500 msecs

### DIFF
--- a/tests/system/source/main.d
+++ b/tests/system/source/main.d
@@ -102,13 +102,13 @@ private void checkBlockHeight (const string[] addresses, ulong height)
         clients ~= new RestInterfaceClient!API(addr);
 
     Hash blockHash;
-    size_t times; // Number of times we slept for 50 msecs
+    size_t times; // Number of times we slept for 500 msecs
     foreach (idx, ref client; clients)
     {
         ulong getHeight;
         do
         {
-            Thread.sleep(50.msecs);
+            Thread.sleep(500.msecs);
             getHeight = client.getBlockHeight();
         }
         while (getHeight < height && times++ < 100); // Retry if we're too early


### PR DESCRIPTION
This extends the timeout to 50 seconds (from 5 seconds),
and avoid bombarding the node(s) with request,
potentially solving some of the issues we're seeing in the test-suite.