### PR TITLE
Make `TransactionPool.opApply` templated

### DIFF
--- a/source/agora/common/TransactionPool.d
+++ b/source/agora/common/TransactionPool.d
@@ -137,7 +137,7 @@ public class TransactionPool
             return false;
 
         // insert each input information of the transaction
-        foreach (input; tx.inputs)
+        foreach (const ref input; tx.inputs)
             this.input_set.put(input.hashFull());
 
         serializeToBuffer(tx, buffer);
@@ -162,7 +162,7 @@ public class TransactionPool
     public void remove (const ref Transaction tx) @trusted
     {
         // delete inputs of transaction from the set of Input hashes
-        foreach (ref input; tx.inputs)
+        foreach (const ref input; tx.inputs)
             this.input_set.remove(input.hashFull());
 
         auto hash = tx.hashFull();
@@ -269,7 +269,7 @@ public class TransactionPool
         if (this.hasTransactionHash(txHash))
             return false;  // double-spend
 
-        foreach (input; tx.inputs)
+        foreach (const ref input; tx.inputs)
         {
             auto hash = input.hashFull();
             if (hash in this.input_set)

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -347,7 +347,7 @@ public class Ledger
 
         this.enroll_man.getEnrollments(data.enrolls,
             Height(this.getBlockHeight()));
-        foreach (hash, tx; this.pool)
+        foreach (ref Transaction tx; this.pool)
         {
             if (auto reason = tx.isInvalidReason(utxo_finder, next_height))
                 log.trace("Rejected invalid ('{}') tx: {}", reason, tx);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -379,7 +379,7 @@ public class Ledger
         const expect_height = Height(this.getBlockHeight() + 1);
         auto utxo_finder = this.utxo_set.getUTXOFinder();
 
-        foreach (tx; data.tx_set)
+        foreach (const ref tx; data.tx_set)
         {
             if (auto fail_reason = tx.isInvalidReason(utxo_finder, expect_height))
                 return fail_reason;
@@ -390,7 +390,7 @@ public class Ledger
         if (data.enrolls.length + active_enrollments < Enrollment.MinValidatorCount)
             return "Enrollment: Insufficient number of active validators";
 
-        foreach (enroll; data.enrolls)
+        foreach (const ref enroll; data.enrolls)
         {
             if (auto fail_reason = this.enroll_man.isInvalidCandidateReason(
                 enroll, expect_height, utxo_finder))


### PR DESCRIPTION
This allows us to have proper attributes being inferred on the users, as currently the delegate has no attributes.

Split off from #1161
Relates issue #1083 
Developed with @Geod24