### PR TITLE
Remove AA `clear` workaround

### DIFF
--- a/source/agora/consensus/state/UTXOSet.d
+++ b/source/agora/consensus/state/UTXOSet.d
@@ -226,12 +226,6 @@ public class TestUTXOSet : UTXOCache
         }
     }
 
-    /// Workaround 20559...
-    public void clear ()
-    {
-        this.storage.clear();
-    }
-
     ///
     public override bool peekUTXO (Hash utxo, out UTXO value) nothrow @safe
     {


### PR DESCRIPTION
Due to a weird coding error, it segfaulted when `alias this` was used, hence the workaround.
[This issue](https://issues.dlang.org/show_bug.cgi?id=20559) has been [fixed](https://github.com/dlang/druntime/pull/2927) by @Geod24 and we can directly call `clear` on an AA.