### PR TITLE
Update SCP confirm statement to include 32 byte field for the signature

### DIFF
--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -76,13 +76,14 @@ struct SCPStatement {
 
         static struct _confirm_t {
             SCPBallot ballot;
+            uint256 value_sig;  // used for Scalar of Signature for this ballot
             uint32_t nPrepared;
             uint32_t nCommit;
             uint32_t nH;
             Hash quorumSetHash;
         }
 
-        static assert(_confirm_t.sizeof == 112);
+        static assert(_confirm_t.sizeof == 144);
 
         static struct _externalize_t {
             SCPBallot commit;
@@ -258,7 +259,7 @@ struct SCPStatement {
     _pledges_t pledges;
 }
 
-static assert(SCPStatement.sizeof == 176);
+static assert(SCPStatement.sizeof == 200);
 static assert(Signature.sizeof == 64);
 
 struct SCPEnvelope {
@@ -266,7 +267,7 @@ struct SCPEnvelope {
   Signature signature;
 }
 
-static assert(SCPEnvelope.sizeof == 240);
+static assert(SCPEnvelope.sizeof == 264);
 
 struct SCPQuorumSet {
     import agora.common.Hash;
@@ -339,8 +340,3 @@ static assert(SCPQuorumSet.sizeof == 56);
 /// From SCPDriver, here for convenience
 public alias SCPQuorumSetPtr = shared_ptr!SCPQuorumSet;
 
-/// TODO: Move to a test folder and/or automate this
-static assert(SCPBallot.sizeof == 32);
-static assert(Value.sizeof == 24);
-static assert(SCPQuorumSet.sizeof == 56);
-static assert(SCPEnvelope.sizeof == 240);

--- a/source/scpp/extra/DLayoutChecks.cpp
+++ b/source/scpp/extra/DLayoutChecks.cpp
@@ -83,6 +83,7 @@ FieldInfo cppFieldInfo ( SCPStatement::_pledges_t::_prepare_t &object, const cha
 FieldInfo cppFieldInfo ( SCPStatement::_pledges_t::_confirm_t &object, const char *field_name )
 {
     HANDLE(ballot)
+    HANDLE(value_sig)
     HANDLE(nPrepared)
     HANDLE(nCommit)
     HANDLE(nH)

--- a/source/scpp/src/xdr/Stellar-SCP.h
+++ b/source/scpp/src/xdr/Stellar-SCP.h
@@ -177,6 +177,7 @@ struct SCPStatement {
     };
     struct _confirm_t {
       SCPBallot ballot{};
+      uint256 value_sig{};
       uint32 nPrepared{};
       uint32 nCommit{};
       uint32 nH{};
@@ -184,23 +185,27 @@ struct SCPStatement {
 
       _confirm_t() = default;
       template<typename _ballot_T,
+               typename _value_sig_T,
                typename _nPrepared_T,
                typename _nCommit_T,
                typename _nH_T,
                typename _quorumSetHash_T,
                typename = typename
                std::enable_if<std::is_constructible<SCPBallot, _ballot_T>::value
+                              && std::is_constructible<uint256, _value_sig_T>::value
                               && std::is_constructible<uint32, _nPrepared_T>::value
                               && std::is_constructible<uint32, _nCommit_T>::value
                               && std::is_constructible<uint32, _nH_T>::value
                               && std::is_constructible<Hash, _quorumSetHash_T>::value
                              >::type>
       explicit _confirm_t(_ballot_T &&_ballot,
+                          _value_sig_T &&_value_sig,
                           _nPrepared_T &&_nPrepared,
                           _nCommit_T &&_nCommit,
                           _nH_T &&_nH,
                           _quorumSetHash_T &&_quorumSetHash)
         : ballot(std::forward<_ballot_T>(_ballot)),
+          value_sig(std::forward<_value_sig_T>(_value_sig)),
           nPrepared(std::forward<_nPrepared_T>(_nPrepared)),
           nCommit(std::forward<_nCommit_T>(_nCommit)),
           nH(std::forward<_nH_T>(_nH)),
@@ -229,7 +234,7 @@ struct SCPStatement {
     };
 
     using _xdr_case_type = xdr::xdr_traits<SCPStatementType>::case_type;
-/*  private:*/  // BPFK note: cannot be private as we require runtime layout checks
+  public:
     _xdr_case_type type_;
     union {
       _prepare_t prepare_;
@@ -439,6 +444,9 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_confirm_t>
                               decltype(::stellar::SCPStatement::_pledges_t::_confirm_t::ballot),
                               &::stellar::SCPStatement::_pledges_t::_confirm_t::ballot>,
                     field_ptr<::stellar::SCPStatement::_pledges_t::_confirm_t,
+                              decltype(::stellar::SCPStatement::_pledges_t::_confirm_t::value_sig),
+                              &::stellar::SCPStatement::_pledges_t::_confirm_t::value_sig>,
+                    field_ptr<::stellar::SCPStatement::_pledges_t::_confirm_t,
                               decltype(::stellar::SCPStatement::_pledges_t::_confirm_t::nPrepared),
                               &::stellar::SCPStatement::_pledges_t::_confirm_t::nPrepared>,
                     field_ptr<::stellar::SCPStatement::_pledges_t::_confirm_t,
@@ -453,6 +461,7 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_confirm_t>
   template<typename Archive> static void
   save(Archive &ar, const ::stellar::SCPStatement::_pledges_t::_confirm_t &obj) {
     archive(ar, obj.ballot, "ballot");
+    archive(ar, obj.value_sig, "value_sig");
     archive(ar, obj.nPrepared, "nPrepared");
     archive(ar, obj.nCommit, "nCommit");
     archive(ar, obj.nH, "nH");
@@ -461,6 +470,7 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_confirm_t>
   template<typename Archive> static void
   load(Archive &ar, ::stellar::SCPStatement::_pledges_t::_confirm_t &obj) {
     archive(ar, obj.ballot, "ballot");
+    archive(ar, obj.value_sig, "value_sig");
     archive(ar, obj.nPrepared, "nPrepared");
     archive(ar, obj.nCommit, "nCommit");
     archive(ar, obj.nH, "nH");

--- a/source/scpp/src/xdr/Stellar-SCP.x
+++ b/source/scpp/src/xdr/Stellar-SCP.x
@@ -51,6 +51,7 @@ struct SCPStatement
         struct
         {
             SCPBallot ballot;   // b
+            uint256 value_sig;  // Bosagora added to sign ballot (only 32 bytes as Scalar)
             uint32 nPrepared;   // p.n
             uint32 nCommit;     // c.n
             uint32 nH;          // h.n

--- a/source/scpp/src/xdr/Stellar-types.h
+++ b/source/scpp/src/xdr/Stellar-types.h
@@ -9,8 +9,6 @@
 
 namespace stellar {
 
-// note: Hash was changed to 64-bytes in #737.
-// uint256 was also changed to reflect that.
 using Hash = xdr::opaque_array<64>;
 using uint256 = xdr::opaque_array<32>;
 using uint512 = xdr::opaque_array<64>;
@@ -115,7 +113,7 @@ template<> struct xdr_traits<::stellar::SignerKeyType>
 
 struct PublicKey {
   using _xdr_case_type = xdr::xdr_traits<PublicKeyType>::case_type;
-/*private:*/  // BPFK note: cannot be private as we require runtime layout checks
+public:
   _xdr_case_type type_;
   union {
     uint256 ed25519_;

--- a/source/scpp/src/xdr/Stellar-types.x
+++ b/source/scpp/src/xdr/Stellar-types.x
@@ -5,9 +5,9 @@
 namespace stellar
 {
 
-typedef opaque Hash[32];
+typedef opaque Hash[64];
 typedef opaque uint256[32];
-
+typedef opaque uint512[64];
 typedef unsigned int uint32;
 typedef int int32;
 

--- a/source/scpp/src/xdr/fix-stellar-scp-public.patch
+++ b/source/scpp/src/xdr/fix-stellar-scp-public.patch
@@ -1,0 +1,13 @@
+diff --git a/source/scpp/src/xdr/Stellar-SCP.h b/source/scpp/src/xdr/Stellar-SCP.h
+index 6f6f4d52..8755b4fc 100644
+--- a/source/scpp/src/xdr/Stellar-SCP.h
++++ b/source/scpp/src/xdr/Stellar-SCP.h
+@@ -234,7 +234,7 @@ struct SCPStatement {
+     };
+ 
+     using _xdr_case_type = xdr::xdr_traits<SCPStatementType>::case_type;
+-  private:
++  public:
+     _xdr_case_type type_;
+     union {
+       _prepare_t prepare_;

--- a/source/scpp/src/xdr/fix-stellar-types-public.patch
+++ b/source/scpp/src/xdr/fix-stellar-types-public.patch
@@ -1,0 +1,13 @@
+diff --git a/source/scpp/src/xdr/Stellar-types.h b/source/scpp/src/xdr/Stellar-types.h
+index a339d691..b2957206 100644
+--- a/source/scpp/src/xdr/Stellar-types.h
++++ b/source/scpp/src/xdr/Stellar-types.h
+@@ -113,7 +113,7 @@ template<> struct xdr_traits<::stellar::SignerKeyType>
+ 
+ struct PublicKey {
+   using _xdr_case_type = xdr::xdr_traits<PublicKeyType>::case_type;
+-private:
++public:
+   _xdr_case_type type_;
+   union {
+     uint256 ed25519_;


### PR DESCRIPTION
Updating SCP to include the value_sig field to be used in signing ballots.