### PR TITLE
Remove Ledger.hasTransactionHash()

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -268,7 +268,7 @@ public class FullNode : API
         log.trace("Received Transaction: {}", prettify(tx));
 
         auto tx_hash = hashFull(tx);
-        if (this.ledger.hasTransactionHash(tx_hash))
+        if (this.pool.hasTransactionHash(tx_hash))
             return;
 
         if (this.ledger.acceptTransaction(tx))
@@ -282,7 +282,7 @@ public class FullNode : API
     /// GET: /has_transaction_hash
     public override bool hasTransactionHash (Hash tx) @safe
     {
-        return this.ledger.hasTransactionHash(tx);
+        return this.pool.hasTransactionHash(tx);
     }
 
     /// GET: /block_height

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -518,23 +518,6 @@ public class Ledger
             return null;
         return block.getMerklePath(index);
     }
-
-    /***************************************************************************
-
-        Check if a transaction hash exists in the transaction pool.
-
-        Params:
-            tx = the transaction hash
-
-        Returns:
-            true if the transaction pool has the transaction hash.
-
-    ***************************************************************************/
-
-    public bool hasTransactionHash (const ref Hash tx) @safe
-    {
-        return this.pool.hasTransactionHash(tx);
-    }
 }
 
 /// Note: these unittests historically assume a block always contains


### PR DESCRIPTION
This function was just a trampoline to the same
method in the transaction pool. It has no benefits
being here.