### PR TITLE
Implement `waitPreimages(distance)`

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -519,6 +519,38 @@ public class TestAPIManager
 
     /***************************************************************************
 
+        Checks if all the nodes contain the given distance of pre-images for
+        the given enrollments.
+
+        The overload allows passing a subset of nodes to verify the distance
+        for only these nodes.
+
+        Params:
+            enrolls = the enrollments whose pre-image will be checked
+            distance = the expected distance of pre-images
+            timeout = the request timeout to each node
+
+    ***************************************************************************/
+
+    public void waitForPreimages (const(Enrollment)[] enrolls, ushort distance,
+        Duration timeout, string file = __FILE__, int line = __LINE__)
+    {
+        this.waitForPreimages(this.clients, enrolls, distance, timeout, file,
+            line);
+    }
+
+    /// Ditto
+    public void waitForPreimages (Clients)(Clients clients,
+        const(Enrollment)[] enrolls, ushort distance, Duration timeout,
+        string file = __FILE__, int line = __LINE__) if (isInputRange!Clients)
+    {
+        clients.each!(node => enrolls.each!(enroll =>
+            retryFor(node.getPreimage(enroll.utxo_key).distance >= distance,
+                timeout)));
+    }
+
+    /***************************************************************************
+
         Create a new node
 
         Params:

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -56,21 +56,22 @@ unittest
 
     // create enrollment data
     // send a request to enroll as a Validator
-    Enrollment enroll_0 = nodes[0].createEnrollmentData();
-    Enrollment enroll_1 = nodes[1].createEnrollmentData();
-    Enrollment enroll_2 = nodes[2].createEnrollmentData();
-    Enrollment enroll_3 = nodes[3].createEnrollmentData();
-    nodes[0].enrollValidator(enroll_1);
-    nodes[1].enrollValidator(enroll_2);
-    nodes[2].enrollValidator(enroll_3);
-    nodes[3].enrollValidator(enroll_0);
+    Enrollment[] enrolls;
+    enrolls ~= nodes[0].createEnrollmentData();
+    enrolls ~= nodes[1].createEnrollmentData();
+    enrolls ~= nodes[2].createEnrollmentData();
+    enrolls ~= nodes[3].createEnrollmentData();
+    nodes[0].enrollValidator(enrolls[0]);
+    nodes[1].enrollValidator(enrolls[1]);
+    nodes[2].enrollValidator(enrolls[2]);
+    nodes[3].enrollValidator(enrolls[3]);
 
     // wait until new enrollments are propagated to the pools
     nodes.each!(node =>
-        retryFor(node.getEnrollment(enroll_0.utxo_key) == enroll_0 &&
-                 node.getEnrollment(enroll_1.utxo_key) == enroll_1 &&
-                 node.getEnrollment(enroll_2.utxo_key) == enroll_2 &&
-                 node.getEnrollment(enroll_3.utxo_key) == enroll_3,
+        retryFor(node.getEnrollment(enrolls[0].utxo_key) == enrolls[0] &&
+                 node.getEnrollment(enrolls[1].utxo_key) == enrolls[1] &&
+                 node.getEnrollment(enrolls[2].utxo_key) == enrolls[2] &&
+                 node.getEnrollment(enrolls[3].utxo_key) == enrolls[3],
             5.seconds));
 
     // re-enroll every validator

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -49,10 +49,7 @@ unittest
     network.expectBlock(Height(validator_cycle - 1), 2.seconds);
 
     // wait for preimages to be revealed before making block 10
-    nodes.each!(node =>
-        network.blocks[0].header.enrollments.each!(enroll =>
-            retryFor(node.getPreimage(enroll.utxo_key).distance >= 9,
-                5.seconds)));
+    network.waitForPreimages(network.blocks[0].header.enrollments, 9, 5.seconds);
 
     // create enrollment data
     // send a request to enroll as a Validator
@@ -80,12 +77,7 @@ unittest
     network.expectBlock(Height(validator_cycle), 2.seconds);
 
     // wait until preimages are revealed before creating a new block
-    nodes.each!(node =>
-        retryFor(node.getPreimage(enroll_0.utxo_key).distance >= 1 &&
-                 node.getPreimage(enroll_1.utxo_key).distance >= 1 &&
-                 node.getPreimage(enroll_2.utxo_key).distance >= 1 &&
-                 node.getPreimage(enroll_3.utxo_key).distance >= 1,
-            5.seconds));
+    network.waitForPreimages(enrolls, 1, 5.seconds);
 
     // verify that consensus can still be reached
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();


### PR DESCRIPTION
This PR is for #1185 of which requirements are adding the utility function checking pre-images for reaching consensus & validating block signatures. In fact, the signature of the function described in the issue has a parameter for `Height`, but using the `distance` is a simple way to implement. If the function has a `Height` as a parameter, it also has to have another `Height` for an enrolled height. And I think we might have another approach I could come up with if needed.

@AndrejMitrovic Please check if the code meets the requirement. It's a draft PR for sharing the concept. If any other opinions, please let me know.