### PR TITLE
Implement additional methods for TestUTXOSet

### DIFF
--- a/source/agora/consensus/state/UTXOSet.d
+++ b/source/agora/consensus/state/UTXOSet.d
@@ -347,7 +347,6 @@ private class UTXODB
 unittest
 {
     import agora.common.Amount;
-    import agora.consensus.data.Transaction;
     import agora.consensus.data.UTXO;
 
     KeyPair[] key_pairs = [KeyPair.random, KeyPair.random];


### PR DESCRIPTION
The storage of the `TestUTXOSet` is able to be updated.
The `UTXO`s could only be added to the storage, and not be deleted.
Now, they are cleared if they are spent.

Improves [faucet](https://github.com/bpfkorea/faucet)