### PR TITLE
Add validation to Point and check constructed Points are valid before use.

### DIFF
--- a/source/agora/common/crypto/Schnorr.d
+++ b/source/agora/common/crypto/Schnorr.d
@@ -148,12 +148,12 @@ public struct Pair
     /// v.G
     public Point V;
 
-    /// Construct a Pair from a Scalar 
-    public static Pair fromScalar(const Scalar v) nothrow @nogc @safe 
+    /// Construct a Pair from a Scalar
+    public static Pair fromScalar(const Scalar v) nothrow @nogc @safe
     {
         return Pair(v, v.toPoint());
-    }    
-    
+    }
+
     /// Generate a random value `v` and a point on the curve `V` where `V = v.G`
     public static Pair random () nothrow @nogc @safe
     {


### PR DESCRIPTION
Fixes Issue #1279: The idea is to validate that the data used to construct a `Point` is for a valid _ED25519 curve point_. For this we use the _libsodium_ `crypto_core_ed25519_is_valid_point` function. This PR adds an `isValid()` function to the Point struct.
When we verify a signature we already check the `Scalar` from the signature is valid. Now we also check that the provided _Public Key Point_ and the _Point R from the signature_ are also a valid `Point`s.
