### PR TITLE
Add commons budget address to `ConsensusParams` & well-known keys

### DIFF
--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -102,6 +102,10 @@ public struct NodeConfig
     static assert(!hasUnsharedAliasing!(typeof(this)),
         "Type must be shareable accross threads");
 
+    /// If set, a commons budget address to use
+    /// in place of the built-in commons budget address as defined by CoinNet
+    public PublicKey commons_budget_address;
+
     /// If set, a hexdump serialized representation of the genesis block to use
     /// in place of the built-in genesis block as defined by CoinNet
     public string genesis_block;
@@ -330,6 +334,12 @@ private NodeConfig parseNodeConfig (Node* node, const ref CommandLine cmdln)
     auto min_listeners = get!(size_t, "node", "min_listeners")(cmdln, node);
     auto max_listeners = get!(size_t, "node", "max_listeners")(cmdln, node);
     auto address = get!(string, "node", "address")(cmdln, node);
+    auto commons_budget = opt!(string, "node", "commons_budget_address")(cmdln, node);
+
+    auto commons_budget_address = (commons_budget.length > 0)
+        ? PublicKey.fromString(commons_budget)
+        : PublicKey.init;
+
     auto genesis_block = opt!(string, "node", "genesis_block")(cmdln, node);
     auto genesis_start_time = get!(time_t, "node", "genesis_start_time",
         str => SysTime(DateTime.fromISOString(str)).toUnixTime)(cmdln, node);
@@ -356,6 +366,7 @@ private NodeConfig parseNodeConfig (Node* node, const ref CommandLine cmdln)
     NodeConfig result = {
             min_listeners : min_listeners,
             max_listeners : max_listeners,
+            commons_budget_address : commons_budget_address,
             genesis_block : genesis_block,
             genesis_start_time : genesis_start_time,
             block_interval_sec : block_interval_sec,
@@ -389,6 +400,7 @@ node:
   data_dir: .cache
   quorum_shuffle_interval: 10
   preimage_reveal_interval: 5
+  commons_budget_address: GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ
 `;
         auto node = Loader.fromString(conf_example).load();
         auto config = parseNodeConfig("node" in node, cmdln);
@@ -397,6 +409,7 @@ node:
         assert(config.data_dir == ".cache");
         assert(config.quorum_shuffle_interval == 10);
         assert(config.preimage_reveal_interval == 5.seconds);
+        assert(config.commons_budget_address.toString() == "GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ");
     }
 }
 

--- a/source/agora/consensus/data/ConsensusParams.d
+++ b/source/agora/consensus/data/ConsensusParams.d
@@ -19,6 +19,7 @@
 
 module agora.consensus.data.ConsensusParams;
 
+import agora.common.crypto.Key;
 import agora.consensus.data.Block;
 
 import core.stdc.time;
@@ -50,6 +51,9 @@ public immutable class ConsensusParams
     /// How often blocks should be created
     public uint BlockIntervalSeconds;
 
+    /// The address of commons budget
+    public PublicKey CommonsBudgetAddress;
+
     /***************************************************************************
 
         Constructor
@@ -63,13 +67,16 @@ public immutable class ConsensusParams
 
     ***************************************************************************/
 
-    public this (immutable(Block) genesis, uint validator_cycle = 1008,
+    public this (immutable(Block) genesis,
+                 in PublicKey commons_budget_address,
+                 uint validator_cycle = 1008,
                  uint max_quorum_nodes = 7, uint quorum_threshold = 80,
                  uint quorum_shuffle_interval = 30,
                  time_t genesis_start_time = 1596179709,
                  uint block_interval_sec = 1)
     {
         this.Genesis = genesis;
+        this.CommonsBudgetAddress = commons_budget_address,
         this.ValidatorCycle = validator_cycle;
         this.MaxQuorumNodes = max_quorum_nodes;
         this.QuorumThreshold = quorum_threshold;
@@ -84,6 +91,7 @@ public immutable class ConsensusParams
         uint quorum_threshold = 80)
     {
         import agora.consensus.data.genesis.Test : GenesisBlock;
-        this(GenesisBlock, validator_cycle, max_quorum_nodes, quorum_threshold);
+        import agora.utils.WellKnownKeys;
+        this(GenesisBlock, CommonsBudget.address, validator_cycle, max_quorum_nodes, quorum_threshold);
     }
 }

--- a/source/agora/consensus/data/genesis/Coinnet.d
+++ b/source/agora/consensus/data/genesis/Coinnet.d
@@ -83,6 +83,24 @@ unittest
            == `GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ`);
 }
 
+/// GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU
+public immutable PublicKey CommonsBudgetAddress = CommonsBudgetUbyte;
+
+///
+private immutable ubyte[] CommonsBudgetUbyte =
+    [
+        0x9c, 0xc6, 0x39, 0xa1, 0x35, 0x2f, 0x77, 0xf2,
+        0x25, 0x16, 0x0c, 0x42, 0xff, 0x89, 0x1a, 0x6a,
+        0xfa, 0x5b, 0x46, 0xa1, 0x1a, 0x69, 0xa9, 0x49,
+        0x20, 0x86, 0xd7, 0x78, 0x06, 0x76, 0xf4, 0x2a,
+    ];
+
+unittest
+{
+    assert(CommonsBudgetAddress.toString()
+           == `GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU`);
+}
+
 unittest
 {
     import agora.common.Serializer;

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -129,6 +129,10 @@ public class FullNode : API
     {
         import CNG = agora.consensus.data.genesis.Coinnet;
 
+        auto commons_budget =
+            config.node.commons_budget_address != PublicKey.init ?
+            config.node.commons_budget_address : CNG.CommonsBudgetAddress;
+
         // custom genesis block provided
         if (config.node.genesis_block.length > 0)
         {
@@ -141,6 +145,7 @@ public class FullNode : API
             auto genesis_block = block_bytes.deserializeFull!(immutable(Block));
             this.params = new immutable(ConsensusParams)(
                 genesis_block,
+                commons_budget,
                 config.node.validator_cycle,
                 config.node.max_quorum_nodes,
                 config.node.quorum_threshold,
@@ -151,6 +156,7 @@ public class FullNode : API
         else
             this.params = new immutable(ConsensusParams)(
                 CNG.GenesisBlock,
+                commons_budget,
                 config.node.validator_cycle,
                 config.node.max_quorum_nodes,
                 config.node.quorum_threshold,

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -544,7 +544,7 @@ version (unittest)
                 ? params_
                 : (blocks.length > 0
                    // Use the provided Genesis block
-                   ? new immutable(ConsensusParams)(cast(immutable)blocks[0])
+                   ? new immutable(ConsensusParams)(cast(immutable)blocks[0], WK.Keys.CommonsBudget.address)
                    // Use the unittest genesis block
                    : new immutable(ConsensusParams)());
 
@@ -1232,7 +1232,7 @@ unittest
         assert(ex.msg == "Genesis block loaded from disk is different from the one in the config file");
     }
 
-    immutable good_params = new immutable(ConsensusParams)(new_gen_block);
+    immutable good_params = new immutable(ConsensusParams)(new_gen_block, WK.Keys.CommonsBudget.address);
     // will not fail
     scope ledger = new TestLedger(WK.Keys.A, [new_gen_block], good_params);
     // Neither will the default

--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -192,6 +192,9 @@ public struct WK
             if (pubkey == Genesis.address)
                 return Genesis;
 
+            if (pubkey == CommonsBudget.address)
+                return CommonsBudget;
+
             if (pubkey == NODE2.address)
                 return NODE2;
             if (pubkey == NODE3.address)

--- a/source/agora/utils/WellKnownKeys.d
+++ b/source/agora/utils/WellKnownKeys.d
@@ -1436,6 +1436,29 @@ static immutable Genesis = KeyPair(
 
 /*******************************************************************************
 
+    Commons Budget KeyPair used in unittests
+
+    In unittests, we need the commons budget key pair to be known for us to be
+    able to write tests.
+    In the real network, there are different values.
+
+    Note that while this is a well-known keys, it is not part of the
+    range returned by `byRange`, nor can it be indexed by `size_t`,
+    to avoid it being mistakenly used.
+
+    Seed:    SCNRULE3Q7NBNX7UIJVVI6HI5DQKP3MNDEHJA66FJZXDEGGH4SRRDSDR
+    Address: GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU
+
+*******************************************************************************/
+
+static immutable CommonsBudget = KeyPair(
+    PublicKey([156, 198, 57, 161, 53, 47, 119, 242, 37, 22, 12, 66, 255, 137, 26, 106, 250, 91, 70, 161, 26, 105, 169, 73, 32, 134, 215, 120, 6, 118, 244, 42]),
+    SecretKey([155, 26, 44, 155, 135, 218, 22, 223, 244, 66, 107, 84, 120, 232, 232, 224, 167, 237, 141, 25, 14, 144, 123, 197, 78, 110, 50, 24, 199, 228, 163, 17, 156, 198, 57, 161, 53, 47, 119, 242, 37, 22, 12, 66, 255, 137, 26, 106, 250, 91, 70, 161, 26, 105, 169, 73, 32, 134, 215, 120, 6, 118, 244, 42]),
+    Seed([155, 26, 44, 155, 135, 218, 22, 223, 244, 66, 107, 84, 120, 232, 232, 224, 167, 237, 141, 25, 14, 144, 123, 197, 78, 110, 50, 24, 199, 228, 163, 17]));
+
+
+/*******************************************************************************
+
     Key pairs used for Enrollments in the genesis block
 
     Note that despite mining for a few days, NODE0, NODE1, NODE8, NODE9 were


### PR DESCRIPTION
I hide the commons budget seed key in the test.
Why don't we add a seed key when we need a seed key later?

I set the key pair like this in the test.
Seed:    SCNRULE3Q7NBNX7UIJVVI6HI5DQKP3MNDEHJA66FJZXDEGGH4SRRDSDR
Address: GCOMMONBGUXXP4RFCYGEF74JDJVPUW2GUENGTKKJECDNO6AGO32CUWGU

Related to #1213 