### PR TITLE
Call GC in-between tests

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -265,6 +265,8 @@ private UnitTestResult customModuleUnitTester ()
 
         while (parallel_tests.length)
         {
+            import core.memory;
+
             auto test = parallel_tests.front;
             parallel_tests.popFront();
 
@@ -272,6 +274,7 @@ private UnitTestResult customModuleUnitTester ()
             available_cores.wait();
 
             (new WorkThread(test)).start();
+            core.memory.GC.collect();
         }
     }
 


### PR DESCRIPTION
I have checked to see that only maximum of 100 fibers are ever in the system at the same time.
But GC is not always triggered in-between tests which results in GC memory keep accumulating.

This fixes the OOM crash I get in my system with 8G of physical memory.