### PR TITLE
Emit hidden version of a secret key in log.trace

### DIFF
--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -37,6 +37,15 @@ public enum CompactMode : bool
     Yes
 }
 
+/// Describe print modes for `toString`
+public enum PrintMode
+{
+    /// Print hidden version
+    Obfuscated,
+    /// Print original value
+    Clear,
+}
+
 unittest
 {
     // Check that our type match libsodium's definition

--- a/source/agora/common/crypto/ECC.d
+++ b/source/agora/common/crypto/ECC.d
@@ -91,10 +91,10 @@ public struct Scalar
     }
 
     /// Expose `toString`
-    public void toString (scope void delegate(const(char)[]) @safe dg)
+    public void toString (scope void delegate(const(char)[]) @safe sink)
         const @safe
     {
-        this.data.toString(dg);
+        this.data.toString(sink);
     }
 
     /// Ditto
@@ -178,7 +178,7 @@ public struct Scalar
     }
 
     /// Return the point corresponding to this scalar multiplied by the generator
-    public Point toPoint () const nothrow @nogc @trusted 
+    public Point toPoint () const nothrow @nogc @trusted
     {
         Point ret = void;
         if (crypto_scalarmult_ed25519_base_noclamp(ret.data[].ptr, this.data[].ptr) != 0)

--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -240,7 +240,6 @@ public struct PublicKey
 /// this does not expose any Stellar serialization shenanigans.
 public struct SecretKey
 {
-    nothrow @nogc:
     /// Alias to the BitBlob type
     private alias DataType = BitBlob!(crypto_sign_ed25519_SECRETKEYBYTES * 8);
 
@@ -271,7 +270,7 @@ public struct SecretKey
 
     ***************************************************************************/
 
-    public Signature sign (scope const(ubyte)[] msg) const
+    public Signature sign (scope const(ubyte)[] msg) const nothrow @nogc
     {
         Signature result;
         // The second argument, `siglen_p`, a pointer to the length of the


### PR DESCRIPTION
Logging should not expose any secret keys. Therefore, `log.trace` now emits a hidden version of `SecretKey`, `Seed`, and `Scalar` by default (`PrintMode.Obfuscated`). Switching the argument to `PrintMode.Clear` argument to `toString` prints the original value.

`PrintMode.Obfuscated`:
```
validator: { enabled: true, key_pair: { address: GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ, secret: **SECRET**, seed: **SEED** }
```
`PrintMode.Clear`:
```
validator: { enabled: true, key_pair: { address: GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ, secret: 0xf52201b3d296424f285ca01391640951cd6a319b9d8ad6c60b4071a1e038029d94b84c9c7e3c72d9c836046c5cd87b5beb6c8e6498ea1b757207e7c22d29c5a7, seed: SCT4KKJNYLTQO4TVDPVJQZEONTVVW66YLRWAINWI3FZDY7U4JS4JJEI4 } 
```
Fixes #719