### PR TITLE
Demonstrate one bad and one potentially good signature scheme

### DIFF
--- a/source/agora/common/crypto/ECC.d
+++ b/source/agora/common/crypto/ECC.d
@@ -166,6 +166,24 @@ public struct Scalar
     {
         dg(this.data[]);
     }
+
+    /***************************************************************************
+
+        Returns:
+            the inverted scalar.
+
+        See_Also: https://libsodium.gitbook.io/doc/advanced/point-arithmetic
+        See_Also: https://tlu.tarilabs.com/cryptography/digital_signatures/introduction_schnorr_signatures.html#why-do-we-need-the-nonce
+
+    ***************************************************************************/
+
+    public Scalar invert () @trusted
+    {
+        Scalar scalar = this;  // copy
+        assert(crypto_core_ed25519_scalar_invert(scalar.data[].ptr,
+            this.data[].ptr) == 0);
+        return scalar;
+    }
 }
 
 ///

--- a/source/agora/common/crypto/ECC.d
+++ b/source/agora/common/crypto/ECC.d
@@ -172,8 +172,9 @@ public struct Scalar
         Returns:
             the inverted scalar.
 
-        See_Also: https://libsodium.gitbook.io/doc/advanced/point-arithmetic
-        See_Also: https://tlu.tarilabs.com/cryptography/digital_signatures/introduction_schnorr_signatures.html#why-do-we-need-the-nonce
+        See_Also:
+            https://libsodium.gitbook.io/doc/advanced/point-arithmetic
+            https://tlu.tarilabs.com/cryptography/digital_signatures/introduction_schnorr_signatures.html#why-do-we-need-the-nonce
 
     ***************************************************************************/
 

--- a/source/agora/common/crypto/Schnorr.d
+++ b/source/agora/common/crypto/Schnorr.d
@@ -269,3 +269,25 @@ nothrow @nogc @safe unittest
     assert(verify(kp2.V, sig2, secret));
     assert(!verify(kp2.V, sig1, secret));
 }
+
+// example of extracting the private key from an insecure signature scheme
+// which did not include 'r' during the signing
+// https://tlu.tarilabs.com/cryptography/digital_signatures/introduction_schnorr_signatures.html#why-do-we-need-the-nonce
+/*@nogc*/ @safe unittest
+{
+    static immutable string message = "BOSAGORA for the win";
+
+    Pair kp = Pair.random();  // key-pair
+    Scalar c = hashFull(message);  // challenge
+    Scalar s = (kp.v * c);  // signature
+
+    // known public data of the node
+    Point K = kp.V;
+
+    // other nodes verify
+    assert(s.toPoint() == K * c);
+
+    // but the other node can also extract the private key!
+    Scalar stolen_key = s * c.invert();
+    assert(stolen_key == kp.v);
+}


### PR DESCRIPTION
This demonstrates what was written on https://tlu.tarilabs.com/cryptography/digital_signatures/introduction_schnorr_signatures.html#why-do-we-need-the-nonce, that not including 'r' in the signature can make it easy to extract the private key.

Note that it might still be possible to have a scheme like this:

```
c = hash(msg)
s = r + (k * c)
```

Where 'r' is included in signing but is not included in the hash. In fact I don't think the hashing part is important at all. The hashing part is what we commit to, but we have already committed to all P (public keys) and R (preimages) beforehand so it's unnecessary to re-commit to it by including it in the hash. However I'll try to write a test-case for this too.