### PR TITLE
Fix API name & log accepted transactions

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -232,7 +232,7 @@ public interface API
             The local clock time of this node (not network-adjusted)
 
         API:
-            GET /time
+            GET /local_time
 
         Warning: this request should be protected via node-to-node encryption,
         or else be signed with a unique challenge/response. Otherwise a

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -281,14 +281,15 @@ public class FullNode : API
 
     public override void putTransaction (Transaction tx) @safe
     {
-        log.trace("Received Transaction: {}", prettify(tx));
-
         auto tx_hash = hashFull(tx);
         if (this.pool.hasTransactionHash(tx_hash))
             return;
 
         if (this.ledger.acceptTransaction(tx))
+        {
+            log.info("Accepted transaction: {} ({})", prettify(tx), tx_hash);
             this.network.gossipTransaction(tx);
+        }
     }
 
     /// GET: /has_transaction_hash


### PR DESCRIPTION
I figured it's unnecessary to log out every time a tx is received, only when it's new (not in the pool & accepted) and when it's rejected (it's logged in `Ledger.d`).