### PR TITLE
Ledger: Remove unused node_config field

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -155,7 +155,7 @@ public class FullNode : API
         this.utxo_set = this.getUtxoSet(config.node.data_dir);
         this.enroll_man = this.getEnrollmentManager(config.node.data_dir,
             config.node, params);
-        this.ledger = new Ledger(config.node, params, this.utxo_set,
+        this.ledger = new Ledger(params, this.utxo_set,
             this.storage, this.enroll_man, this.pool, &this.onAcceptedBlock);
         this.exception = new RestException(
             400, Json("The query was incorrect"), string.init, int.init);


### PR DESCRIPTION
This is a leftover from a serie of refactors which have seen
the parameters moved to ConsensusParams et al.