### PR TITLE
dub.json: Correctly version out LDC-specific flag

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -115,7 +115,7 @@
                 "source/scpp/build/DSizeChecks.obj",
                 "source/scpp/build/DLayoutChecks.obj"
             ],
-            "dflags": [ "-extern-std=c++14", "--link-defaultlib-debug" ]
+            "dflags-ldc": [ "--link-defaultlib-debug" ],
         },
         {
             "name": "multi",


### PR DESCRIPTION
The extern '-extern-std' part was removed because 'dub' correctly applies the flags from
outside of the configuration (they are additive).
Additionally, link-defaultlib-debug is LDC-specific, so properly version it.
While we don't support DMD, it can be sometimes useful for some experiment.