### PR TITLE
Simplify config generation in the tests

### DIFF
--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -30,7 +30,7 @@ unittest
     const txs_to_nominate = 8;
     TestConf conf =
     {
-        validators : 2,
+        validators : 4,
         full_nodes : 1,
         retry_delay : 10.msecs,
         max_retries : 10,
@@ -44,11 +44,8 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    // three nodes, two validators, and 1 non-validator
-    auto node_1 = network.nodes[0].client;
-    auto node_2 = network.nodes[1].client;
-    auto node_3 = network.nodes[2].client;  // non-validator
-    auto nodes = [node_1, node_2, node_3];
+    // 4 validators and 1 full node
+    auto nodes = network.clients.array;
     auto gen_key = WK.Keys.Genesis;
 
     Transaction[] all_txs;
@@ -78,45 +75,45 @@ unittest
          return txes;
     }
 
-    genBlockTransactions(1).each!(tx => node_1.putTransaction(tx));
+    genBlockTransactions(1).each!(tx => nodes[0].putTransaction(tx));
     // wait until the transactions were gossiped
     network.expectBlock(Height(1), 3.seconds);
 
 
-    // node 3 will be banned if it cannot communicate
-    node_1.filter!(node_1.getBlocksFrom);  // node 1 refuses to send blocks
-    node_2.filter!(node_2.getBlocksFrom);  // node 2 refuses to send blocks
-    node_3.filter!(node_3.putTransaction); // node 3 won't receive transactions
+    // full node will be banned if it cannot communicate
+    // validators refuse to to send blocks
+    nodes[0 .. 4].each!(node => node.filter!(node.getBlocksFrom));
+    nodes[4].filter!(nodes[4].putTransaction); // full node won't receive transactions
 
-    // leftover txs which node 3 will reject due to its filter
+    // leftover txs which full node will reject due to its filter
     Transaction[] left_txs;
 
     foreach (block_idx; 0 .. 4)
     {
         auto new_tx = genBlockTransactions(1);
         left_txs ~= new_tx;
-        new_tx.each!(tx => node_1.putTransaction(tx));
-        network.expectBlock([node_1, node_2], Height(1 + block_idx + 1), 4.seconds);
-        retryFor(node_3.getBlockHeight() == 1, 1.seconds, node_3.getBlockHeight().to!string);
+        new_tx.each!(tx => nodes[0].putTransaction(tx));
+        network.expectBlock(nodes[0 .. 4], Height(1 + block_idx + 1), 4.seconds);
+        retryFor(nodes[4].getBlockHeight() == 1, 1.seconds,
+            nodes[4].getBlockHeight().to!string);
     }
 
-    // wait for node 3 to be banned and all putTransaction requests to time-out
+    // wait for full node to be banned and all putTransaction requests to time-out
     Thread.sleep(2.seconds);
 
-    // sanity check: block height should not be updated, node 3 is not a validator and cannot make new blocks,
+    // sanity check: block height should not be updated, full node is not a validator and cannot make new blocks,
     // it may only add to its ledger through the getBlocksFrom() API.
-    node_3.clearFilter();
-    left_txs.each!(tx => node_3.putTransaction(tx));
-    retryFor(node_3.getBlockHeight() == 1, 1.seconds);
+    nodes[4].clearFilter();
+    left_txs.each!(tx => nodes[4].putTransaction(tx));
+    retryFor(nodes[4].getBlockHeight() == 1, 1.seconds);
 
     // clear the filter
-    node_1.clearFilter();
-    node_2.clearFilter();
+    nodes[0 .. 4].each!(node => node.clearFilter());
 
-    FakeClockBanManager.time += 500;  // node 3 should be unbanned now
+    FakeClockBanManager.time += 500;  // full node should be unbanned now
 
     auto new_tx = genBlockTransactions(1);
     left_txs ~= new_tx;
-    new_tx.each!(tx => node_1.putTransaction(tx));
+    new_tx.each!(tx => nodes[0].putTransaction(tx));
     network.expectBlock(Height(6), 4.seconds);
 }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1347,10 +1347,9 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager,
     static import std.concurrency;
     std.concurrency.scheduler = null;
 
+    assert(test_conf.validators >= 4, "Must include at least 4 validators");
     const TotalNodes = test_conf.validators + test_conf.full_nodes +
         test_conf.outsider_validators + test_conf.outsider_full_nodes;
-
-    assert(TotalNodes >= 2, "Creating a network require at least 2 nodes");
 
     size_t full_node_idx;
     size_t validator_idx;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1335,8 +1335,8 @@ public struct TestConf
 
 *******************************************************************************/
 
-public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager, string file = __FILE__, int line = __LINE__)(
-    in TestConf test_conf)
+public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
+    (in TestConf test_conf, string file = __FILE__, int line = __LINE__)
 {
     import agora.common.Serializer;
     import std.digest;

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -124,9 +124,9 @@ unittest
 
     TestConf conf = {
         timeout : 10.seconds,
-        validators : 3,
+        validators : 4,
         validator_cycle : 10,
-        quorum_threshold : 66
+        quorum_threshold : 51
     };
 
     auto network = makeTestNetwork!CustomAPIManager(conf);
@@ -137,7 +137,7 @@ unittest
     auto nodes = network.clients;
     auto validator = network.clients[0];
 
-    // Make two of three validators disable to respond
+    // Make two of three validators stop responding
     nodes[1].ctrl.sleep(10.seconds, true);
     nodes[2].ctrl.sleep(10.seconds, true);
 

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -41,9 +41,9 @@ unittest
     TestConf conf =
     {
         topology : NetworkTopology.MinimallyConnected,
-        validators : 0,
+        validators : 4,
         full_nodes : 4,
-        min_listeners : 3,
+        min_listeners : 7,
     };
     auto network = makeTestNetwork(conf);
 
@@ -55,7 +55,7 @@ unittest
     foreach (key, node; network.nodes)
     {
         auto addresses = node.client.getNodeInfo().addresses.keys;
-        assert(addresses.sort.uniq.count == 3,
+        assert(addresses.sort.uniq.count == 7,
                format("Node %s has %d peers: %s", key, addresses.length, addresses));
     }
 }

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -149,17 +149,19 @@ unittest
 ///     has started to validate immediately.
 unittest
 {
-    TestConf conf = { validators : 3, full_nodes : 1 , quorum_threshold : 66 };
+    TestConf conf = { validators : 4, full_nodes : 1 , quorum_threshold : 75 };
     auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    // The node_1, node_2, node_3 are the validators
+    // The node_1, node_2, node_3, node_4 are the validators
     auto nodes = network.clients;
     auto node_1 = nodes[0];
     auto node_2 = nodes[1];
+    auto node_3 = nodes[2];
+    auto node_4 = nodes[3];
     auto on_nodes = nodes[1 .. $-1];
 
     // Create a block from the Genesis block
@@ -167,7 +169,7 @@ unittest
     txs.each!(tx => node_1.putTransaction(tx));
     network.expectBlock(Height(1), 5.seconds);
 
-    // The node_1 restarts and is disabled to respond
+    // node_1 restarts and becomes unresponsive
     network.restart(node_1);
     node_1.ctrl.sleep(5.seconds);
 


### PR DESCRIPTION
It's not the most efficient code because of the `.array` calls, but it should not matter for the vast majority of tests as this is only the set-up stage. And I wanted to keep the code reasonably clean.