### PR TITLE
Blocks loaded from the ledger are validated when the UTXO set is rebuilt

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -848,6 +848,17 @@ public class EnrollmentManager
     {
         this.enroll_pool.remove(enroll_hash);
     }
+
+    /***************************************************************************
+
+        Remove all validators from the validator set
+
+    ***************************************************************************/
+
+    public void removeAllValidators () @trusted
+    {
+        this.validator_set.removeAll();
+    }
 }
 
 /// tests for member functions of EnrollmentManager

--- a/source/agora/consensus/ValidatorSet.d
+++ b/source/agora/consensus/ValidatorSet.d
@@ -162,6 +162,24 @@ public class ValidatorSet
 
     /***************************************************************************
 
+        Remove all validators from the validator set
+
+    ***************************************************************************/
+
+    public void removeAll () @trusted nothrow
+    {
+        try
+        {
+            this.db.execute("DELETE FROM validator_set");
+        }
+        catch (Exception ex)
+        {
+            log.error("Error while calling ValidatorSet.removeAll(): {}", ex);
+        }
+    }
+
+    /***************************************************************************
+
         In validatorSet DB, return the enrolled block height.
 
         Params:
@@ -577,14 +595,13 @@ unittest
     assert(keys.length == 3);
     assert(keys.isStrictlyMonotonic!("a < b"));
 
-    // remove an enrollment
+    // remove ValidatorSet
     set.remove(utxos[1]);
     assert(set.count() == 2);
     assert(set.hasEnrollment(utxos[0]));
     set.remove(utxos[0]);
     assert(!set.hasEnrollment(utxos[0]));
-    set.remove(utxos[1]);
-    set.remove(utxos[2]);
+    set.removeAll();
     assert(set.count() == 0);
 
     Enrollment[] ordered_enrollments;

--- a/source/agora/consensus/validation/package.d
+++ b/source/agora/consensus/validation/package.d
@@ -35,6 +35,7 @@
 module agora.consensus.validation;
 
 public import agora.consensus.validation.Block       : isInvalidReason;
+public import agora.consensus.validation.Block       : isGenesisBlockInvalidReason;
 public import agora.consensus.validation.Enrollment  : isInvalidReason;
 public import agora.consensus.validation.PreImage    : isInvalidReason;
 public import agora.consensus.validation.Transaction : isInvalidReason;


### PR DESCRIPTION
For defensive measures, we should validate every block which is read
during the regeneration of the UTXO set / Validator set.

Related to #1142 