### PR TITLE
Add UTXO hash component in making pre-images

### DIFF
--- a/source/agora/consensus/PreImage.d
+++ b/source/agora/consensus/PreImage.d
@@ -342,6 +342,7 @@ public struct PreImageCycle
 
         Params:
           secret = The secret key of the node, used as part of the hash
+          enroll_key = The enrollment key of the node, used as part of the hash
                    to generate the cycle seeds
           consume = If true, calculate the cycle index. Otherwise, just
                    get the random seed which is the first pre-image
@@ -351,14 +352,14 @@ public struct PreImageCycle
 
     ***************************************************************************/
 
-    public Hash populate (scope const ref Scalar secret, bool consume)
-        @safe nothrow
+    public Hash populate (scope const ref Scalar secret,
+        scope const ref Hash enroll_key, bool consume) @safe nothrow
     {
         // Populate the nonce cache if necessary
         if (this.index == 0)
         {
             const cycle_seed = hashMulti(
-                secret, "consensus.preimages", this.nonce);
+                secret, enroll_key, "consensus.preimages", this.nonce);
             this.seeds.reset(cycle_seed);
         }
 

--- a/source/agora/consensus/data/genesis/Test.d
+++ b/source/agora/consensus/data/genesis/Test.d
@@ -55,66 +55,66 @@ public immutable Block GenesisBlock = {
             Enrollment(
                 Hash(`0x46883e83778481d640a95fcffd6e1a1b6defeaac5a8001cd3f99e17576b809c` ~
                      `7e9bc7a44c3917806765a5ff997366e217ff54cd4da09c0c51dc339c47052a3ac`),
-                Hash(`0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2` ~
-                     `349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328`),
+                Hash(`0xcd0224554a748ce42bdec03663938d030d702f01a035c44c44f61defd882ec1` ~
+                     `dc39dd416bf3f02f3fb6be85c60b4535d7051fbb6415cfff6b8a133e3539507a8`),
                 20,
-                Signature(`0x0cab27862571d2d2e33d6480e1eab4c82195a508b72672d609610d01f23b0be` ~
-                          `edc8b89135fe3f5df9e2815b9bdb763c41b8b2dab5911e313acc82470c2147422`)
+                Signature(`0x0795b2ba8d2ca2a13d97013e9b37141a1c10e63d7da83fc686ba7fd783727aa7` ~
+                          `dc8b89135fe3f5df9e2815b9bdb763c41b8b2dab5911e313acc82470c2147422`)
             ),
 
             // Node 7
             Enrollment(
-                Hash(`0x4dde806d2e09367f9d5bdaaf46deab01a336a64fdb088dbb94edb171560c63cf` ~
-                     `6a39377bf0c4d35118775681d989dee46531926299463256da303553f09be6ef`),
-                Hash(`0xd0348a88f9b7456228e4df5689a57438766f4774d760776ec450605c82348c4` ~
-                     `61db84587c2c9b01c67c8ed17f297ee4008424ad3e0e5039179719d7e9df297c1`),
+                Hash(`0x4dde806d2e09367f9d5bdaaf46deab01a336a64fdb088dbb94edb171560c63c` ~
+                     `f6a39377bf0c4d35118775681d989dee46531926299463256da303553f09be6ef`),
+                Hash(`0xea68cf358bb14f7d92278c6c502fb1a4e2e5ac3fa57f6ca5934b1834c466d53` ~
+                     `db546c4fd7d76f998ba272602b9fec17a9e8cf77a807a1c7244d9122f9e863a71`),
                 20,
-                Signature(`0x0ed498b867c33d316b468d817ba8238aec68541abd912cecc499f8e780a8cda` ~
-                          `f2692d0b8b04133a34716169a4b1d33d77c3e585357d8a2a2c48a772275255c01`)
+                Signature(`0x0e578cde3da4fdac7627629eeb4bd5fa773f52f38e1a1e0a7e3be4da27973290` ~
+                          `2692d0b8b04133a34716169a4b1d33d77c3e585357d8a2a2c48a772275255c01`)
             ),
 
             // Node 6
             Enrollment(
                 Hash(`0x8c1561a4475df42afa0830da1f8a678ad4b1d82b6c610f7b03ce69b7e0fabcf` ~
                      `537d48ecd0aee6f1cab14290a0fc6313c729edf928ff3576f8656f3b7be5670e0`),
-                Hash(`0xaf43c67d9dd0f53de3eaede63cdcda8643422d62205df0b5af65706ec28b372` ~
-                     `adb785ce681d559d7a7137a4494ccbab4658ce11ec75a8ec84be5b73590bffceb`),
+                Hash(`0xcf62b43d7ca6ef43358ab4e4f238651014fe571bc67060ee6feceb8d1fd28ee` ~
+                     `670704f0d1943579545c39ade771a17616500f9a2eb77d5294121a2f6197f7c61`),
                 20,
-                Signature(`0x09474f489579c930dbac46f638f3202ac24407f1fa419c1d95be38ab474da29` ~
-                          `d7e3d4753b6b4ccdb35c2864be4195e83b7b8433ca1d27a57fb9f48a631001304`)
+                Signature(`0x0f82970da3ccfc41f8c29d86f88a5aab8404ffa63417f1bd1fe36af6abe793bc` ~
+                          `7e3d4753b6b4ccdb35c2864be4195e83b7b8433ca1d27a57fb9f48a631001304`)
             ),
 
             // Node 5
             Enrollment(
                 Hash(`0x94908ec79866cf54bb8e87b605e31ce0b5d7c3090f3498237d83edaca9c8ba2` ~
                      `d3d180c572af46c1221fb81add163e14adf738df26e3679626e82113b9fe085b0`),
-                Hash(`0xa24b7e6843220d3454523ceb7f9b43f037e56a01d2bee82958b080dc6350eba` ~
-                     `c2da12b561cbd96c6fb3f5ae5a3c8df0ac2c559ae1c45b11d42fdf866558112bc`),
+                Hash(`0xc9012e17a8a020a1907a31e4ebaed44dabd21cca0d82cd8f236cb4441656b77` ~
+                     `5f1b448eb3849a62d76c5a1442fa58eea934d14afbadef847b4610822ea78301c`),
                 20,
-                Signature(`0x0e4566eca30feb9ad47a65e7ff7e7ce1a7555ccedcf61e1143c2e5fddbec686` ~
-                          `6fd787c4518b78ab9ed73a3760741d557ac2aca631fc2796be86fcf391d3a6634`)
+                Signature(`0x0eb34417c056c0050525e62b79dd36f129edd0ad7962ceeb265875172ed71f9b` ~
+                          `fd787c4518b78ab9ed73a3760741d557ac2aca631fc2796be86fcf391d3a6634`)
             ),
 
             // Node 2
             Enrollment(
                 Hash(`0xb20da9cfbda971f3f573f55eabcd677feaf12f7948e8994a97cdf9e570799b7` ~
                      `1631e87bb9ebce0d6a402275adfb6e365fdb72139c18559a10df0e5fe4bae08eb`),
-                Hash(`0xa0502960ddbe816729f60aeaa480c7924fb020d864deec6a9db778b8e56dd2f` ~
-                     `f8e987be748ff6ca0a43597ecb575da5d532696e376dc70bb4567b5b1fa512cb4`),
+                Hash(`0x9f19e44ef4b3828f3b8f52cfc3364761089351ae87ade5f23de606b09f960b3` ~
+                     `9db56d60d154c276be637e58da69ac954ad35c1c6133f0f6fc50b8bc5c2983f45`),
                 20,
-                Signature(`0x052ee1d975c49f19fd26b077740dcac399f174f40b5df1aba5f09ebea11faac` ~
-                          `fd79a36ace4d3097869dc009b8939fc83bdf940c8822c6931d5c09326aa746b31`)
+                Signature(`0x0703844358eef98718704cb08a30530f5a8a90c4e0228200c574d3e5969b7b8a` ~
+                          `d79a36ace4d3097869dc009b8939fc83bdf940c8822c6931d5c09326aa746b31`)
             ),
-            
+
             // Node 3
             Enrollment(
                 Hash(`0xdb3931bd87d2cea097533d82be0a5e36c54fec8e5570790c3369bd8300c65a0` ~
                      `3d76d12a74aa38ec3e6866fd64ae56091ed3cbc3ca278ae0c8265ab699ffe2d85`),
-                Hash(`0xdd1b9c62d4c62246ea124e5422d5a2e23d3ca9accb0eba0e46cd46708a4e7b4` ~
-                     `17f46df34dc2e3cba9a57b1dc35a66dfc2d5ef239ebeaaa00299232bc7e3b7bfa`),
+                Hash(`0x6f2312e19e32f0744c49e330be4f1fad27100d5e773a1fde5eacc6a8436ef9c` ~
+                     `a3da6c600382f2d67801ffd71a134f2f302b9b59c3392e1904ba0ccc9db6555a0`),
                 20,
-                Signature(`0x0e0070e5951ef5be897cb593c4c57ce28b7529463f7e5644b1314ab7cc69fd6` ~
-                          `25c71e74382a24b7e644d32b0306fe3cf14ecd7de5635c70aa592f4721aa74fe2`)
+                Signature(`0x08d18637a3ede72edd19b5a01807319eba213f47a9354087448021f5d34a6a33` ~
+                          `5c71e74382a24b7e644d32b0306fe3cf14ecd7de5635c70aa592f4721aa74fe2`)
             ),
         ],
     },

--- a/source/agora/test/EnrollDifferentUTXOs.d
+++ b/source/agora/test/EnrollDifferentUTXOs.d
@@ -1,0 +1,348 @@
+/*******************************************************************************
+
+    Contains networking tests with multiple enrollments with different UTXOs.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.EnrollDifferentUTXOs;
+
+version (unittest):
+
+import agora.common.Amount;
+import agora.common.Config;
+import agora.common.Hash;
+import agora.common.crypto.ECC;
+import agora.common.crypto.Key;
+import agora.common.crypto.Schnorr;
+import agora.consensus.EnrollmentManager;
+import agora.consensus.data.Block;
+import agora.consensus.data.ConsensusParams;
+import agora.consensus.data.Enrollment;
+import agora.consensus.data.Transaction;
+import agora.test.Base;
+
+import core.stdc.time;
+import core.thread;
+import geod24.Registry;
+
+private class SameKeyValidator : TestValidatorNode
+{
+    private shared(Hash*) prev_enroll_key;
+
+    /// Ctor
+    public this (Config config, Registry* reg, immutable(Block)[] blocks,
+                    ulong txs_to_nominate, shared(time_t)* cur_time,
+                    shared(Hash*) prev_enroll_key)
+    {
+        this.prev_enroll_key = prev_enroll_key;
+        super(config, reg, blocks, txs_to_nominate, cur_time);
+    }
+
+    /// Create an enrollment with new UTXO which is not yet used
+    public override Enrollment createEnrollmentData ()
+    {
+        Hash[] utxo_hashes;
+        auto utxos = this.utxo_set.getUTXOs(
+            this.config.validator.key_pair.address);
+        foreach (key, utxo; utxos)
+        {
+            if (utxo.type == TxType.Freeze &&
+                utxo.output.value.integral() >= Amount.MinFreezeAmount.integral())
+            {
+                utxo_hashes ~= key;
+            }
+        }
+
+        // Find a UTXO which is not used for the enrollments in Genesis block
+        Hash unused_utxo;
+        Hash[] enroll_keys;
+        assert(this.enroll_man.getEnrolledUTXOs(enroll_keys));
+        foreach (utxo; utxo_hashes)
+        {
+            if (!canFind(enroll_keys, utxo))
+            {
+                unused_utxo = utxo;
+                break;
+            }
+        }
+        assert(unused_utxo != Hash.init);
+
+        // Set the previous enrollment key
+        *this.prev_enroll_key =
+            cast(shared(Hash)) this.enroll_man.getEnrollmentKey();
+
+        return this.enroll_man.createEnrollment(unused_utxo);
+    }
+}
+
+private class SameKeyNodeAPIManager : TestAPIManager
+{
+    // Used for sharing the enrollment key of a SameKeyValidator
+    shared Hash prev_enroll_key;
+
+    ///
+    public this (immutable(Block)[] blocks, TestConf test_conf, time_t initial_time)
+    {
+        super(blocks, test_conf, initial_time);
+    }
+
+    /// See base class
+    public override void createNewNode (Config conf, string file, int line)
+    {
+        if (this.nodes.length == 0)
+        {
+            auto time = new shared(time_t)(this.initial_time);
+            auto api = RemoteAPI!TestAPI.spawn!SameKeyValidator(
+                conf, &this.reg, this.blocks, this.test_conf.txs_to_nominate,
+                time, &this.prev_enroll_key, conf.node.timeout);
+            this.reg.register(conf.node.address, api.tid());
+            this.nodes ~= NodePair(conf.node.address, api, time);
+        }
+        else
+            super.createNewNode(conf, file, line);
+    }
+}
+
+/// Situation: There is six validators enrolled in Genesis block. Right before
+///     the cycle ends, the first validator reenrolls with another UTXO and
+///     other validators reenrolls again with the same UTXO used in the current
+///     enrollments.
+/// Expectation: Enrolling with a different UTXO succeeds and blocks are
+///     created normally after that.
+unittest
+{
+    TestConf conf = {
+        extra_blocks : 16,
+    };
+
+    auto network = makeTestNetwork!SameKeyNodeAPIManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+    auto nodes = network.clients;
+
+    // Sanity check
+    assert(network.blocks[0].header.enrollments.length >= 1);
+    network.expectBlock(Height(16), network.blocks[0].header, 5.seconds);
+
+    // Discarded UTXOs (just to trigger block creation)
+    auto spendable = network.blocks[$ - 1].spendable().array;
+    auto txs = spendable[0 .. 5]
+        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
+        .array;
+
+    // 8 utxos for freezing, 16 utxos for creating a block later
+    txs ~= spendable[5].split(WK.Keys.A.address.repeat(8)).sign();
+    txs ~= spendable[6].split(WK.Keys.Z.address.repeat(8)).sign();
+    txs ~= spendable[7].split(WK.Keys.Z.address.repeat(8)).sign();
+
+    // Block 17
+    txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(17), network.blocks[0].header, 5.seconds);
+
+    // Freeze builders
+    auto freezable = txs[$ - 3]
+        .outputs.length.iota
+        .takeExactly(8)
+        .map!(idx => TxBuilder(txs[$ - 3], cast(uint)idx));
+
+    // Create 8 freeze TXs
+    auto freeze_txs = freezable
+        .enumerate
+        .map!(pair => pair.value.refund(WK.Keys.A.address)
+            .sign(TxType.Freeze))
+        .array;
+    assert(freeze_txs.length == 8);
+
+    // Block 18
+    freeze_txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(18), network.blocks[0].header, 5.seconds);
+
+    // Block 19
+    auto new_txs = txs[$ - 2]
+        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 2], cast(uint)idx))
+        .takeExactly(8)
+        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
+    new_txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(19), network.blocks[0].header, 5.seconds);
+
+    // Now we re-enroll the first validator with a new UTXO
+    Enrollment new_enroll = nodes[0].createEnrollmentData();
+    nodes[0].enrollValidator(new_enroll);
+    nodes.each!(node =>
+        retryFor(node.getEnrollment(new_enroll.utxo_key) == new_enroll, 5.seconds));
+
+    // Now we re-enroll other five validators
+    foreach (node; nodes[1 .. $])
+    {
+        Enrollment enroll = node.createEnrollmentData();
+        nodes[0].enrollValidator(enroll);
+        nodes.each!(node =>
+            retryFor(node.getEnrollment(enroll.utxo_key) == enroll, 5.seconds));
+    }
+
+    // Block 20
+    new_txs = txs[$ - 1]
+        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 1], cast(uint)idx))
+        .takeExactly(8)
+        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
+    new_txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(20), 5.seconds);
+    auto b20 = nodes[0].getBlocksFrom(20, 2)[0];
+    assert(b20.header.enrollments.length == 6);
+
+    // Check the two enrollments of the first validator which has WK.Keys.A key.
+    Enrollment genesis_enroll;
+    Hash prev_enroll_key = cast(Hash)network.prev_enroll_key;
+    foreach (enroll; network.blocks[0].header.enrollments)
+    {
+        if (enroll.utxo_key[] == prev_enroll_key[])
+        {
+            genesis_enroll = enroll;
+            break;
+        }
+    }
+    auto pubkey = Point(nodes[0].getPublicKey());
+    assert(genesis_enroll.random_seed[] != new_enroll.random_seed[]);
+    assert(verify(pubkey, genesis_enroll.enroll_sig, genesis_enroll));
+    assert(verify(pubkey, new_enroll.enroll_sig, new_enroll));
+
+    // Block 21
+    new_txs = new_txs
+        .map!(tx => TxBuilder(tx))
+        .takeExactly(8)
+        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
+    new_txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(21), 5.seconds);
+}
+
+/// Situation: There are six validators enrolled in Genesis block. A few blocks
+///     before the cycle, the first validator enrolls with the first validator
+///     enrolls with another UTXO.
+/// Expectation: Enrolling with a different UTXO succeeds and blocks are
+///     created normally after that.
+/// Node: It's currently making the problem happen. But it's not rare case,
+///     so we remain it as `version (none)`. See the link.
+///     https://github.com/bpfkorea/agora/pull/1268#issuecomment-716384194
+version (none)
+unittest
+{
+    TestConf conf = {
+        extra_blocks : 15
+    };
+
+    auto network = makeTestNetwork!SameKeyNodeAPIManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+    auto nodes = network.clients;
+
+    // Sanity check
+    assert(network.blocks[0].header.enrollments.length >= 1);
+    network.expectBlock(Height(15), network.blocks[0].header, 5.seconds);
+
+    // Discarded UTXOs (just to trigger block creation)
+    auto spendable = network.blocks[$ - 1].spendable().array;
+    auto txs = spendable[0 .. 4]
+        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
+        .array;
+
+    // 8 utxos for freezing, 16 utxos for creating a block later
+    txs ~= spendable[4].split(WK.Keys.A.address.repeat(8)).sign();
+    txs ~= spendable[5].split(WK.Keys.Z.address.repeat(8)).sign();
+    txs ~= spendable[6].split(WK.Keys.Z.address.repeat(8)).sign();
+    txs ~= spendable[7].split(WK.Keys.Z.address.repeat(8)).sign();
+
+    // Block 16
+    txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(16), network.blocks[0].header, 5.seconds);
+
+    // Freeze builders
+    auto freezable = txs[$ - 4]
+        .outputs.length.iota
+        .takeExactly(8)
+        .map!(idx => TxBuilder(txs[$ - 4], cast(uint)idx));
+
+    // Create 8 freeze TXs
+    auto freeze_txs = freezable
+        .enumerate
+        .map!(pair => pair.value.refund(WK.Keys.A.address)
+            .sign(TxType.Freeze))
+        .array;
+    assert(freeze_txs.length == 8);
+
+    // Block 17
+    freeze_txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(17), network.blocks[0].header, 5.seconds);
+
+    // Block 18
+    auto new_txs = txs[$ - 3]
+        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 3], cast(uint)idx))
+        .takeExactly(8)
+        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
+    new_txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(18), network.blocks[0].header, 5.seconds);
+
+    // Now we re-enroll the first validator with a new UTXO
+    Enrollment new_enroll = nodes[0].createEnrollmentData();
+    nodes[0].enrollValidator(new_enroll);
+    nodes.each!(node =>
+        retryFor(node.getEnrollment(new_enroll.utxo_key) == new_enroll, 5.seconds));
+
+    // Now we re-enroll other five validators
+    foreach (node; nodes[1 .. $])
+    {
+        Enrollment enroll = node.createEnrollmentData();
+        nodes[0].enrollValidator(enroll);
+        nodes.each!(node =>
+            retryFor(node.getEnrollment(enroll.utxo_key) == enroll, 5.seconds));
+    }
+
+    // Block 19
+    new_txs = txs[$ - 2]
+        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 2], cast(uint)idx))
+        .takeExactly(8)
+        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
+    new_txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(19), 5.seconds);
+    auto b19 = nodes[0].getBlocksFrom(19, 2)[0];
+    assert(b19.header.enrollments.length == 1);
+
+    // Check the two enrollments of the first validator which has WK.Keys.A key.
+    Enrollment genesis_enroll;
+    Hash prev_enroll_key = cast(Hash)network.prev_enroll_key;
+    foreach (enroll; network.blocks[0].header.enrollments)
+    {
+        if (enroll.utxo_key[] == prev_enroll_key[])
+        {
+            genesis_enroll = enroll;
+            break;
+        }
+    }
+    auto pubkey = Point(nodes[0].getPublicKey());
+    assert(genesis_enroll.random_seed[] != new_enroll.random_seed[]);
+    assert(verify(pubkey, genesis_enroll.enroll_sig, genesis_enroll));
+    assert(verify(pubkey, new_enroll.enroll_sig, new_enroll));
+
+    network.waitForPreimages([new_enroll], 0);
+    network.waitForPreimages(network.blocks[0].header.enrollments, 19);
+
+    // Block 20
+    new_txs = txs[$ - 1]
+        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 1], cast(uint)idx))
+        .takeExactly(8)
+        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
+    new_txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(20), 5.seconds);
+    auto b20 = nodes[0].getBlocksFrom(20, 2)[0];
+    assert(b20.header.enrollments.length == 5);
+}

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -190,16 +190,16 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
+            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address]),
 
         // 1
         QuorumConfig(6, [
+            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
@@ -214,19 +214,9 @@ unittest
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE5.address]),
+            WK.Keys.NODE7.address]),
 
         // 3
-        QuorumConfig(6, [
-            WK.Keys.NODE2.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.B.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address]),
-
-        // 4
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
@@ -236,10 +226,20 @@ unittest
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
+        // 4
+        QuorumConfig(6, [
+            WK.Keys.NODE4.address,
+            WK.Keys.NODE6.address,
+            WK.Keys.B.address,
+            WK.Keys.NODE3.address,
+            WK.Keys.A.address,
+            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address]),
+
         // 5
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
-            WK.Keys.NODE6.address,
+            WK.Keys.NODE4.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
@@ -258,13 +258,13 @@ unittest
 
         // 7
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
+            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address]),
     ];
 
     static assert(quorums_1 != quorums_2);
@@ -320,22 +320,22 @@ unittest
         // 1
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
+            WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
         // 2
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
+            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address]),
 
         // 3
         QuorumConfig(6, [
@@ -355,12 +355,12 @@ unittest
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
+            WK.Keys.NODE5.address]),
 
         // 5
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
-            WK.Keys.NODE4.address,
+            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
@@ -370,22 +370,22 @@ unittest
         // 6
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
+            WK.Keys.NODE4.address,
+            WK.Keys.NODE6.address,
+            WK.Keys.B.address,
+            WK.Keys.NODE3.address,
+            WK.Keys.A.address,
+            WK.Keys.NODE5.address]),
+
+        // 7
+        QuorumConfig(6, [
+            WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
-
-        // 7
-        QuorumConfig(6, [
-            WK.Keys.NODE2.address,
-            WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.B.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
     ];
 
     static assert(quorums_2 != quorums_3);

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -341,12 +341,12 @@ private struct BlockHeaderFmt
 @safe unittest
 {
     static immutable GenesisHStr = `Height: 0, Prev: 0x0000...0000, Root: 0x788c...9254, Enrollments: [
-{ utxo: 0x4688...a3ac, seed: 0x0a82...4328, cycles: 20, sig: 0x0cab...7422 }
-{ utxo: 0x4dde...e6ef, seed: 0xd034...97c1, cycles: 20, sig: 0x0ed4...5c01 }
-{ utxo: 0x8c15...70e0, seed: 0xaf43...fceb, cycles: 20, sig: 0x0947...1304 }
-{ utxo: 0x9490...85b0, seed: 0xa24b...12bc, cycles: 20, sig: 0x0e45...6634 }
-{ utxo: 0xb20d...08eb, seed: 0xa050...2cb4, cycles: 20, sig: 0x052e...6b31 }
-{ utxo: 0xdb39...2d85, seed: 0xdd1b...7bfa, cycles: 20, sig: 0x0e00...4fe2 }]`;
+{ utxo: 0x4688...a3ac, seed: 0xcd02...07a8, cycles: 20, sig: 0x0795...7422 }
+{ utxo: 0x4dde...e6ef, seed: 0xea68...3a71, cycles: 20, sig: 0x0e57...5c01 }
+{ utxo: 0x8c15...70e0, seed: 0xcf62...7c61, cycles: 20, sig: 0x0f82...1304 }
+{ utxo: 0x9490...85b0, seed: 0xc901...301c, cycles: 20, sig: 0x0eb3...6634 }
+{ utxo: 0xb20d...08eb, seed: 0x9f19...3f45, cycles: 20, sig: 0x0703...6b31 }
+{ utxo: 0xdb39...2d85, seed: 0x6f23...55a0, cycles: 20, sig: 0x08d1...4fe2 }]`;
     const actual = format("%s", BlockHeaderFmt(GenesisBlock.header));
     assert(GenesisHStr == actual, actual);
 }
@@ -380,12 +380,12 @@ private struct BlockFmt
 @safe unittest
 {
     static immutable ResultStr = `Height: 0, Prev: 0x0000...0000, Root: 0x788c...9254, Enrollments: [
-{ utxo: 0x4688...a3ac, seed: 0x0a82...4328, cycles: 20, sig: 0x0cab...7422 }
-{ utxo: 0x4dde...e6ef, seed: 0xd034...97c1, cycles: 20, sig: 0x0ed4...5c01 }
-{ utxo: 0x8c15...70e0, seed: 0xaf43...fceb, cycles: 20, sig: 0x0947...1304 }
-{ utxo: 0x9490...85b0, seed: 0xa24b...12bc, cycles: 20, sig: 0x0e45...6634 }
-{ utxo: 0xb20d...08eb, seed: 0xa050...2cb4, cycles: 20, sig: 0x052e...6b31 }
-{ utxo: 0xdb39...2d85, seed: 0xdd1b...7bfa, cycles: 20, sig: 0x0e00...4fe2 }],
+{ utxo: 0x4688...a3ac, seed: 0xcd02...07a8, cycles: 20, sig: 0x0795...7422 }
+{ utxo: 0x4dde...e6ef, seed: 0xea68...3a71, cycles: 20, sig: 0x0e57...5c01 }
+{ utxo: 0x8c15...70e0, seed: 0xcf62...7c61, cycles: 20, sig: 0x0f82...1304 }
+{ utxo: 0x9490...85b0, seed: 0xc901...301c, cycles: 20, sig: 0x0eb3...6634 }
+{ utxo: 0xb20d...08eb, seed: 0x9f19...3f45, cycles: 20, sig: 0x0703...6b31 }
+{ utxo: 0xdb39...2d85, seed: 0x6f23...55a0, cycles: 20, sig: 0x08d1...4fe2 }],
 Transactions: 2
 Type : Freeze, Inputs: None
 Outputs (6): GDNO...LVHQ(2,000,000), GDNO...EACM(2,000,000), GDNO...OSNY(2,000,000),


### PR DESCRIPTION
Our previous pre-image scheme relied only on the private key, a nonce, and a fixed string. But the scheme made it unable for a node to enroll with different frozen UTXOs because it made the same pre-images for the UTXOs.  So we have made it possible to enroll with different UTXOs by adding UXTO hash to our pre-image scheme.

Fixes #849 