### PR TITLE
Make UTXO-sensible tests use either `peekUTXO` or `getUTXOFinder`

### DIFF
--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -355,10 +355,10 @@ unittest
         enrollments ~= createEnrollment(utxo_hash, key_pair, seed_sources[utxo_hash],
             params.ValidatorCycle);
         avail_height = Height(params.ValidatorCycle);
-        assert(pool.add(enrollments[$ - 1], avail_height, &storage.findUTXO));
+        assert(pool.add(enrollments[$ - 1], avail_height, storage.getUTXOFinder()));
         assert(pool.count() == index + 1);
         assert(pool.hasEnrollment(utxo_hash, avail_height));
-        assert(!pool.add(enrollments[$ - 1], avail_height, &storage.findUTXO));
+        assert(!pool.add(enrollments[$ - 1], avail_height, storage.getUTXOFinder()));
     }
 
     // check if enrolled heights are not set
@@ -396,7 +396,7 @@ unittest
     Enrollment[] ordered_enrollments = enrollments.dup;
     ordered_enrollments.sort!("a.utxo_key > b.utxo_key");
     foreach (ordered_enroll; ordered_enrollments)
-        assert(pool.add(ordered_enroll, Height(1), &storage.findUTXO));
+        assert(pool.add(ordered_enroll, Height(1), &storage.peekUTXO));
     pool.getEnrollments(enrolls, Height(1));
     assert(enrolls.length == 3);
     assert(enrolls.isStrictlyMonotonic!("a.utxo_key < b.utxo_key"));

--- a/source/agora/consensus/Quorum.d
+++ b/source/agora/consensus/Quorum.d
@@ -503,7 +503,7 @@ private QuorumConfig[PublicKey] buildTestQuorums (Range)(Range amounts,
     foreach (idx, _; amounts.enumerate)
     {
         quorums[keys[idx]] = buildQuorumConfig(
-            keys[idx], utxos, &storage.findUTXO, rand_seed, params);
+            keys[idx], utxos, &storage.peekUTXO, rand_seed, params);
     }
 
     return quorums;

--- a/source/agora/consensus/data/UTXO.d
+++ b/source/agora/consensus/data/UTXO.d
@@ -84,12 +84,8 @@ public class TestUTXOSet
     public UTXOFinder getUTXOFinder () @trusted nothrow
     {
         this.used_utxos.clear();
-        return &this.findUTXO_;
+        return &this.findUTXO;
     }
-
-    /// FIXME: Remove and make UTXO-sensible tests use either `peekUTXO`
-    /// or `getUTXOFinder`
-    public alias findUTXO = peekUTXO;
 
     /// Get an UTXO, no double-spend protection
     public bool peekUTXO (Hash utxo, out UTXO value)
@@ -126,7 +122,7 @@ public class TestUTXOSet
     }
 
     /// Get an UTXO, does not return double spend
-    private bool findUTXO_ (Hash utxo, out UTXO value)
+    public bool findUTXO (Hash utxo, out UTXO value)
         nothrow @safe
     {
         // Note: Keep this in sync with the real `findUTXO`

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -572,21 +572,21 @@ unittest
     seed_sources[utxos[0]] = Scalar.random();
     auto enroll = createEnrollment(utxos[0], WK.Keys[0], seed_sources[utxos[0]],
         set.params.ValidatorCycle);
-    assert(set.add(Height(1), &storage.findUTXO, enroll) is null);
+    assert(set.add(Height(1), &storage.peekUTXO, enroll) is null);
     assert(set.count() == 1);
     assert(set.hasEnrollment(utxos[0]));
-    assert(set.add(Height(1), &storage.findUTXO, enroll) !is null);
+    assert(set.add(Height(1), &storage.peekUTXO, enroll) !is null);
 
     seed_sources[utxos[1]] = Scalar.random();
     auto enroll2 = createEnrollment(utxos[1], WK.Keys[1], seed_sources[utxos[1]],
         set.params.ValidatorCycle);
-    assert(set.add(Height(1), &storage.findUTXO, enroll2) is null);
+    assert(set.add(Height(1), &storage.peekUTXO, enroll2) is null);
     assert(set.count() == 2);
 
     seed_sources[utxos[2]] = Scalar.random();
     auto enroll3 = createEnrollment(utxos[2], WK.Keys[2], seed_sources[utxos[2]],
         set.params.ValidatorCycle);
-    assert(set.add(Height(9), &storage.findUTXO, enroll3) is null);
+    assert(set.add(Height(9), &storage.peekUTXO, enroll3) is null);
     assert(set.count() == 3);
 
     // check if enrolled heights are not set
@@ -615,7 +615,7 @@ unittest
     // Reverse ordering
     ordered_enrollments.sort!("a.utxo_key > b.utxo_key");
     foreach (ordered_enroll; ordered_enrollments)
-        assert(set.add(Height(1), &storage.findUTXO, ordered_enroll) is null);
+        assert(set.add(Height(1), storage.getUTXOFinder(), ordered_enroll) is null);
     set.getEnrolledUTXOs(keys);
     assert(keys.length == 3);
     assert(keys.isStrictlyMonotonic!("a < b"));
@@ -643,7 +643,7 @@ unittest
     seed_sources[utxos[3]] = Scalar.random();
     enroll = createEnrollment(utxos[3], WK.Keys[3], seed_sources[utxos[3]],
         set.params.ValidatorCycle);
-    assert(set.add(Height(9), &storage.findUTXO, enroll) is null);
+    assert(set.add(Height(9), &storage.peekUTXO, enroll) is null);
     set.clearExpiredValidators(Height(1016));
     keys.length = 0;
     assert(set.getEnrolledUTXOs(keys));
@@ -657,7 +657,7 @@ unittest
     seed_sources[utxos[0]] = Scalar.random();
     enroll = createEnrollment(utxos[0], WK.Keys[0], seed_sources[utxos[0]],
         set.params.ValidatorCycle);
-    assert(set.add(Height(0), &storage.findUTXO, enroll) is null);
+    assert(set.add(Height(0), &storage.peekUTXO, enroll) is null);
 
     // not cleared yet at height 1007
     set.clearExpiredValidators(Height(1007));
@@ -677,7 +677,7 @@ unittest
     seed_sources[utxos[0]] = Scalar.random();
     enroll = createEnrollment(utxos[0], WK.Keys[0], seed_sources[utxos[0]],
         set.params.ValidatorCycle);
-    assert(set.add(Height(1), &storage.findUTXO, enroll) is null);
+    assert(set.add(Height(1), &storage.peekUTXO, enroll) is null);
 
     // not cleared yet at height 1008
     set.clearExpiredValidators(Height(1008));

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -427,7 +427,7 @@ unittest
     import std.range;
 
     scope utxos = new TestUTXOSet();
-    scope findUTXO = &utxos.findUTXO;
+    scope findUTXO = &utxos.peekUTXO;
 
     auto gen_key = WK.Keys.Genesis;
     assert(GenesisBlock.isGenesisBlockValid());

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -171,21 +171,21 @@ unittest
     secondTx.inputs[0].signature = key_pairs[0].secret.sign(hashFull(secondTx)[]);
 
     // It is validated. (the sum of `Output` < the sum of `Input`)
-    assert(secondTx.isValid(&storage.findUTXO, Height(0)),
+    assert(secondTx.isValid(storage.getUTXOFinder(), Height(0)),
            format("Transaction data is not validated %s", secondTx));
 
     secondTx.outputs ~= Output(Amount(50), key_pairs[2].address);
     secondTx.inputs[0].signature = key_pairs[0].secret.sign(hashFull(secondTx)[]);
 
     // It is validated. (the sum of `Output` == the sum of `Input`)
-    assert(secondTx.isValid(&storage.findUTXO, Height(0)),
+    assert(secondTx.isValid(storage.getUTXOFinder(), Height(0)),
            format("Transaction data is not validated %s", secondTx));
 
     secondTx.outputs ~= Output(Amount(50), key_pairs[3].address);
     secondTx.inputs[0].signature = key_pairs[0].secret.sign(hashFull(secondTx)[]);
 
     // It isn't validated. (the sum of `Output` > the sum of `Input`)
-    assert(!secondTx.isValid(&storage.findUTXO, Height(0)),
+    assert(!secondTx.isValid(storage.getUTXOFinder(), Height(0)),
            format("Transaction data is not validated %s", secondTx));
 }
 
@@ -210,7 +210,7 @@ unittest
 
     tx_2.inputs[0].signature = key_pairs[0].secret.sign(hashFull(tx_2)[]);
 
-    assert(!tx_2.isValid(&storage.findUTXO, Height(0)));
+    assert(!tx_2.isValid(storage.getUTXOFinder(), Height(0)));
 
     // Creates the third transaction.
     // Reject a transaction whose output value is zero
@@ -223,7 +223,7 @@ unittest
 
     tx_3.inputs[0].signature = key_pairs[0].secret.sign(hashFull(tx_3)[]);
 
-    assert(!tx_3.isValid(&storage.findUTXO, Height(0)));
+    assert(!tx_3.isValid(storage.getUTXOFinder(), Height(0)));
 }
 
 /// This creates a new transaction and signs it as a publickey
@@ -260,7 +260,7 @@ unittest
     tx1.inputs[0].signature = key_pairs[0].secret.sign(tx1Hash[]);
     storage.put(tx1);
 
-    assert(tx1.isValid(&storage.findUTXO, Height(0)),
+    assert(tx1.isValid(storage.getUTXOFinder(), Height(0)),
            format("Transaction signature is not validated %s", tx1));
 
     Transaction tx2 = Transaction(
@@ -278,7 +278,7 @@ unittest
     tx2.inputs[0].signature = key_pairs[2].secret.sign(tx2Hash[]);
     storage.put(tx2);
     // Signature verification must be error
-    assert(!tx2.isValid(&storage.findUTXO, Height(0)),
+    assert(!tx2.isValid(storage.getUTXOFinder(), Height(0)),
            format("Transaction signature is not validated %s", tx2));
 }
 
@@ -319,7 +319,7 @@ unittest
         secondTx.inputs[0].signature = key_pairs[0].secret.sign(hashFull(secondTx)[]);
 
         // Second Transaction is valid.
-        assert(secondTx.isValid(&storage.findUTXO, Height(0)));
+        assert(secondTx.isValid(storage.getUTXOFinder(), Height(0)));
     }
 
     // When the privious transaction type is `Freeze`, second transaction type is `Freeze`.
@@ -349,7 +349,7 @@ unittest
         secondTx.inputs[0].signature = key_pairs[0].secret.sign(hashFull(secondTx)[]);
 
         // Second Transaction is invalid.
-        assert(!secondTx.isValid(&storage.findUTXO, Height(0)));
+        assert(!secondTx.isValid(storage.getUTXOFinder(), Height(0)));
     }
 
     // When the privious transaction with not enough amount at freezing.
@@ -379,7 +379,7 @@ unittest
         secondTx.inputs[0].signature = key_pairs[0].secret.sign(hashFull(secondTx)[]);
 
         // Second Transaction is invalid.
-        assert(!secondTx.isValid(&storage.findUTXO, Height(0)));
+        assert(!secondTx.isValid(storage.getUTXOFinder(), Height(0)));
     }
 
     // When the privious transaction with too many amount at freezings.
@@ -408,7 +408,7 @@ unittest
         secondTx.inputs[0].signature = key_pairs[0].secret.sign(hashFull(secondTx)[]);
 
         // Second Transaction is valid.
-        assert(secondTx.isValid(&storage.findUTXO, Height(0)));
+        assert(secondTx.isValid(storage.getUTXOFinder(), Height(0)));
     }
 }
 
@@ -480,7 +480,7 @@ unittest
         secondTx.inputs[0].signature = key_pairs[0].secret.sign(hashFull(secondTx)[]);
 
         // Second Transaction is VALID.
-        assert(secondTx.isValid(&storage.findUTXO, block_height));
+        assert(secondTx.isValid(storage.getUTXOFinder(), block_height));
 
         // Save to UTXOSet
         secondHash = hashFull(secondTx);
@@ -511,7 +511,7 @@ unittest
         thirdTx.inputs[0].signature = key_pairs[1].secret.sign(hashFull(thirdTx)[]);
 
         // Third Transaction is VALID.
-        assert(thirdTx.isValid(&storage.findUTXO, block_height));
+        assert(thirdTx.isValid(storage.getUTXOFinder(), block_height));
 
         // Save to UTXOSet
         thirdHash = hashFull(thirdTx);
@@ -542,7 +542,7 @@ unittest
         fourthTx.inputs[0].signature = key_pairs[2].secret.sign(hashFull(fourthTx)[]);
 
         // Third Transaction is INVALID.
-        assert(!fourthTx.isValid(&storage.findUTXO, block_height));
+        assert(!fourthTx.isValid(storage.getUTXOFinder(), block_height));
     }
 
     // Creates the fifth payment transaction
@@ -560,7 +560,7 @@ unittest
         fifthTx.inputs[0].signature = key_pairs[2].secret.sign(hashFull(fourthTx)[]);
 
         // Third Transaction is VALID.
-        assert(fifthTx.isValid(&storage.findUTXO, block_height));
+        assert(fifthTx.isValid(storage.getUTXOFinder(), block_height));
 
         // Save to UTXOSet
         fifthHash = hashFull(fifthTx);
@@ -596,7 +596,7 @@ unittest
     storage.put(oneTx);
 
     // test for Payment transaction having no input
-    assert(canFind(toLower(oneTx.isInvalidReason(&storage.findUTXO, Height(0))), "no input"),
+    assert(canFind(toLower(oneTx.isInvalidReason(storage.getUTXOFinder(), Height(0))), "no input"),
         format("Tx having no input should not pass validation. tx: %s", oneTx));
 
     // create a transaction
@@ -613,7 +613,7 @@ unittest
     storage.put(secondTx);
 
     // test for Freeze transaction having no output
-    assert(canFind(toLower(secondTx.isInvalidReason(&storage.findUTXO, Height(0))), "no output"),
+    assert(canFind(toLower(secondTx.isInvalidReason(storage.getUTXOFinder(), Height(0))), "no output"),
         format("Tx having no output should not pass validation. tx: %s", secondTx));
 }
 
@@ -654,7 +654,7 @@ unittest
     thirdTx.inputs[1].signature = key_pairs[0].secret.sign(thirdHash[]);
 
     // test for transaction having combined inputs
-    assert(!thirdTx.isValid(&storage.findUTXO, Height(0)),
+    assert(!thirdTx.isValid(storage.getUTXOFinder(), Height(0)),
         format("Tx having combined inputs should not pass validation. tx: %s", thirdTx));
 }
 


### PR DESCRIPTION
The `alias` has been removed and the function `findUTXO_` has been renamed to `findUTXO`.
The alias was calling only `peekUTXO`. `findUTXO` has double-spend protection, whereas `peekUTXO` does not. In the unittests, these two functions should be called according to their purpose.

Improves #1318 