### PR TITLE
Improve logging when exception occurs during combineCandidates: part of #1210

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -651,7 +651,6 @@ extern(D):
         }
         catch (Exception ex)
         {
-            import std.conv;
             assert(0, ex.to!string);
         }
     }

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -695,7 +695,7 @@ extern(D):
             }
         } catch (Exception ex)
         {
-            assert(0, format!"[%s]:[%s] combineCandidates: slot %u. Exception:%s"(
+            assert(0, format!"[%s:%s] combineCandidates: slot %u. Exception: %s"(
                 __FILE__, __LINE__, slot_idx, ex.to!string));
         }
         // should not reach here


### PR DESCRIPTION
If exception is thrown during deserization for example (I forced it to fail by adding bug in the code):-
#### FATAL ERROR: [source/agora/consensus/protocol/Nominator.d]:[700] combineCandidates: slot 1. Exception:object.Exception@source/agora/common/Serializer.d(584): Requested 1 bytes but only 0 bytes available