### PR TITLE
Disable tests on Windows again

### DIFF
--- a/ci/run.bat
+++ b/ci/run.bat
@@ -1,6 +1,7 @@
-call dub test --skip-registry=all --compiler=%DC%
+rem call dub test --skip-registry=all --compiler=%DC%
+call dub build --skip-registry=all --compiler=%DC% -c unittest -b unittest
 if %errorlevel% neq 0 exit /b %errorlevel%
-call rdmd --compiler=%DC% ./tests/runner.d --compiler=%DC% -cov
+call rdmd --build-only --compiler=%DC% ./tests/runner.d --compiler=%DC% -cov
 if %errorlevel% neq 0 exit /b %errorlevel%
 call dub build --skip-registry=all --compiler=%DC%
 if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
```
Those are very flakey, not actively looked at,
and slow down development. We're going to have
to live without it for the time being.
Partially reverts 2d47eeacc435724bf44c6d3550025c1685651ffe
```