### PR TITLE
Use Genesis test block for Network unit tests

### DIFF
--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -15,7 +15,7 @@ module agora.test.ManyValidators;
 
 // temporarily disabled until failures are resolved
 // see #1145
-version (none):
+// version (none):
 
 import agora.api.Validator;
 import agora.common.Amount;
@@ -39,9 +39,7 @@ import core.time;
 /// 16 nodes
 unittest
 {
-    TestConf conf = {
-        outsider_validators : 10,
-        extra_blocks : GenesisValidatorCycle - 4 };
+    TestConf conf = { outsider_validators : 10 };
 
     auto network = makeTestNetwork(conf);
     network.start();
@@ -50,104 +48,53 @@ unittest
     network.waitForDiscovery();
 
     auto nodes = network.clients;
-    Height expected_block = Height(conf.extra_blocks);
-    network.expectBlock(expected_block++);
 
-    auto spendable = network.blocks[$ - 1].txs
-        .filter!(tx => tx.type == TxType.Payment)
-        .map!(tx => iota(tx.outputs.length)
-            .map!(idx => TxBuilder(tx, cast(uint)idx)))
-        .joiner().array;
+    // generate 18 blocks, 2 short of the enrollments expiring.
+    network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    // discarded UTXOs (just to trigger block creation)
-    auto txs = spendable[0 .. 6]
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
-        .array;
+    const keys = network.nodes.map!(node => node.client.getPublicKey())
+        .drop(GenesisValidators).array;
 
-    // 16 utxos for freezing, 8 utxos for creating a block later
-    txs ~= spendable[6].split(WK.Keys.byRange
-        .take(conf.outsider_validators + GenesisValidators).map!(k => k.address))
-        .sign();
-    txs ~= spendable[7].split(WK.Keys.Genesis.address.repeat(8)).sign();
-    txs.each!(tx => nodes[0].putTransaction(tx));
-    // block 17
-    network.expectBlock(expected_block++);
-
-    // freeze builders
-    auto freezable = txs[$ - 2]  // contains 16 payment UTXOs
-        .outputs.length.iota
-        .takeExactly(conf.outsider_validators + GenesisValidators)  // there might be more UTXOs
-        .map!(idx => TxBuilder(txs[$ - 2], cast(uint)idx))
-        .array;
-
-    // create 16 freeze TXs
-    auto freeze_txs = freezable
-        .enumerate
-        .map!(pair => pair.value.refund(WK.Keys[pair.index].address)
-            .sign(TxType.Freeze))
-        .array;
-
-    // block 18
-    freeze_txs[0 .. 8].each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(expected_block++);
+    // prepare frozen outputs for outsider validators to enroll
+    genesisSpendable().drop(1).takeExactly(1)
+        .map!(txb => txb.split(keys).sign(TxType.Freeze))
+        .each!(tx => nodes[0].putTransaction(tx));
 
     // block 19
-    freeze_txs[8 .. 16].each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(expected_block++);
+    network.generateBlocks(Height(GenesisValidatorCycle - 1));
 
-    // now we re-enroll existing validators (extension),
-    // and enroll 10 new validators.
-    foreach (node; nodes)
-    {
-        Enrollment enroll = node.createEnrollmentData();
-        node.enrollValidator(enroll);
+    // wait for other nodes to get to same block height
+    nodes.drop(GenesisValidators).enumerate.each!((idx, node) =>
+        retryFor(node.getBlockHeight() == GenesisValidatorCycle - 1, 2.seconds,
+            format!"Expected block height %s but outsider %s has height %s."
+                (GenesisValidatorCycle - 1, idx, node.getBlockHeight())));
 
-        // check enrollment
-        nodes.each!(n =>
-            retryFor(n.getEnrollment(enroll.utxo_key) == enroll, 5.seconds));
-    }
+    auto validators = GenesisValidators + conf.outsider_validators;
 
-    // at block height 20 the validator set changes
-    txs = txs[$ - 1]  // take those 8 UTXOs from #L184
-            .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 1], cast(uint)idx))
-            .takeExactly(8)  // there might be more than 8
-            .map!(txb => txb.refund(WK.Keys.Genesis.address).sign()).array;
-        txs.each!(tx => nodes[0].putTransaction(tx));
+    // Now we enroll new validators and re-enroll the original validators
+    iota(0, validators).each!(idx => network.enroll(idx));
 
-    // Block 20
-    network.expectBlock(expected_block++);
+    network.generateBlocks(nodes, Height(GenesisValidatorCycle));
 
-    // sanity check
+    // check 16 validators are enrolled
     nodes.enumerate.each!((idx, node) =>
-        retryFor(node.getValidatorCount() == 16, 3.seconds,
+        retryFor(node.getValidatorCount() == validators, 5.seconds,
             format("Node %s has validator count %s. Expected: %s",
-                idx, node.getValidatorCount(), 16)));
+                idx, node.getValidatorCount(), validators)));
 
     // first validated block using 16 nodes
-    txs = txs
-        .map!(tx => iota(tx.outputs.length)
-            .map!(idx => TxBuilder(tx, cast(uint)idx)))
-        .joiner()
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
-        .takeExactly(8)
-        .array;
-    txs.each!(tx => nodes[0].putTransaction(tx));
-
-    // consensus check
-    network.expectBlock(expected_block);
+    network.generateBlocks(nodes, Height(GenesisValidatorCycle + 1),
+        Height(GenesisValidatorCycle));
 }
 
 /// 32 nodes
 /// Disabled due to significant network overhead,
 /// Block creation fails for 32 nodes.
+// temporarily disabled until failures are resolved
 version (none)
 unittest
 {
-    TestConf conf = {
-        timeout : 10.seconds,
-        outsider_validators : 26,
-        extra_blocks : 7,
-        validator_cycle : 13 };
+    TestConf conf = { outsider_validators : 26 };
 
     auto network = makeTestNetwork(conf);
     network.start();
@@ -156,95 +103,40 @@ unittest
     network.waitForDiscovery();
 
     auto nodes = network.clients;
-    network.expectBlock(Height(7));
 
-    auto spendable = network.blocks[$ - 1].txs
-        .filter!(tx => tx.type == TxType.Payment)
-        .map!(tx => iota(tx.outputs.length)
-            .map!(idx => TxBuilder(tx, cast(uint)idx)))
-        .joiner().array;
+    // generate 18 blocks, 2 short of the enrollments expiring.
+    network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    // discarded UTXOs (just to trigger block creation)
-    auto txs = spendable[0 .. 6]
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
-        .array;
+    const keys = network.nodes.map!(node => node.client.getPublicKey()).array;
 
-    // 32 utxos for freezing, 8 utxos for creating a block later
-    txs ~= spendable[6].split(WK.Keys.byRange.take(32).map!(k => k.address)).sign();
-    txs ~= spendable[7].split(WK.Keys.Genesis.address.repeat(8)).sign();
-    txs.each!(tx => nodes[0].putTransaction(tx));
+    // prepare frozen outputs for outsider validators to enroll
+    genesisSpendable().drop(1).takeExactly(1)
+        .map!(txb => txb.split(keys).sign(TxType.Freeze))
+        .each!(tx => nodes[0].putTransaction(tx));
 
-    // block 8
-    network.expectBlock(Height(8));
+    // block 19
+    network.generateBlocks(Height(GenesisValidatorCycle - 1));
 
-    // freeze builders
-    auto freezable = txs[$ - 2]  // contains 32 payment UTXOs
-        .outputs.length.iota
-        .takeExactly(32)  // there might be more UTXOs
-        .map!(idx => TxBuilder(txs[$ - 2], cast(uint)idx))
-        .array;
+    // wait for other nodes to get to same block height
+    nodes.drop(GenesisValidators).enumerate.each!((idx, node) =>
+        retryFor(node.getBlockHeight() == GenesisValidatorCycle - 1, 2.seconds,
+            format!"Expected block height %s but outsider %s has height %s."
+                (GenesisValidatorCycle - 1, idx, node.getBlockHeight())));
 
-    // create 32 freeze TXs
-    auto freeze_txs = freezable
-        .enumerate
-        .map!(pair => pair.value.refund(WK.Keys[pair.index].address)
-            .sign(TxType.Freeze))
-        .array;
-    assert(freeze_txs.length == 32);
+    auto validators = GenesisValidators + conf.outsider_validators;
 
-    // block 9
-    freeze_txs[0 .. 8].each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(9));
+    // Now we enroll new validators and re-enroll the original validators
+    iota(0, validators).each!(idx => network.enroll(idx));
 
-    // block 10
-    freeze_txs[8 .. 16].each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(10));
+    network.generateBlocks(nodes, Height(GenesisValidatorCycle));
 
-    // block 11
-    freeze_txs[16 .. 24].each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(11));
-
-    // block 12
-    freeze_txs[24 .. 32].each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(12));
-
-    // now we re-enroll existing validators (extension),
-    // and enroll 10 new validators.
-    foreach (node; nodes)
-    {
-        Enrollment enroll = node.createEnrollmentData();
-        node.enrollValidator(enroll);
-
-        // check enrollment
-        nodes.each!(n =>
-            retryFor(n.getEnrollment(enroll.utxo_key) == enroll, 5.seconds));
-    }
-
-    // at block height 13 the validator set changes
-    txs = txs[$ - 1]  // take those 8 UTXOs from #L184
-            .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 1], cast(uint)idx))
-            .takeExactly(8)  // there might be more than 8
-            .map!(txb => txb.refund(WK.Keys.Genesis.address).sign()).array;
-        txs.each!(tx => nodes[0].putTransaction(tx));
-
-    network.expectBlock(Height(13));
-
-    // sanity check
+    // check 16 validators are enrolled
     nodes.enumerate.each!((idx, node) =>
-        retryFor(node.getValidatorCount() == 32, 8.seconds,
+        retryFor(node.getValidatorCount() == validators, 5.seconds,
             format("Node %s has validator count %s. Expected: %s",
-                idx, node.getValidatorCount(), 32)));
+                idx, node.getValidatorCount(), validators)));
 
     // first validated block using 32 nodes
-    txs = txs
-        .map!(tx => iota(tx.outputs.length)
-            .map!(idx => TxBuilder(tx, cast(uint)idx)))
-        .joiner()
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
-        .takeExactly(8)
-        .array;
-    txs.each!(tx => nodes[0].putTransaction(tx));
-
-    // consensus check
-    network.expectBlock(Height(14));
+    network.generateBlocks(nodes, Height(GenesisValidatorCycle + 1),
+        Height(GenesisValidatorCycle));
 }

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -38,9 +38,7 @@ import core.time;
 ///
 unittest
 {
-    TestConf conf = {
-        outsider_validators : 2,
-        extra_blocks: GenesisValidatorCycle - 2 };
+    TestConf conf = { outsider_validators : 2 };
     auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();
@@ -50,72 +48,42 @@ unittest
     auto nodes = network.clients;
     const b0 = nodes[0].getBlocksFrom(0, 2)[0];
 
-    Height expected_block = Height(conf.extra_blocks);
-    network.expectBlock(expected_block++, b0.header);
+    // generate 18 blocks, 1 short of the enrollments expiring.
+    network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    // create block with 6 payment and 2 freeze tx's
-    auto txs = network.blocks[$ - 1].spendable().map!(txb => txb.sign()).array();
-
-    // rewrite 3rd to last tx to multiple outputs so we can create 8 spend tx's
-    // in next block
-    txs[$ - 3] = TxBuilder(network.blocks[$ - 1].txs[$ - 3])
-        .split(WK.Keys.Genesis.address.repeat(3)).sign();
-
-    // rewrite the last two tx's to be freeze tx's for our outsider validator nodes
-    txs[$ - 2] = TxBuilder(network.blocks[$ - 1].txs[$ - 2])
-        .draw(txs[$ - 2].outputs[0].value,
-            iota(txs[$ - 2].outputs.length).map!(k => nodes[$ - 2].getPublicKey()))
-        .sign(TxType.Freeze);
-    txs[$ - 1] = TxBuilder(network.blocks[$ - 1].txs[$ - 1])
-        .draw(txs[$ - 1].outputs[0].value,
-            iota(txs[$ - 1].outputs.length).map!(k => nodes[$ - 1].getPublicKey()))
-        .sign(TxType.Freeze);
-    txs.each!(tx => nodes[0].putTransaction(tx));
+    const keys = network.nodes.map!(node => node.client.getPublicKey()).array;
+    
+    // Freeze outputs for outsiders
+    genesisSpendable().dropExactly(1).takeExactly(1)
+        .map!(txb => txb.split(keys).sign(TxType.Freeze))
+        .each!(tx => nodes[0].putTransaction(tx));
 
     // at block height 19 the freeze tx's are available
-    network.expectBlock(expected_block++, b0.header);
+    network.generateBlocks(Height(GenesisValidatorCycle - 1));
 
-    // now we can create enrollments
-    Enrollment enroll_0 = nodes[$ - 2].createEnrollmentData();
-    Enrollment enroll_1 = nodes[$ - 1].createEnrollmentData();
-    nodes[$ - 2].enrollValidator(enroll_0);
-    nodes[$ - 1].enrollValidator(enroll_1);
+    // wait for other nodes to get to same block height
+    nodes.drop(GenesisValidators).enumerate.each!((idx, node) =>
+        retryFor(node.getBlockHeight() == GenesisValidatorCycle - 1, 2.seconds,
+            format!"Expected block height %s but outsider %s has height %s."
+                (GenesisValidatorCycle - 1, idx, node.getBlockHeight())));
 
-    // check enrollments
-    nodes.enumerate.each!((idx, node) =>
-        retryFor(node.getEnrollment(enroll_0.utxo_key) == enroll_0, 5.seconds,
-            format!"Node #%s: failed to getEnrollment for enroll_0"(idx)));
+    iota(GenesisValidators, GenesisValidators + conf.outsider_validators)
+        .each!(idx => network.enroll(idx));
 
-    nodes.enumerate.each!((idx, node) =>
-        retryFor(node.getEnrollment(enroll_1.utxo_key) == enroll_1, 5.seconds,
-            format!"Node #%s: failed to getEnrollment for enroll_1"(idx)));
+    // at block height 20 the validator set will change
+    network.generateBlocks(nodes, Height(GenesisValidatorCycle));
 
-    auto new_txs = txs.map!(tx => TxBuilder(tx).sign()).array();
-    // the last 3 tx's must refer to the outputs in txs[$ - 3] before
-    new_txs[$ - 3] = TxBuilder(txs[$ - 3], 0)
-        .split(WK.Keys.Genesis.address.only()).sign();
-    new_txs[$ - 2] = TxBuilder(txs[$ - 3], 1)
-        .split(WK.Keys.Genesis.address.only()).sign();
-    new_txs[$ - 1] = TxBuilder(txs[$ - 3], 2)
-        .split(WK.Keys.Genesis.address.only()).sign();
-    new_txs.each!(tx => nodes[0].putTransaction(tx));
-
-    // at block height 20 the validator set has changed
-    network.expectBlock(expected_block++, b0.header);
-
-    //// these are un-enrolled now
-    nodes[0 .. $ - 2].each!(node => node.sleep(10.minutes, true));
+    //// these are no longer enrolled
+    nodes[0 .. GenesisValidators].each!(node => node.sleep(10.minutes, true));
 
     // verify that consensus can still be reached by the leftover validators
-    txs = new_txs.map!(tx => TxBuilder(tx).sign()).array();
-    txs.each!(tx => nodes[$ - 2].putTransaction(tx));
-
-    const b10 = nodes[$ - 2].getBlocksFrom(10, 2)[0];
-    network.expectBlock(nodes[$ - 2 .. $], expected_block, b10.header);
+    network.generateBlocks(nodes.drop(GenesisValidators),
+        Height(GenesisValidatorCycle + 1), Height(GenesisValidatorCycle));
 
     // force wake up
-    nodes[0 .. $ - 2].each!(node => node.sleep(0.seconds, false));
+    nodes.takeExactly(GenesisValidators).each!(node => node.sleep(0.seconds, false));
 
     // all nodes should have same block height now
-    network.expectBlock(expected_block, b10.header);
+    network.expectBlock(Height(GenesisValidatorCycle + 1),
+        nodes[0].getAllBlocks()[GenesisValidatorCycle].header);
 }

--- a/source/agora/test/QuorumShuffle.d
+++ b/source/agora/test/QuorumShuffle.d
@@ -13,8 +13,6 @@
 
 module agora.test.QuorumShuffle;
 
-version (unittest):
-
 import agora.common.Serializer;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
@@ -31,7 +29,7 @@ unittest
 {
     import agora.common.Types;
     TestConf conf = {
-        max_listeners : 7,
+        txs_to_nominate : 8,
         max_quorum_nodes : 4,  // makes it easier to test shuffle cycling
         quorum_shuffle_interval : 6
     };
@@ -45,7 +43,7 @@ unittest
 
     Height block_height = Height(0);
 
-    const keys = WK.Keys.byRange.map!(kp => kp.address).take(6).array;
+    const keys = WK.Keys.byRange.map!(kp => kp.address).take(GenesisValidators).array;
 
     // check that the preimages were revealed before we trigger block creation
     // note: this is a workaround. A block should not be accepted if there

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -34,8 +34,7 @@ unittest
 {
     TestConf conf = {
         timeout : 10.seconds,
-        outsider_validators : 2,
-        extra_blocks : GenesisValidatorCycle - 3 };
+        outsider_validators : 2 };
 
     auto network = makeTestNetwork(conf);
     network.start();
@@ -47,72 +46,41 @@ unittest
     auto set_a = network.clients[0 .. GenesisValidators];
     auto set_b = network.clients[GenesisValidators .. $];
 
-    Height expected_block = Height(conf.extra_blocks);
-    network.expectBlock(expected_block++, network.blocks[0].header);
+    // generate 18 blocks, 2 short of the enrollments expiring.
+    network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    auto spendable = network.blocks[$ - 1].spendable().array;
+    const keys = WK.Keys.byRange.map!(kp => kp.address)
+        .drop(GenesisValidators).take(conf.outsider_validators).array;
 
-    // Discarded UTXOs (just to trigger block creation)
-    auto txs = spendable[0 .. 5]
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
-        .array;
+    // Block 19 we add the freeze utxos for set_b validators
+    // prepare frozen outputs for outsider validators to enroll
+    genesisSpendable().drop(1).takeExactly(1)
+        .map!(txb => txb
+            .split(keys).sign(TxType.Freeze))
+        .each!(tx => set_a[0].putTransaction(tx));
 
-    // 8 utxos for freezing, 16 utxos for creating a block later
-    txs ~= spendable[5].split(WK.Keys.byRange.take(GenesisValidators + conf.outsider_validators).map!(k => k.address)).sign();
-    txs ~= spendable[6].split(WK.Keys.Z.address.repeat(8)).sign();
-    txs ~= spendable[7].split(WK.Keys.Z.address.repeat(8)).sign();
+    network.generateBlocks(Height(GenesisValidatorCycle - 1));
 
-    // Block 18
-    txs.each!(tx => set_a[0].putTransaction(tx));
-    network.expectBlock(expected_block++, network.blocks[0].header);
+    // wait for other nodes to get to same block height
+    set_b.enumerate.each!((idx, node) =>
+        retryFor(node.getBlockHeight() == GenesisValidatorCycle - 1, 2.seconds,
+            format!"Expected block height %s but outsider %s has height %s."
+                (GenesisValidatorCycle - 1, idx, node.getBlockHeight())));
 
-    // Freeze builders
-    auto freezable = txs[$ - 3]
-        .outputs.length.iota
-        .takeExactly(GenesisValidators + conf.outsider_validators)
-        .map!(idx => TxBuilder(txs[$ - 3], cast(uint)idx))
-        .array;
+    // Now we enroll four new validators.
+    set_b.enumerate.each!((idx, _) => network.enroll(GenesisValidators + idx));
 
-    // Create 8 freeze TXs
-    auto freeze_txs = freezable
-        .enumerate
-        .map!(pair => pair.value.refund(WK.Keys[pair.index].address)
-            .sign(TxType.Freeze))
-        .array;
-    assert(freeze_txs.length == 8);
-
-    // Block 19
-    freeze_txs.each!(tx => set_a[0].putTransaction(tx));
-    network.expectBlock(expected_block++, network.blocks[0].header);
-
-    // Now we enroll two new validators. After this, the already enrolled
-    // validators will be expired.
-    foreach (ref node; set_b)
-    {
-        Enrollment enroll = node.createEnrollmentData();
-        node.enrollValidator(enroll);
-
-        // Check enrollment
-        set_b.each!(node =>
-            retryFor(node.getEnrollment(enroll.utxo_key) == enroll, 5.seconds));
-    }
-
-    // Block 20
-    auto new_txs = txs[$ - 2]
-        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 2], cast(uint)idx))
-        .takeExactly(8)
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign()).array;
-    new_txs.each!(tx => set_a[0].putTransaction(tx));
-    network.expectBlock(expected_block, network.blocks[0].header);
+    // Block 20, After this the Genesis block enrolled validators will be expired.
+    network.generateBlocks(Height(GenesisValidatorCycle));
 
     // Sanity check
-    auto b20 = set_a[0].getBlocksFrom(20, 2)[0];
+    auto b20 = set_a[0].getBlocksFrom(GenesisValidatorCycle, 1)[0];
     assert(b20.header.enrollments.length == conf.outsider_validators);
 
     // Now restarting the validators in the set B, all the data of those
     // validators has been wiped out.
     set_b.each!(node => network.restart(node));
-    network.expectBlock(expected_block++);
+    network.expectBlock(Height(GenesisValidatorCycle));
 
     // Sanity check
     nodes.enumerate.each!((idx, node) =>
@@ -122,24 +90,22 @@ unittest
 
     // Check the connection states are complete for the set B
     set_b.each!(node =>
-        retryFor(node.getNodeInfo().state == NetworkState.Complete, 5.seconds));
+        retryFor(node.getNodeInfo().state == NetworkState.Complete,
+            5.seconds));
 
     // Check if the validators in the set B have all the addresses for
     // current validators and previous validators except themselves.
     set_b.each!(node =>
         retryFor(node.getNodeInfo().addresses.length ==
-                    GenesisValidators + conf.outsider_validators - 1 , 5.seconds));
+            GenesisValidators + conf.outsider_validators - 1,
+            5.seconds));
 
     // Make all the validators of the set A disable to respond
     set_a.each!(node => node.ctrl.sleep(6.seconds, true));
 
     // Block 21 with the new validators in the set B
-    new_txs = txs[$ - 1]
-        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 1], cast(uint)idx))
-        .takeExactly(8)
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign()).array;
-    new_txs.each!(tx => set_b[0].putTransaction(tx));
-    network.expectBlock(set_b, expected_block, b20.header);
+    network.generateBlocks(set_b, Height(GenesisValidatorCycle + 1),
+        Height(GenesisValidatorCycle));
 }
 
 /// Situation: A validator is stopped and wiped clean after the block height
@@ -149,7 +115,7 @@ unittest
 ///     has started to validate immediately.
 unittest
 {
-    TestConf conf = { full_nodes : 1 ,
+    TestConf conf = { full_nodes : 1,
         quorum_threshold : 75 };
     auto network = makeTestNetwork(conf);
     network.start();


### PR DESCRIPTION
This pull request removes the generation of a Genesis block for each network unit test. These tests in the [folder](https://github.com/bpfkorea/agora/tree/v0.x.x/source/agora/test) now always use the test [GenesisBlock](https://github.com/bpfkorea/agora/blob/v0.x.x/source/agora/consensus/data/genesis/Test.d). 