### PR TITLE
Remove quorum hashes from SCP protocol messages

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -125,13 +125,13 @@ extern(D):
         // store the list of other node's quorum hashes
         foreach (qc; other_quorums)
         {
-            auto quorum_set = buildSCPConfig(qc);
+            auto quorum_set = buildSCPQuorumSet(qc);
             auto shared_set = makeSharedSCPQuorumSet(quorum_set);
             this.known_quorums[hashFull(quorum_set)] = shared_set;
         }
 
         // set up our own quorum
-        auto quorum_set = buildSCPConfig(quorum);
+        auto quorum_set = buildSCPQuorumSet(quorum);
         () @trusted { this.scp.updateLocalQuorumSet(quorum_set); }();
         auto shared_set = makeSharedSCPQuorumSet(quorum_set);
         this.known_quorums[hashFull(quorum_set)] = shared_set;
@@ -224,7 +224,7 @@ extern(D):
 
     ***************************************************************************/
 
-    private static SCPQuorumSet buildSCPConfig (ref const QuorumConfig config)
+    private static SCPQuorumSet buildSCPQuorumSet (ref const QuorumConfig config)
         @safe nothrow
     {
         import scpd.scp.QuorumSetUtils;

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -408,8 +408,6 @@ private struct EnrollmentFmt
 ///
 unittest
 {
-    Hash quorumSetHash;
-
     Hash key = Hash("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f" ~
                     "1b60a8ce26f000000000019d6689c085ae165831e934ff763ae46a2" ~
                     "a6c172b3f1b60a8ce26f");
@@ -459,8 +457,6 @@ unittest
 {
     import agora.common.Serializer;
     import agora.common.Set;
-
-    Hash quorumSetHash;
 
     Hash key = Hash("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f" ~
                     "1b60a8ce26f000000000019d6689c085ae165831e934ff763ae46a2" ~

--- a/source/scpd/scp/BallotProtocol.d
+++ b/source/scpd/scp/BallotProtocol.d
@@ -111,12 +111,6 @@ extern(C++, class) public struct BallotProtocol
     void* getJsonQuorumInfo(ref const(NodeID)  id, bool summary,
         bool fullKeys = false);
 
-    // returns the hash of the QuorumSet that should be downloaded
-    // with the statement.
-    // note: the companion hash for an EXTERNALIZE statement does
-    // not match the hash of the QSet, but the hash of commitQuorumSetHash
-    static Hash getCompanionQuorumSetHashFromStatement(const ref SCPStatement st);
-
     // helper function to retrieve b for PREPARE, P for CONFIRM or
     // c for EXTERNALIZE messages
     static SCPBallot getWorkingBallot(const ref SCPStatement st);

--- a/source/scpd/scp/SCPDriver.d
+++ b/source/scpd/scp/SCPDriver.d
@@ -31,9 +31,8 @@ nothrow:
     // Envelope signature/verification
     abstract void signEnvelope(ref SCPEnvelope envelope);
 
-    // Delegates the retrieval of the quorum set designated by `qSetHash` to
-    // the user of SCP.
-    abstract SCPQuorumSetPtr getQSet(ref const(Hash) qSetHash);
+    // Delegates the retrieval of the quorum set associated with this node ID
+    abstract SCPQuorumSetPtr getNodeQSet(ref const(NodeID) nodeID);
 
     // Users of the SCP library should inherit from SCPDriver and implement the
     // virtual methods which are called by the SCP implementation to

--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -45,12 +45,11 @@ enum SCPStatementType : int32_t {
 }
 
 struct SCPNomination {
-    Hash quorumSetHash;
     xvector!(Value) votes;
     xvector!(Value) accepted;
 }
 
-static assert(SCPNomination.sizeof == 112);
+static assert(SCPNomination.sizeof == 48);
 
 struct SCPStatement {
 
@@ -64,7 +63,6 @@ struct SCPStatement {
 
     static struct _pledges_t {
         static struct _prepare_t {
-            Hash quorumSetHash;
             SCPBallot ballot;
             pointer!(SCPBallot) prepared;
             pointer!(SCPBallot) preparedPrime;
@@ -72,25 +70,23 @@ struct SCPStatement {
             uint32_t nH;
         }
 
-        static assert(_prepare_t.sizeof == 120);
+        static assert(_prepare_t.sizeof == 56);
 
         static struct _confirm_t {
             SCPBallot ballot;
             uint32_t nPrepared;
             uint32_t nCommit;
             uint32_t nH;
-            Hash quorumSetHash;
         }
 
-        static assert(_confirm_t.sizeof == 112);
+        static assert(_confirm_t.sizeof == 48);
 
         static struct _externalize_t {
             SCPBallot commit;
             uint32_t nH;
-            Hash commitQuorumSetHash;
         }
 
-        static assert(_externalize_t.sizeof == 104);
+        static assert(_externalize_t.sizeof == 40);
 
         //using _xdr_case_type = xdr::xdr_traits<SCPStatementType>::case_type;
         //private:
@@ -258,7 +254,7 @@ struct SCPStatement {
     _pledges_t pledges;
 }
 
-static assert(SCPStatement.sizeof == 176);
+static assert(SCPStatement.sizeof == 112);
 static assert(Signature.sizeof == 64);
 
 struct SCPEnvelope {
@@ -266,7 +262,7 @@ struct SCPEnvelope {
   Signature signature;
 }
 
-static assert(SCPEnvelope.sizeof == 240);
+static assert(SCPEnvelope.sizeof == 176);
 
 struct SCPQuorumSet {
     import agora.common.Hash;
@@ -343,4 +339,4 @@ public alias SCPQuorumSetPtr = shared_ptr!SCPQuorumSet;
 static assert(SCPBallot.sizeof == 32);
 static assert(Value.sizeof == 24);
 static assert(SCPQuorumSet.sizeof == 56);
-static assert(SCPEnvelope.sizeof == 240);
+static assert(SCPEnvelope.sizeof == 176);

--- a/source/scpp/extra/DLayoutChecks.cpp
+++ b/source/scpp/extra/DLayoutChecks.cpp
@@ -63,7 +63,6 @@ FieldInfo cppFieldInfo ( SCPBallot &object, const char *field_name )
 
 FieldInfo cppFieldInfo ( SCPNomination &object, const char *field_name )
 {
-    HANDLE(quorumSetHash)
     HANDLE(votes)
     HANDLE(accepted)
     return FieldInfo(-1, -1);  // assert on the D side for better error messages
@@ -71,7 +70,6 @@ FieldInfo cppFieldInfo ( SCPNomination &object, const char *field_name )
 
 FieldInfo cppFieldInfo ( SCPStatement::_pledges_t::_prepare_t &object, const char *field_name )
 {
-    HANDLE(quorumSetHash)
     HANDLE(ballot)
     HANDLE(prepared)
     HANDLE(preparedPrime)
@@ -86,7 +84,6 @@ FieldInfo cppFieldInfo ( SCPStatement::_pledges_t::_confirm_t &object, const cha
     HANDLE(nPrepared)
     HANDLE(nCommit)
     HANDLE(nH)
-    HANDLE(quorumSetHash)
     return FieldInfo(-1, -1);  // assert on the D side for better error messages
 }
 
@@ -94,7 +91,6 @@ FieldInfo cppFieldInfo ( SCPStatement::_pledges_t::_externalize_t &object, const
 {
     HANDLE(commit)
     HANDLE(nH)
-    HANDLE(commitQuorumSetHash)
     return FieldInfo(-1, -1);  // assert on the D side for better error messages
 }
 

--- a/source/scpp/src/scp/BallotProtocol.h
+++ b/source/scpp/src/scp/BallotProtocol.h
@@ -91,12 +91,6 @@ class BallotProtocol
     Json::Value getJsonQuorumInfo(NodeID const& id, bool summary,
                                   bool fullKeys = false);
 
-    // returns the hash of the QuorumSet that should be downloaded
-    // with the statement.
-    // note: the companion hash for an EXTERNALIZE statement does
-    // not match the hash of the QSet, but the hash of commitQuorumSetHash
-    static Hash getCompanionQuorumSetHashFromStatement(SCPStatement const& st);
-
     // helper function to retrieve b for PREPARE, P for CONFIRM or
     // c for EXTERNALIZE messages
     static SCPBallot getWorkingBallot(SCPStatement const& st);

--- a/source/scpp/src/scp/NominationProtocol.cpp
+++ b/source/scpp/src/scp/NominationProtocol.cpp
@@ -148,8 +148,6 @@ NominationProtocol::emitNomination()
     st.pledges.type(SCP_ST_NOMINATE);
     auto& nom = st.pledges.nominate();
 
-    nom.quorumSetHash = mSlot.getLocalNode()->getQuorumSetHash();
-
     for (auto const& v : mVotes)
     {
         nom.votes.emplace_back(v);

--- a/source/scpp/src/scp/SCP.cpp
+++ b/source/scpp/src/scp/SCP.cpp
@@ -316,8 +316,6 @@ SCP::envToStr(SCPStatement const& st, bool fullKeys) const
 {
     std::ostringstream oss;
 
-    Hash const& qSetHash = Slot::getCompanionQuorumSetHashFromStatement(st);
-
     std::string nodeId = mDriver.toStrKey(st.nodeID, fullKeys);
 
     oss << "{ENV@" << nodeId << " | "
@@ -328,7 +326,6 @@ SCP::envToStr(SCPStatement const& st, bool fullKeys) const
     {
         auto const& p = st.pledges.prepare();
         oss << " | PREPARE"
-            << " | D: " << hexAbbrev(qSetHash)
             << " | b: " << ballotToStr(p.ballot)
             << " | p: " << ballotToStr(p.prepared)
             << " | p': " << ballotToStr(p.preparedPrime) << " | c.n: " << p.nC
@@ -339,7 +336,6 @@ SCP::envToStr(SCPStatement const& st, bool fullKeys) const
     {
         auto const& c = st.pledges.confirm();
         oss << " | CONFIRM"
-            << " | D: " << hexAbbrev(qSetHash)
             << " | b: " << ballotToStr(c.ballot) << " | p.n: " << c.nPrepared
             << " | c.n: " << c.nCommit << " | h.n: " << c.nH;
     }
@@ -348,15 +344,13 @@ SCP::envToStr(SCPStatement const& st, bool fullKeys) const
     {
         auto const& ex = st.pledges.externalize();
         oss << " | EXTERNALIZE"
-            << " | c: " << ballotToStr(ex.commit) << " | h.n: " << ex.nH
-            << " | (lastD): " << hexAbbrev(qSetHash);
+            << " | c: " << ballotToStr(ex.commit) << " | h.n: " << ex.nH;
     }
     break;
     case SCPStatementType::SCP_ST_NOMINATE:
     {
         auto const& nom = st.pledges.nominate();
-        oss << " | NOMINATE"
-            << " | D: " << hexAbbrev(qSetHash) << " | X: {";
+        oss << " | NOMINATE";
         bool first = true;
         for (auto const& v : nom.votes)
         {

--- a/source/scpp/src/scp/SCPDriver.h
+++ b/source/scpp/src/scp/SCPDriver.h
@@ -26,17 +26,15 @@ class SCPDriver
     // Envelope signature
     virtual void signEnvelope(SCPEnvelope& envelope) = 0;
 
-    // Retrieves a quorum set from its hash
+    // Retrieves the quorum set configuration for the given node ID
     //
-    // All SCP statement (see `SCPNomination` and `SCPStatement`) include
-    // a quorum set hash.
-    // SCP does not define how quorum sets are exchanged between nodes,
-    // hence their retrieval is delegated to the user of SCP.
-    // The return value is not cached by SCP, as quorum sets are transient.
+    // Note: In our modified version of SCP we do not include quorum set hashes
+    // in SCP protocol messages as the quorums are implicitly known by the
+    // system for all active validator nodes.
     //
     // `nullptr` is a valid return value which cause the statement to be
     // considered invalid.
-    virtual SCPQuorumSetPtr getQSet(Hash const& qSetHash) = 0;
+    virtual SCPQuorumSetPtr getNodeQSet(NodeID const& nodeID) = 0;
 
     // Users of the SCP library should inherit from SCPDriver and implement the
     // virtual methods which are called by the SCP implementation to

--- a/source/scpp/src/scp/Slot.h
+++ b/source/scpp/src/scp/Slot.h
@@ -146,12 +146,6 @@ class Slot : public std::enable_shared_from_this<Slot>
     Json::Value getJsonQuorumInfo(NodeID const& id, bool summary,
                                   bool fullKeys = false);
 
-    // returns the hash of the QuorumSet that should be downloaded
-    // with the statement.
-    // note: the companion hash for an EXTERNALIZE statement does
-    // not match the hash of the QSet, but the hash of commitQuorumSetHash
-    static Hash getCompanionQuorumSetHashFromStatement(SCPStatement const& st);
-
     // returns the values associated with the statement
     static std::vector<Value> getStatementValues(SCPStatement const& st);
 

--- a/source/scpp/src/xdr/Stellar-SCP.h
+++ b/source/scpp/src/xdr/Stellar-SCP.h
@@ -90,32 +90,24 @@ template<> struct xdr_traits<::stellar::SCPStatementType>
 } namespace stellar {
 
 struct SCPNomination {
-  Hash quorumSetHash{};
   xdr::xvector<Value> votes{};
   xdr::xvector<Value> accepted{};
 
   SCPNomination() = default;
-  template<typename _quorumSetHash_T,
-           typename _votes_T,
+  template<typename _votes_T,
            typename _accepted_T,
            typename = typename
-           std::enable_if<std::is_constructible<Hash, _quorumSetHash_T>::value
-                          && std::is_constructible<xdr::xvector<Value>, _votes_T>::value
+           std::enable_if<std::is_constructible<xdr::xvector<Value>, _votes_T>::value
                           && std::is_constructible<xdr::xvector<Value>, _accepted_T>::value
                          >::type>
-  explicit SCPNomination(_quorumSetHash_T &&_quorumSetHash,
-                         _votes_T &&_votes,
+  explicit SCPNomination(_votes_T &&_votes,
                          _accepted_T &&_accepted)
-    : quorumSetHash(std::forward<_quorumSetHash_T>(_quorumSetHash)),
-      votes(std::forward<_votes_T>(_votes)),
+    : votes(std::forward<_votes_T>(_votes)),
       accepted(std::forward<_accepted_T>(_accepted)) {}
 };
 } namespace xdr {
 template<> struct xdr_traits<::stellar::SCPNomination>
   : xdr_struct_base<field_ptr<::stellar::SCPNomination,
-                              decltype(::stellar::SCPNomination::quorumSetHash),
-                              &::stellar::SCPNomination::quorumSetHash>,
-                    field_ptr<::stellar::SCPNomination,
                               decltype(::stellar::SCPNomination::votes),
                               &::stellar::SCPNomination::votes>,
                     field_ptr<::stellar::SCPNomination,
@@ -123,13 +115,11 @@ template<> struct xdr_traits<::stellar::SCPNomination>
                               &::stellar::SCPNomination::accepted>> {
   template<typename Archive> static void
   save(Archive &ar, const ::stellar::SCPNomination &obj) {
-    archive(ar, obj.quorumSetHash, "quorumSetHash");
     archive(ar, obj.votes, "votes");
     archive(ar, obj.accepted, "accepted");
   }
   template<typename Archive> static void
   load(Archive &ar, ::stellar::SCPNomination &obj) {
-    archive(ar, obj.quorumSetHash, "quorumSetHash");
     archive(ar, obj.votes, "votes");
     archive(ar, obj.accepted, "accepted");
     xdr::validate(obj);
@@ -140,7 +130,6 @@ template<> struct xdr_traits<::stellar::SCPNomination>
 struct SCPStatement {
   struct _pledges_t {
     struct _prepare_t {
-      Hash quorumSetHash{};
       SCPBallot ballot{};
       xdr::pointer<SCPBallot> prepared{};
       xdr::pointer<SCPBallot> preparedPrime{};
@@ -148,28 +137,24 @@ struct SCPStatement {
       uint32 nH{};
 
       _prepare_t() = default;
-      template<typename _quorumSetHash_T,
-               typename _ballot_T,
+      template<typename _ballot_T,
                typename _prepared_T,
                typename _preparedPrime_T,
                typename _nC_T,
                typename _nH_T,
                typename = typename
-               std::enable_if<std::is_constructible<Hash, _quorumSetHash_T>::value
-                              && std::is_constructible<SCPBallot, _ballot_T>::value
+               std::enable_if<std::is_constructible<SCPBallot, _ballot_T>::value
                               && std::is_constructible<xdr::pointer<SCPBallot>, _prepared_T>::value
                               && std::is_constructible<xdr::pointer<SCPBallot>, _preparedPrime_T>::value
                               && std::is_constructible<uint32, _nC_T>::value
                               && std::is_constructible<uint32, _nH_T>::value
                              >::type>
-      explicit _prepare_t(_quorumSetHash_T &&_quorumSetHash,
-                          _ballot_T &&_ballot,
+      explicit _prepare_t(_ballot_T &&_ballot,
                           _prepared_T &&_prepared,
                           _preparedPrime_T &&_preparedPrime,
                           _nC_T &&_nC,
                           _nH_T &&_nH)
-        : quorumSetHash(std::forward<_quorumSetHash_T>(_quorumSetHash)),
-          ballot(std::forward<_ballot_T>(_ballot)),
+        : ballot(std::forward<_ballot_T>(_ballot)),
           prepared(std::forward<_prepared_T>(_prepared)),
           preparedPrime(std::forward<_preparedPrime_T>(_preparedPrime)),
           nC(std::forward<_nC_T>(_nC)),
@@ -180,52 +165,42 @@ struct SCPStatement {
       uint32 nPrepared{};
       uint32 nCommit{};
       uint32 nH{};
-      Hash quorumSetHash{};
 
       _confirm_t() = default;
       template<typename _ballot_T,
                typename _nPrepared_T,
                typename _nCommit_T,
                typename _nH_T,
-               typename _quorumSetHash_T,
                typename = typename
                std::enable_if<std::is_constructible<SCPBallot, _ballot_T>::value
                               && std::is_constructible<uint32, _nPrepared_T>::value
                               && std::is_constructible<uint32, _nCommit_T>::value
                               && std::is_constructible<uint32, _nH_T>::value
-                              && std::is_constructible<Hash, _quorumSetHash_T>::value
                              >::type>
       explicit _confirm_t(_ballot_T &&_ballot,
                           _nPrepared_T &&_nPrepared,
                           _nCommit_T &&_nCommit,
-                          _nH_T &&_nH,
-                          _quorumSetHash_T &&_quorumSetHash)
+                          _nH_T &&_nH)
         : ballot(std::forward<_ballot_T>(_ballot)),
           nPrepared(std::forward<_nPrepared_T>(_nPrepared)),
           nCommit(std::forward<_nCommit_T>(_nCommit)),
-          nH(std::forward<_nH_T>(_nH)),
-          quorumSetHash(std::forward<_quorumSetHash_T>(_quorumSetHash)) {}
+          nH(std::forward<_nH_T>(_nH)) {}
     };
     struct _externalize_t {
       SCPBallot commit{};
       uint32 nH{};
-      Hash commitQuorumSetHash{};
 
       _externalize_t() = default;
       template<typename _commit_T,
                typename _nH_T,
-               typename _commitQuorumSetHash_T,
                typename = typename
                std::enable_if<std::is_constructible<SCPBallot, _commit_T>::value
                               && std::is_constructible<uint32, _nH_T>::value
-                              && std::is_constructible<Hash, _commitQuorumSetHash_T>::value
                              >::type>
       explicit _externalize_t(_commit_T &&_commit,
-                              _nH_T &&_nH,
-                              _commitQuorumSetHash_T &&_commitQuorumSetHash)
+                              _nH_T &&_nH)
         : commit(std::forward<_commit_T>(_commit)),
-          nH(std::forward<_nH_T>(_nH)),
-          commitQuorumSetHash(std::forward<_commitQuorumSetHash_T>(_commitQuorumSetHash)) {}
+          nH(std::forward<_nH_T>(_nH)) {}
     };
 
     using _xdr_case_type = xdr::xdr_traits<SCPStatementType>::case_type;
@@ -397,9 +372,6 @@ struct SCPStatement {
 } namespace xdr {
 template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_prepare_t>
   : xdr_struct_base<field_ptr<::stellar::SCPStatement::_pledges_t::_prepare_t,
-                              decltype(::stellar::SCPStatement::_pledges_t::_prepare_t::quorumSetHash),
-                              &::stellar::SCPStatement::_pledges_t::_prepare_t::quorumSetHash>,
-                    field_ptr<::stellar::SCPStatement::_pledges_t::_prepare_t,
                               decltype(::stellar::SCPStatement::_pledges_t::_prepare_t::ballot),
                               &::stellar::SCPStatement::_pledges_t::_prepare_t::ballot>,
                     field_ptr<::stellar::SCPStatement::_pledges_t::_prepare_t,
@@ -416,7 +388,6 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_prepare_t>
                               &::stellar::SCPStatement::_pledges_t::_prepare_t::nH>> {
   template<typename Archive> static void
   save(Archive &ar, const ::stellar::SCPStatement::_pledges_t::_prepare_t &obj) {
-    archive(ar, obj.quorumSetHash, "quorumSetHash");
     archive(ar, obj.ballot, "ballot");
     archive(ar, obj.prepared, "prepared");
     archive(ar, obj.preparedPrime, "preparedPrime");
@@ -425,7 +396,6 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_prepare_t>
   }
   template<typename Archive> static void
   load(Archive &ar, ::stellar::SCPStatement::_pledges_t::_prepare_t &obj) {
-    archive(ar, obj.quorumSetHash, "quorumSetHash");
     archive(ar, obj.ballot, "ballot");
     archive(ar, obj.prepared, "prepared");
     archive(ar, obj.preparedPrime, "preparedPrime");
@@ -446,17 +416,13 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_confirm_t>
                               &::stellar::SCPStatement::_pledges_t::_confirm_t::nCommit>,
                     field_ptr<::stellar::SCPStatement::_pledges_t::_confirm_t,
                               decltype(::stellar::SCPStatement::_pledges_t::_confirm_t::nH),
-                              &::stellar::SCPStatement::_pledges_t::_confirm_t::nH>,
-                    field_ptr<::stellar::SCPStatement::_pledges_t::_confirm_t,
-                              decltype(::stellar::SCPStatement::_pledges_t::_confirm_t::quorumSetHash),
-                              &::stellar::SCPStatement::_pledges_t::_confirm_t::quorumSetHash>> {
+                              &::stellar::SCPStatement::_pledges_t::_confirm_t::nH>> {
   template<typename Archive> static void
   save(Archive &ar, const ::stellar::SCPStatement::_pledges_t::_confirm_t &obj) {
     archive(ar, obj.ballot, "ballot");
     archive(ar, obj.nPrepared, "nPrepared");
     archive(ar, obj.nCommit, "nCommit");
     archive(ar, obj.nH, "nH");
-    archive(ar, obj.quorumSetHash, "quorumSetHash");
   }
   template<typename Archive> static void
   load(Archive &ar, ::stellar::SCPStatement::_pledges_t::_confirm_t &obj) {
@@ -464,7 +430,6 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_confirm_t>
     archive(ar, obj.nPrepared, "nPrepared");
     archive(ar, obj.nCommit, "nCommit");
     archive(ar, obj.nH, "nH");
-    archive(ar, obj.quorumSetHash, "quorumSetHash");
     xdr::validate(obj);
   }
 };
@@ -474,21 +439,16 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_externalize_t
                               &::stellar::SCPStatement::_pledges_t::_externalize_t::commit>,
                     field_ptr<::stellar::SCPStatement::_pledges_t::_externalize_t,
                               decltype(::stellar::SCPStatement::_pledges_t::_externalize_t::nH),
-                              &::stellar::SCPStatement::_pledges_t::_externalize_t::nH>,
-                    field_ptr<::stellar::SCPStatement::_pledges_t::_externalize_t,
-                              decltype(::stellar::SCPStatement::_pledges_t::_externalize_t::commitQuorumSetHash),
-                              &::stellar::SCPStatement::_pledges_t::_externalize_t::commitQuorumSetHash>> {
+                              &::stellar::SCPStatement::_pledges_t::_externalize_t::nH>> {
   template<typename Archive> static void
   save(Archive &ar, const ::stellar::SCPStatement::_pledges_t::_externalize_t &obj) {
     archive(ar, obj.commit, "commit");
     archive(ar, obj.nH, "nH");
-    archive(ar, obj.commitQuorumSetHash, "commitQuorumSetHash");
   }
   template<typename Archive> static void
   load(Archive &ar, ::stellar::SCPStatement::_pledges_t::_externalize_t &obj) {
     archive(ar, obj.commit, "commit");
     archive(ar, obj.nH, "nH");
-    archive(ar, obj.commitQuorumSetHash, "commitQuorumSetHash");
     xdr::validate(obj);
   }
 };

--- a/source/scpp/src/xdr/Stellar-SCP.x
+++ b/source/scpp/src/xdr/Stellar-SCP.x
@@ -25,7 +25,6 @@ enum SCPStatementType
 
 struct SCPNomination
 {
-    Hash quorumSetHash; // D
     Value votes<>;      // X
     Value accepted<>;   // Y
 };
@@ -40,7 +39,6 @@ struct SCPStatement
     case SCP_ST_PREPARE:
         struct
         {
-            Hash quorumSetHash;       // D
             SCPBallot ballot;         // b
             SCPBallot* prepared;      // p
             SCPBallot* preparedPrime; // p'
@@ -54,14 +52,12 @@ struct SCPStatement
             uint32 nPrepared;   // p.n
             uint32 nCommit;     // c.n
             uint32 nH;          // h.n
-            Hash quorumSetHash; // D
         } confirm;
     case SCP_ST_EXTERNALIZE:
         struct
         {
             SCPBallot commit;         // c
             uint32 nH;                // h.n
-            Hash commitQuorumSetHash; // D used before EXTERNALIZE
         } externalize;
     case SCP_ST_NOMINATE:
         SCPNomination nominate;


### PR DESCRIPTION
The quorum hashes can be implicitly derived from the `node_id` and `slot_idx` fields which are part of every `SCPEnvelope` message.

This reduces the total network overhead.

Fixes #982