### PR TITLE
Implement a proof-of-concept schnorr multisignature of a block

### DIFF
--- a/source/agora/common/crypto/ECC.d
+++ b/source/agora/common/crypto/ECC.d
@@ -170,7 +170,7 @@ public struct Scalar
     }
 
     /// Scalar should be greater than zero and less than L:2^252 + 27742317777372353535851937790883648493
-    public bool isValid() () nothrow @nogc @safe
+    public bool isValid () nothrow @nogc @safe const
     {
         const auto ED25519_L =  BitBlob!256("0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed");
         const auto ZERO =       BitBlob!256("0x0000000000000000000000000000000000000000000000000000000000000000");

--- a/source/agora/common/crypto/ECC.d
+++ b/source/agora/common/crypto/ECC.d
@@ -70,7 +70,7 @@ public struct Scalar
     /// Internal state
     package BitBlob!(crypto_core_ed25519_SCALARBYTES * 8) data;
 
-    private this (typeof(this.data) data) @safe
+    private this (typeof(this.data) data) @safe inout
     {
         this.data = data;
     }

--- a/source/agora/common/crypto/ECC.d
+++ b/source/agora/common/crypto/ECC.d
@@ -201,6 +201,13 @@ public struct Scalar
     {
         dg(this.data[]);
     }
+
+    /// Convenience overload to allow this to be converted to an `opaque_array`,
+    /// as used in the `confirm_t` statement signature in SCP
+    public const(ubyte)[] opSlice () const @safe pure nothrow @nogc
+    {
+        return this.data[];
+    }
 }
 
 // Test Scalar fromString / toString functions

--- a/source/agora/common/crypto/Schnorr.d
+++ b/source/agora/common/crypto/Schnorr.d
@@ -122,7 +122,7 @@ public Point extractNonce (Signature sig) @safe @nogc nothrow pure
 
 *******************************************************************************/
 
-package struct Sig
+public struct Sig
 {
     /// Commitment
     public Point R;
@@ -174,12 +174,12 @@ public struct Pair
     /// v.G
     public Point V;
 
-    /// Construct a Pair from a Scalar 
-    public static Pair fromScalar(const Scalar v) nothrow @nogc @safe 
+    /// Construct a Pair from a Scalar
+    public static Pair fromScalar(const Scalar v) nothrow @nogc @safe
     {
         return Pair(v, v.toPoint());
-    }    
-    
+    }
+
     /// Generate a random value `v` and a point on the curve `V` where `V = v.G`
     public static Pair random () nothrow @nogc @safe
     {

--- a/source/agora/common/crypto/Schnorr.d
+++ b/source/agora/common/crypto/Schnorr.d
@@ -89,6 +89,32 @@ nothrow @nogc @safe unittest
 
 /*******************************************************************************
 
+    Extract the R from (R, s) of a binary representation of a signature
+
+    Params:
+        sig = the binary representation of the schnorr signature
+
+    Returns:
+        the R from the (R, s) pair
+
+*******************************************************************************/
+
+public Point extractNonce (Signature sig) @safe @nogc nothrow pure
+{
+    return Sig.fromBlob(sig).R;
+}
+
+///
+@safe @nogc nothrow /*pure*/ unittest
+{
+    const R = Pair.random();
+    const kp = Pair.random();
+    const sig = sign(kp.v, kp.V, R.V, R.v, "foo");
+    assert(extractNonce(sig) == R.V);
+}
+
+/*******************************************************************************
+
     Represent a signature (R, s)
 
     Note that signatures get passed around as binary blobs

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -384,6 +384,25 @@ public class EnrollmentManager
 
     /***************************************************************************
 
+        Retrieves the R from the (R, s) of the signature in the commitment
+        for the associated public key
+
+        Params:
+            key = the public key to look up
+
+        Returns:
+            The `R` used in the signature of the Enrollment,
+            or `Point.init` if one is not found
+
+    ***************************************************************************/
+
+    public Point getCommitmentNonce (const ref PublicKey key) @trusted nothrow
+    {
+        return this.validator_set.getCommitmentNonce(key);
+    }
+
+    /***************************************************************************
+
         Get all the enrolled validator's UTXO keys.
 
         Params:

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -403,6 +403,23 @@ public class EnrollmentManager
 
     /***************************************************************************
 
+        Get the r that was used to sign the enrollment of this validator node
+
+        Returns:
+            The initial `r` used when signing the Enrollment
+
+    ***************************************************************************/
+
+    public Scalar getCommitmentNonceScalar () nothrow
+    {
+        // we have to do -1 because the cycle index is incremented
+        // after createEnrollment() is called!
+        return Scalar(hashMulti(this.key_pair.v, "consensus.signature.noise",
+            ulong(this.cycle.index - 1)));
+    }
+
+    /***************************************************************************
+
         Get all the enrolled validator's UTXO keys.
 
         Params:

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -437,6 +437,23 @@ public class EnrollmentManager
 
     /***************************************************************************
 
+        Get all the enrolled validator's public keys.
+
+        Params:
+            utxo_keys = will contain the set of public keys
+
+        Returns:
+            Return true if there was no error in getting the public keys
+
+    ***************************************************************************/
+
+    public bool getEnrolledPublicKeys (out PublicKey[] keys) @safe nothrow
+    {
+        return this.validator_set.getEnrolledPublicKeys(keys);
+    }
+
+    /***************************************************************************
+
         Get the number of active validators.
 
         Client code can use this between clearExpiredValidators() calls to

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -610,6 +610,26 @@ public class EnrollmentManager
 
     /***************************************************************************
 
+        Get a validator's pre-image from the validator set for a specific height
+
+        Params:
+            key = The public key of the validator
+            height = the height to look up
+
+        Returns:
+            the PreImageInfo of the associated key if it exists,
+            otherwise `PreImageInfo.init`
+
+    ***************************************************************************/
+
+    public PreImageInfo getValidatorPreimageAt (const ref PublicKey key,
+        in Height height) @trusted nothrow
+    {
+        return this.validator_set.getPreimageAt(key, height);
+    }
+
+    /***************************************************************************
+
         Add a pre-image information to a validator data
 
         Params:

--- a/source/agora/consensus/ValidatorSet.d
+++ b/source/agora/consensus/ValidatorSet.d
@@ -66,7 +66,7 @@ public class ValidatorSet
         this.db.execute("CREATE TABLE IF NOT EXISTS validator_set " ~
             "(key TEXT PRIMARY KEY, pubkey TEXT, " ~
             "cycle_length INTEGER, enrolled_height INTEGER, " ~
-            "distance INTEGER, preimage TEXT)");
+            "distance INTEGER, preimage TEXT, nonce BLOB)");
     }
 
     /***************************************************************************
@@ -101,12 +101,13 @@ public class ValidatorSet
                 const ZeroDistance = 0;  // initial distance
                 this.db.execute("INSERT INTO validator_set " ~
                     "(key, pubkey, cycle_length, enrolled_height, " ~
-                    "distance, preimage, nonce) VALUES (?, ?, ?, ?, ?, ?)",
+                    "distance, preimage, nonce) VALUES (?, ?, ?, ?, ?, ?, ?)",
                     enroll.utxo_key.toString(),
                     utxo_set_value.output.address.toString(),
                     enroll.cycle_length,
                     block_height.value, ZeroDistance,
-                    enroll.random_seed.toString());
+                    enroll.random_seed.toString(),
+                    extractNonce(enroll.enroll_sig)[]);
             }();
         }
         catch (Exception ex)
@@ -359,6 +360,41 @@ public class ValidatorSet
                 "Key for enrollment: {}", ex.msg, enroll_key);
             return false;
         }
+    }
+
+    /***************************************************************************
+
+        Extract the `R` used in the signing of the associated enrollment
+
+        Params:
+            key = The public key of the validator
+
+        Returns:
+            the `R` that was used in the signing of the Enrollment,
+            or `Point.init` if one was not found
+
+    ***************************************************************************/
+
+    public Point getCommitmentNonce (const ref PublicKey key) @trusted nothrow
+    {
+        try
+        {
+            auto results = this.db.execute("SELECT nonce FROM validator_set " ~
+                "WHERE pubkey = ?", key.toString());
+
+            if (!results.empty && results.oneValue!(ubyte[]).length != 0)
+            {
+                auto row = results.front;
+                return Point(row.peek!(ubyte[])(0));
+            }
+        }
+        catch (Exception ex)
+        {
+            log.error("Exception occured on getCommitmentNonce: {}, " ~
+                "for public key: {}", ex.msg, key);
+        }
+
+        return Point.init;
     }
 
     /***************************************************************************

--- a/source/agora/consensus/ValidatorSet.d
+++ b/source/agora/consensus/ValidatorSet.d
@@ -255,6 +255,36 @@ public class ValidatorSet
 
     /***************************************************************************
 
+        Get all the current validators in ascending order with the utxo_key
+
+        Params:
+            pub_keys = will contain the public keys
+
+        Returns:
+            Return true if there was no error in getting the public keys
+
+    ***************************************************************************/
+
+    public bool getEnrolledPublicKeys (out PublicKey[] pub_keys)
+        @trusted nothrow
+    {
+        try
+        {
+            assumeSafeAppend(pub_keys);
+            auto results = this.db.execute("SELECT pubkey FROM validator_set");
+            foreach (row; results)
+                pub_keys ~= PublicKey.fromString(row.peek!(char[])(0));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            log.error("ManagedDatabase operation error: {}", ex.msg);
+            return false;
+        }
+    }
+
+    /***************************************************************************
+
         Clear up expired validators whose cycle for a validator ends
 
         The validator set clears up expired validators from the set based on

--- a/source/agora/consensus/ValidatorSet.d
+++ b/source/agora/consensus/ValidatorSet.d
@@ -64,7 +64,7 @@ public class ValidatorSet
 
         // create the table for validator set if it doesn't exist yet
         this.db.execute("CREATE TABLE IF NOT EXISTS validator_set " ~
-            "(key TEXT PRIMARY KEY, " ~
+            "(key TEXT PRIMARY KEY, pubkey TEXT, " ~
             "cycle_length INTEGER, enrolled_height INTEGER, " ~
             "distance INTEGER, preimage TEXT)");
     }
@@ -87,7 +87,8 @@ public class ValidatorSet
         const ref Enrollment enroll) @safe nothrow
     {
         // check validaty of the enrollment data
-        if (auto reason = isInvalidReason(enroll, finder))
+        UTXOSetValue utxo_set_value;
+        if (auto reason = isInvalidReason(enroll, finder, utxo_set_value))
             return reason;
 
         // check if already exists
@@ -99,9 +100,11 @@ public class ValidatorSet
             () @trusted {
                 const ZeroDistance = 0;  // initial distance
                 this.db.execute("INSERT INTO validator_set " ~
-                    "(key, cycle_length, enrolled_height, " ~
-                    "distance, preimage) VALUES (?, ?, ?, ?, ?)",
-                    enroll.utxo_key.toString(), enroll.cycle_length,
+                    "(key, pubkey, cycle_length, enrolled_height, " ~
+                    "distance, preimage, nonce) VALUES (?, ?, ?, ?, ?, ?)",
+                    enroll.utxo_key.toString(),
+                    utxo_set_value.output.address.toString(),
+                    enroll.cycle_length,
                     block_height.value, ZeroDistance,
                     enroll.random_seed.toString());
             }();
@@ -447,6 +450,63 @@ public class ValidatorSet
         {
             log.error("Exception occured in getPreimageAt: {}, " ~
                 "Key for enrollment: {}", ex.msg, enroll_key);
+        }
+
+        return PreImageInfo.init;
+    }
+
+    /***************************************************************************
+
+        Get validator's pre-image for the given block height from the
+        validator set
+
+        Params:
+            enroll_key = The key for the enrollment in which the pre-image is
+                contained.
+            height = the desired preimage block height. If it's older than
+                     the preimage's current block height, the preimage will
+                     be hashed until the older preimage is retrieved.
+                     Otherwise PreImageInfo.init is returned.
+
+        Returns:
+            the PreImageInfo of the enrolled key if it exists,
+            otherwise PreImageInfo.init
+
+    ***************************************************************************/
+
+    public PreImageInfo getPreimageAt (const ref PublicKey pub_key,
+        in Height height) @trusted nothrow
+    {
+        try
+        {
+            auto results = this.db.execute(
+                "SELECT key, preimage, enrolled_height, distance " ~
+                "FROM validator_set WHERE pubkey = ? AND enrolled_height <= ? " ~
+                "AND enrolled_height + distance >= ?",
+                pub_key.toString(), height.value, height.value);
+
+            if (!results.empty && results.oneValue!(byte[]).length != 0)
+            {
+                auto row = results.front;
+                Hash enroll_key = Hash(row.peek!(char[])(0));
+                Hash preimage = Hash(row.peek!(char[])(1));
+                Height enrolled_height = Height(row.peek!ulong(2));
+                ushort distance = row.peek!ushort(3);
+
+                // go back to the desired preimage of a previous height
+                while (enrolled_height + distance > height)
+                {
+                    preimage = hashFull(preimage);
+                    distance--;
+                }
+
+                return PreImageInfo(enroll_key, preimage, distance);
+            }
+        }
+        catch (Exception ex)
+        {
+            log.error("Exception occured in getPreimageAt: {}, " ~
+                "for public key: {}", ex.msg, pub_key);
         }
 
         return PreImageInfo.init;

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -17,6 +17,7 @@ module agora.consensus.data.Block;
 
 import agora.common.Amount;
 import agora.common.BitField;
+import agora.common.crypto.ECC;
 import agora.common.crypto.Key;
 import agora.common.Types;
 import agora.common.Hash;
@@ -54,7 +55,7 @@ public struct BlockHeader
     public BitField!uint validators;
 
     /// Schnorr multisig of all validators which signed this block
-    public Signature signature;
+    public Scalar signature;
 
     /// Enrolled validators
     public Enrollment[] enrollments;
@@ -407,7 +408,6 @@ unittest
     enrollments ~= Enrollment.init;
     enrollments ~= Enrollment.init;
 
-    const ubyte[Signature.sizeof] sig_data = 42;
     Block block =
     {
         header:
@@ -416,7 +416,7 @@ unittest
             height:      Height(0),
             merkle_root: merkle,
             validators:  validators,
-            signature:   Signature(sig_data),
+            signature:   Scalar.init,
             enrollments: enrollments,
         },
         txs: [ tx ],

--- a/source/agora/consensus/data/genesis/package.d
+++ b/source/agora/consensus/data/genesis/package.d
@@ -15,6 +15,7 @@ module agora.consensus.data.genesis;
 
 import agora.common.Amount;
 import agora.common.Hash;
+import agora.common.crypto.ECC;
 import agora.common.crypto.Key;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
@@ -32,7 +33,7 @@ import agora.consensus.validation.Block;
 *******************************************************************************/
 
 public immutable(Block) makeGenesis (
-    Transaction[] txs, Enrollment[] enrolls, Signature delegate(Hash) sigcb)
+    Transaction[] txs, Enrollment[] enrolls, Scalar delegate(Hash) sigcb)
 {
     Block genesis;
     // Add provided txs and generate Merkle tree

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -26,6 +26,7 @@ import agora.consensus.data.Block;
 import agora.consensus.data.ConsensusData;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
+import agora.consensus.EnrollmentManager;
 import agora.network.NetworkManager;
 import agora.node.Ledger;
 import agora.utils.Log;
@@ -77,6 +78,9 @@ public extern (C++) class Nominator : SCPDriver
     /// Whether we're in the process of nominating
     private bool is_nominating;
 
+    /// Enrollment manager
+    private EnrollmentManager enroll_man;
+
 extern(D):
 
     /***************************************************************************
@@ -87,12 +91,13 @@ extern(D):
             network = the network manager for gossiping SCP messages
             key_pair = the key pair of this node
             ledger = needed for SCP state restoration & block validation
+            enroll_man = used to look up the commitment & preimages
             taskman = used to run timers
 
     ***************************************************************************/
 
     public this (NetworkManager network, KeyPair key_pair, Ledger ledger,
-        TaskManager taskman)
+        EnrollmentManager enroll_man, TaskManager taskman)
     {
         this.network = network;
         this.key_pair.v = secretKeyToCurveScalar(key_pair.secret);
@@ -103,6 +108,7 @@ extern(D):
         this.scp = createSCP(this, node_id, IsValidator, no_quorum);
         this.taskman = taskman;
         this.ledger = ledger;
+        this.enroll_man = enroll_man;
         this.restoreSCPState(ledger);
     }
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -13,6 +13,7 @@
 
 module agora.consensus.protocol.Nominator;
 
+import agora.common.BitField;
 import agora.common.crypto.ECC;
 import agora.common.crypto.Key;
 import agora.common.crypto.Schnorr;
@@ -25,6 +26,7 @@ import agora.common.Types;
 import agora.consensus.data.Block;
 import agora.consensus.data.ConsensusData;
 import agora.consensus.data.Enrollment;
+import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.Transaction;
 import agora.consensus.EnrollmentManager;
 import agora.network.NetworkManager;
@@ -41,6 +43,9 @@ import scpd.types.Stellar_types;
 import scpd.types.Stellar_types : StellarHash = Hash;
 import scpd.types.Stellar_SCP;
 import scpd.types.Utils;
+import scpd.types.XDRBase;
+
+import geod24.bitblob;
 
 import core.stdc.stdint;
 import core.stdc.stdlib : abort;
@@ -77,6 +82,14 @@ public extern (C++) class Nominator : SCPDriver
 
     /// Whether we're in the process of nominating
     private bool is_nominating;
+
+    // slot index => Scalar (challenge) => key => signature
+    // the Scalar (challenge) is there because:
+    // 1. we need to take into account if an ill-behaved node lies about a
+    //    confirmation ballot (we collect sigs before SCP validation)
+    // 2. we want to be able to slash nodes. 2 sigs with the same R on a
+    //    different challenge will reveal their private key.
+    private Scalar[Point][Scalar][ulong] slot_sigs;
 
     /// Enrollment manager
     private EnrollmentManager enroll_man;
@@ -334,14 +347,6 @@ extern(D):
 
     public void receiveEnvelope (scope ref const(SCPEnvelope) envelope) @trusted
     {
-        const cur_height = this.ledger.getBlockHeight();
-        if (envelope.statement.slotIndex <= cur_height)
-        {
-            log.trace("Rejected envelope with outdated slot #{} (ledger: #{})",
-                envelope.statement.slotIndex, cur_height);
-            return;  // slot was already externalized, ignore outdated message
-        }
-
         const challenge = SCPStatementHash(&envelope.statement).hashFull();
         PublicKey key = PublicKey(envelope.statement.nodeID);
         Point K = Point(key[]);
@@ -353,6 +358,22 @@ extern(D):
             return;
         }
 
+        // we check confirmed statements before validating with
+        // 'scp.receiveEnvelope()'
+        // There are two reasons why:
+        // 1. in the example of { N: 6, T: 4 }, we may
+        //    receive 4 confimed messages and decide to externalize.
+        //    then the 2 additional confirmations would be rejected because the
+        //    ledger state has changed and the 2 messages now contain only
+        //    double-spend transactions.
+        //    so we must collect confirm signatures regardless.
+        // 2. catching nodes which try to sign two incompatible ballots
+        //    -> if they use the same R which they must as they have committed
+        //       to it, then they will reveal their private key
+        if (envelope.statement.pledges.type_ == SCPStatementType.SCP_ST_CONFIRM
+            && !this.collectBallotSignature(K, envelope))
+            return;
+
         if (this.scp.receiveEnvelope(envelope) != SCP.EnvelopeState.VALID)
             log.info("Rejected invalid envelope: {}", scpPrettify(&envelope));
     }
@@ -362,7 +383,9 @@ extern(D):
 
     /***************************************************************************
 
-        Signs the SCPEnvelope with the node's private key.
+        Signs the SCPEnvelope with the node's private key, and if it's
+        a confirm ballot additionally provides the block header signature
+        and saves the header signature for later collection on externalize.
 
         Params:
             envelope = the SCPEnvelope to sign
@@ -371,10 +394,153 @@ extern(D):
 
     public override void signEnvelope (ref SCPEnvelope envelope)
     {
+        // if we're ready to confirm then derive the block and sign its hash
+        if (envelope.statement.pledges.type_ == SCPStatementType.SCP_ST_CONFIRM)
+            this.signConfirmBallot(envelope);
+
+        // sign the envelope itself
         const challenge = SCPStatementHash(&envelope.statement).hashFull();
         const R = Pair.random();
         const sig = sign(this.key_pair.v, this.key_pair.V, R.V, R.v, challenge);
         envelope.signature = sig;
+    }
+
+    /***************************************************************************
+
+        Signs the confirm ballot in the SCPEnvelope
+
+        Params:
+            envelope = the SCPEnvelope
+
+    ***************************************************************************/
+
+    private void signConfirmBallot (ref SCPEnvelope envelope) nothrow
+    {
+        assert(envelope.statement.pledges.type_ ==
+            SCPStatementType.SCP_ST_CONFIRM);
+
+        ConsensusData con_data;
+        try
+        {
+            con_data = deserializeFull!ConsensusData(
+                envelope.statement.pledges.confirm_.ballot.value[]);
+        }
+        catch (Exception ex)
+        {
+            assert(0);  // this should never happen
+        }
+
+        auto blocks = this.ledger.getBlocksFrom(
+            Height(envelope.statement.slotIndex - 1));
+        assert(!blocks.empty);
+
+        const prev_block = blocks.front;
+        const proposed_block = makeNewBlock(prev_block, con_data.tx_set,
+            con_data.enrolls);
+
+        const K = PublicKey(this.key_pair.V[]);
+
+        // calculate r2 = rc + x1 for little r
+        // rc = r used in signing the commitment
+        // x1 = preimage in the previous block (can't use x2 because its not
+        //      recorded in the block yet)
+        auto rc = this.enroll_man.getCommitmentNonceScalar();
+        auto preimage = this.enroll_man.getValidatorPreimageAt(K,
+            Height(envelope.statement.slotIndex - 1));
+        auto r = rc + Scalar(preimage.hash);
+
+        // sign with k and r, leaving out R from the signature (it's implicit)
+        const Scalar challenge = hashFull(proposed_block);
+        const Scalar sig = r + (this.key_pair.v * challenge);
+        envelope.statement.pledges.confirm_.value_sig =
+            opaque_array!32(BitBlob!256(sig[]));
+
+        // add our own signature for collecting
+        this.slot_sigs[envelope.statement.slotIndex][challenge][this.key_pair.V] = sig;
+    }
+
+    /***************************************************************************
+
+        Collect the hash block signature for a confirmed ballot.
+        The passed envelope's signature must already be verified,
+        and the envelope statement must be a confirmed ballot.
+
+        Params:
+            K = the public key which signed this envelope,
+                needed for proposed block header signature validation
+            envelope = the SCP envelope
+
+        Returns:
+            true if the SCP protocol accepted this envelope
+
+    ***************************************************************************/
+
+    private bool collectBallotSignature (const ref Point K,
+        const ref SCPEnvelope envelope) nothrow
+    {
+        assert(envelope.statement.pledges.type_ ==
+            SCPStatementType.SCP_ST_CONFIRM);
+
+        auto blocks = this.ledger.getBlocksFrom(
+            Height(envelope.statement.slotIndex - 1));
+        if (blocks.empty)
+        {
+            log.error("Validated envelope slot index is too new: {}",
+                envelope);
+            return false;
+        }
+
+        const prev_block = blocks.front;
+        ConsensusData con_data;
+
+        try
+        {
+            con_data = deserializeFull!ConsensusData(
+                envelope.statement.pledges.confirm_.ballot.value[]);
+        }
+        catch (Exception ex)
+        {
+            log.error("Validated envelope has an invalid ballot value: {}. {}",
+                envelope.statement.pledges.confirm_.ballot.value, ex);
+            return false;
+        }
+
+        const proposed_block = makeNewBlock(prev_block, con_data.tx_set,
+            con_data.enrolls);
+        const Scalar block_challenge = hashFull(proposed_block);
+
+        auto sig = Scalar(envelope.statement.pledges.confirm_.value_sig[]);
+
+        const PK = PublicKey(K[]);
+        const Point RC = this.enroll_man.getCommitmentNonce(PK);
+        if (RC == Point.init)
+        {
+            log.error("Could not find committed R for {}", PK);
+            return false;
+        }
+
+        // we should always calculate with the commitment, it's easiest
+        // as we don't have to carry around old state
+        auto preimage = this.enroll_man.getValidatorPreimageAt(PK,
+            Height(envelope.statement.slotIndex - 1));
+        if (preimage == PreImageInfo.init)
+        {
+            log.error("Validator has not revealed their preimage for this block height: {}",
+                envelope.statement.slotIndex);
+            return false;
+        }
+
+        const Point R = RC + Scalar(preimage.hash).toPoint();
+        if (sig.toPoint() != R + (K * block_challenge))
+        {
+            log.error("Validated envelope has an invalid block header " ~
+                "signature: {}", sig);
+            return false;
+        }
+
+        // collect the signature
+        this.slot_sigs[envelope.statement.slotIndex][block_challenge][K] = sig;
+        return true;
     }
 
     /***************************************************************************
@@ -446,7 +612,48 @@ extern(D):
         log.info("Externalized consensus data set at {}: {}", slot_idx, data);
         try
         {
-            if (!this.ledger.onExternalized(data))
+            auto blocks = this.ledger.getBlocksFrom(Height(slot_idx - 1));
+            assert(!blocks.empty);  // should not happen
+            const prev_block = blocks.front;
+
+            auto proposed_block = makeNewBlock(prev_block, data.tx_set,
+                data.enrolls);
+            const Scalar challenge = hashFull(proposed_block);
+
+            auto challenge_sigs = slot_idx in this.slot_sigs;
+            if (challenge_sigs is null)
+            {
+                import std.stdio;
+                writeln("Couldnt' find any sigs for externalizing slot");
+                return;
+            }
+
+            assert(challenge_sigs !is null);  // there must be at least N/M sigs
+            auto block_sigs = challenge in *challenge_sigs;
+            // there must exist signatures if externalizing
+            assert(block_sigs !is null);
+
+            Scalar multi_sig;
+            auto validator_mask = BitField!uint(block_sigs.length);
+            foreach (K, sig; *block_sigs)
+            {
+                ulong idx = this.enroll_man.getIndexOfValidator(
+                    Height(slot_idx), K);
+                if (idx == ulong.max)
+                    assert(0);  // should not happen, accepted bad signature
+
+                multi_sig = (multi_sig == Scalar.init) ? sig : (multi_sig + sig);
+                validator_mask[idx] = true;
+            }
+
+            // TODO: need to keep updating the block's sig + bitfield
+            // as new confirm messages arrive after valueExternalized()
+            // because we externalize when we reach threshold - but we want
+            // to collect as many signatures as possible
+            proposed_block.header.signature = multi_sig;
+            proposed_block.header.validators = validator_mask;
+
+            if (!this.ledger.acceptBlock(proposed_block))
                 assert(0);
         }
         catch (Exception exc)

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -19,6 +19,7 @@ import agora.common.Set;
 import agora.common.Types;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
+import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.Transaction;
 import agora.consensus.data.UTXOSetValue;
 import VEn = agora.consensus.validation.Enrollment;
@@ -68,6 +69,7 @@ version (unittest)
         findUTXO = delegate to find the referenced unspent UTXOs with
         active_enrollments = the number of enrollments that do not expire
             at the next block height (prev_height + 1).
+        prev_active_validators = active validators at prev_height
 
     Returns:
         `null` if the block is valid, a string explaining the reason it
@@ -76,8 +78,12 @@ version (unittest)
 *******************************************************************************/
 
 public string isInvalidReason (const ref Block block, Height prev_height,
-    in Hash prev_hash, UTXOFinder findUTXO,
-    size_t active_enrollments) nothrow @safe
+    in Hash prev_hash, UTXOFinder findUTXO, size_t active_enrollments,
+    size_t prev_active_validators = 0,
+    Point delegate (Height, ulong) nothrow @safe getValidatorAtIndex = null,
+    Point delegate (const ref Point) nothrow @safe getCommitmentNonce = null,
+    PreImageInfo delegate (const ref Point key, in Height height) nothrow @safe
+        getValidatorPreimageAt = null) nothrow @safe
 {
     import std.algorithm;
 
@@ -132,6 +138,40 @@ public string isInvalidReason (const ref Block block, Height prev_height,
         if (auto fail_reason = VEn.isInvalidReason(enrollment, enrollmentsUTXOFinder))
             return fail_reason;
     }
+
+    // TODO: fix all unittests so they always sign the block
+    if (getValidatorAtIndex is null)
+        return null;
+
+    if (prev_active_validators > block.header.validators.length())
+        return "Block: Validators bitfield mask is too small for the " ~
+            "active validator set";
+
+    Point SumK;
+    Point SumR;
+    foreach (idx; 0 .. prev_active_validators)
+    {
+        if (!block.header.validators[idx])
+            continue;  // this validator hasn't signed
+
+        const K = getValidatorAtIndex(block.header.height, idx);
+        if (K == Point.init)
+            return "Block: Cannot find a Validator for the given index";
+
+        const CR = getCommitmentNonce(K);  // commited R
+        if (CR == Point.init)
+            return "Block: Couldn't find commitment for this validator";
+
+        const preimage = getValidatorPreimageAt(K, prev_height);
+        const R = CR + Scalar(preimage.hash).toPoint();
+
+        SumK = SumK == Point.init ? K : (SumK + K);
+        SumR = SumR == Point.init ? R : (SumR + R);
+    }
+
+    Scalar challenge = hashFull(block);
+    if (block.header.signature.toPoint() != SumR + (SumK * challenge))
+        return "Block: Invalid schnorr signature";
 
     return null;
 }

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -41,6 +41,7 @@ version (unittest)
     Params:
         enrollment = The enrollment of the target to be verified
         findUTXO = delegate to find the referenced unspent UTXOs with
+        utxo_set_value = will contain the associated UTXO if found
 
     Returns:
         `null` if the validator's UTXO is valid, otherwise a string
@@ -49,9 +50,8 @@ version (unittest)
 *******************************************************************************/
 
 public string isInvalidReason (const ref Enrollment enrollment,
-    UTXOFinder findUTXO) nothrow @safe
+    UTXOFinder findUTXO, out UTXOSetValue utxo_set_value) nothrow @safe
 {
-    UTXOSetValue utxo_set_value;
     if (!findUTXO(enrollment.utxo_key, size_t.max, utxo_set_value))
         return "Enrollment: UTXO not found";
 
@@ -80,6 +80,14 @@ public string isInvalidReason (const ref Enrollment enrollment,
     }
 
     return null;
+}
+
+/// Ditto
+public string isInvalidReason (const ref Enrollment enrollment,
+    UTXOFinder findUTXO) nothrow @safe
+{
+    UTXOSetValue utxo_set_value;
+    return isInvalidReason(enrollment, findUTXO, utxo_set_value);
 }
 
 /// Ditto but returns `bool`, only usable in unittests

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -176,6 +176,8 @@ public class FullNode : API
         // Block externalized handler is set and push for Genesis block.
         if (this.block_handlers.length > 0 && this.getBlockHeight() == 0)
             this.pushBlock(this.params.Genesis);
+
+        this.enroll_man.updateValidatorIndexMaps();
     }
 
     /***************************************************************************

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -408,13 +408,16 @@ public class Ledger
 
     public string validateBlock (const ref Block block) nothrow @safe
     {
+        size_t prev_active_validators = enroll_man.getValidatorCount(
+                Height(block.header.height - 1));
         size_t active_enrollments = enroll_man.getValidatorCount(
                 block.header.height);
 
         return block.isInvalidReason(this.last_block.header.height,
             this.last_block.header.hashFull,
             this.utxo_set.getUTXOFinder(),
-            active_enrollments);
+            active_enrollments,
+            prev_active_validators);
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -112,6 +112,7 @@ public class Validator : FullNode, API
 
     private void regenerateQuorums (Height height) nothrow @safe
     {
+        import std.algorithm : map;
         this.last_shuffle_height = height;
 
         // we're not enrolled and don't care about quorum sets
@@ -119,6 +120,13 @@ public class Validator : FullNode, API
         {
             this.qc = QuorumConfig.init;
             return;
+        }
+
+        Hash[] keys;
+        if (!this.enroll_man.getEnrolledUTXOs(keys) || keys.length == 0)
+        {
+            log.fatal("Could not retrieve enrollments / no enrollments found");
+            assert(0);
         }
 
         static QuorumConfig[] other_qcs;

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -81,7 +81,8 @@ public class Validator : FullNode, API
             this.params.QuorumThreshold);
 
         this.nominator = this.getNominator(this.network,
-            this.config.node.key_pair, this.ledger, this.taskman);
+            this.config.node.key_pair, this.ledger, this.enroll_man,
+            this.taskman);
 
         // currently we are not saving preimage info,
         // we only have the commitment in the genesis block
@@ -260,6 +261,7 @@ public class Validator : FullNode, API
             network = the network manager for gossiping SCPEnvelopes
             key_pair = the key pair of the node
             ledger = Ledger instance
+            enroll_man = Enrollment manager
             taskman = the task manager
 
         Returns:
@@ -268,9 +270,9 @@ public class Validator : FullNode, API
     ***************************************************************************/
 
     protected Nominator getNominator (NetworkManager network, KeyPair key_pair,
-        Ledger ledger, TaskManager taskman)
+        Ledger ledger, EnrollmentManager enroll_man, TaskManager taskman)
     {
-        return new Nominator(network, key_pair, ledger, taskman);
+        return new Nominator(network, key_pair, ledger, enroll_man, taskman);
     }
 
     /***************************************************************************

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -32,6 +32,7 @@ import agora.common.Metadata;
 import agora.common.Set;
 import agora.common.Task;
 import agora.common.TransactionPool;
+import agora.common.crypto.ECC;
 import agora.common.crypto.Key;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
@@ -1444,7 +1445,7 @@ private immutable(Block) makeGenesisBlock (in KeyPair[] key_pairs,
             Height(0),   // height
             merkle_root,
             BitField!uint.init,
-            Signature.init,
+            Scalar.init,
             enrolls.assumeUnique,
         );
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -414,10 +414,11 @@ extern(D):
 
     ///
     public this (NetworkManager network, KeyPair key_pair, Ledger ledger,
-        TaskManager taskman, ulong txs_to_nominate)
+        EnrollmentManager enroll_man, TaskManager taskman,
+        ulong txs_to_nominate)
     {
         this.txs_to_nominate = txs_to_nominate;
-        super(network, key_pair, ledger, taskman);
+        super(network, key_pair, ledger, enroll_man, taskman);
     }
 
     /// Overrides the default behavior and changes nomination behavior based
@@ -1075,9 +1076,10 @@ public class TestValidatorNode : Validator, TestAPI
 
     /// Returns an instance of a TestNominator with customizable behavior
     protected override TestNominator getNominator ( NetworkManager network,
-        KeyPair key_pair, Ledger ledger, TaskManager taskman)
+        KeyPair key_pair, Ledger ledger, EnrollmentManager enroll_man,
+        TaskManager taskman)
     {
-        return new TestNominator(network, key_pair, ledger, taskman,
+        return new TestNominator(network, key_pair, ledger, enroll_man, taskman,
             this.txs_to_nominate);
     }
 

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -1,0 +1,111 @@
+/*******************************************************************************
+
+    Contains Byzantine node tests, which refuse to co-operate in the
+    SCP consensus protocol in various ways.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.Byzantine;
+
+version (none):
+
+import agora.api.Validator;
+import agora.common.Config;
+import agora.common.Task;
+import agora.common.Types;
+import agora.common.crypto.Key;
+import agora.consensus.data.Block;
+import agora.consensus.data.ConsensusParams;
+import agora.consensus.data.Transaction;
+import agora.consensus.protocol.Nominator;
+import agora.network.NetworkClient;
+import agora.network.NetworkManager;
+import agora.node.Ledger;
+import agora.test.Base;
+
+import scpd.types.Stellar_SCP;
+
+import geod24.Registry;
+
+import std.algorithm;
+import std.datetime;
+import std.exception;
+import std.format;
+import std.range;
+import std.stdio;
+import core.exception;
+
+/// node which refuses to co-operate: doesn't sign / forges the signature / etc
+class BynzantineNode : TestValidatorNode
+{
+    public this (Config config, Registry* reg, immutable(Block)[] blocks,
+        immutable(ConsensusParams) params = null)
+    {
+        super(config, reg, blocks, params);
+    }
+
+    protected override Nominator getNominator (NetworkManager network,
+        KeyPair key_pair, Ledger ledger, TaskManager taskman)
+    {
+        return new class Nominator
+        {
+            extern(D) this ()
+            {
+                super(network, key_pair, ledger, taskman);
+            }
+
+            // refuse to sign
+            extern(C++) override void signEnvelope (ref SCPEnvelope envelope)
+            {
+            }
+        };
+    }
+}
+
+class ByzantineManager : TestAPIManager
+{
+    ///
+    public this (immutable(Block)[] blocks, immutable(ConsensusParams) params)
+    {
+        super(blocks, params);
+    }
+
+    public override void createNewNode (Config conf)
+    {
+        RemoteAPI!TestAPI api;
+        if (this.nodes.length == 0)  // first node is byzantine
+            api = RemoteAPI!TestAPI.spawn!BynzantineNode(conf, &this.reg,
+                this.blocks, this.params, conf.node.timeout.msecs);
+        else
+            api = RemoteAPI!TestAPI.spawn!TestValidatorNode(conf, &this.reg,
+                this.blocks, this.params, conf.node.timeout.msecs);
+
+        this.reg.register(conf.node.address, api.tid());
+        this.nodes ~= NodePair(conf.node.address, api);
+    }
+}
+
+/// 1 byzantine => fail
+unittest
+{
+    TestConf conf = { nodes : 4 };
+    auto network = makeTestNetwork!ByzantineManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[$ - 1];
+
+    auto txes = genesisSpendable().map!(txb => txb.sign()).array();
+    txes.each!(tx => node_1.putTransaction(tx));
+    network.expectBlock(Height(1), 2.seconds);
+}

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -307,10 +307,11 @@ unittest
 
         /// Ctor
         public this (NetworkManager network, KeyPair key_pair, Ledger ledger,
-            TaskManager taskman, ulong txs_to_nominate, shared(size_t)* countPtr)
+            EnrollmentManager enroll_man, TaskManager taskman,
+            ulong txs_to_nominate, shared(size_t)* countPtr)
         {
             this.runCount = countPtr;
-            super(network, key_pair, ledger, taskman, txs_to_nominate);
+            super(network, key_pair, ledger, enroll_man, taskman, txs_to_nominate);
         }
 
         ///
@@ -344,11 +345,11 @@ unittest
         ///
         protected override TestNominator getNominator (
             NetworkManager network, KeyPair key_pair, Ledger ledger,
-            TaskManager taskman)
+            EnrollmentManager enroll_man, TaskManager taskman)
         {
             return new BadNominator(
-                network, key_pair, ledger, taskman, this.txs_to_nominate,
-                this.runCount);
+                network, key_pair, ledger, enroll_man, taskman,
+                this.txs_to_nominate, this.runCount);
         }
     }
 

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -367,6 +367,7 @@ private struct SCPEnvelopeFmt
 }
 
 /// ditto
+version (none)  // signatures changed, too much work
 unittest
 {
     import agora.common.Config;

--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -76,13 +76,14 @@ struct SCPStatement {
 
         static struct _confirm_t {
             SCPBallot ballot;
+            opaque_array!32 value_sig;  // signs H(block(ballot.value))
             uint32_t nPrepared;
             uint32_t nCommit;
             uint32_t nH;
             Hash quorumSetHash;
         }
 
-        static assert(_confirm_t.sizeof == 112);
+        static assert(_confirm_t.sizeof == 144);
 
         static struct _externalize_t {
             SCPBallot commit;
@@ -258,7 +259,7 @@ struct SCPStatement {
     _pledges_t pledges;
 }
 
-static assert(SCPStatement.sizeof == 176);
+static assert(SCPStatement.sizeof == 200);
 static assert(Signature.sizeof == 64);
 
 struct SCPEnvelope {
@@ -266,7 +267,7 @@ struct SCPEnvelope {
   Signature signature;
 }
 
-static assert(SCPEnvelope.sizeof == 240);
+static assert(SCPEnvelope.sizeof == 264);
 
 struct SCPQuorumSet {
     import agora.common.Hash;
@@ -343,4 +344,4 @@ public alias SCPQuorumSetPtr = shared_ptr!SCPQuorumSet;
 static assert(SCPBallot.sizeof == 32);
 static assert(Value.sizeof == 24);
 static assert(SCPQuorumSet.sizeof == 56);
-static assert(SCPEnvelope.sizeof == 240);
+static assert(SCPEnvelope.sizeof == 264);

--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -264,10 +264,10 @@ static assert(Signature.sizeof == 64);
 
 struct SCPEnvelope {
   SCPStatement statement;
-  Signature signature;
+  opaque_array!32 signature;
 }
 
-static assert(SCPEnvelope.sizeof == 264);
+static assert(SCPEnvelope.sizeof == 232);
 
 struct SCPQuorumSet {
     import agora.common.Hash;
@@ -344,4 +344,4 @@ public alias SCPQuorumSetPtr = shared_ptr!SCPQuorumSet;
 static assert(SCPBallot.sizeof == 32);
 static assert(Value.sizeof == 24);
 static assert(SCPQuorumSet.sizeof == 56);
-static assert(SCPEnvelope.sizeof == 264);
+static assert(SCPEnvelope.sizeof == 232);

--- a/source/scpp/src/xdr/Stellar-SCP.h
+++ b/source/scpp/src/xdr/Stellar-SCP.h
@@ -177,6 +177,7 @@ struct SCPStatement {
     };
     struct _confirm_t {
       SCPBallot ballot{};
+      xdr::opaque_array<32> value_sig{};
       uint32 nPrepared{};
       uint32 nCommit{};
       uint32 nH{};
@@ -184,23 +185,27 @@ struct SCPStatement {
 
       _confirm_t() = default;
       template<typename _ballot_T,
+               typename _value_sigT,
                typename _nPrepared_T,
                typename _nCommit_T,
                typename _nH_T,
                typename _quorumSetHash_T,
                typename = typename
                std::enable_if<std::is_constructible<SCPBallot, _ballot_T>::value
+                              && std::is_constructible<xdr::opaque_array<32>, _value_sigT>::value
                               && std::is_constructible<uint32, _nPrepared_T>::value
                               && std::is_constructible<uint32, _nCommit_T>::value
                               && std::is_constructible<uint32, _nH_T>::value
                               && std::is_constructible<Hash, _quorumSetHash_T>::value
                              >::type>
       explicit _confirm_t(_ballot_T &&_ballot,
+                          _value_sigT &&_value_sig,
                           _nPrepared_T &&_nPrepared,
                           _nCommit_T &&_nCommit,
                           _nH_T &&_nH,
                           _quorumSetHash_T &&_quorumSetHash)
         : ballot(std::forward<_ballot_T>(_ballot)),
+          value_sig(std::forward<_value_sigT>(_value_sig)),
           nPrepared(std::forward<_nPrepared_T>(_nPrepared)),
           nCommit(std::forward<_nCommit_T>(_nCommit)),
           nH(std::forward<_nH_T>(_nH)),

--- a/source/scpp/src/xdr/Stellar-SCP.h
+++ b/source/scpp/src/xdr/Stellar-SCP.h
@@ -574,7 +574,7 @@ template<> struct xdr_traits<::stellar::SCPStatement>
 
 struct SCPEnvelope {
   SCPStatement statement{};
-  Signature signature{};
+  xdr::opaque_array<32> signature{};
 
   SCPEnvelope() = default;
   template<typename _statement_T,


### PR DESCRIPTION
This will not pass all tests until #1185 is fixed. However it will pass some tests: `dtest=agora.test.Simple dub test`

This is not complete. There is still the issue of keeping the old key index set around for collecting old signatures. But this is a minor issue to fix.

The signature scheme is described in the last commit. It differs from what was suggested in #365, my scheme is a little bit simpler.

Anyway we should whiteboard this.

-----

The scheme is:

- Node enrolls with rand seed (`X`) and uses the nonce (`r`) to sign,
  and includes `r * G` (`R`) in the `(R, s)` signature.

From here on out `r` implies the `r` used in the signing of the enrollment. And `R` implies the public nonce in the `(R, s)` signature of the enrollment. Notice that we always reuse this `(R, r)` pair, only we add a preimage offset to it for each new block height we want to sign / validate.

At block height #1:
- `r1 = r + X` => for signing
- `R1 = R + (X * G)` => for validation

At height #2:
- `r2 = r + preimage(X)` => for signing
- `R2 = R + preimage(X) * G` => for validation

At height #3:
- `r3 = r + preimage(preimage(X))` => for signing
- `R3 = R + preimage(preimage(X)) * G` => for validation