### PR TITLE
Test-case for wrong preimage behavior

### DIFF
--- a/source/agora/consensus/ValidatorSet.d
+++ b/source/agora/consensus/ValidatorSet.d
@@ -477,7 +477,15 @@ public class ValidatorSet
 
         // Ignore same height pre-image because validators will gossip them
         if (prev_preimage.distance == preimage.distance)
+        {
+            if (prev_preimage == preimage)
+                log.info("Rejected pre-image: distance is same: {}. Prev: {}. New: {}",
+                    preimage.hash, prev_preimage, preimage);
+            else
+                log.info("Rejected pre-image: distance is same (HASHES DIFFER): {}. Prev: {}. New: {}",
+                    preimage.hash, prev_preimage, preimage);
             return false;
+        }
 
         if (auto reason = isInvalidReason(preimage, prev_preimage,
             this.params.ValidatorCycle))

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -833,6 +833,12 @@ public class NetworkManager
                 continue;
             }
 
+            if (preimage.hash == Hash(`0xabfa663edf1156503d4da365e1163268778991cc5a694b4a1b34a1d0ff773719b4a5b37c1cb13ce1c64576a34d4a92db0c4db264e9b83eb79168f37f1befe353`))
+            {
+                log.info("Sending `0xabfa663edf1156503d4da365e1163268778991cc5a694b4a1b34a1d0ff773719b4a5b37c1cb13ce1c64576a34d4a92db0c4db264e9b83eb79168f37f1befe353` to {}",
+                    node.address);
+            }
+
             node.sendPreimage(preimage);
         }
     }

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -486,8 +486,16 @@ public class FullNode : API
 
         if (this.enroll_man.addPreimage(preimage))
         {
+            if (preimage.hash == Hash(`0xabfa663edf1156503d4da365e1163268778991cc5a694b4a1b34a1d0ff773719b4a5b37c1cb13ce1c64576a34d4a92db0c4db264e9b83eb79168f37f1befe353`))
+                log.info("Accepted `0xabfa663edf1156503d4da365e1163268778991cc5a694b4a1b34a1d0ff773719b4a5b37c1cb13ce1c64576a34d4a92db0c4db264e9b83eb79168f37f1befe353`");
+
             this.network.sendPreimage(preimage);
             this.pushPreImage(preimage);
+        }
+        else
+        {
+            if (preimage.hash == Hash(`0xabfa663edf1156503d4da365e1163268778991cc5a694b4a1b34a1d0ff773719b4a5b37c1cb13ce1c64576a34d4a92db0c4db264e9b83eb79168f37f1befe353`))
+                log.error("Rejected `0xabfa663edf1156503d4da365e1163268778991cc5a694b4a1b34a1d0ff773719b4a5b37c1cb13ce1c64576a34d4a92db0c4db264e9b83eb79168f37f1befe353`");
         }
     }
 

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -148,11 +148,13 @@ unittest
     // at block height 9 the freeze txs are available
     network.expectBlock(Height(9), 10.seconds);
 
+    Enrollment[] enrolls;
     // now we re-enroll existing validators (extension),
     // and enroll 2 new validators.
     foreach (node; nodes)
     {
         Enrollment enroll = node.createEnrollmentData();
+        enrolls ~= enroll;
         node.enrollValidator(enroll);
 
         // check enrollment
@@ -174,6 +176,22 @@ unittest
 
     // at block height 10 the validator set has changed
     network.expectBlock(Height(10), 3.seconds);
+
+    auto b10 = nodes[0].getBlocksFrom(10, 1)[0];
+
+    retryFor(nodes[0].getPreimage(enrolls[0].utxo_key).distance >= 9, 5.seconds);
+    retryFor(nodes[1].getPreimage(enrolls[0].utxo_key).distance >= 9, 5.seconds);
+    retryFor(nodes[2].getPreimage(enrolls[0].utxo_key).distance >= 9, 5.seconds);
+    retryFor(nodes[3].getPreimage(enrolls[0].utxo_key).distance >= 9, 5.seconds);
+    retryFor(nodes[4].getPreimage(enrolls[0].utxo_key).distance >= 9, 5.seconds);
+    retryFor(nodes[5].getPreimage(enrolls[0].utxo_key).distance >= 9, 5.seconds);
+
+    // fails
+    retryFor(nodes[6].getPreimage(enrolls[0].utxo_key).distance >= 9, 5.seconds,
+        format("\nGot '%s'.\n\nExpected '%s'.\n\nBlock 10 enrollments: %s",
+            nodes[6].getPreimage(enrolls[0].utxo_key),
+            nodes[0].getPreimage(enrolls[0].utxo_key),
+            b10.header.enrollments));
 
     enum quorums_2 = [
         // 0


### PR DESCRIPTION
`Node #6` is the first outsider node.

For some reason `Node #0`'s preimages which are new beginning from the node's re-enrollment at height 10 are either not propagated to `Node #6` or `Node #6` somehow rejects them.

The output is:

```
core.exception.AssertError@source/agora/test/QuorumPreimage.d(190): Check condition failed after timeout of 5 secs and 50 attempts:
Got 'PreImageInfo(0xb82cb96710af2e9804c59d1f1e1679f8b8b69f4c0f6cd79c8c12f365dd766c09aaa4febcc18b3665d33301cb248ac7afd343ac7b98b27beaf246ad12d3b3219a, 0xabb640e7c36df355074971ae3dc98759b5a80ee0270f98973b9045c9000f6c583ebf425ffb08e5c84466a1a4521c004141268c34aa34f6c224759d66b9b69251, 0)'.

Expected 'PreImageInfo(0xb82cb96710af2e9804c59d1f1e1679f8b8b69f4c0f6cd79c8c12f365dd766c09aaa4febcc18b3665d33301cb248ac7afd343ac7b98b27beaf246ad12d3b3219a, 0xabfa663edf1156503d4da365e1163268778991cc5a694b4a1b34a1d0ff773719b4a5b37c1cb13ce1c64576a34d4a92db0c4db264e9b83eb79168f37f1befe353, 9)'.

Block 10 enrollments: [const(Enrollment)(0x190dd12450d9f1972e21e39d676d9e5bb690071d98ed5c0859077e409741912a4baf07dabc2c879725f0af67f783bbb0161c68d55ef6835639eaaedff2317561, 0x1e49fd58c9f20a7923955e332e34b0f7b1d88c93c27fd59aa2228dbec3d2446734f580c23c7f42e7f3ae7399ed064933916edcc26d1049da5492223b7fc4e672, 10, 0x0b1ec01efb1b35d3bacb85c646396689868262e05d1dd11a514382f4d60cd78a76293e021964959cceba5a6c7fa86ff200b7215df9184a147acef12d84bdccfc), const(Enrollment)(0x4028965b7408566a66e4cf8c603a1cdebc7659a3e693d36d2fdcb39b196da967914f40ef4966d5b4b1f4b3aae00fbd68ffe8808b070464c2a101d44f4d7b0170, 0xda432b9cc15fff1891f3cae0005132265deba66af44de849107a7fa402bb89d1bd9c3b5c578ab5e8f26bccadb597f780dccdda44dac97cd58e68ff9f6e1b5f91, 10, 0x03c602b2e2164761b7c921f93127dec7ef623fdfe3f1a1d6c89f9582b5654044483340d6b9faa8d3f0814f11c18f28076c347de76db84ea0547d892a72592c81), const(Enrollment)(0x4e4495177703423406edb374e959fd0012c978df5279970b8bb1d2c681d96c24142ace5aa4bfac189e2ca5721f98bd487f9d73360b263817823e504fb69163ca, 0xfa7269df4bbceaf44bdee8919c060fa10c42e0e25dd7427c1780e9121df7562b1e28e8a79d28d149ab97ac7d80d6d1f4108f76f27f8f2c99315dc61e2dfae9e1, 10, 0x09dac580ecf4004964a92c171aae1d61af3706250d72b4a108df1ce5404494691d5968b441abe668fda843850e51e5857c713eae89abab480e0566eb61ce83f7), const(Enrollment)(0x79cd79372b837061517881ad463bef00416db1d3382896e13e903f3fdca31adb8bf1e3d3c16b671b57529546e734f79e2763ad6ca59fe6a3126ca67dc89225ec, 0x886a85fda7f48be50dc813f3e3746b74eaa54323c300606091844fe748813732330028aa757e558fc1470b899c829c70846b7dd84d34cb4d90b4a84cfb8210ce, 10, 0x04b568cddd8e8f775a61372e705cae60e2eadc3750d9dd41c916f8bfc0616d0dbcb9e9a11ee14e88192e68317e45a3801fe77d85550385c05d63a6f064b3c28e), const(Enrollment)(0x81660954e2e1e98d2595d566c0f7ada12bf5c377b4136dd991d596ea0db3c758a45d7cad13cfc1227b39968340c455b46c0eb51a6b6e816f5eeb453c66df468c, 0xf99f56dce4faf23bf7e748614feec9195480f3e8d349cd5931668e138ce05464c22ae246f4d5a317419875f547faf4b07147f24fe78d58f5b3a5b731d2f430ef, 10, 0x0d4f45478808697d8e93e2d551b754ce0c23d273d8381d3d5f33f0eac8adece06b291c4ed0cb3c9682a3b8d068811b6761ecc53c7d28c96cd6e54f6f5588dc38), const(Enrollment)(0x81a326afa790003c32517a2a2556613004e6147edac28d576cf7bcc2daadf4bb60be1f644c229b775e7894844ec66b2d70ddf407b8196b46bc1dfe42061c7497, 0x166eaf37749bdec4ee6258a2faa5aa590b75ee6eec3eae3c6b5d06bd6c00e26cf2943fc34ffe2d3c63c0208b7f27a8521da5493829e34fa3ac5c72d4c9fc29a4, 10, 0x012c380370decafa841937106b79148942d83d09d59a34e5282655730d1cb42b4e609af8644eb3991079989aafd9d1793161935ee5d16be5f90e20058b8c05a4), const(Enrollment)(0x8ead57513b90ac4042884695a328ab16cb8fe440080664d556dcf7d63146fbf37b4318ff526c26a15ac0a1166a17a508a5113e4f46f211cbf5c5748424e86cec, 0x1fbe0b433d0999183c89d6a978c4821ef63e98092a9cf9fa622fd32d03d508dec58880428ab61e8de05d824ff7651c911017687768b04b0df3e69b3a48068167, 10, 0x0f69caf48101fe373a871b243bf950e68da826badbde4cba81c7fcbc52ec8a9a0677704da7093dec2bd1bd28a6997b7e70a11d28e33aa48a12828b7f98dd79a3), const(Enrollment)(0xb82cb96710af2e9804c59d1f1e1679f8b8b69f4c0f6cd79c8c12f365dd766c09aaa4febcc18b3665d33301cb248ac7afd343ac7b98b27beaf246ad12d3b3219a, 0xabb640e7c36df355074971ae3dc98759b5a80ee0270f98973b9045c9000f6c583ebf425ffb08e5c84466a1a4521c004141268c34aa34f6c224759d66b9b69251, 10, 0x09cf6c4c3722aee7c83e4bbeba99bc3233574433f90b759ef3308d8e06b43762ec335415eb1064e6fcaf43ef02dcd1132e50e0948951463f28e4d82b4308cb37)]
```

The preimage that Node #6 has is still the Enrollment commitment (`0xabb640e7c36df355074971ae3dc98759b5a80ee0270f98973b9045c9000f6c583ebf425ffb08e5c84466a1a4521c004141268c34aa34f6c224759d66b9b69251`) at distance 0.

But if you look into the logs you will see that a validator does send the preimage to Validator 6:

```
2020-09-02 16:56:18,238 Info [agora.network.NetworkManager] - Sending `0xabfa663edf1156503d4da365e1163268778991cc5a694b4a1b34a1d0ff773719b4a5b37c1cb13ce1c64576a34d4a92db0c4db264e9b83eb79168f37f1befe353` to Validator #6 (GDG2...6ZGD)
```

But then Validator 6 rejects it:

```
2020-09-02 17:03:30,844 [36mTrace[0m [agora.node.FullNode] - Received Preimage: { enroll_key: 0xb82cb96710af2e9804c59d1f1e1679f8b8b69f4c0f6cd79c8c12f365dd766c09aaa4febcc18b3665d33301cb248ac7afd343ac7b98b27beaf246ad12d3b3219a, hash: 0xabfa663edf1156503d4da365e1163268778991cc5a694b4a1b34a1d0ff773719b4a5b37c1cb13ce1c64576a34d4a92db0c4db264e9b83eb79168f37f1befe353, distance: 9 }
2020-09-02 17:03:30,844 [32mInfo[0m [agora.consensus.ValidatorSet] - Rejected pre-image: distance is same (HASHES DIFFER): 0xabfa663edf1156503d4da365e1163268778991cc5a694b4a1b34a1d0ff773719b4a5b37c1cb13ce1c64576a34d4a92db0c4db264e9b83eb79168f37f1befe353. Prev: { enroll_key: 0xb82cb96710af2e9804c59d1f1e1679f8b8b69f4c0f6cd79c8c12f365dd766c09aaa4febcc18b3665d33301cb248ac7afd343ac7b98b27beaf246ad12d3b3219a, hash: 0x5de2b8330f17b4e39b8160788c0200af444901d470b46d0946a7f3f0f6b70e0f8092a15804c3ab545e3136a8ef75a1edfd1e62b8c824ff74f9cdc9b509779e58, distance: 9 }. New: { enroll_key: 0xb82cb96710af2e9804c59d1f1e1679f8b8b69f4c0f6cd79c8c12f365dd766c09aaa4febcc18b3665d33301cb248ac7afd343ac7b98b27beaf246ad12d3b3219a, hash: 0xabfa663edf1156503d4da365e1163268778991cc5a694b4a1b34a1d0ff773719b4a5b37c1cb13ce1c64576a34d4a92db0c4db264e9b83eb79168f37f1befe353, distance: 9 }
```

Notice the `(HASHES DIFFER):` log here. Somehow `Validator #6` contains a different preimage hash for the same utxo key and the same distance. Since this test includes re-enrolling, it's possible this is the preimage of the old cycle..