### PR TITLE
Update documentation of test util function spendable

### DIFF
--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -540,8 +540,11 @@ public struct TxBuilder
 
     /***************************************************************************
 
-        Takes a block object and filters the spendable outputs
-        into a `TxBuilder` object.
+        Takes a block object and filters the payment outputs
+        into a range of `TxBuilder` objects.
+
+        Note that the outputs may not be spendable anymore if other
+        blocks have been externalized after this block.
 
         Params:
             block = a `Block` object


### PR DESCRIPTION
Whilst working on issue #1176 and adding transactions in unit tests I was initially mislead into thinking "spendable" would give me an unspent payment. To help make it clearer this PR will change the name to txbRange which is what it returns. The txs that it can build may have already been spent so should not be assumed to be spendable.