### PR TITLE
Make UTXOFinder accept the UTXO hash as parameter

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -654,7 +654,7 @@ public class EnrollmentManager
         foreach (utxo_key; utxo_keys)
         {
             UTXOSetValue value;
-            if (!finder(utxo_key, size_t.max, value))
+            if (!finder(utxo_key, value))
                 assert(0, "UTXO for validator not found!");  // should never happen
 
             if (value.output.address == key)

--- a/source/agora/consensus/Quorum.d
+++ b/source/agora/consensus/Quorum.d
@@ -459,8 +459,7 @@ private NodeStake[] buildStakesDescending (const ref PublicKey filter,
     foreach (utxo_key; utxo_keys)
     {
         UTXOSetValue value;
-        assert(finder(utxo_key, size_t.max, value),
-            "UTXO for validator not found!");
+        assert(finder(utxo_key, value), "UTXO for validator not found!");
 
         if (value.output.address != filter)
             stakes ~= NodeStake(value.output.address, value.output.value);

--- a/source/agora/consensus/UTXOSet.d
+++ b/source/agora/consensus/UTXOSet.d
@@ -171,9 +171,7 @@ public class UTXOSet
         Find an UTXOSetValue in the UTXO set.
 
         Params:
-            hash = the hash of the transaction introducing the `Output`
-            index = the index of the output
-                If size_t.max, find the hash parameter by UTXO Hash.
+            hash = the hash of the UTXO (`hashFull(tx_hash, index)`)
             output = will contain the UTXOSetValue if found
 
         Return:
@@ -181,28 +179,21 @@ public class UTXOSet
 
     ***************************************************************************/
 
-    private bool findUTXO (Hash hash, size_t index, out UTXOSetValue value)
+    private bool findUTXO (Hash utxo, out UTXOSetValue value)
         nothrow @safe
     {
-        Hash utxo_hash;
-
-        if (index == size_t.max)
-            utxo_hash = hash;
-        else
-            utxo_hash = UTXOSetValue.getHash(hash, index);
-
-        if (utxo_hash in this.used_utxos)
+        if (utxo in this.used_utxos)
         {
-            log.trace("findUTXO: utxo_hash {} found in used_utxos: {}", utxo_hash, used_utxos);
+            log.trace("findUTXO: utxo_hash {} found in used_utxos: {}", utxo, used_utxos);
             return false;  // double-spend
         }
 
-        if (this.utxo_db.find(utxo_hash, value))
+        if (this.utxo_db.find(utxo, value))
         {
-            this.used_utxos.put(utxo_hash);
+            this.used_utxos.put(utxo);
             return true;
         }
-        log.trace("findUTXO: utxo_hash {} not found", utxo_hash);
+        log.trace("findUTXO: utxo_hash {} not found", utxo);
         return false;
     }
 }

--- a/source/agora/consensus/data/UTXOSetValue.d
+++ b/source/agora/consensus/data/UTXOSetValue.d
@@ -21,8 +21,8 @@ import agora.common.Types;
 import agora.consensus.data.Transaction;
 
 /// Delegate to find an unspent UTXO
-public alias UTXOFinder = bool delegate (Hash hash, size_t index,
-    out UTXOSetValue) @safe nothrow;
+public alias UTXOFinder = bool delegate (Hash utxo, out UTXOSetValue)
+    @safe nothrow;
 
 /// The structure of spendable transaction output
 public struct UTXOSetValue
@@ -92,13 +92,11 @@ public class TestUTXOSet
     public alias findUTXO = peekUTXO;
 
     /// Get an UTXO, no double-spend protection
-    public bool peekUTXO (Hash hash, size_t index, out UTXOSetValue value)
+    public bool peekUTXO (Hash utxo, out UTXOSetValue value)
         nothrow @safe
     {
         // Note: Keep this in sync with `findUTXO`
-        Hash utxo_hash = (index == size_t.max) ?
-            hash : UTXOSetValue.getHash(hash, index);
-        if (auto ptr = utxo_hash in this.storage)
+        if (auto ptr = utxo in this.storage)
         {
             value = *ptr;
             return true;
@@ -128,19 +126,17 @@ public class TestUTXOSet
     }
 
     /// Get an UTXO, does not return double spend
-    private bool findUTXO_ (Hash hash, size_t index, out UTXOSetValue value)
+    private bool findUTXO_ (Hash utxo, out UTXOSetValue value)
         nothrow @safe
     {
         // Note: Keep this in sync with the real `findUTXO`
-        Hash utxo_hash = (index == size_t.max) ?
-            hash : UTXOSetValue.getHash(hash, index);
         // double-spend
-        if (utxo_hash in this.used_utxos)
+        if (utxo in this.used_utxos)
             return false;
-        if (auto ptr = utxo_hash in this.storage)
+        if (auto ptr = utxo in this.storage)
         {
             value = *ptr;
-            this.used_utxos.put(utxo_hash);
+            this.used_utxos.put(utxo);
             return true;
         }
         return false;

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -119,11 +119,11 @@ public string isInvalidReason (const ref Block block, Height prev_height,
             extraSet.put(tx);
         scope extraFinder = extraSet.getUTXOFinder();
         scope UTXOFinder enrollmentsUTXOFinder =
-            (Hash hash, size_t index, out UTXOSetValue val)
+            (Hash utxo, out UTXOSetValue val)
             {
-                if (findUTXO(hash, index, val))
+                if (findUTXO(utxo, val))
                     return true;
-                return extraFinder(hash, index, val);
+                return extraFinder(utxo, val);
             };
     }
 
@@ -225,16 +225,15 @@ public string isGenesisBlockInvalidReason (const ref Block block) nothrow @safe
             ~ "ascending order by the utxo_key";
 
     Set!Hash used_utxos;
-    bool findUTXO (Hash utxo_hash, size_t index, out UTXOSetValue value)
-        nothrow @safe
+    bool findUTXO (Hash utxo, out UTXOSetValue value) nothrow @safe
     {
-        if (utxo_hash in used_utxos)
+        if (utxo in used_utxos)
             return false;  // double-spend
 
-        if (auto ptr = utxo_hash in utxo_set)
+        if (auto ptr = utxo in utxo_set)
         {
             value = *ptr;
-            used_utxos.put(utxo_hash);
+            used_utxos.put(utxo);
             return true;
         }
         return false;
@@ -527,10 +526,8 @@ unittest
 
     // contains the used set of UTXOs during validation (to prevent double-spend)
     Output[Hash] used_set;
-    UTXOFinder findNonSpent = (Hash hash, size_t index, out UTXOSetValue value)
+    scope UTXOFinder findNonSpent = (Hash utxo_hash, out UTXOSetValue value)
     {
-        auto utxo_hash = hashMulti(hash, index);
-
         if (utxo_hash in used_set)
             return false;  // double-spend
 

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -52,7 +52,7 @@ public string isInvalidReason (const ref Enrollment enrollment,
     UTXOFinder findUTXO) nothrow @safe
 {
     UTXOSetValue utxo_set_value;
-    if (!findUTXO(enrollment.utxo_key, size_t.max, utxo_set_value))
+    if (!findUTXO(enrollment.utxo_key, utxo_set_value))
         return "Enrollment: UTXO not found";
 
     if (utxo_set_value.type != typeof(utxo_set_value.type).Freeze)

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -67,7 +67,7 @@ public string isInvalidReason (
     string isInvalidInput (const ref Input input, ref UTXOSetValue utxo_value,
         ref Amount sum_unspent)
     {
-        if (!findUTXO(input.previous, input.index, utxo_value))
+        if (!findUTXO(UTXOSetValue.getHash(input.previous, input.index), utxo_value))
             return "Transaction: Input ref not in UTXO";
 
         if (!utxo_value.output.address.verify(input.signature, tx_hash[]))

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -846,7 +846,7 @@ unittest
             txs.all!(
                 tx => iota(tx.outputs.length).all!(
                     (idx) {
-                        return findUTXO(tx.hashFull(), idx, utxo) &&
+                        return findUTXO(UTXOSetValue.getHash(tx.hashFull(), idx), utxo) &&
                             utxo.output == tx.outputs[idx];
                     }
                 )

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -196,7 +196,7 @@ public class Validator : FullNode, API
         foreach (utxo; utxos)
         {
             UTXOSetValue value;
-            assert(finder(utxo, size_t.max, value));
+            assert(finder(utxo, value));
             keys ~= value.output.address;
         }
 

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -213,7 +213,7 @@ unittest
     // even if it's double spending
     const genesis_block = node_1.getBlocksFrom(0, 1)[0];
     auto reason = txs[0].isInvalidReason(
-        (Hash hash, size_t index, out UTXOSetValue value)
+        (Hash utxo, out UTXOSetValue value)
         {
             value = UTXOSetValue(0, TxType.Payment, txs[0].outputs[0]);
             return true;


### PR DESCRIPTION
The UTXOFinder should find UTXOs by their key,
which is the hash of the UTXO, instead of relying
on the decomposed key (tx hash + index).
This is a break of abstraction that is also present in `Input`,
and this commit is a first step towards fixing bpfkora/agora#1286 .