### PR TITLE
Name registry: don't unnecessarily check signatures & emit better logs

### DIFF
--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -596,6 +596,12 @@ public class NetworkManager
                     retry!
                     ({
                         auto payload = this.registry_client.getValidator(key);
+                        if (payload == RegistryPayload.init)
+                        {
+                            log.warn("Could not find mapping in registry for key {}", key);
+                            return false;
+                        }
+
                         if (!payload.verifySignature(key))
                         {
                             log.warn("RegistryPayload signature is incorrect for {}", key);

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -500,11 +500,10 @@ public class FullNode : API
     /// PUT: /enroll_validator
     public override void enrollValidator (Enrollment enroll) @safe
     {
-        log.trace("Received Enrollment: {}", prettify(enroll));
-
         if (this.enroll_man.addEnrollment(enroll, this.ledger.getBlockHeight(),
             this.utxo_set.getUTXOFinder()))
         {
+            log.info("Accepted enrollment: {}", prettify(enroll));
             this.network.sendEnrollment(enroll);
         }
     }
@@ -518,10 +517,9 @@ public class FullNode : API
     /// PUT: /receive_preimage
     public override void receivePreimage (PreImageInfo preimage) @safe
     {
-        log.trace("Received Preimage: {}", prettify(preimage));
-
         if (this.enroll_man.addPreimage(preimage))
         {
+            log.info("Accepted preimage: {}", prettify(preimage));
             this.network.sendPreimage(preimage);
             this.pushPreImage(preimage);
         }


### PR DESCRIPTION
We should also move the entire `if (this.registry_client !is null)` block logic into its own task (just like there is `AddressDiscoveryTask`), however I don't have time for this now.