### PR TITLE
Clear up a deprecation from v2.094.0

### DIFF
--- a/source/agora/consensus/data/UTXOSetValue.d
+++ b/source/agora/consensus/data/UTXOSetValue.d
@@ -21,7 +21,7 @@ import agora.common.Types;
 import agora.consensus.data.Transaction;
 
 /// Delegate to find an unspent UTXO
-public alias UTXOFinder = scope bool delegate (Hash hash, size_t index,
+public alias UTXOFinder = bool delegate (Hash hash, size_t index,
     out UTXOSetValue) @safe nothrow;
 
 /// The structure of spendable transaction output


### PR DESCRIPTION
'scope' as no effect here, as storage classes don't affect the type.
We already use it everywhere it's needed on the parameter so it's not an issue.