### PR TITLE
Change Input hash to match UTXO's hash

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -1332,15 +1332,15 @@ unittest
 
     utxos.sort();  // must be sorted by enrollment key
     assert(man.getRandomSeed(utxos, Height(1)) ==
-        Hash(`0xbc2a03ae4e9f00074ff201425bf5ad330c311dfd5c9ae54d38bfcfe4f2f02dbd99d6a25c975be9228fe4c9833e423bec9cb1039b05f4d0a23ca2c9310b936849`),
+        Hash(`0xd8cfe737d39a17c8715600036b29cb15d5fea5fad805c10eb405f694f343c30ed652fb1195efd1e3078723dfa669de70532cc35f8ac993503670658f92142155`),
         man.getRandomSeed(utxos, Height(1)).to!string);
 
     assert(man.getRandomSeed(utxos, Height(504)) ==
-        Hash(`0xfd2e526f102abb279b21dfaa88ced3eae8bc373fbda3a5b377776bf7b5830c0776370fca30ab978f058a0690e05ae7e795ed65cc3cd069236e78ad486d216b61`),
+        Hash(`0x05b19f0be29f24645220402a401a0d9f76ccc303082009104368180f620bc85080f9e5271f462178aeab57e1094dc525b8ba6f2e2cede1cb6b453016659cb359`),
         man.getRandomSeed(utxos, Height(504)).to!string);
 
     assert(man.getRandomSeed(utxos, Height(1008)) ==
-        Hash(`0xa9eca761735203ad896929790aa83c03a2154d8390137b2b59e92ca90150220c1992a1e3ebe318ad8049cf801b9a8b85119410131fc3c4d784ce430dd780a861`),
+        Hash(`0xa97a91babf140c65c54d168143096eb16d93ca3ecc7a9ffca46e864314e9398e9ad7063005a6b5d6c867f88abe6daf9236b15621ebb1bcad13b35b3db456122c`),
         man.getRandomSeed(utxos, Height(1008)).to!string);
 }
 

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -150,7 +150,7 @@ public struct Input
     public void computeHash (scope HashDg dg) const nothrow @safe @nogc
     {
         hashPart(this.previous, dg);
-        hashPart(this.index, dg);
+        hashPart(ulong(this.index), dg);
     }
 }
 
@@ -230,8 +230,8 @@ unittest
     );
 
     const tx_payment_hash = Hash(
-    "0x9a87d86f702cd0f519efba81cf379f2a06907f34df6546f93c8619af113d0d774" ~
-    "041b8e45f7975890b98890c7f5b0c062f6dae88ac1ec8d2c25dcf88b9aa01c9");
+        `0x1e69620e3f5cdb18952b98148d91f945383492ed6be65ec3b4ea4447e8e5ac35c` ~
+        `06d9f0734c5e558722044d68a3e9374da119025edb1a60cee18e05526256315`);
     assert(hashFull(payment_tx) == tx_payment_hash);
 
     Transaction freeze_tx = Transaction(
@@ -241,8 +241,8 @@ unittest
     );
 
     const tx_freeze_hash = Hash(
-    "0x7c8f238f70318aae788487e57eb6f4793e3b0e48fbe017c1829ec269d07a76661" ~
-    "5173e9a33739e916b1d40248a48add0296b2a8e51d0f8e1a87bf7acc7c4f136");
+        `0x2b080fbc36fee98c69578932148d77bd41680d54ba592f40c3b023e1dbaaa214` ~
+        `a8b5eec7bb19927d877dd18c567814cfea81189bd1e9236db9e91c52a6512170`);
     assert(hashFull(freeze_tx) == tx_freeze_hash);
 }
 

--- a/source/agora/consensus/data/genesis/Test.d
+++ b/source/agora/consensus/data/genesis/Test.d
@@ -105,7 +105,7 @@ public immutable Block GenesisBlock = {
                 Signature(`0x052ee1d975c49f19fd26b077740dcac399f174f40b5df1aba5f09ebea11faac` ~
                           `fd79a36ace4d3097869dc009b8939fc83bdf940c8822c6931d5c09326aa746b31`)
             ),
-            
+
             // Node 3
             Enrollment(
                 Hash(`0xdb3931bd87d2cea097533d82be0a5e36c54fec8e5570790c3369bd8300c65a0` ~

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -190,23 +190,13 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.B.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
-
-        // 1
-        QuorumConfig(6, [
-            WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
-        // 2
+        // 1
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
@@ -214,14 +204,24 @@ unittest
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
+            WK.Keys.NODE7.address]),
+
+        // 2
+        QuorumConfig(6, [
+            WK.Keys.NODE2.address,
+            WK.Keys.NODE4.address,
+            WK.Keys.B.address,
+            WK.Keys.NODE3.address,
+            WK.Keys.A.address,
+            WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
         // 3
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
+            WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
-            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
@@ -229,16 +229,16 @@ unittest
         // 4
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
-            WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
+            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
         // 5
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
+            WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
@@ -248,23 +248,23 @@ unittest
 
         // 6
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
+            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address]),
 
         // 7
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
+            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address]),
     ];
 
     static assert(quorums_1 != quorums_2);
@@ -311,8 +311,8 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
+            WK.Keys.NODE6.address,
             WK.Keys.B.address,
-            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
@@ -331,16 +331,16 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
+            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address,]),
 
         // 3
         QuorumConfig(6, [
+            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
@@ -355,12 +355,12 @@ unittest
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
+            WK.Keys.NODE5.address]),
 
         // 5
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
+            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
@@ -369,7 +369,7 @@ unittest
 
         // 6
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
+            WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
@@ -385,7 +385,7 @@ unittest
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
+            WK.Keys.NODE5.address]),
     ];
 
     static assert(quorums_2 != quorums_3);


### PR DESCRIPTION
```
There was a minor difference in how hashing was done: UTXOs were hashed using (Hash, ulong),
while the hash of an Input was done using (Hash, uint).
As a pre-requisite to fixing this, we change it to be consistent (using ulong).
```