### PR TITLE
Use base class functions to simplify test code

### DIFF
--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -93,7 +93,7 @@ unittest
         auto new_tx = genBlockTransactions(1);
         left_txs ~= new_tx;
         new_tx.each!(tx => nodes[0].putTransaction(tx));
-        network.expectBlock(nodes[0 .. 4], Height(1 + block_idx + 1));
+        network.expectBlock(iota(0, 4), Height(1 + block_idx + 1));
         retryFor(nodes[full_node_idx].getBlockHeight() == 1, 1.seconds,
             format!"Expected Full node height of exactly 1 not %s"(nodes[full_node_idx].getBlockHeight()));
     }

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -13,238 +13,87 @@
 
 module agora.test.ManyValidators;
 
+version (unittest):
+
+void manyValidators (size_t validators)
+{
+    import agora.test.Base : TestConf, GenesisValidators, GenesisValidatorCycle,
+        makeTestNetwork;
+    import agora.common.Types : Height;
+    import agora.consensus.data.Transaction : TxType;
+    import agora.utils.Test : genesisSpendable, retryFor;
+    import std.algorithm;
+    import std.format;
+    import std.range;
+    import core.time : seconds;
+
+    TestConf conf = { outsider_validators : validators - GenesisValidators,
+        txs_to_nominate : 0 };
+
+    auto network = makeTestNetwork(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    // generate 18 blocks, 2 short of the enrollments expiring.
+    network.generateBlocks(Height(GenesisValidatorCycle - 2));
+
+    const keys = network.nodes.map!(node => node.client.getPublicKey())
+        .dropExactly(GenesisValidators).takeExactly(conf.outsider_validators)
+        .array;
+
+    // prepare frozen outputs for outsider validators to enroll
+    genesisSpendable().dropExactly(1).takeExactly(1)
+        .map!(txb => txb.split(keys).sign(TxType.Freeze))
+        .each!(tx => network.clients[0].putTransaction(tx));
+
+    // block 19
+    network.generateBlocks(Height(GenesisValidatorCycle - 1));
+
+    // make sure outsiders are up to date
+    network.expectBlock(iota(GenesisValidators, validators),
+        Height(GenesisValidatorCycle - 1));
+
+    // Now we enroll new validators and re-enroll the original validators
+    iota(validators).each!(idx => network.enroll(idx));
+
+    // Generate the last block of cycle with Genesis validators
+    network.generateBlocks(iota(GenesisValidators),
+        Height(GenesisValidatorCycle), Height(0));
+
+    // make sure outsiders are up to date
+    network.expectBlock(iota(GenesisValidators, validators),
+        Height(GenesisValidatorCycle));
+
+    // check all validators are enrolled
+    network.clients.enumerate.each!((idx, node) =>
+        retryFor(node.getValidatorCount() == validators, 5.seconds,
+            format("Node %s has validator count %s. Expected: %s",
+                idx, node.getValidatorCount(), validators)));
+
+    // first validated block using all nodes
+    network.generateBlocks(iota(validators), Height(GenesisValidatorCycle + 1),
+        Height(GenesisValidatorCycle));
+}
+
+/// 8 nodes
+unittest
+{
+    manyValidators(8);
+}
+
 // temporarily disabled until failures are resolved
 // see #1145
 version (none):
-
-import agora.api.Validator;
-import agora.common.Amount;
-import agora.common.Config;
-import agora.consensus.data.Params;
-import agora.common.crypto.Key;
-import agora.common.Hash;
-import agora.consensus.data.Block;
-import agora.consensus.data.Enrollment;
-import agora.consensus.data.Transaction;
-import agora.node.FullNode;
-import agora.test.Base;
-
-import std.algorithm;
-import std.format;
-import std.range;
-
-import core.thread;
-import core.time;
-
 /// 16 nodes
 unittest
 {
-    TestConf conf = {
-        outsider_validators : 10,
-        extra_blocks : GenesisValidatorCycle - 4 };
-
-    auto network = makeTestNetwork(conf);
-    network.start();
-    scope(exit) network.shutdown();
-    scope(failure) network.printLogs();
-    network.waitForDiscovery();
-
-    auto nodes = network.clients;
-    Height expected_block = Height(conf.extra_blocks);
-    network.expectBlock(expected_block++);
-
-    auto spendable = network.blocks[$ - 1].txs
-        .filter!(tx => tx.type == TxType.Payment)
-        .map!(tx => iota(tx.outputs.length)
-            .map!(idx => TxBuilder(tx, cast(uint)idx)))
-        .joiner().array;
-
-    // discarded UTXOs (just to trigger block creation)
-    auto txs = spendable[0 .. 6]
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
-        .array;
-
-    // 16 utxos for freezing, 8 utxos for creating a block later
-    txs ~= spendable[6].split(WK.Keys.byRange
-        .take(conf.outsider_validators + GenesisValidators).map!(k => k.address))
-        .sign();
-    txs ~= spendable[7].split(WK.Keys.Genesis.address.repeat(8)).sign();
-    txs.each!(tx => nodes[0].putTransaction(tx));
-    // block 17
-    network.expectBlock(expected_block++);
-
-    // freeze builders
-    auto freezable = txs[$ - 2]  // contains 16 payment UTXOs
-        .outputs.length.iota
-        .takeExactly(conf.outsider_validators + GenesisValidators)  // there might be more UTXOs
-        .map!(idx => TxBuilder(txs[$ - 2], cast(uint)idx))
-        .array;
-
-    // create 16 freeze TXs
-    auto freeze_txs = freezable
-        .enumerate
-        .map!(pair => pair.value.refund(WK.Keys[pair.index].address)
-            .sign(TxType.Freeze))
-        .array;
-
-    // block 18
-    freeze_txs[0 .. 8].each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(expected_block++);
-
-    // block 19
-    freeze_txs[8 .. 16].each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(expected_block++);
-
-    // now we re-enroll existing validators (extension),
-    // and enroll 10 new validators.
-    foreach (node; nodes)
-    {
-        Enrollment enroll = node.createEnrollmentData();
-        node.enrollValidator(enroll);
-
-        // check enrollment
-        nodes.each!(n =>
-            retryFor(n.getEnrollment(enroll.utxo_key) == enroll, 5.seconds));
-    }
-
-    // at block height 20 the validator set changes
-    txs = txs[$ - 1]  // take those 8 UTXOs from #L184
-            .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 1], cast(uint)idx))
-            .takeExactly(8)  // there might be more than 8
-            .map!(txb => txb.refund(WK.Keys.Genesis.address).sign()).array;
-        txs.each!(tx => nodes[0].putTransaction(tx));
-
-    // Block 20
-    network.expectBlock(expected_block++);
-
-    // sanity check
-    nodes.enumerate.each!((idx, node) =>
-        retryFor(node.getValidatorCount() == 16, 3.seconds,
-            format("Node %s has validator count %s. Expected: %s",
-                idx, node.getValidatorCount(), 16)));
-
-    // first validated block using 16 nodes
-    txs = txs
-        .map!(tx => iota(tx.outputs.length)
-            .map!(idx => TxBuilder(tx, cast(uint)idx)))
-        .joiner()
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
-        .takeExactly(8)
-        .array;
-    txs.each!(tx => nodes[0].putTransaction(tx));
-
-    // consensus check
-    network.expectBlock(expected_block);
+    manyValidators(16);
 }
 
 /// 32 nodes
-/// Disabled due to significant network overhead,
-/// Block creation fails for 32 nodes.
-version (none)
 unittest
 {
-    TestConf conf = {
-        timeout : 10.seconds,
-        outsider_validators : 26,
-        extra_blocks : 7,
-        validator_cycle : 13 };
-
-    auto network = makeTestNetwork(conf);
-    network.start();
-    scope(exit) network.shutdown();
-    scope(failure) network.printLogs();
-    network.waitForDiscovery();
-
-    auto nodes = network.clients;
-    network.expectBlock(Height(7));
-
-    auto spendable = network.blocks[$ - 1].txs
-        .filter!(tx => tx.type == TxType.Payment)
-        .map!(tx => iota(tx.outputs.length)
-            .map!(idx => TxBuilder(tx, cast(uint)idx)))
-        .joiner().array;
-
-    // discarded UTXOs (just to trigger block creation)
-    auto txs = spendable[0 .. 6]
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
-        .array;
-
-    // 32 utxos for freezing, 8 utxos for creating a block later
-    txs ~= spendable[6].split(WK.Keys.byRange.take(32).map!(k => k.address)).sign();
-    txs ~= spendable[7].split(WK.Keys.Genesis.address.repeat(8)).sign();
-    txs.each!(tx => nodes[0].putTransaction(tx));
-
-    // block 8
-    network.expectBlock(Height(8));
-
-    // freeze builders
-    auto freezable = txs[$ - 2]  // contains 32 payment UTXOs
-        .outputs.length.iota
-        .takeExactly(32)  // there might be more UTXOs
-        .map!(idx => TxBuilder(txs[$ - 2], cast(uint)idx))
-        .array;
-
-    // create 32 freeze TXs
-    auto freeze_txs = freezable
-        .enumerate
-        .map!(pair => pair.value.refund(WK.Keys[pair.index].address)
-            .sign(TxType.Freeze))
-        .array;
-    assert(freeze_txs.length == 32);
-
-    // block 9
-    freeze_txs[0 .. 8].each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(9));
-
-    // block 10
-    freeze_txs[8 .. 16].each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(10));
-
-    // block 11
-    freeze_txs[16 .. 24].each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(11));
-
-    // block 12
-    freeze_txs[24 .. 32].each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(12));
-
-    // now we re-enroll existing validators (extension),
-    // and enroll 10 new validators.
-    foreach (node; nodes)
-    {
-        Enrollment enroll = node.createEnrollmentData();
-        node.enrollValidator(enroll);
-
-        // check enrollment
-        nodes.each!(n =>
-            retryFor(n.getEnrollment(enroll.utxo_key) == enroll, 5.seconds));
-    }
-
-    // at block height 13 the validator set changes
-    txs = txs[$ - 1]  // take those 8 UTXOs from #L184
-            .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 1], cast(uint)idx))
-            .takeExactly(8)  // there might be more than 8
-            .map!(txb => txb.refund(WK.Keys.Genesis.address).sign()).array;
-        txs.each!(tx => nodes[0].putTransaction(tx));
-
-    network.expectBlock(Height(13));
-
-    // sanity check
-    nodes.enumerate.each!((idx, node) =>
-        retryFor(node.getValidatorCount() == 32, 8.seconds,
-            format("Node %s has validator count %s. Expected: %s",
-                idx, node.getValidatorCount(), 32)));
-
-    // first validated block using 32 nodes
-    txs = txs
-        .map!(tx => iota(tx.outputs.length)
-            .map!(idx => TxBuilder(tx, cast(uint)idx)))
-        .joiner()
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
-        .takeExactly(8)
-        .array;
-    txs.each!(tx => nodes[0].putTransaction(tx));
-
-    // consensus check
-    network.expectBlock(Height(14));
+    manyValidators(32);
 }

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -185,17 +185,18 @@ unittest
     // create genesis block
     last_txs = genesisSpendable().map!(txb => txb.sign()).array();
     last_txs.each!(tx => node_validators[0].putTransaction(tx));
-    network.expectBlock([node_validators[0]], Height(1));
+    network.expectBlock(iota(1), Height(1));
 
     // create 1 additional block and enough `tx`es
     auto txs = last_txs.map!(tx => TxBuilder(tx).sign()).array();
     // send it to one node
     txs.each!(tx => node_validators[0].putTransaction(tx));
-    network.expectBlock([node_validators[0]], Height(2));
+    network.expectBlock(iota(1), Height(2));
     last_txs = txs;
 
     // the validator node has 2 blocks, but bad node pretends to have 3
-    assert(node_validators[0].getBlockHeight() == 2, node_validators[0].getBlockHeight().to!string);
+    assert(node_validators[0].getBlockHeight() == 2,
+        node_validators[0].getBlockHeight().to!string);
     assert(node_bad.getBlockHeight() == 3);
     assert(node_test.getBlockHeight() == 0);  // only genesis
 
@@ -204,6 +205,5 @@ unittest
 
     // node test will accept its blocks from node_validator,
     // as the blocks in node_bad do not pass validation
-    retryFor(node_test.getBlockHeight() == 2, 4.seconds);
-    assert(containSameBlocks([node_test, node_validators[0]], 2));
+    network.assertSameBlocks(iota(GenesisValidators + 1), Height(2));
 }

--- a/source/agora/test/TimeBlockInterval.d
+++ b/source/agora/test/TimeBlockInterval.d
@@ -54,19 +54,15 @@ unittest
 
     // time updated, block height 1
     const b0 = nodes[0].getBlocksFrom(0, 2)[0];
-    network.setTimeFor(Height(1));
-    network.waitForPreimages(b0.header.enrollments, 1);
-    ensureConsistency(nodes, 1);
 
-    network.setTimeFor(Height(2));
-    network.waitForPreimages(b0.header.enrollments, 2);
-    ensureConsistency(nodes, 2);
+    void checkHeight(Height height)
+    {
+        network.waitForPreimages(b0.header.enrollments,
+            cast(ushort) (height - 1));
+        network.setTimeFor(height);
+        network.assertSameBlocks(height);
+    }
 
-    network.setTimeFor(Height(3));
-    network.waitForPreimages(b0.header.enrollments, 3);
-    ensureConsistency(nodes, 3);
-
-    network.setTimeFor(Height(4));
-    network.waitForPreimages(b0.header.enrollments, 4);
-    ensureConsistency(nodes, 4);
+    // Check for adding blocks 1 to 4
+    [1, 2, 3, 4].each!(h => checkHeight(Height(h)));
 }

--- a/source/agora/test/ValidatorCount.d
+++ b/source/agora/test/ValidatorCount.d
@@ -63,8 +63,9 @@ unittest
 
     // Block will not be created because otherwise there would be no active validators
     {
-        txs = blocks[GenesisValidatorCycle - 1].spendable().map!(txb => txb.sign()).array();
-        txs.each!(tx => node_1.putTransaction(tx));
+        blocks[GenesisValidatorCycle - 1].spendable()
+            .map!(txb => txb.sign())
+            .each!(tx => node_1.putTransaction(tx));
 
         // try to add next block
          blocks ~= node_1.getBlocksFrom(GenesisValidatorCycle, 1);
@@ -74,5 +75,6 @@ unittest
     Thread.sleep(2.seconds);  // wait for propagation
 
     // New block was not created because all validators would expire
-    containSameBlocks(nodes, GenesisValidatorCycle - 1).retryFor(5.seconds);
+    network.assertSameBlocks(iota(network.nodes.length),
+        Height(GenesisValidatorCycle - 1));
 }

--- a/source/agora/test/VariableBlockSize.d
+++ b/source/agora/test/VariableBlockSize.d
@@ -30,9 +30,6 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.clients;
-    auto node_1 = nodes[0];
-
     auto spendable = network.blocks[0].txs
         .filter!(tx => tx.type == TxType.Payment)
         .map!(tx => iota(tx.outputs.length)
@@ -45,11 +42,11 @@ unittest
 
     foreach (block_idx, block_txs; txs.chunks(txs_to_nominate).enumerate)
     {
-        block_txs.each!(tx => nodes[0].putTransaction(tx));
+        block_txs.each!(tx => network.clients[0].putTransaction(tx));
         network.expectBlock(Height(block_idx + 1), network.blocks[0].header,
             5.seconds);
     }
 
     // 8 txs will create 4 blocks if we nominate 2 per block
-    ensureConsistency(nodes, 4);
+    network.assertSameBlocks(Height(4));
 }


### PR DESCRIPTION
Now that we are using the test GenesisBlock many of the tests can be simplified.