### PR TITLE
Validator recurring enrollments

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -63,6 +63,9 @@ validator:
   addresses_to_register:
     - 88.88.88.88
     - best.validator.io
+  # Whether or not the Validator will enroll automatically at the startup or
+  # at the end of Validator cycle
+  recurring_enrollment: true
 
 ################################################################################
 ##                         Ban manager configuration                          ##

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -183,6 +183,9 @@ public struct ValidatorConfig
 
     // Registry address
     public string registry_address;
+
+    // If the enrollments will be renewed or not at the end of the cycle
+    public bool recurring_enrollment = true;
 }
 
 /// Admin API config
@@ -443,12 +446,14 @@ private ValidatorConfig parseValidatorConfig (Node* node, const ref CommandLine 
         return ValidatorConfig(false);
 
     auto registry_address = get!(string, "validator", "registry_address")(cmdln, node);
+    const recurring_enrollment = get!(bool, "validator", "recurring_enrollment")(cmdln, node);
     ValidatorConfig result = {
         enabled: true,
         key_pair:
             KeyPair.fromSeed(Seed.fromString(get!(string, "validator", "seed")(cmdln, node))),
         registry_address: registry_address,
         addresses_to_register : assumeUnique(parseSequence("addresses_to_register", cmdln, *node, true)),
+        recurring_enrollment : recurring_enrollment
     };
     return result;
 }
@@ -465,12 +470,14 @@ validator:
   enabled: true
   seed: SCT4KKJNYLTQO4TVDPVJQZEONTVVW66YLRWAINWI3FZDY7U4JS4JJEI4
   registry_address: http://127.0.0.1:3003
+  recurring_enrollment : false
 `;
         auto node = Loader.fromString(conf_example).load();
         auto config = parseValidatorConfig("validator" in node, cmdln);
         assert(config.enabled);
         assert(config.key_pair == KeyPair.fromSeed(
             Seed.fromString("SCT4KKJNYLTQO4TVDPVJQZEONTVVW66YLRWAINWI3FZDY7U4JS4JJEI4")));
+        assert(!config.recurring_enrollment);
     }
     {
     immutable conf_example = `

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -637,7 +637,13 @@ public class EnrollmentManager
     }
 
     /// Returns: true if this validator is currently enrolled
-    public bool isEnrolled (UTXOFinder finder) nothrow @safe
+    public bool isEnrolled (scope UTXOFinder finder) nothrow @safe
+    {
+        return this.getEnrolledUTXO(finder) != Hash.init;
+    }
+
+    /// Returns: The UTXO hash that this Validator is enrolled with or Hash.init if not enrolled
+    public Hash getEnrolledUTXO (scope UTXOFinder finder) nothrow @safe
     {
         Hash[] utxo_keys;
         assert(this.validator_set.getEnrolledUTXOs(utxo_keys));
@@ -650,10 +656,10 @@ public class EnrollmentManager
                 assert(0, "UTXO for validator not found!");  // should never happen
 
             if (value.output.address == key)
-                return true;
+                return utxo_key;
         }
 
-        return false;
+        return Hash.init;
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -233,6 +233,8 @@ public class Validator : FullNode, API
 
         if (this.enroll_man.isEnrolled(this.utxo_set.getUTXOFinder()))
             this.nominator.startNominatingTimer();
+        else if (this.config.validator.recurring_enrollment)
+            this.checkAndEnroll(this.ledger.getBlockHeight());
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -452,7 +452,11 @@ public class Validator : FullNode, API
 
         // This validators enrollment will expire next cycle or not enrolled at all
         if (enrolled == ulong.max || block_height + 1 >= enrolled + this.params.ValidatorCycle)
+        {
+            log.trace("Sending Enrollment at height {} for {} cycles with {}", block_height,
+                                            this.params.ValidatorCycle , enroll_key);
             this.network.sendEnrollment(this.enroll_man.createEnrollment(enroll_key));
+        }
     }
 
     /***************************************************************************

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1687,6 +1687,9 @@ public struct TestConf
 
     /// How often blocks should be created - in seconds
     uint block_interval_sec = 1;
+
+    /// If the enrollments will be renewed or not at the end of the cycle
+    bool recurring_enrollment = true;
 }
 
 /*******************************************************************************
@@ -1775,7 +1778,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
         {
             banman : ban_conf,
             node : makeNodeConfig(self_address),
-            validator : ValidatorConfig(true, key_pair, [self_address]),
+            validator : ValidatorConfig(true, key_pair, [self_address], "", test_conf.recurring_enrollment),
             network : makeNetworkConfig(idx, addresses),
         };
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -35,7 +35,10 @@ import core.time;
 /// test for enrollment process & revealing a pre-image periodically
 unittest
 {
-    auto network = makeTestNetwork(TestConf.init);
+    TestConf conf = {
+        recurring_enrollment : false,
+    };
+    auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
@@ -65,8 +68,10 @@ unittest
 unittest
 {
     import agora.consensus.data.genesis.Test;
-
-    auto network = makeTestNetwork(TestConf.init);
+    TestConf conf = {
+        recurring_enrollment : false,
+    };
+    auto network = makeTestNetwork(conf);
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
     network.start();
@@ -97,7 +102,8 @@ unittest
 ///     reveals its pre-images periodically.
 unittest
 {
-    auto network = makeTestNetwork(TestConf.init);
+    TestConf conf = { recurring_enrollment : false };
+    auto network = makeTestNetwork(conf);
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
     network.start();

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -39,7 +39,9 @@ import core.time;
 unittest
 {
     TestConf conf = { outsider_validators : 2,
-        txs_to_nominate : 0 };  // zero allows any number of txs for nomination
+        txs_to_nominate : 0,  // zero allows any number of txs for nomination
+        recurring_enrollment : false,
+    };
     auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -41,6 +41,7 @@ unittest
 {
     import agora.common.Types;
     TestConf conf = {
+        recurring_enrollment : false,
         outsider_validators : 2,
         max_listeners : 7,
         txs_to_nominate : 0 };

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -35,7 +35,9 @@ unittest
     TestConf conf = {
         timeout : 10.seconds,
         outsider_validators : 2,
-        txs_to_nominate : 0 }; // zero allows any number of txs for nomination
+        txs_to_nominate : 0, // zero allows any number of txs for nomination
+        recurring_enrollment : false,
+    };
     auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/ValidatorCount.d
+++ b/source/agora/test/ValidatorCount.d
@@ -31,7 +31,7 @@ import core.thread;
 /// ditto
 unittest
 {
-    const TestConf conf = TestConf.init;
+    const TestConf conf = { recurring_enrollment : false };
     auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -1,0 +1,65 @@
+/*******************************************************************************
+
+    Ensures validators re-enroll at the end of their validator cycle
+    when configured to do so
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.ValidatorRecurringEnrollment;
+
+import agora.test.Base;
+import agora.consensus.data.Transaction;
+
+unittest
+{
+    TestConf conf = {
+        quorum_threshold : 100
+    };
+    auto network = makeTestNetwork(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[0];
+
+    // Get the genesis block, make sure it's the only block externalized
+    auto blocks = node_1.getBlocksFrom(0, 2);
+    assert(blocks.length == 1);
+
+    Transaction[] txs;
+
+    void createAndExpectNewBlock (Height new_block_height)
+    {
+        // create enough tx's for a single block
+        txs = blocks[new_block_height - 1].spendable().map!(txb => txb.sign()).array();
+
+        // send it to one node
+        txs.each!(tx => node_1.putTransaction(tx));
+
+        network.expectBlock(new_block_height, blocks[0].header);
+
+        // add next block
+        blocks ~= node_1.getBlocksFrom(new_block_height, 1);
+    }
+
+    // create GenesisValidatorCycle - 1 blocks
+    foreach (block_idx; 1 .. GenesisValidatorCycle)
+    {
+        createAndExpectNewBlock(Height(block_idx));
+    }
+
+    // Create one last block
+    // if Validators don't re-enroll, this would fail
+    createAndExpectNewBlock(Height(GenesisValidatorCycle));
+    // Check if all validators in genesis are enrolled again
+    assert(blocks[blocks.length - 1].header.enrollments.length == blocks[0].header.enrollments.length);
+}


### PR DESCRIPTION
Validators used to not re-enroll at the end of their validator
cycle. Now they re-enroll with the existing UTXO one block before
their enrollment expire.

Some tests rely on the old behaviour. So a field for configuring the
re-enrollment is also added. Recurring enrollments are disabled by default.
We may enable it for tests that don't rely on the old behaviour.

hopefully fixes #1254 