### PR TITLE
Demonstrate Schnorr multi-sig rogue-key attack

### DIFF
--- a/source/agora/common/crypto/Schnorr.d
+++ b/source/agora/common/crypto/Schnorr.d
@@ -148,12 +148,12 @@ public struct Pair
     /// v.G
     public Point V;
 
-    /// Construct a Pair from a Scalar 
-    public static Pair fromScalar(const Scalar v) nothrow @nogc @safe 
+    /// Construct a Pair from a Scalar
+    public static Pair fromScalar(const Scalar v) nothrow @nogc @safe
     {
         return Pair(v, v.toPoint());
-    }    
-    
+    }
+
     /// Generate a random value `v` and a point on the curve `V` where `V = v.G`
     public static Pair random () nothrow @nogc @safe
     {

--- a/source/agora/common/crypto/Schnorr.d
+++ b/source/agora/common/crypto/Schnorr.d
@@ -324,7 +324,7 @@ nothrow @nogc @safe unittest
     assert(stolen_key == kp.v);
 }
 
-// possibly secure signature scheme
+// possibly secure signature scheme (requires proving ownership of private key)
 /*@nogc*/ @safe unittest
 {
     static immutable string message = "BOSAGORA for the win";


### PR DESCRIPTION
This attack is possible when the parties in a multi-signature process do not prove ownership of their private keys.

Our block multi-sig scheme is secure because each node proves ownership of their key through the signing of the Enrollment. We do not have to change that scheme.

However, for regular users using the existing schnorr multi-sig scheme is insecure.

Resources:
- https://tlu.tarilabs.com/cryptography/digital_signatures/introduction_schnorr_signatures.html#key-cancellation-attack
- https://blockstream.com/2018/01/23/en-musig-key-aggregation-schnorr-signatures/#:~:text=not%20secure.

I strongly suggest that we look into some of the proposed secure multi-sig schemes, such as MuSig (there are other alternatives too).

Resources:
- https://tlu.tarilabs.com/cryptography/musig-schnorr-sig-scheme/The_MuSig_Schnorr_Signature_Scheme.html