### PR TITLE
Fix revelation of wrong pre-images after re-enrollment

### DIFF
--- a/source/agora/consensus/PreImage.d
+++ b/source/agora/consensus/PreImage.d
@@ -362,24 +362,32 @@ public struct PreImageCycle
             this.seeds.reset(cycle_seed);
         }
 
-        // Populate the current enrollment round cache
-        // The index into `seeds` is the absolute index of the cycle,
-        // not the number of round, hence why we use `byStrides`
-        // The alternative would be:
-        // [$ - (this.index + 1) * this.preimages.length]
-        this.preimages.reset(this.seeds.byStride[$ - 1 - this.index]);
-
-        // Increment index if there are rounds left in this cycle
         if (consume)
         {
+            // Populate the current enrollment round cache
+            // The index into `seeds` is the absolute index of the cycle,
+            // not the number of round, hence why we use `byStrides`
+            // The alternative would be:
+            // [$ - (this.index + 1) * this.preimages.length]
+            this.preimages.reset(this.seeds.byStride[$ - 1 - this.index]);
+
+            // Increment index if there are rounds left in this cycle
             this.index += 1;
             if (this.index >= NumberOfCycles)
             {
                 this.index = 0;
                 this.nonce += 1;
             }
+            return this.preimages[$ - 1];
         }
-
-        return this.preimages[$ - 1];
+        else
+        {
+            // If this is used for getting initial pre-image for enrollment
+            // it just creates initial pre-image of the cycle seed.
+            auto next_images = PreImageCache(this.preimages.data.length,
+            this.preimages.interval);
+            next_images.reset(this.seeds.byStride[$ - 1 - this.index]);
+            return next_images[$ - 1];
+        }
     }
 }

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -117,6 +117,7 @@ unittest
     {
         auto txs = prev_txs.map!(tx => TxBuilder(tx).sign()).array();
         txs.each!(tx => nodes[0].putTransaction(tx));
+        network.waitForPreimages(b0.header.enrollments, cast(ushort)height, 5.seconds);
         network.expectBlock(Height(height + 1), 2.seconds);
         prev_txs = txs;
     }


### PR DESCRIPTION
There was a critical bug when `EnrollmentManager` reveals pre-images in the case when a validator re-enrolls before the validator cycle ends. In the previous code, we `reset` pre-images while creating new `Enrollment`, which means that the pre-images of the current cycle have been replaced with a new set of pre-images. So I make the `populate` function only generate the initial random seed for enrollment. After being a validator for the new cycle, the `populate` generates the whole pre-images for the new cycle.

Relates #1079 

