### PR TITLE
Add LatestEnvelopes and store & restore envelopes

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -98,6 +98,7 @@
                 "source/scpp/*",
                 "source/scpd/*",
                 "source/agora/consensus/protocol/*",
+                "source/agora/consensus/SCPEnvelopeStore.d",
                 "source/agora/cli/checkvtable/*",
                 "source/agora/cli/multi/*",
                 "source/agora/cli/vanity/*"

--- a/source/agora/consensus/SCPEnvelopeStore.d
+++ b/source/agora/consensus/SCPEnvelopeStore.d
@@ -1,0 +1,199 @@
+/*******************************************************************************
+
+    Contains supporting code for storing the latest SCP envelopes,
+    using SQLite as a backing store.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.consensus.SCPEnvelopeStore;
+
+import agora.common.ManagedDatabase;
+import agora.common.Serializer;
+import agora.common.Types;
+import agora.utils.Log;
+
+import d2sqlite3.library;
+import d2sqlite3.results;
+import d2sqlite3.sqlite3;
+
+import scpd.types.Stellar_SCP;
+
+import std.file : exists;
+import std.range;
+
+mixin AddLogger!();
+
+
+/// Ditto
+public class SCPEnvelopeStore
+{
+    /// SQLite db instance
+    private ManagedDatabase db;
+
+    /***************************************************************************
+
+        Constructor
+
+        Params:
+            db_path = path to the database file, or in-memory storage if
+                      :memory: was passed
+
+    ***************************************************************************/
+
+    public this (in string db_path)
+    {
+        const db_exists = db_path.exists;
+        if (db_exists)
+            log.info("Loading database from: {}", db_path);
+
+        this.db = new ManagedDatabase(db_path);
+
+        this.db.execute("CREATE TABLE IF NOT EXISTS scp_envelopes " ~
+            "(seq INTEGER PRIMARY KEY AUTOINCREMENT, envelope BLOB NOT NULL)");
+    }
+
+    /***************************************************************************
+
+        Store the envelope to the database.
+
+        First, clean with 'removeAll' before Adding it in new envelopes.
+
+        Params:
+            envelope = the envelop to add
+
+        Returns:
+            true if the envelope has been added to the database
+
+    ***************************************************************************/
+
+    public bool add (const ref SCPEnvelope envelope) @safe nothrow
+    {
+        static ubyte[] envelope_bytes;
+
+        try
+        {
+            envelope_bytes = serializeFull(envelope);
+        }
+        catch (Exception ex)
+        {
+            log.error("Serialization error: {}, Data was: {}", ex.msg,
+                envelope_bytes);
+            return false;
+        }
+
+        try
+        {
+            () @trusted {
+                db.execute("INSERT INTO scp_envelopes (envelope) VALUES(?)",
+                    envelope_bytes);
+            }();
+        }
+        catch (Exception ex)
+        {
+            log.error("Unexpected error while adding envelope: {}", ex.msg);
+            return false;
+        }
+        return true;
+    }
+
+    /***************************************************************************
+
+        Remove all envelopes from the database
+
+    ***************************************************************************/
+
+    public void removeAll () @trusted nothrow
+    {
+        try
+        {
+            this.db.execute("DELETE FROM scp_envelopes");
+        }
+        catch (Exception ex)
+        {
+            log.error("Error while calling SCPEnvelopeStore.removeAll(): {}", ex);
+        }
+    }
+
+    /***************************************************************************
+
+        Walk over the envelopes in the database
+        and call the provided delegate
+
+        Params:
+            dg = the delegate to call
+
+        Returns:
+            the status code of the delegate, or zero
+
+    ***************************************************************************/
+
+    public int opApply (scope int delegate(const ref SCPEnvelope) dg)
+    {
+        () @trusted
+        {
+            auto results = this.db.execute(
+                "SELECT envelope FROM scp_envelopes");
+
+            foreach (ref row; results)
+            {
+                auto env = deserializeFull!(const SCPEnvelope)(row.peek!(ubyte[])(0));
+
+                if (auto ret = dg(env))
+                    return ret;
+            }
+            return 0;
+        }();
+
+        return 0;
+    }
+
+    /***************************************************************************
+
+        Returns:
+            the number of envelope in the database
+
+    ***************************************************************************/
+
+    public size_t length () @safe
+    {
+        return () @trusted {
+            return db.execute("SELECT count(*) FROM scp_envelopes")
+                .oneValue!size_t;
+        }();
+    }
+}
+
+/// add & opApply & remove tests
+unittest
+{
+    auto envelope_store = new SCPEnvelopeStore(":memory:");
+
+    SCPEnvelope[] envelopes;
+
+    foreach (_; 0 .. 2)
+    {
+        envelopes ~= SCPEnvelope.init;
+    }
+
+    foreach (env; envelopes)
+    {
+        envelope_store.add(env);
+    }
+
+    assert(envelope_store.length == 2);
+
+    foreach (const ref SCPEnvelope env; envelope_store)
+    {
+        assert(env == SCPEnvelope.init);
+    }
+
+    envelope_store.removeAll();
+    assert(envelope_store.length == 0);
+}

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -87,7 +87,8 @@ public class Validator : FullNode, API
             this.params.QuorumThreshold);
 
         this.nominator = this.getNominator(this.params, this.clock,
-            this.network, this.config.validator.key_pair, this.ledger, this.taskman);
+            this.network, this.config.validator.key_pair, this.ledger, this.taskman,
+            this.config.node.data_dir);
 
         // currently we are not saving preimage info,
         // we only have the commitment in the genesis block
@@ -274,6 +275,7 @@ public class Validator : FullNode, API
             key_pair = the key pair of the node
             ledger = Ledger instance
             taskman = the task manager
+            data_dir = path to the data directory
 
         Returns:
             An instance of a `Nominator`
@@ -282,9 +284,10 @@ public class Validator : FullNode, API
 
     protected Nominator getNominator (immutable(ConsensusParams) params,
         Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        TaskManager taskman)
+        TaskManager taskman, string data_dir)
     {
-        return new Nominator(params, clock, network, key_pair, ledger, taskman);
+        return new Nominator(params, clock, network, key_pair, ledger, taskman,
+            data_dir);
     }
 
     /***************************************************************************
@@ -389,5 +392,17 @@ public class Validator : FullNode, API
             this.pushPreImage(preimage);
             this.enroll_man.updateRevealDistance(this.ledger.getBlockHeight());
         }
+    }
+
+    /***************************************************************************
+
+        Calls the base class `shutdown` and store the latest SCP state
+
+    ***************************************************************************/
+
+    override void shutdown ()
+    {
+        super.shutdown();
+        this.nominator.storeLatestState();
     }
 }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -43,6 +43,7 @@ import agora.consensus.data.UTXOSetValue;
 import agora.consensus.UTXOSet;
 import agora.consensus.EnrollmentManager;
 import agora.consensus.data.genesis.Test;
+import agora.consensus.SCPEnvelopeStore;
 import agora.consensus.protocol.Nominator;
 import agora.consensus.Quorum;
 import agora.network.Clock;
@@ -417,10 +418,10 @@ extern(D):
     ///
     public this (immutable(ConsensusParams) params, Clock clock,
         NetworkManager network, KeyPair key_pair, Ledger ledger,
-        TaskManager taskman, ulong txs_to_nominate)
+        TaskManager taskman, string data_dir, ulong txs_to_nominate)
     {
         this.txs_to_nominate = txs_to_nominate;
-        super(params, clock, network, key_pair, ledger, taskman);
+        super(params, clock, network, key_pair, ledger, taskman, data_dir);
     }
 
     /// Overrides the default behavior and changes nomination behavior based
@@ -439,6 +440,18 @@ extern(D):
             return false;
 
         return true;
+    }
+
+    // set the DB instance of SCPEnvelopeStore
+    protected void setSCPEnvelopeStore (SCPEnvelopeStore envelope_store)
+    {
+        this.scp_envelope_store = envelope_store;
+    }
+
+    // return a SCPEnvelopeStore backed by an in-memory SQLite db
+    protected override SCPEnvelopeStore getSCPEnvelopeStore (string data_dir)
+    {
+        return new SCPEnvelopeStore(":memory:");
     }
 }
 
@@ -1275,10 +1288,10 @@ public class TestValidatorNode : Validator, TestAPI
     /// Returns an instance of a TestNominator with customizable behavior
     protected override TestNominator getNominator (
         immutable(ConsensusParams) params, Clock clock, NetworkManager network,
-        KeyPair key_pair, Ledger ledger, TaskManager taskman)
+        KeyPair key_pair, Ledger ledger, TaskManager taskman, string data_dir)
     {
         return new TestNominator(params, clock, network, key_pair, ledger,
-            taskman, this.txs_to_nominate);
+            taskman, data_dir, this.txs_to_nominate);
     }
 
     /// Provides a unittest-adjusted clock source for the node

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -72,10 +72,10 @@ private extern(C++) class ByzantineNominator : TestNominator
 
     extern(D) this (immutable(ConsensusParams) params,
         Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        TaskManager taskman, ByzantineReason reason)
+        TaskManager taskman, string data_dir, ByzantineReason reason)
     {
         this.reason = reason;
-        super(params, clock, network, key_pair, ledger, taskman,
+        super(params, clock, network, key_pair, ledger, taskman, data_dir,
             this.txs_to_nominate);
     }
 
@@ -109,10 +109,10 @@ class ByzantineNode (ByzantineReason reason) : TestValidatorNode
 
     protected override TestNominator getNominator (immutable(ConsensusParams) params,
         Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        TaskManager taskman)
+        TaskManager taskman, string data_dir)
     {
         return new ByzantineNominator(params, clock, network, key_pair, ledger,
-            taskman, reason);
+            taskman, data_dir, reason);
     }
 }
 
@@ -125,11 +125,13 @@ private class SpyNominator : TestNominator
     /// Ctor
     public this (immutable(ConsensusParams) params, Clock clock,
         NetworkManager network, KeyPair key_pair, Ledger ledger,
-        TaskManager taskman, ulong txs_to_nominate, shared(time_t)* curr_time,
+        TaskManager taskman, string data_dir, ulong txs_to_nominate,
+        shared(time_t)* curr_time,
         shared(EnvelopeTypeCounts)* envelope_type_counts)
     {
         this.envelope_type_counts = envelope_type_counts;
-        super(params, clock, network, key_pair, ledger, taskman, txs_to_nominate);
+        super(params, clock, network, key_pair, ledger, taskman, data_dir,
+        txs_to_nominate);
     }
 
     public override void receiveEnvelope (scope ref const(SCPEnvelope) envelope) @trusted
@@ -171,11 +173,11 @@ private class SpyingValidator : TestValidatorNode
     protected override TestNominator getNominator (
         immutable(ConsensusParams) params, Clock clock,
         NetworkManager network, KeyPair key_pair, Ledger ledger,
-        TaskManager taskman)
+        TaskManager taskman, string data_dir)
     {
         return new SpyNominator(
-            params, clock, network, key_pair, ledger, taskman, this.txs_to_nominate, this.cur_time,
-            this.envelope_type_counts);
+            params, clock, network, key_pair, ledger, taskman, data_dir,
+            this.txs_to_nominate, this.cur_time, this.envelope_type_counts);
     }
 }
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -305,12 +305,12 @@ unittest
         /// Ctor
         public this (immutable(ConsensusParams) params, Clock clock,
             NetworkManager network, KeyPair key_pair, Ledger ledger,
-            TaskManager taskman, ulong txs_to_nominate,
+            TaskManager taskman, string data_dir, ulong txs_to_nominate,
             shared(time_t)* curr_time, shared(size_t)* countPtr)
         {
             this.runCount = countPtr;
             super(params, clock, network, key_pair, ledger, taskman,
-                txs_to_nominate);
+                data_dir, txs_to_nominate);
         }
 
         ///
@@ -346,11 +346,11 @@ unittest
         protected override TestNominator getNominator (
             immutable(ConsensusParams) params, Clock clock,
             NetworkManager network, KeyPair key_pair, Ledger ledger,
-            TaskManager taskman)
+            TaskManager taskman, string data_dir)
         {
             return new BadNominator(
                 params, clock, network, key_pair, ledger, taskman,
-                this.txs_to_nominate, this.cur_time, this.runCount);
+                data_dir, this.txs_to_nominate, this.cur_time, this.runCount);
         }
     }
 

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -55,11 +55,11 @@ unittest
         /// Ctor
         public this (immutable(ConsensusParams) params, Clock clock,
             NetworkManager network, KeyPair key_pair, Ledger ledger,
-            TaskManager taskman, ulong txs_to_nominate,
+            TaskManager taskman, string data_dir, ulong txs_to_nominate,
             shared(time_t)* curr_time)
         {
             super(params, clock, network, key_pair, ledger, taskman,
-                txs_to_nominate);
+                data_dir, txs_to_nominate);
         }
 
     extern (C++):
@@ -88,11 +88,11 @@ unittest
         protected override CustomNominator getNominator (
             immutable(ConsensusParams) params, Clock clock,
             NetworkManager network, KeyPair key_pair, Ledger ledger,
-            TaskManager taskman)
+            TaskManager taskman, string data_dir)
         {
             return new CustomNominator(
                 params, clock, network, key_pair, ledger, taskman,
-                this.txs_to_nominate, this.cur_time);
+                data_dir, this.txs_to_nominate, this.cur_time);
         }
     }
 

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -1,0 +1,178 @@
+/*******************************************************************************
+
+    Tests restoring SCP Envelope state on restart
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.RestoreSCPState;
+
+version (unittest):
+
+import agora.common.Config;
+import agora.common.Serializer;
+import agora.common.Task;
+import agora.common.Hash;
+import agora.common.crypto.Key;
+import agora.consensus.protocol.Nominator;
+import agora.consensus.data.Block;
+import agora.consensus.data.ConsensusParams;
+import agora.consensus.data.Transaction;
+import agora.consensus.SCPEnvelopeStore;
+import agora.node.Ledger;
+import agora.node.Validator;
+import agora.network.Clock;
+import agora.network.NetworkManager;
+import agora.test.Base;
+
+import geod24.Registry;
+
+import scpd.Cpp;
+import scpd.types.Stellar_SCP;
+
+import core.stdc.time;
+import core.thread;
+
+/// Class containing gshared store for SCPEnvelopeStoreTest
+public class TestSCPEnvelopeStore : SCPEnvelopeStore
+{
+    __gshared const(SCPEnvelope)[] store;
+
+    this ()
+    {
+        super(":memory:");
+    }
+
+    public override bool add (const ref SCPEnvelope envelope) @trusted nothrow
+    {
+        store ~= envelope;
+        return true;
+    }
+
+    public override void removeAll () @trusted nothrow
+    {
+        // no-op
+    }
+
+    public override int opApply (scope int delegate(const ref SCPEnvelope) dg) @trusted
+    {
+        foreach (ref env; store)
+        {
+            if (auto ret = dg(env))
+                return ret;
+        }
+        return 0;
+    }
+
+    public override size_t length () @trusted
+    {
+        return store.length;
+    }
+}
+
+/// A test to store SCP state and recover SCP state
+unittest
+{
+    __gshared bool Checked = false;
+
+    static class ReNominator : TestNominator
+    {
+        /// Ctor
+        public this (immutable(ConsensusParams) params, Clock clock,
+            NetworkManager network, KeyPair key_pair, Ledger ledger,
+            TaskManager taskman, string data_dir, ulong txs_to_nominate)
+        {
+            super(params, clock, network, key_pair, ledger, taskman, data_dir,
+                txs_to_nominate);
+        }
+
+        ///
+        override void restoreSCPState ()
+        {
+            // on first boot the envelope store will be empty,
+            // but on restart it should contain two envelopes
+            // (nominate & ballot protocol messages)
+            if (Checked)
+            {
+                assert(TestSCPEnvelopeStore.store.length == 2);
+                Checked = false;
+            }
+            super.restoreSCPState();
+        }
+        protected override SCPEnvelopeStore getSCPEnvelopeStore (string)
+        {
+            return new TestSCPEnvelopeStore();
+        }
+    }
+
+    static class ReValidator : TestValidatorNode
+    {
+        /// Ctor
+        public this (Config config, Registry* reg, immutable(Block)[] blocks,
+                     ulong txs_to_nominate, shared(time_t)* cur_time)
+        {
+            super(config, reg, blocks, txs_to_nominate, cur_time);
+        }
+
+        ///
+        protected override TestNominator getNominator (
+            immutable(ConsensusParams) params, Clock clock,
+            NetworkManager network, KeyPair key_pair, Ledger ledger,
+            TaskManager taskman, string data_dir)
+        {
+            return new ReNominator(
+                params, clock, network, key_pair, ledger, taskman, data_dir,
+                    this.txs_to_nominate);
+        }
+    }
+
+    static class ReAPIManager : TestAPIManager
+    {
+        /// Ctor
+        public this (immutable(Block)[] blocks, TestConf test_conf, time_t initial_time)
+        {
+            super(blocks, test_conf, initial_time);
+        }
+
+        ///
+        public override void createNewNode (Config conf, string file, int line)
+        {
+            if (this.nodes.length == 0)
+            {
+                auto time = new shared(time_t)(this.initial_time);
+                auto api = RemoteAPI!TestAPI.spawn!ReValidator(
+                    conf, &this.reg, this.blocks,
+                    this.test_conf.txs_to_nominate, time);
+                this.reg.register(conf.node.address, api.tid());
+                this.nodes ~= NodePair(conf.node.address, api, time);
+                assert(conf.validator.enabled);
+            }
+            else
+                super.createNewNode(conf, file, line);
+        }
+    }
+
+    auto network = makeTestNetwork!ReAPIManager(TestConf.init);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto re_validator = network.clients[0];
+    auto txes = genesisSpendable().map!(txb => txb.sign()).array();
+    txes.each!(tx => re_validator.putTransaction(tx));
+    network.expectBlock(Height(1), 2.seconds);
+
+    Checked = true;
+    // Now shut down & restart one node
+    network.restart(re_validator);
+    network.waitForDiscovery();
+    network.expectBlock(Height(1), 5.seconds);
+    assert(!Checked);
+}


### PR DESCRIPTION
It restores the node's latest nomination & ballot protocol messages
the next time the node boots up.
Store the latest envelopes in DB and restore to 'scp.setStateFromEnvelope'.

Related to #1170 