### PR TITLE
Stats: Add version, frontend, and other non-dimensional info

### DIFF
--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -165,8 +165,8 @@ public struct NodeConfig
 
     /// The local address where the stats server (currently Prometheus)
     /// is going to connect to, for example: http://0.0.0.0:8008
-    /// It can also be set to -1 do disable listening
-    public int stats_listening_port = -1;
+    /// It can also be set to 0 do disable listening
+    public ushort stats_listening_port;
 }
 
 /// Validator config
@@ -382,7 +382,7 @@ private NodeConfig parseNodeConfig (Node* node, const ref CommandLine cmdln)
         cmdln, node);
     auto preimage_reveal_interval = get!(Duration, "node", "preimage_reveal_interval",
         str => str.to!ulong.seconds)(cmdln, node);
-    const stats_listening_port = get!(int, "node", "stats_listening_port")(cmdln, node);
+    const stats_listening_port = opt!(ushort, "node", "stats_listening_port")(cmdln, node);
 
     NodeConfig result = {
             min_listeners : min_listeners,

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -348,15 +348,15 @@ public class FullNode : API
     /// Start the StatsServer
     public void startStatsServer ()
     {
-        this.stats_server = getStatsServer();
+        if (config.node.stats_listening_port != 0)
+            this.stats_server = getStatsServer();
     }
 
     /// Stop the StatsServer
     public void stopStatsServer ()
     {
-        assert(this.stats_server !is null,
-            "Stats server is stopped without being started");
-        this.stats_server.shutdown();
+        if (this.stats_server !is null)
+            this.stats_server.shutdown();
     }
 
     /// Returns a newly constructed StatsServer

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -39,6 +39,7 @@ import agora.network.NetworkClient;
 import agora.network.NetworkManager;
 import agora.node.BlockStorage;
 import agora.node.Ledger;
+import agora.stats.App;
 import agora.stats.EndpointReq;
 import agora.stats.Server;
 import agora.stats.Utils;
@@ -128,6 +129,9 @@ public class FullNode : API
     /// Endpoint request stats
     protected EndpointRequestStats endpoint_request_stats;
 
+    /// Application-wide stats
+    protected ApplicationStats app_stats;
+
     /***************************************************************************
 
         Constructor
@@ -209,9 +213,18 @@ public class FullNode : API
         if (this.block_handlers.length > 0 && this.getBlockHeight() == 0)
             this.pushBlock(this.params.Genesis);
 
+        Utils.getCollectorRegistry().addCollector(&this.collectAppStats);
         Utils.getCollectorRegistry().addCollector(&this.collectStats);
+        this.app_stats.setMetricTo!"agora_application_info"(
+            1, // Unused, see article linked in the struct's documentationx
+            "HEAD", // TODO: FIXME
+            __TIMESTAMP__, __VERSION__.to!string,
+            config.validator.enabled
+                ? config.validator.key_pair.address.toString() : null,
+        );
     }
 
+    mixin DefineCollectorForStats!("app_stats", "collectAppStats");
     mixin DefineCollectorForStats!("endpoint_request_stats", "collectStats");
 
     /***************************************************************************

--- a/source/agora/stats/App.d
+++ b/source/agora/stats/App.d
@@ -1,0 +1,50 @@
+/*******************************************************************************
+
+    Expose stats specific to the application, such as GC stats, or version.
+
+    Copyright:
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.stats.App;
+
+import agora.stats.Stats;
+
+/*******************************************************************************
+
+    Expose non-dimensional data, such as version and build date
+
+    Those labels are actually not following the usual time-series pattern,
+    instead exposing data based on labels.
+
+    See_Also:
+    https://www.robustperception.io/exposing-the-software-version-to-prometheus
+
+*******************************************************************************/
+
+public struct ApplicationStatsLabels
+{
+    /// Version of Agora being run (git commit / tag)
+    public string version_;
+    /// Build date of this node
+    public string build_timestamp;
+    /// Compiler used for building
+    public string frontend_version;
+    /// Expose this node's public key, if any
+    public string public_key;
+}
+
+/// Dummy stats with a single variable
+public struct ApplicationStatsValue
+{
+    /// This is not actually needed, only the labels are
+    public ulong agora_application_info = 1;
+}
+
+///
+public alias ApplicationStats = Stats!(ApplicationStatsValue, ApplicationStatsLabels);

--- a/source/agora/stats/Block.d
+++ b/source/agora/stats/Block.d
@@ -16,10 +16,6 @@ module agora.stats.Block;
 import agora.stats.Stats;
 
 ///
-public struct BlockStatsLabel
-{
-}
-
 ///
 public struct BlockStatsValue
 {
@@ -30,4 +26,4 @@ public struct BlockStatsValue
 }
 
 ///
-public alias BlockStats = Stats!(BlockStatsValue, BlockStatsLabel);
+public alias BlockStats = Stats!(BlockStatsValue, NoLabel);

--- a/source/agora/stats/Server.d
+++ b/source/agora/stats/Server.d
@@ -19,45 +19,40 @@ import ocean.util.prometheus.collector.CollectorRegistry;
 import vibe.http.server;
 import vibe.http.router;
 
-class StatsServer
+public class StatsServer
 {
     private HTTPListener http_listener;
 
     /***************************************************************************
 
-            Constructs a StatsServer instance
+        Constructs a StatsServer instance
 
-            Params
-                port = port on which the server will listen on,
-                -1 to disable listening
+        Params:
+            port = port on which the server will listen on
 
     ***************************************************************************/
 
-    public this (int port)
+    public this (ushort port)
     {
-        if (port == -1)
-            return;
-
-        assert(port > 0 && port < 65536, "port number for stats server has to be between 1 and 65535");
-
         auto router = new URLRouter;
         router.get("/metrics", &handle_metrics);
 
         auto settings = new HTTPServerSettings;
-        settings.port = cast(ushort) port;
-        http_listener = listenHTTP(settings, router);
+        settings.port = port;
+        this.http_listener = listenHTTP(settings, router);
     }
 
     ///
     public void shutdown ()
     {
-        if (http_listener !is HTTPListener.init)
-            http_listener.stopListening();
+        this.http_listener.stopListening();
     }
 
     ///
-    private void handle_metrics (HTTPServerRequest req, HTTPServerResponse res)
+    private void handle_metrics (
+        scope HTTPServerRequest req, scope HTTPServerResponse res)
     {
-        res.writeBody(cast(const(ubyte[])) Utils.getCollectorRegistry().collect(),"text/plain");
+        res.writeBody(cast(const(ubyte[])) Utils.getCollectorRegistry().collect(),
+                      "text/plain");
     }
 }

--- a/source/agora/stats/Stats.d
+++ b/source/agora/stats/Stats.d
@@ -130,16 +130,15 @@ public struct Stats (ValueType, LabelType)
     }
 }
 
+/// Convenience struct for easier stats definition
+public struct NoLabel {}
+
 version (unittest)
 {
     import agora.stats.Utils;
 
     import ocean.util.prometheus.collector.CollectorRegistry;
     import ocean.util.prometheus.collector.Collector;
-
-    public struct TestStatsWithoutLabelT
-    {
-    }
 
     public struct TestStatsWithLabelT
     {
@@ -152,7 +151,7 @@ version (unittest)
     }
 
     Stats!(TestStatsValueT, TestStatsWithLabelT) test_stats_with_label;
-    Stats!(TestStatsValueT, TestStatsWithoutLabelT) test_stats_without_label;
+    Stats!(TestStatsValueT, NoLabel) test_stats_without_label;
 
     mixin DefineCollectorForStats!("test_stats_with_label", "collectTestStatWithLabel");
     mixin DefineCollectorForStats!("test_stats_without_label", "collectTestStatWithoutLabel");

--- a/source/agora/stats/Tx.d
+++ b/source/agora/stats/Tx.d
@@ -16,10 +16,6 @@ module agora.stats.Tx;
 import agora.stats.Stats;
 
 ///
-public struct TxStatsLabel
-{
-}
-
 ///
 public struct TxStatsValue
 {
@@ -31,4 +27,4 @@ public struct TxStatsValue
 }
 
 ///
-public alias TxStats = Stats!(TxStatsValue, TxStatsLabel);
+public alias TxStats = Stats!(TxStatsValue, NoLabel);

--- a/source/agora/stats/Utils.d
+++ b/source/agora/stats/Utils.d
@@ -48,16 +48,17 @@ public mixin template DefineCollectorForStats (string statVar,
     }.format(statVar, collector_name));
 }
 
-/// collection of Utility classes for stats collection
+/// Provides a namespace for stats utilities
 public class Utils
 {
     /***************************************************************************
 
-            Static function that returns a singleton instance
-            of type `CollectorRegistry`
+        Static function that returns a singleton instance
+        of type `CollectorRegistry`
 
-            Returns:
-                a singleton instance of type `CollectorRegistry`
+        Returns:
+            a singleton instance of type `CollectorRegistry`
+
     ***************************************************************************/
 
     public static CollectorRegistry getCollectorRegistry ()

--- a/source/agora/stats/Validator.d
+++ b/source/agora/stats/Validator.d
@@ -16,10 +16,6 @@ module agora.stats.Validator;
 import agora.stats.Stats;
 
 ///
-public struct ValidatorCountStatsLabel
-{
-}
-
 ///
 public struct ValidatorCountStatsValue
 {
@@ -39,7 +35,7 @@ public struct ValidatorPreimagesStatsValue
 }
 
 ///
-public alias ValidatorCountStats = Stats!(ValidatorCountStatsValue, ValidatorCountStatsLabel);
+public alias ValidatorCountStats = Stats!(ValidatorCountStatsValue, NoLabel);
 
 ///
 public alias ValidatorPreimagesStats = Stats!(ValidatorPreimagesStatsValue, ValidatorPreimagesStatsLabel);

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -57,7 +57,6 @@ import agora.registry.NameRegistryAPI;
 import agora.registry.NameRegistryImpl;
 import agora.utils.Log;
 import agora.utils.PrettyPrinter;
-import agora.stats.Server;
 public import agora.utils.Utility : retryFor;
 import agora.api.FullNode : NodeInfo, NetworkState;
 import agora.api.Validator : ValidatorAPI = API;
@@ -1503,11 +1502,6 @@ public struct TestConf
 
     /// How often blocks should be created - in seconds
     uint block_interval_sec = 1;
-
-    // The local address where the stats server (currently Prometheus)
-    // is going to connect to, for example: http://0.0.0.0:8008
-    // It can also be set to 0 do disable listening
-    int stats_listening_port = -1;
 }
 
 /*******************************************************************************
@@ -1562,7 +1556,6 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
                 : test_conf.min_listeners,
             max_listeners : (test_conf.max_listeners == 0)
                 ? TotalNodes - 1 : test_conf.max_listeners,
-            stats_listening_port: test_conf.stats_listening_port
         };
 
         return conf;


### PR DESCRIPTION
This should help to get a feel of the system from Grafana.
Example output with `dub run -- -c doc/config.example.yaml`:

```
agora_application_info {version_="HEAD",build_timestamp="Fri Oct 30 19:30:51 2020",frontend_version="2094",public_key="GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ"} 1
```

The `HEAD` things needs to be fixed to refer to a commit, but for the time being, the build timestamp will suffice.