### PR TITLE
Use more `in` parameters, especially for `Hash`

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -77,7 +77,7 @@ public class BanManager
 
         /// Deserialization hook
         public static QT fromBinary (QT) (
-            scope DeserializeDg dg, const ref DeserializerOptions opts) @safe
+            scope DeserializeDg dg, in DeserializerOptions opts) @safe
         {
             BannedList ret;
             size_t length = deserializeLength(dg, opts.maxLength);

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -264,7 +264,7 @@ public GetoptResult parseCommandLine (ref CommandLine cmdline, string[] args)
 
 *******************************************************************************/
 
-public Config parseConfigFile (ref const CommandLine cmdln)
+public Config parseConfigFile (in CommandLine cmdln)
 {
     Node root = Loader.fromFile(cmdln.config_path).load();
     return parseConfigImpl(cmdln, root);
@@ -302,7 +302,7 @@ network:
 }
 
 ///
-private const(string)[] parseSequence (string section, ref const CommandLine cmdln,
+private const(string)[] parseSequence (string section, in CommandLine cmdln,
         Node root, bool optional = false)
 {
     if (auto val = section in cmdln.overrides)
@@ -326,7 +326,7 @@ private const(string)[] parseSequence (string section, ref const CommandLine cmd
 }
 
 /// ditto
-private Config parseConfigImpl (ref const CommandLine cmdln, Node root)
+private Config parseConfigImpl (in CommandLine cmdln, Node root)
 {
     Config conf =
     {
@@ -352,7 +352,7 @@ private Config parseConfigImpl (ref const CommandLine cmdln, Node root)
 }
 
 /// Parse the node config section
-private NodeConfig parseNodeConfig (Node* node, const ref CommandLine cmdln)
+private NodeConfig parseNodeConfig (Node* node, in CommandLine cmdln)
 {
     auto min_listeners = get!(size_t, "node", "min_listeners")(cmdln, node);
     auto max_listeners = get!(size_t, "node", "max_listeners")(cmdln, node);
@@ -439,7 +439,7 @@ node:
 }
 
 /// Parse the validator config section
-private ValidatorConfig parseValidatorConfig (Node* node, const ref CommandLine cmdln)
+private ValidatorConfig parseValidatorConfig (Node* node, in CommandLine cmdln)
 {
     const enabled = get!(bool, "validator", "enabled")(cmdln, node);
     if (!enabled)
@@ -490,7 +490,7 @@ validator:
 }
 
 /// Parse the banman config section
-private BanManager.Config parseBanManagerConfig (Node* node, const ref CommandLine cmdln)
+private BanManager.Config parseBanManagerConfig (Node* node, in CommandLine cmdln)
 {
     BanManager.Config conf;
     conf.max_failed_requests = get!(size_t, "banman", "max_failed_requests")(cmdln, node);
@@ -511,7 +511,7 @@ private BanManager.Config parseBanManagerConfig (Node* node, const ref CommandLi
 
 *******************************************************************************/
 
-private LoggingConfig parseLoggingSection (Node* ptr, const ref CommandLine c)
+private LoggingConfig parseLoggingSection (Node* ptr, in CommandLine c)
 {
     LoggingConfig ret;
     ret.level = get!(LogLevel, "logging", "level")(c, ptr);
@@ -558,7 +558,7 @@ logging:
 
 /// Optionally get a value
 private T opt (T, string section, string name) (
-    const ref CommandLine cmdln, Node* node, lazy T def = T.init)
+    in CommandLine cmdln, Node* node, lazy T def = T.init)
 {
     try
         return get!(T, section, name)(cmdln, node);
@@ -567,15 +567,14 @@ private T opt (T, string section, string name) (
 }
 
 /// Helper function to get a config parameter
-private T get (T, string section, string name) (
-    const ref CommandLine cmdln, Node* node)
+private T get (T, string section, string name) (in CommandLine cmdln, Node* node)
 {
     return get!(T, section, name, (string val) => val.to!T)(cmdln, node);
 }
 
 /// Helper function to get a config parameter with a conversion routine
 private T get (T, string section, string name, alias conv)
-    (const ref CommandLine cmdl, Node* node)
+    (in CommandLine cmdl, Node* node)
 {
     static immutable QualifiedName = (section ~ "." ~ name);
 
@@ -602,7 +601,7 @@ private T get (T, string section, string name, alias conv)
 
 /// Helper function to get a config parameter with a converter
 private auto get (string section, string name, Converter) (
-    const ref CommandLine cmdl, Node* node, scope Converter converter)
+    in CommandLine cmdl, Node* node, scope Converter converter)
 {
     return converter(get!(ParameterType!convert, section, name)(cmdl, node));
 }
@@ -710,7 +709,7 @@ unittest
 
 *******************************************************************************/
 
-private EventHandlerConfig parserEventHandlers (Node* node, const ref CommandLine c)
+private EventHandlerConfig parserEventHandlers (Node* node, in CommandLine c)
 {
     if (node is null)
         return EventHandlerConfig.init;

--- a/source/agora/common/Serializer.d
+++ b/source/agora/common/Serializer.d
@@ -33,7 +33,7 @@
     struct Foo
     {
         static T fromBinary (T) (scope DeserializeDg data,
-            scope const ref DeserializerOptions) @safe;
+            in DeserializerOptions) @safe;
     }
     ---
     The deserializer might request an instance of a `const` or `immutable`
@@ -156,7 +156,7 @@ unittest
         }
 
         static QT fromBinary (QT) (
-            scope DeserializeDg dg, const ref DeserializerOptions opts)
+            scope DeserializeDg dg, in DeserializerOptions opts)
             @safe
         {
             // One need to use temporary values for this,
@@ -218,7 +218,7 @@ unittest
         ubyte[] data;
 
         public static QT fromBinary (QT) (
-            scope DeserializeDg dg, const ref DeserializerOptions opts) @safe
+            scope DeserializeDg dg, in DeserializerOptions opts) @safe
         {
             // The following is incorrect because it doesn't account for
             // type constructors (e.g. `immutable`).
@@ -593,7 +593,7 @@ public T deserializeFull (T) (scope const(ubyte)[] data) @safe
 
 /// Ditto
 public T deserializeFull (T) (scope DeserializeDg dg,
-    const ref DeserializerOptions opts = DeserializerOptions.Default) @safe
+    in DeserializerOptions opts = DeserializerOptions.Default) @safe
 {
     // Custom deserialization trumps everything
     static if (hasFromBinaryFunction!T)

--- a/source/agora/common/TransactionPool.d
+++ b/source/agora/common/TransactionPool.d
@@ -201,7 +201,8 @@ public class TransactionPool
         if (is(DGT : int delegate(Transaction)) ||
             is(DGT : int delegate(ref Transaction)) ||
             is(DGT : int delegate(const Transaction)) ||
-            is(DGT : int delegate(const ref Transaction)))
+            is(DGT : int delegate(const ref Transaction)) ||
+            is(DGT : int delegate(in Transaction)))
     {
         () @trusted
         {

--- a/source/agora/common/TransactionPool.d
+++ b/source/agora/common/TransactionPool.d
@@ -245,7 +245,7 @@ public class TransactionPool
 
     ***************************************************************************/
 
-    public bool hasTransactionHash (const ref Hash tx) @trusted
+    public bool hasTransactionHash (in Hash tx) @trusted
     {
         return this.db.execute("SELECT EXISTS(SELECT 1 FROM " ~
             "tx_pool WHERE key = ?)", tx[]).front.peek!bool(0);

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -180,7 +180,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public Height getEnrolledHeight (const ref Hash enroll_hash)
+    public Height getEnrolledHeight (in Hash enroll_hash)
         @trusted nothrow
     {
         return this.validator_set.getEnrolledHeight(enroll_hash);
@@ -310,7 +310,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public Enrollment createEnrollment (Hash utxo) @safe nothrow
+    public Enrollment createEnrollment (in Hash utxo) @safe nothrow
     {
         // K, frozen UTXO hash
         this.enroll_key = utxo;
@@ -353,7 +353,7 @@ public class EnrollmentManager
     ***************************************************************************/
 
     public static Enrollment makeEnrollment (
-        Pair key, const ref Hash utxo, uint cycle_length, Hash seed, ulong offset)
+        Pair key, in Hash utxo, uint cycle_length, in Hash seed, ulong offset)
         @safe nothrow @nogc
     {
         Enrollment result = {
@@ -372,7 +372,7 @@ public class EnrollmentManager
 
     /// Ditto
     version (unittest) public static Enrollment makeEnrollment (
-        KeyPair key, const Hash utxo, uint cycle_length, uint offset = 0)
+        KeyPair key, in Hash utxo, uint cycle_length, uint offset = 0)
         @trusted nothrow
     {
         // Convert stellar-type keypair to curve scalars
@@ -513,7 +513,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public bool hasPreimage (const ref Hash enroll_key, ushort distance) @safe
+    public bool hasPreimage (in Hash enroll_key, ushort distance) @safe
         nothrow
     {
         return this.validator_set.hasPreimage(enroll_key, distance);
@@ -572,7 +572,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public PreImageInfo getValidatorPreimage (const ref Hash enroll_key)
+    public PreImageInfo getValidatorPreimage (in Hash enroll_key)
         @trusted nothrow
     {
         return this.validator_set.getPreimage(enroll_key);
@@ -708,7 +708,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    private void setEnrollmentKey (const ref Hash enroll_key) @trusted nothrow
+    private void setEnrollmentKey (in Hash enroll_key) @trusted nothrow
     {
         this.enroll_key = enroll_key;
 
@@ -880,7 +880,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public Enrollment getEnrollment (const ref Hash enroll_hash) @trusted
+    public Enrollment getEnrollment (in Hash enroll_hash) @trusted
     {
         return this.enroll_pool.getEnrollment(enroll_hash);
     }
@@ -894,7 +894,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public void removeEnrollment (const ref Hash enroll_hash) @trusted
+    public void removeEnrollment (in Hash enroll_hash) @trusted
     {
         this.enroll_pool.remove(enroll_hash);
     }

--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -154,7 +154,7 @@ public class EnrollmentPool
 
     ***************************************************************************/
 
-    public void remove (const ref Hash enroll_hash) @trusted nothrow
+    public void remove (in Hash enroll_hash) @trusted nothrow
     {
         try
         {
@@ -180,7 +180,7 @@ public class EnrollmentPool
 
     ***************************************************************************/
 
-    public bool hasEnrollment (const ref Hash enroll_hash, Height avail_height)
+    public bool hasEnrollment (in Hash enroll_hash, Height avail_height)
         @trusted nothrow
     {
         try
@@ -211,7 +211,7 @@ public class EnrollmentPool
 
     ***************************************************************************/
 
-    public Enrollment getEnrollment (const ref Hash enroll_hash)
+    public Enrollment getEnrollment (in Hash enroll_hash)
         @trusted nothrow
     {
         try
@@ -246,7 +246,7 @@ public class EnrollmentPool
 
     ***************************************************************************/
 
-    public Height getAvailableHeight (const ref Hash enroll_hash)
+    public Height getAvailableHeight (in Hash enroll_hash)
         @trusted nothrow
     {
         try
@@ -304,7 +304,7 @@ public class EnrollmentPool
 }
 
 version (unittest)
-private Enrollment createEnrollment(const ref Hash utxo_key,
+private Enrollment createEnrollment(in Hash utxo_key,
     const ref KeyPair key_pair, ref Scalar random_seed_src,
     uint validator_cycle)
 {

--- a/source/agora/consensus/Quorum.d
+++ b/source/agora/consensus/Quorum.d
@@ -76,9 +76,9 @@ public struct QuorumParams
 
 *******************************************************************************/
 
-public QuorumConfig buildQuorumConfig ( const ref PublicKey key,
-    in Hash[] utxo_keys, scope UTXOFinder finder, const ref Hash rand_seed,
-    const ref QuorumParams params )
+public QuorumConfig buildQuorumConfig (in PublicKey key,
+    in Hash[] utxo_keys, scope UTXOFinder finder, in Hash rand_seed,
+    const ref QuorumParams params)
     @safe nothrow
 {
     // special-case: only 1 validator is active
@@ -374,7 +374,7 @@ private const(PublicKey)[] getKeys (size_t count)
 }
 
 /// Create a shorthash from a 64-byte blob for RNG initialization
-private ulong toShortHash (const ref Hash hash) @trusted nothrow
+private ulong toShortHash (in Hash hash) @trusted nothrow
 {
     import libsodium.crypto_shorthash;
     import std.bitmanip;
@@ -416,7 +416,7 @@ unittest
 
 *******************************************************************************/
 
-private auto getGenerator (const ref PublicKey key, const ref Hash rand_seed)
+private auto getGenerator (const ref PublicKey key, in Hash rand_seed)
     @safe nothrow
 {
     Mt19937_64 gen;

--- a/source/agora/consensus/data/UTXO.d
+++ b/source/agora/consensus/data/UTXO.d
@@ -43,7 +43,7 @@ public struct UTXO
 
     ***************************************************************************/
 
-    public static Hash getHash (Hash hash, ulong index) @safe nothrow
+    public static Hash getHash (in Hash hash, ulong index) @safe nothrow
     {
         return hashMulti(hash, index);
     }

--- a/source/agora/consensus/state/UTXODB.d
+++ b/source/agora/consensus/state/UTXODB.d
@@ -77,19 +77,19 @@ public class UTXOSet : UTXOCache
     }
 
     ///
-    public override bool peekUTXO (Hash utxo, out UTXO value) nothrow @safe
+    public override bool peekUTXO (in Hash utxo, out UTXO value) nothrow @safe
     {
         return this.utxo_db.find(utxo, value);
     }
 
     ///
-    protected override void remove (Hash utxo) @safe
+    protected override void remove (in Hash utxo) @safe
     {
         this.utxo_db.remove(utxo);
     }
 
     ///
-    protected override void add (Hash utxo, UTXO value) @safe
+    protected override void add (in Hash utxo, UTXO value) @safe
     {
         this.utxo_db[utxo] = value;
     }
@@ -162,7 +162,7 @@ private class UTXODB
 
     ***************************************************************************/
 
-    public bool find (Hash key, out UTXO value) nothrow @trusted
+    public bool find (in Hash key, out UTXO value) nothrow @trusted
     {
         scope (failure) assert(0);
         auto results = db.execute("SELECT val FROM utxo_map WHERE key = ?",
@@ -217,7 +217,7 @@ private class UTXODB
 
     ***************************************************************************/
 
-    public void opIndexAssign (const ref UTXO value, Hash key) @safe
+    public void opIndexAssign (const ref UTXO value, in Hash key) @safe
     {
         static ubyte[] buffer;
         serializeToBuffer(value, buffer);
@@ -237,7 +237,7 @@ private class UTXODB
 
     ***************************************************************************/
 
-    public void remove (Hash key) nothrow @safe
+    public void remove (in Hash key) nothrow @safe
     {
         scope (failure) assert(0);
         () @trusted {

--- a/source/agora/consensus/state/UTXOSet.d
+++ b/source/agora/consensus/state/UTXOSet.d
@@ -27,7 +27,7 @@ import std.file;
 mixin AddLogger!();
 
 /// Delegate to find an unspent UTXO
-public alias UTXOFinder = bool delegate (Hash utxo, out UTXO) nothrow @safe;
+public alias UTXOFinder = bool delegate (in Hash utxo, out UTXO) nothrow @safe;
 
 /*******************************************************************************
 
@@ -97,7 +97,7 @@ abstract class UTXOCache
 
     ***************************************************************************/
 
-    protected UTXO getUTXO (Hash utxo) nothrow @safe
+    protected UTXO getUTXO (in Hash utxo) nothrow @safe
     {
         UTXO value;
         if (!this.peekUTXO(utxo, value))
@@ -134,7 +134,7 @@ abstract class UTXOCache
 
     ***************************************************************************/
 
-    public bool findUTXO (Hash utxo, out UTXO value) nothrow @safe
+    public bool findUTXO (in Hash utxo, out UTXO value) nothrow @safe
     {
         if (utxo in this.used_utxos)
         {
@@ -161,7 +161,7 @@ abstract class UTXOCache
 
     ***************************************************************************/
 
-    public abstract bool peekUTXO (Hash utxo, out UTXO value) nothrow @safe;
+    public abstract bool peekUTXO (in Hash utxo, out UTXO value) nothrow @safe;
 
     /***************************************************************************
 
@@ -172,7 +172,7 @@ abstract class UTXOCache
 
     ***************************************************************************/
 
-    protected abstract void remove (Hash utxo) @safe;
+    protected abstract void remove (in Hash utxo) @safe;
 
     /***************************************************************************
 
@@ -184,7 +184,7 @@ abstract class UTXOCache
 
     ***************************************************************************/
 
-    protected abstract void add (Hash utxo, UTXO value) @safe;
+    protected abstract void add (in Hash utxo, UTXO value) @safe;
 }
 
 /*******************************************************************************
@@ -233,7 +233,7 @@ public class TestUTXOSet : UTXOCache
     }
 
     ///
-    public override bool peekUTXO (Hash utxo, out UTXO value) nothrow @safe
+    public override bool peekUTXO (in Hash utxo, out UTXO value) nothrow @safe
     {
         // Note: Keep this in sync with `findUTXO`
         if (auto ptr = utxo in this.storage)
@@ -245,13 +245,13 @@ public class TestUTXOSet : UTXOCache
     }
 
     ///
-    protected override void remove (Hash utxo) @safe
+    protected override void remove (in Hash utxo) @safe
     {
         this.storage.remove(utxo);
     }
 
     ///
-    protected override void add (Hash utxo, UTXO value) @safe
+    protected override void add (in Hash utxo, in UTXO value) @safe
     {
         this.storage[utxo] = value;
     }

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -147,7 +147,7 @@ public class ValidatorSet
 
     ***************************************************************************/
 
-    public void remove (const ref Hash enroll_hash) @trusted nothrow
+    public void remove (in Hash enroll_hash) @trusted nothrow
     {
         try
         {
@@ -190,7 +190,7 @@ public class ValidatorSet
 
     ***************************************************************************/
 
-    public Height getEnrolledHeight (const ref Hash enroll_hash) @trusted nothrow
+    public Height getEnrolledHeight (in Hash enroll_hash) @trusted nothrow
     {
         try
         {
@@ -221,7 +221,7 @@ public class ValidatorSet
 
     ***************************************************************************/
 
-    public bool hasEnrollment (const ref Hash enroll_hash) @trusted nothrow
+    public bool hasEnrollment (in Hash enroll_hash) @trusted nothrow
     {
         try
         {
@@ -356,7 +356,7 @@ public class ValidatorSet
 
     ***************************************************************************/
 
-    public bool hasPreimage (const ref Hash enroll_key, ushort distance) @safe
+    public bool hasPreimage (in Hash enroll_key, ushort distance) @safe
         nothrow
     {
         try
@@ -390,7 +390,7 @@ public class ValidatorSet
 
     ***************************************************************************/
 
-    public PreImageInfo getPreimage (const ref Hash enroll_key) @trusted nothrow
+    public PreImageInfo getPreimage (in Hash enroll_key) @trusted nothrow
     {
         try
         {
@@ -433,8 +433,8 @@ public class ValidatorSet
 
     ***************************************************************************/
 
-    public PreImageInfo getPreimageAt (const ref Hash enroll_key,
-        in Height height) @trusted nothrow
+    public PreImageInfo getPreimageAt (in Hash enroll_key, in Height height)
+        @trusted nothrow
     {
         try
         {
@@ -527,7 +527,7 @@ public class ValidatorSet
 }
 
 version (unittest)
-private Enrollment createEnrollment(const ref Hash utxo_key,
+private Enrollment createEnrollment(in Hash utxo_key,
     const KeyPair key_pair, ref Scalar random_seed_src,
     uint validator_cycle)
 {

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -119,7 +119,7 @@ public string isInvalidReason (const ref Block block, Height prev_height,
             extraSet.put(tx);
         scope extraFinder = extraSet.getUTXOFinder();
         scope UTXOFinder enrollmentsUTXOFinder =
-            (Hash utxo, out UTXO val)
+            (in Hash utxo, out UTXO val)
             {
                 if (findUTXO(utxo, val))
                     return true;
@@ -225,7 +225,7 @@ public string isGenesisBlockInvalidReason (const ref Block block) nothrow @safe
             ~ "ascending order by the utxo_key";
 
     Set!Hash used_utxos;
-    bool findUTXO (Hash utxo, out UTXO value) nothrow @safe
+    bool findUTXO (in Hash utxo, out UTXO value) nothrow @safe
     {
         if (utxo in used_utxos)
             return false;  // double-spend
@@ -526,7 +526,7 @@ unittest
 
     // contains the used set of UTXOs during validation (to prevent double-spend)
     Output[Hash] used_set;
-    scope UTXOFinder findNonSpent = (Hash utxo_hash, out UTXO value)
+    scope UTXOFinder findNonSpent = (in Hash utxo_hash, out UTXO value)
     {
         if (utxo_hash in used_set)
             return false;  // double-spend

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -122,7 +122,7 @@ public interface IBlockStorage
 
     ***************************************************************************/
 
-    public bool tryReadBlock (ref Block block, Hash hash) nothrow;
+    public bool tryReadBlock (ref Block block, in Hash hash) nothrow;
 
     /***************************************************************************
 
@@ -156,7 +156,7 @@ public interface IBlockStorage
 
     ***************************************************************************/
 
-    public final void readBlock (ref Block block, Hash hash)
+    public final void readBlock (ref Block block, in Hash hash)
     {
         if (!this.tryReadBlock(block, hash))
             throw new Exception(format("Reading block failed. Hash: %s", hash));
@@ -516,7 +516,8 @@ public class BlockStorage : IBlockStorage
     }
 
     /// See `BlockStorage.tryReadBlock(ref Block, Hash)`
-    public override bool tryReadBlock (ref Block block, Hash hash) @safe nothrow
+    public override bool tryReadBlock (ref Block block, in Hash hash)
+        @safe nothrow
     {
         ubyte[Hash.sizeof] hash_bytes = hash[];
 
@@ -1042,7 +1043,7 @@ public class MemBlockStorage : IBlockStorage
     }
 
     /// See `IBlockStorage.tryReadBlock(ref Block, hash)`
-    public bool tryReadBlock (ref Block block, Hash hash) @safe nothrow
+    public bool tryReadBlock (ref Block block, in Hash hash) @safe nothrow
     {
         ubyte[Hash.sizeof] hash_bytes = hash[];
 

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -560,7 +560,7 @@ public class Ledger
 
     ***************************************************************************/
 
-    public Hash[] getMerklePath (Height block_height, Hash hash) @safe nothrow
+    public Hash[] getMerklePath (Height block_height, in Hash hash) @safe nothrow
     {
         if (this.getBlockHeight() < block_height)
             return null;

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -213,7 +213,7 @@ unittest
     // even if it's double spending
     const genesis_block = node_1.getBlocksFrom(0, 1)[0];
     auto reason = txs[0].isInvalidReason(
-        (Hash utxo, out UTXO value)
+        (in Hash utxo, out UTXO value)
         {
             value = UTXO(0, TxType.Payment, txs[0].outputs[0]);
             return true;

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -69,8 +69,7 @@ public struct SCPBallotFmt
             {
                 formattedWrite(sink,
                     "value: %s }",
-                    prettify(  // cast: deserializer should take const(ubyte)[]
-                    (cast(ubyte[])this.ballot.value[]).deserializeFull!ConsensusData));
+                    prettify(this.ballot.value[].deserializeFull!ConsensusData));
             }
             catch (Exception ex)
             {
@@ -229,8 +228,7 @@ private struct SCPNominationFmt
                     "votes: %s, ",
                     this.nominate.votes[]
                         .map!(cd => prettify(
-                            // cast: deserializer should take const(ubyte)[]
-                            (cast(ubyte[])cd[]).deserializeFull!ConsensusData)));
+                            cd[].deserializeFull!ConsensusData)));
             }
             catch (Exception ex)
             {
@@ -243,8 +241,7 @@ private struct SCPNominationFmt
                     "accepted: %s }",
                     this.nominate.accepted[]
                         .map!(cd => prettify(
-                            // cast: deserializer should take const(ubyte)[]
-                            (cast(ubyte[])cd[]).deserializeFull!ConsensusData)));
+                            cd[].deserializeFull!ConsensusData)));
             }
             catch (Exception ex)
             {

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -214,7 +214,8 @@ private struct SCPNominationFmt
     private const(SCPNomination) nominate;
     private const(GetQSetDg) getQSet;
 
-    public void toString (scope void delegate (in char[]) @safe sink) @trusted nothrow
+    public void toString (scope void delegate (in char[]) @safe sink)
+        scope @trusted nothrow
     {
         try
         {

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -46,8 +46,8 @@ import std.range;
 
 *******************************************************************************/
 
-public SCPEnvelopeFmt scpPrettify (in SCPEnvelope* env,
-    in GetQSetDg get_qset = null) nothrow @trusted @nogc
+public SCPEnvelopeFmt scpPrettify (const SCPEnvelope* env,
+    const GetQSetDg get_qset = null) nothrow @trusted @nogc
 {
     return SCPEnvelopeFmt(env, get_qset);
 }


### PR DESCRIPTION
I have a local diff to test if `-preview=in` works with Agora, but this is aiming to reduce it.
It won't enable the functionality, as we need a dub bugfix for this (https://github.com/bpfkorea/agora/issues/1327).