### PR TITLE
Refine the formulas for next distance of pre-image revelation

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -777,7 +777,7 @@ public class EnrollmentManager
 
         assert(height >= enrolled);
         auto curr = cast(uint)(height - enrolled);
-        auto next = min(PreimageRevealPeriod * ((curr / PreimageRevealPeriod) + 1),
+        auto next = min(curr + PreimageRevealPeriod,
             this.params.ValidatorCycle - 1);
         this.setNextRevealDistance(next);
     }


### PR DESCRIPTION
The previous formulas for calculating the distance for pre-image revelation is not exactly correct because we have already implemented the time-based revelation. So we just need to reveal pre-images in advance as much as the specified interval based on the current height.

Relates to #1079 which is already closed.