### PR TITLE
Make ledger routines consistent

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -411,9 +411,16 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public size_t validatorCount () @safe
+    public size_t validatorCount () @safe nothrow
     {
-        return this.validator_set.count();
+        try
+        {
+            return this.validator_set.count();
+        }
+        catch (Exception ex)
+        {
+            log.error("Error while getting validator count: {}", ex.msg);
+        }
     }
 
     /***************************************************************************
@@ -482,7 +489,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public bool getNextPreimage (out PreImageInfo preimage) @safe
+    public bool getNextPreimage (out PreImageInfo preimage) @safe nothrow
     {
         const enrolled = this.getEnrolledHeight(this.enroll_key);
         if (enrolled == ulong.max)
@@ -631,7 +638,7 @@ public class EnrollmentManager
     }
 
     /// Returns: true if this validator is currently enrolled
-    public bool isEnrolled (UTXOFinder finder) nothrow @safe
+    public bool isEnrolled (UTXOFinder finder) @safe nothrow
     {
         Hash[] utxo_keys;
         assert(this.validator_set.getEnrolledUTXOs(utxo_keys));
@@ -830,7 +837,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public Enrollment getEnrollment (const ref Hash enroll_hash) @trusted
+    public Enrollment getEnrollment (const ref Hash enroll_hash) @trusted nothrow
     {
         return this.enroll_pool.getEnrollment(enroll_hash);
     }
@@ -844,7 +851,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public void removeEnrollment (const ref Hash enroll_hash) @trusted
+    public void removeEnrollment (const ref Hash enroll_hash) @trusted nothrow
     {
         this.enroll_pool.remove(enroll_hash);
     }

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -62,7 +62,7 @@ public interface IBlockStorage
 
     ***************************************************************************/
 
-    public bool load (const ref Block genesis);
+    public bool load (const ref Block genesis) nothrow;
 
     /***************************************************************************
 
@@ -76,7 +76,7 @@ public interface IBlockStorage
 
     ***************************************************************************/
 
-    public bool readLastBlock (ref Block block);
+    public bool readLastBlock (ref Block block) nothrow;
 
 
     /***************************************************************************
@@ -91,7 +91,7 @@ public interface IBlockStorage
 
     ***************************************************************************/
 
-    public bool saveBlock (const ref Block block);
+    public bool saveBlock (const ref Block block) nothrow;
 
 
     /***************************************************************************
@@ -973,7 +973,7 @@ public class MemBlockStorage : IBlockStorage
 
     ***************************************************************************/
 
-    public bool readLastBlock (ref Block block) @safe
+    public bool readLastBlock (ref Block block) @safe nothrow
     {
         if (this.height_idx.length == 0)
             return false;

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -522,9 +522,17 @@ public class FullNode : API
     ***************************************************************************/
 
     protected void onAcceptedBlock (const ref Block block,
-        bool validators_changed) @safe
+        bool validators_changed) @safe nothrow
     {
-        this.pushBlock(block);
+        try
+        {
+            this.pushBlock(block);
+        }
+        catch (Exception ex)
+        {
+            log.error("Error pushing block: {}" ~
+                "Block: {}", ex.msg, block);
+        }
     }
 
     /***************************************************************************

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -75,7 +75,7 @@ public class Ledger
 
     /// If not null call this delegate
     /// A block was externalized
-    private void delegate (const ref Block, bool) @safe onAcceptedBlock;
+    private void delegate (const ref Block, bool) @safe nothrow onAcceptedBlock;
 
     /// Parameters for consensus-critical constants
     private immutable(ConsensusParams) params;
@@ -98,7 +98,7 @@ public class Ledger
     public this (immutable(ConsensusParams) params,
         UTXOSet utxo_set, IBlockStorage storage,
         EnrollmentManager enroll_man, TransactionPool pool,
-        void delegate (const ref Block, bool) @safe onAcceptedBlock = null)
+        void delegate (const ref Block, bool) @safe nothrow onAcceptedBlock = null)
     {
         this.params = params;
         this.utxo_set = utxo_set;
@@ -218,7 +218,7 @@ public class Ledger
 
     ***************************************************************************/
 
-    public bool acceptTransaction (Transaction tx) @safe
+    public bool acceptTransaction (Transaction tx) @safe nothrow
     {
         const Height expected_height = Height(this.getBlockHeight() + 1);
         auto reason = tx.isInvalidReason(this.utxo_set.getUTXOFinder(),
@@ -368,7 +368,7 @@ public class Ledger
 
     ***************************************************************************/
 
-    public string validateConsensusData (ConsensusData data) @trusted
+    public string validateConsensusData (ConsensusData data) @trusted nothrow
     {
         const expect_height = Height(this.getBlockHeight() + 1);
         auto utxo_finder = this.utxo_set.getUTXOFinder();
@@ -406,7 +406,7 @@ public class Ledger
 
     ***************************************************************************/
 
-    public string validateBlock (const ref Block block) nothrow @safe
+    public string validateBlock (const ref Block block) @safe nothrow
     {
         size_t active_enrollments = enroll_man.getValidatorCount(
                 block.header.height);
@@ -497,7 +497,7 @@ public class Ledger
 
     ***************************************************************************/
 
-    public bool hasTransactionHash (const ref Hash tx) @safe
+    public bool hasTransactionHash (const ref Hash tx) @safe nothrow
     {
         return this.pool.hasTransactionHash(tx);
     }


### PR DESCRIPTION
The ledger routines are currently inconsistent, with a routine returning either boolean status codes, exceptions, or `assert`.

They should not return boolean status codes **and** also throw. There was a situation in the code below
https://github.com/bpfkorea/agora/blob/1af3731d063a8b52f1e114a4b31e5ac65ad70869/source/agora/node/Ledger.d#L268-L269
where the `assert` might not get triggered because `saveBlock` is not nothrow. `saveBlock` is now `nothrow`, but the other routines need to be fixed.
I would like some suggestions on how to structure the routines.

Relates #1083 