### PR TITLE
Change the way pre-images are revealed

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -496,24 +496,6 @@ public class EnrollmentManager
 
         const height = Height(min(this.next_reveal_height + PreimageRevealPeriod * 2,
                                 enrolled + this.params.ValidatorCycle));
-        return getPreimage(height, preimage);
-    }
-
-    /***************************************************************************
-
-        Get a pre-image at a certain height
-
-        Params:
-            height = the number of the height at which the pre-image exists
-            preimage = will contain the PreImageInfo if exists
-
-        Returns:
-            true if the pre-image exists
-
-    ***************************************************************************/
-
-    public bool getPreimage (Height height, out PreImageInfo preimage) @safe
-    {
         const enrolled_height =
             this.validator_set.getEnrolledHeight(this.enroll_key);
         assert(enrolled_height != ulong.max);
@@ -997,18 +979,10 @@ unittest
     // clear up all validators
     man.clearExpiredValidators(Height(1018));
 
-    // get a pre-image at a certain height
-    // A validation can start at the height of the enrolled height plus 1.
-    // So, a pre-image can only be got from the start height.
+    // A validation is enrolled at the height of 10.
     PreImageInfo preimage;
     enroll = man.createEnrollment(utxo_hash);
     assert(man.addValidator(enroll, Height(10), &utxo_set.findUTXO, utxos) is null);
-    assert(!man.getPreimage(Height(10), preimage));
-    assert(man.getPreimage(Height(11), preimage));
-    assert(preimage.hash == man.cycle.preimages[$ - 1]);
-    assert(man.getPreimage(Height(10 + man.params.ValidatorCycle), preimage));
-    assert(preimage.hash == man.cycle.preimages[0]);
-    assert(!man.getPreimage(Height(11 + man.params.ValidatorCycle), preimage));
 
     /// test for the functions about periodic revelation of a pre-image
     assert(man.needRevealPreimage(Height(10)));

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -570,7 +570,7 @@ public class FullNode : API
 
     ***************************************************************************/
 
-    private void pushPreImage (const PreImageInfo pre_image) @safe
+    protected void pushPreImage (const PreImageInfo pre_image) @safe
     {
         foreach (address, handler; this.preimage_handlers)
         {

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -352,14 +352,13 @@ public class Validator : FullNode, API
 
     private void checkRevealPreimage () @safe
     {
-        if (!this.enroll_man.needRevealPreimage(this.ledger.getBlockHeight()))
-            return;
-
         PreImageInfo preimage;
         if (this.enroll_man.getNextPreimage(preimage))
         {
-            this.receivePreimage(preimage);
-            this.enroll_man.increaseNextRevealHeight();
+            this.enroll_man.addPreimage(preimage);
+            this.network.sendPreimage(preimage);
+            this.pushPreImage(preimage);
+            this.enroll_man.updateRevealDistance(this.ledger.getBlockHeight());
         }
     }
 }

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -150,9 +150,11 @@ unittest
 
     // now we re-enroll existing validators (extension),
     // and enroll 2 new validators.
+    Enrollment[] enrolls;
     foreach (node; nodes)
     {
         Enrollment enroll = node.createEnrollmentData();
+        enrolls ~= enroll;
         node.enrollValidator(enroll);
 
         // check enrollment
@@ -174,6 +176,11 @@ unittest
 
     // at block height 10 the validator set has changed
     network.expectBlock(Height(10), 3.seconds);
+
+    // check if the needed pre-images are revealed timely
+    enrolls.each!(enroll =>
+        nodes.each!(node =>
+            retryFor(node.getPreimage(enroll.utxo_key).distance >= 6, 5.seconds)));
 
     enum quorums_2 = [
         // 0


### PR DESCRIPTION
There was a timing issue where the pre-image of a new validator cycle arrives before the new cycle does not start yet which means a receiving node never gets the pre-image again. So, we need to change the way a validator reveals pre-images. We have decided that validators keep revealing the pre-image set to be revealed in the revealing period. After the period, validators start and keep revealing new pre-image for a new period.

Fixes #1166 