### PR TITLE
Added support for collecting various statistics

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -33,6 +33,10 @@ node:
   timeout: 2500
   # Path to the data directory (if the path doesn't exist it will be created)
   data_dir: .cache
+  # The local address where the stats server (currently Prometheus)
+  # is going to connect to, for example: http://0.0.0.0:8008
+  # It can also be set to -1 do disable listening
+  stats_listening_port: 9110
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -159,6 +159,11 @@ public struct NodeConfig
 
     /// How often should the periodic preimage reveal timer trigger (in seconds)
     public Duration preimage_reveal_interval = 10.seconds;
+
+    /// The local address where the stats server (currently Prometheus)
+    /// is going to connect to, for example: http://0.0.0.0:8008
+    /// It can also be set to -1 do disable listening
+    public int stats_listening_port = -1;
 }
 
 /// Validator config
@@ -370,6 +375,7 @@ private NodeConfig parseNodeConfig (Node* node, const ref CommandLine cmdln)
         cmdln, node);
     auto preimage_reveal_interval = get!(Duration, "node", "preimage_reveal_interval",
         str => str.to!ulong.seconds)(cmdln, node);
+    const stats_listening_port = get!(int, "node", "stats_listening_port")(cmdln, node);
 
     NodeConfig result = {
             min_listeners : min_listeners,
@@ -389,6 +395,7 @@ private NodeConfig parseNodeConfig (Node* node, const ref CommandLine cmdln)
             quorum_threshold : quorum_threshold,
             quorum_shuffle_interval : quorum_shuffle_interval,
             preimage_reveal_interval : preimage_reveal_interval,
+            stats_listening_port : stats_listening_port
     };
     return result;
 }

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -214,6 +214,7 @@ public class Validator : FullNode, API
         this.started = true;
         this.network.startPeriodicNameRegistration();
         this.startPeriodicDiscovery();
+        this.startStatsServer();
         this.clock.startSyncing();
         this.taskman.setTimer(this.config.node.preimage_reveal_interval,
             &this.checkRevealPreimage, Periodic.Yes);
@@ -241,8 +242,9 @@ public class Validator : FullNode, API
     }
 
     /// GET /public_key
-    public override PublicKey getPublicKey () pure nothrow @safe @nogc
+    public override PublicKey getPublicKey () pure nothrow @safe
     {
+        endpoint_request_stats.increaseMetricBy!"agora_endpoint_calls_total"(1, "public_key", "http");
         return this.config.validator.key_pair.address;
     }
 
@@ -260,6 +262,7 @@ public class Validator : FullNode, API
 
     public override void receiveEnvelope (SCPEnvelope envelope) @safe
     {
+        endpoint_request_stats.increaseMetricBy!"agora_endpoint_calls_total"(1, "receive_envelope", "http");
         this.nominator.receiveEnvelope(envelope);
     }
 

--- a/source/agora/stats/Block.d
+++ b/source/agora/stats/Block.d
@@ -1,0 +1,33 @@
+/*******************************************************************************
+
+    Stats corresponding to blocks
+
+    Copyright:
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.stats.Block;
+
+import agora.stats.Stats;
+
+///
+public struct BlockStatsLabel
+{
+}
+
+///
+public struct BlockStatsValue
+{
+    public ulong agora_block_externalized_total;
+    public ulong agora_block_enrollments_gauge;
+    public ulong agora_block_txs_total;
+    public ulong agora_block_txs_amount_total;
+}
+
+///
+public alias BlockStats = Stats!(BlockStatsValue, BlockStatsLabel);

--- a/source/agora/stats/EndpointReq.d
+++ b/source/agora/stats/EndpointReq.d
@@ -1,0 +1,32 @@
+/*******************************************************************************
+
+    Stats corresponding to endpoint requests
+
+    Copyright:
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.stats.EndpointReq;
+
+import agora.stats.Stats;
+
+///
+public struct EndpointReqStatsLabel
+{
+    public string endpoint;
+    public string protocol;
+}
+
+///
+public struct EndpointReqStatsValue
+{
+    public ulong agora_endpoint_calls_total;
+}
+
+///
+public alias EndpointRequestStats = Stats!(EndpointReqStatsValue, EndpointReqStatsLabel);

--- a/source/agora/stats/Server.d
+++ b/source/agora/stats/Server.d
@@ -1,0 +1,63 @@
+/*******************************************************************************
+
+    Starts up a HTTP server and listen to queries from Prometheus
+
+    Copyright:
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.stats.Server;
+
+import agora.stats.Utils;
+
+import ocean.util.prometheus.collector.CollectorRegistry;
+import vibe.http.server;
+import vibe.http.router;
+
+class StatsServer
+{
+    private HTTPListener http_listener;
+
+    /***************************************************************************
+
+            Constructs a StatsServer instance
+
+            Params
+                port = port on which the server will listen on,
+                -1 to disable listening
+
+    ***************************************************************************/
+
+    public this (int port)
+    {
+        if (port == -1)
+            return;
+
+        assert(port > 0 && port < 65536, "port number for stats server has to be between 1 and 65535");
+
+        auto router = new URLRouter;
+        router.get("/metrics", &handle_metrics);
+
+        auto settings = new HTTPServerSettings;
+        settings.port = cast(ushort) port;
+        http_listener = listenHTTP(settings, router);
+    }
+
+    ///
+    public void shutdown ()
+    {
+        if (http_listener !is HTTPListener.init)
+            http_listener.stopListening();
+    }
+
+    ///
+    private void handle_metrics (HTTPServerRequest req, HTTPServerResponse res)
+    {
+        res.writeBody(cast(const(ubyte[])) Utils.getCollectorRegistry().collect(),"text/plain");
+    }
+}

--- a/source/agora/stats/Stats.d
+++ b/source/agora/stats/Stats.d
@@ -1,0 +1,173 @@
+/*******************************************************************************
+
+    Base stats class that helps define other stats classes
+
+    Copyright:
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.stats.Stats;
+
+import agora.utils.Utility : underscoreSeparatedToUpperCamelCase;
+
+import std.array : join, split, byPair;
+import std.typecons : Tuple, tuple;
+
+/***************************************************************************
+
+        Base stats class that helps define other stats classes.class
+        Usage is Stats!(ConcreateStatsValue, ConcreateStatsLabel) concreate_stats;
+
+        Params:
+            ValueType = fields of this struct will correspond to metric names
+            LabelType = fields of this struct will correspond to label names
+
+***************************************************************************/
+
+public struct Stats (ValueType, LabelType)
+{
+
+    public alias ValueType ValueTypeT;
+    public alias LabelType LabelTypeT;
+    public alias StatValueLabelTup = Tuple!(const ValueType, "value", const LabelType, "label");
+    private ValueType[string] stats_maps;
+
+    private static immutable SEPARATOR = "|SEPARATORSYM|";
+
+    /***************************************************************************
+
+        Increases the metric's value by some amount and attach some labels to it
+
+        Params:
+            metricName = name of the metric we want to change
+            LabelTs... = types of the labels
+            number = metric will be increased by this amount
+            labels_packed = labels that will be attached to the metric
+
+    ***************************************************************************/
+
+    public void increaseMetricBy (string metricName, LabelTs...)(ulong number, LabelTs labels_packed) pure nothrow @safe
+    {
+        static assert(labels_packed.length == LabelType.tupleof.length);
+
+        string[] labels;
+        foreach (label; labels_packed)
+            labels ~= label;
+        auto key = labels.join(SEPARATOR);
+
+        if (auto metrics = key in stats_maps)
+            __traits(getMember, *metrics, metricName) += number;
+        else
+        {
+            stats_maps[key] = ValueType.init;
+            __traits(getMember, stats_maps[key], metricName) = number;
+        }
+    }
+
+    /***************************************************************************
+
+        Sets the metric's value to some amount and attach some labels to it
+
+        Params:
+            metricName = name of the metric we want to change
+            LabelTs... = types of the labels
+            number = metric will be increased by this amount
+            labels_packed = labels that will be attached to the metric
+
+    ***************************************************************************/
+
+    public void setMetricTo (string metricName, LabelTs...)(ulong number, LabelTs labels_packed)
+    {
+        static assert(labels_packed.length == LabelType.tupleof.length);
+
+        string[] labels;
+        foreach (label; labels_packed)
+            labels ~= label;
+        auto key = labels.join(SEPARATOR);
+
+        ValueType* metrics;
+        if ((metrics = key in stats_maps) is null)
+            metrics = &(stats_maps[key] = ValueType.init);
+        __traits(getMember, *metrics, metricName) = number;
+    }
+
+    /***************************************************************************
+
+        Function that prepares and returns the metrics with the corresponding
+        labels
+
+        Returns:
+            an array of pairs of metrics and label names
+
+    ***************************************************************************/
+
+    public StatValueLabelTup[] getStats () const pure nothrow @safe
+    {
+        StatValueLabelTup[] res;
+        foreach (pair; stats_maps.byPair)
+        {
+            LabelType label;
+            immutable field_value = pair.key.split(SEPARATOR);
+            foreach (i, ref field; label.tupleof)
+                field = field_value[i];
+            res ~= tuple!("value", "label")(pair.value, cast(const LabelType) label);
+        }
+        return res;
+    }
+}
+
+version (unittest)
+{
+    import agora.stats.Utils;
+
+    import ocean.util.prometheus.collector.CollectorRegistry;
+    import ocean.util.prometheus.collector.Collector;
+
+    public struct TestStatsWithoutLabelT
+    {
+    }
+
+    public struct TestStatsWithLabelT
+    {
+        public string test_metric_label;
+    }
+
+    public struct TestStatsValueT
+    {
+        public ulong test_metric_value;
+    }
+
+    Stats!(TestStatsValueT, TestStatsWithLabelT) test_stats_with_label;
+    Stats!(TestStatsValueT, TestStatsWithoutLabelT) test_stats_without_label;
+
+    mixin DefineCollectorForStats!("test_stats_with_label", "collectTestStatWithLabel");
+    mixin DefineCollectorForStats!("test_stats_without_label", "collectTestStatWithoutLabel");
+}
+
+unittest
+{
+    import std.functional : toDelegate;
+
+    // stats with one label
+    CollectorRegistry collector_registry_with_label = new CollectorRegistry([]);
+    collector_registry_with_label.addCollector(toDelegate(&collectTestStatWithLabel));
+    test_stats_with_label.setMetricTo!"test_metric_value"(41, "interesting_label1");
+    test_stats_with_label.increaseMetricBy!"test_metric_value"(1, "interesting_label1");
+    test_stats_with_label.setMetricTo!"test_metric_value"(5, "interesting_label2");
+    test_stats_with_label.increaseMetricBy!"test_metric_value"(2, "interesting_label2");
+    assert(collector_registry_with_label.collect() ==
+        "test_metric_value {test_metric_label=\"interesting_label1\"} 42\n" ~
+        "test_metric_value {test_metric_label=\"interesting_label2\"} 7\n");
+
+    // stats without label
+    CollectorRegistry collector_registry_without_label = new CollectorRegistry([]);
+    collector_registry_without_label.addCollector(toDelegate(&collectTestStatWithoutLabel));
+    test_stats_without_label.setMetricTo!"test_metric_value"(41);
+    test_stats_without_label.increaseMetricBy!"test_metric_value"(1);
+    assert(collector_registry_without_label.collect() == "test_metric_value 42\n");
+}

--- a/source/agora/stats/Tx.d
+++ b/source/agora/stats/Tx.d
@@ -1,0 +1,34 @@
+/*******************************************************************************
+
+    Stats corresponding to Blocks
+
+    Copyright:
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.stats.Tx;
+
+import agora.stats.Stats;
+
+///
+public struct TxStatsLabel
+{
+}
+
+///
+public struct TxStatsValue
+{
+    public ulong agora_transactions_received_total;
+    public ulong agora_transactions_accepted_total;
+    public ulong agora_transactions_rejected_total;
+    public ulong agora_transactions_poolsize_gauge;
+    public ulong agora_transactions_amount_gauge;
+}
+
+///
+public alias TxStats = Stats!(TxStatsValue, TxStatsLabel);

--- a/source/agora/stats/Utils.d
+++ b/source/agora/stats/Utils.d
@@ -1,0 +1,70 @@
+/*******************************************************************************
+
+    Stats corresponding to Blocks
+
+    Copyright:
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.stats.Utils;
+
+public import ocean.util.prometheus.collector.Collector;
+import ocean.util.prometheus.collector.CollectorRegistry;
+import vibe.vibe;
+
+import std.stdio;
+
+/***************************************************************************
+
+        Utility method to generate a collector delegate for a particular `Stats`
+        The generated function will have the signature of
+        void <collector_name>(Collector collector)
+
+        Params:
+            statVar = variable of `Stats` type that we want to collect
+            collector_name = name of the generated function
+
+***************************************************************************/
+
+mixin template DefineCollectorForStats (string statVar, string collector_name)
+{
+    import std.format;
+    mixin(
+    q{
+        private void %2$s (Collector collector) @safe
+        {
+            foreach (stat; %1$s.getStats())
+                if (%1$s.LabelTypeT.tupleof.length)
+                    collector.collect(stat.value, stat.label);
+                else
+                    collector.collect(stat.value);
+        }
+    }.format(statVar, collector_name));
+}
+
+/// collection of Utility classes for stats collection
+class Utils
+{
+
+    /***************************************************************************
+
+            Static function that returns a singleton instance
+            of type `CollectorRegistry`
+
+            Returns:
+                a singleton instance of type `CollectorRegistry`
+    ***************************************************************************/
+
+    public static CollectorRegistry getCollectorRegistry ()
+    {
+        static CollectorRegistry collector_registry;
+        if (collector_registry is null)
+            collector_registry = new CollectorRegistry([]);
+        return collector_registry;
+    }
+}

--- a/source/agora/stats/Validator.d
+++ b/source/agora/stats/Validator.d
@@ -1,0 +1,45 @@
+/*******************************************************************************
+
+    Stats corresponding to validators
+
+    Copyright:
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.stats.Validator;
+
+import agora.stats.Stats;
+
+///
+public struct ValidatorCountStatsLabel
+{
+}
+
+///
+public struct ValidatorCountStatsValue
+{
+    public  ulong agora_validators_gauge;
+}
+
+///
+public struct ValidatorPreimagesStatsLabel
+{
+    public string key;
+}
+
+///
+public struct ValidatorPreimagesStatsValue
+{
+    public ulong agora_preimages_gauge;
+}
+
+///
+public alias ValidatorCountStats = Stats!(ValidatorCountStatsValue, ValidatorCountStatsLabel);
+
+///
+public alias ValidatorPreimagesStats = Stats!(ValidatorPreimagesStatsValue, ValidatorPreimagesStatsLabel);

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -57,6 +57,7 @@ import agora.registry.NameRegistryAPI;
 import agora.registry.NameRegistryImpl;
 import agora.utils.Log;
 import agora.utils.PrettyPrinter;
+import agora.stats.Server;
 public import agora.utils.Utility : retryFor;
 import agora.api.FullNode : NodeInfo, NetworkState;
 import agora.api.Validator : ValidatorAPI = API;
@@ -1463,6 +1464,11 @@ public struct TestConf
 
     /// How often blocks should be created - in seconds
     uint block_interval_sec = 1;
+
+    // The local address where the stats server (currently Prometheus)
+    // is going to connect to, for example: http://0.0.0.0:8008
+    // It can also be set to 0 do disable listening
+    int stats_listening_port = -1;
 }
 
 /*******************************************************************************
@@ -1518,6 +1524,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
                 : test_conf.min_listeners,
             max_listeners : (test_conf.max_listeners == 0)
                 ? TotalNodes - 1 : test_conf.max_listeners,
+            stats_listening_port: test_conf.stats_listening_port
         };
 
         return conf;

--- a/source/agora/utils/Utility.d
+++ b/source/agora/utils/Utility.d
@@ -15,9 +15,13 @@ module agora.utils.Utility;
 
 import agora.utils.Log;
 
+import std.algorithm : map;
+import std.array : join, split;
+import std.conv;
 import std.format;
 import std.typecons;
 import std.traits;
+import std.uni : asCapitalized;
 
 import core.exception;
 import core.time;
@@ -118,6 +122,32 @@ public struct ThreadWaiter
         import core.thread;
         Thread.sleep(duration);
     }
+}
+
+/*******************************************************************************
+
+    Converts a string with underscore separator to upper camel case, for example
+    converts "this_is_me" to "ThisIsMe"
+
+    Params:
+        original = string that we want to convert to upper camel case
+
+*******************************************************************************/
+
+string underscoreSeparatedToUpperCamelCase(string original)
+{
+    return to!string(original.split("_").map!(part => part.asCapitalized).join(""));
+}
+
+///
+unittest
+{
+    // base case
+    assert(underscoreSeparatedToUpperCamelCase("this_is_me") == "ThisIsMe");
+    // extra underscore in the middle
+    assert(underscoreSeparatedToUpperCamelCase("this__is_me") == "ThisIsMe");
+    // unnecessary underscores in the beginning and at the end
+    assert(underscoreSeparatedToUpperCamelCase("_this_is_me_") == "ThisIsMe");
 }
 
 ///


### PR DESCRIPTION
Currently using Prometheus to collect the following statistics:
Transactions: Received, accepted to TxPool, rejected (perhaps even with reason), TxPool size, total amount in pool;
Endpoints: Number of request received per endpoints (e.g. GET /public_key);
Blocks: For each externalized block, new enrollments, transactions, tx total amount;
Validators: Number of validator, number of pre-images known ahead of time;