### PR TITLE
Implement transaction-level absolute and input-level relative time locks

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -1338,15 +1338,15 @@ unittest
 
     utxos.sort();  // must be sorted by enrollment key
     assert(man.getRandomSeed(utxos, Height(1)) ==
-        Hash(`0xc689b81d03b1793514fd0725930db06c3b1c1de6339073f82bb4ad39948877b8c1c8e72e1afba5f86419cc900cdbf46b50fed5e0e97c610dd82c98e81574424b`),
+        Hash(`0xb003a628184d4ed0c764b6728229d0bd5f111e91b64ec22abd7a0cf6cbf29554034c28b8279419e55f2043b3eed6c14ae0b040ecab089d36d4592155bcaa4582`),
         man.getRandomSeed(utxos, Height(1)).to!string);
 
     assert(man.getRandomSeed(utxos, Height(504)) ==
-        Hash(`0x49008dfc5c470b580146349a2fda59901914c37001507a31bf37252102675af31898c50331407f21015b4ae04606136b857955a2fd1b0f382c5a30339d24c88c`),
+        Hash(`0xb7546db79980b146b653ca55f426812ce1f81ebc984a8992563d4792ceb9e8676be970cf3bfcabc182280a58fc36494bbc71eaecb75e11dc53103a6ff1c9a977`),
         man.getRandomSeed(utxos, Height(504)).to!string);
 
     assert(man.getRandomSeed(utxos, Height(1008)) ==
-        Hash(`0xec51f4e21932ab7269ddbf461c4339dcdc493cb9f65941ebc816ff26e097fa07e2ee914e824b17b90c7a3640ac063148eaac56bb25a00c3934a13a16984ed546`),
+        Hash(`0x47a42367111619442f801535e9b3f02abf8e9cc9373fce52e199b04457a78cf878e2b0587b7bd3fb699881bedbe04d9d0840a40137f9259a1094de9b1d4c10c2`),
         man.getRandomSeed(utxos, Height(1008)).to!string);
 }
 

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -1338,15 +1338,15 @@ unittest
 
     utxos.sort();  // must be sorted by enrollment key
     assert(man.getRandomSeed(utxos, Height(1)) ==
-        Hash(`0xb003a628184d4ed0c764b6728229d0bd5f111e91b64ec22abd7a0cf6cbf29554034c28b8279419e55f2043b3eed6c14ae0b040ecab089d36d4592155bcaa4582`),
+        Hash(`0x28e5f0ed454f96852478a7b83f1b20378bc5d8a978add52ff30ace0f255e552afb3bd08dd2141291259f1f9794d4417c3c12187df52d20ade28ec74d305aeb94`),
         man.getRandomSeed(utxos, Height(1)).to!string);
 
     assert(man.getRandomSeed(utxos, Height(504)) ==
-        Hash(`0xb7546db79980b146b653ca55f426812ce1f81ebc984a8992563d4792ceb9e8676be970cf3bfcabc182280a58fc36494bbc71eaecb75e11dc53103a6ff1c9a977`),
+        Hash(`0x9038006d68ed7e5d42311887075e62e0d5ac98b7133dd9895f85bbe170564f2ddac7d11396ec426a5dd0a35efdc9aaae991098e907c6ce76024dbf3f93582464`),
         man.getRandomSeed(utxos, Height(504)).to!string);
 
     assert(man.getRandomSeed(utxos, Height(1008)) ==
-        Hash(`0x47a42367111619442f801535e9b3f02abf8e9cc9373fce52e199b04457a78cf878e2b0587b7bd3fb699881bedbe04d9d0840a40137f9259a1094de9b1d4c10c2`),
+        Hash(`0x5748c01b54639413b41e57c6e82c3c2da53ba2b6966596cdaea3d77b378a252bd20b727bb3cdb52d255288f00cc3decb14aa99cf1156512ac51aa31413357e74`),
         man.getRandomSeed(utxos, Height(1008)).to!string);
 }
 

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -109,19 +109,14 @@ unittest
     auto address = `GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW`;
     PublicKey pubkey = PublicKey.fromString(address);
 
-    // above parts not @safe/@nogc yet
-    () @safe @nogc nothrow
-    {
-        Output[1] outputs = [ Output(Amount(100), pubkey) ];
-        Transaction tx = { outputs: outputs[] };
-        BlockHeader header = { merkle_root : tx.hashFull() };
+    import std.conv;
+    Output[1] outputs = [ Output(Amount(100), pubkey) ];
+    Transaction tx = { outputs: outputs[] };
+    BlockHeader header = { merkle_root : tx.hashFull() };
 
-        auto hash = hashFull(header);
-        auto exp_hash = Hash("0xc04f3226bdc07c6d3141e3ac14888cd3b4199d84877" ~
-            "e591927063af65e5f56b14f9236e764bacb980aed5acefb98981b221e5c99e" ~
-            "aaaf1100c87c250cec2f32c");
-        assert(hash == exp_hash);
-    }();
+    auto hash = hashFull(header);
+    auto exp_hash = Hash("0x7aa86e99fc817341bcf1b92e11089f57e82a850d2db4e1d157261b8ee22a98cb3ae8911fe0b0d705cbf713dae8ba2655cd82531eb283f3205f6eecbc3b1a5bd9");
+    assert(hash == exp_hash, hash.to!string);
 }
 
 /*******************************************************************************

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -130,24 +130,32 @@ public struct Input
     /// A signature that should be verified using the `previous[index].address` public key
     public Signature signature;
 
+    /// The UTXO this `Input` references must be at least `unlock_age` older
+    /// than the block height at which the spending transaction wants to be
+    /// included in the block. Use for implementing relative time locks.
+    public uint unlock_age = 0;
+
     /// Simple ctor
-    public this (in Hash utxo_, in Signature sig = Signature.init)
+    public this (in Hash utxo_, in Signature sig = Signature.init, uint unlock_age = 0)
         inout pure nothrow @nogc @safe
     {
         this.utxo = utxo_;
         this.signature = sig;
+        this.unlock_age = unlock_age;
     }
 
     /// Ctor which does hashing based on index
-    public this (Hash txhash, ulong index) nothrow @safe
+    public this (Hash txhash, ulong index, uint unlock_age = 0) nothrow @safe
     {
         this.utxo = hashMulti(txhash, index);
+        this.unlock_age = unlock_age;
     }
 
     /// Ctor which does hashing based on the `Transaction` and index
-    public this (in Transaction tx, ulong index) nothrow @safe
+    public this (in Transaction tx, ulong index, uint unlock_age = 0) nothrow @safe
     {
         this.utxo = hashMulti(tx.hashFull(), index);
+        this.unlock_age = unlock_age;
     }
 
     /***************************************************************************
@@ -162,6 +170,7 @@ public struct Input
     public void computeHash (scope HashDg dg) const nothrow @safe @nogc
     {
         dg(this.utxo[]);
+        hashPart(this.unlock_age, dg);
     }
 }
 
@@ -202,7 +211,7 @@ unittest
     );
 
     const tx_payment_hash = Hash(
-        `0x79a7bb3cae7e4d46a45674fefd3708557574890ce7a554c09c7d486346a31feb82005aa593620db332c1ae32c5ab44f0977c8834969883a1928e8db0d1b3ccac`);
+        `0x428d691addd27708b719a5e47cbac932618f0f843681dc0a46c97971ff8c419c817c65d90f3b74394db46801843b79537a583903bec5da57de70155276d2aa46`);
     const expected1 = payment_tx.hashFull();
     assert(expected1 == tx_payment_hash, expected1.toString());
 
@@ -213,7 +222,7 @@ unittest
     );
 
     const tx_freeze_hash = Hash(
-        `0x7b8f848dcc4deab1c2161aa4e91401b6d9e57f2ac8126493f0343efbc23a89217871e7b1c2ef8f1a40736cd4b331e26de43b48f593097fe97941a92673635895`);
+        `0x6ce6bdeac41ffa444e6c2250ec09e04652597c3ec92f54f69029cc16ae4fc84faa5372b56e24c4c8667d00a8d1c0a7bc550999e4cdcd039548361a15e72fa081`);
     const expected2 = freeze_tx.hashFull();
     assert(expected2 == tx_freeze_hash, expected2.toString());
 }

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -53,6 +53,10 @@ public struct Transaction
     /// The list of newly created outputs to put in the UTXO
     public Output[] outputs;
 
+    /// This transaction may only be included in a block with `height >= height_lock`.
+    /// Note that another tx with a lower lock time could double-spend this tx.
+    public Height height_lock = Height(0);
+
     /***************************************************************************
 
         Transactions Serialization
@@ -73,6 +77,8 @@ public struct Transaction
         serializePart(this.outputs.length, dg);
         foreach (const ref output; this.outputs)
             serializePart(output, dg);
+
+        serializePart(this.height_lock, dg);
     }
 
     /// Support for sorting transactions
@@ -196,8 +202,7 @@ unittest
     );
 
     const tx_payment_hash = Hash(
-        `0x35927f79ab7f2c8273f5dc24bb1efa5ebe3ac050fd4fd84d014b51124d0322ed` ~
-        `709225b92ba28b3ee6b70144d4acafb9a5289fc48ecb4a4f273b537837c78cb0`);
+        `0x79a7bb3cae7e4d46a45674fefd3708557574890ce7a554c09c7d486346a31feb82005aa593620db332c1ae32c5ab44f0977c8834969883a1928e8db0d1b3ccac`);
     const expected1 = payment_tx.hashFull();
     assert(expected1 == tx_payment_hash, expected1.toString());
 
@@ -208,8 +213,7 @@ unittest
     );
 
     const tx_freeze_hash = Hash(
-        `0x0277044f0628605485a8f8a999f9a2519231e8c59c1568ef2dac2f241ce569d8` ~
-        `54e15f950e0fd3d88460309d3e0ef3fbd57b8f5af998f8bacbe391ddb9aea328`);
+        `0x7b8f848dcc4deab1c2161aa4e91401b6d9e57f2ac8126493f0343efbc23a89217871e7b1c2ef8f1a40736cd4b331e26de43b48f593097fe97941a92673635895`);
     const expected2 = freeze_tx.hashFull();
     assert(expected2 == tx_freeze_hash, expected2.toString());
 }

--- a/source/agora/consensus/data/genesis/Coinnet.d
+++ b/source/agora/consensus/data/genesis/Coinnet.d
@@ -45,8 +45,7 @@ unittest
 
 ///
 private immutable Hash GenesisMerkleRoot =
-    Hash(`0x5d7f6a7a30f7ff591c8649f61eb8a35d034824ed5cd252c2c6f10cdbd223671`
-         ~ `3dc369ef2a44b62ba113814a9d819a276ff61582874c9aee9c98efa2aa1f10d73`);
+    Hash(`0xa31cf9a3256400486916c2ab9617dfa1fc084fac64ea6b77e02c5524343940ad44ba717d5a77e4241ab4fb7a9ae0fb5834d9d7d6e27a8200569fbce00f060761`);
 
 /// The single transaction that are part of the genesis block
 private immutable Transaction GenesisTransaction =

--- a/source/agora/consensus/data/genesis/Test.d
+++ b/source/agora/consensus/data/genesis/Test.d
@@ -51,72 +51,37 @@ public immutable Block GenesisBlock = {
         height:      Height(0),
         merkle_root: GenesisMerkleTree[$ - 1],
         enrollments: [
-            // Node 4
             Enrollment(
-                Hash(`0x46883e83778481d640a95fcffd6e1a1b6defeaac5a8001cd3f99e17576b809c` ~
-                     `7e9bc7a44c3917806765a5ff997366e217ff54cd4da09c0c51dc339c47052a3ac`),
-                Hash(`0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2` ~
-                     `349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328`),
+                Hash(`0x23f35dcecc3c7ab1c91bfbd24c9568a63fdfe273bfc263ebaf81349c063c43a32b978fb5d058281f39c6c0a9b918a4a6b7c0f16b2e37f738ba0c2999a692afbf`),
+                Hash(`0x0a8201f9f5096e1ce8e8de4147694940a57a188b78293a55144fc8777a774f2349b3a910fb1fb208514fb16deaf49eb05882cdb6796a81f913c6daac3eb74328`),
                 20,
-                Signature(`0x0cab27862571d2d2e33d6480e1eab4c82195a508b72672d609610d01f23b0be` ~
-                          `edc8b89135fe3f5df9e2815b9bdb763c41b8b2dab5911e313acc82470c2147422`)
-            ),
-
-            // Node 7
+                Signature(`0x09acec80dfe1c10b8b936ad9169774e3c58362ea02fab0171f8c845c0fa23835dc8b89135fe3f5df9e2815b9bdb763c41b8b2dab5911e313acc82470c2147422`)),
             Enrollment(
-                Hash(`0x4dde806d2e09367f9d5bdaaf46deab01a336a64fdb088dbb94edb171560c63cf` ~
-                     `6a39377bf0c4d35118775681d989dee46531926299463256da303553f09be6ef`),
-                Hash(`0xd0348a88f9b7456228e4df5689a57438766f4774d760776ec450605c82348c4` ~
-                     `61db84587c2c9b01c67c8ed17f297ee4008424ad3e0e5039179719d7e9df297c1`),
+                Hash(`0x376109201ce9be10edfe3d5f44255a2d0909587ef310efe9d52bfa95089b70766d979b8b31fbf6cc24dcf0150fc8cc05de1c7861bc63015c3bd65cef155b2000`),
+                Hash(`0xa24b7e6843220d3454523ceb7f9b43f037e56a01d2bee82958b080dc6350ebac2da12b561cbd96c6fb3f5ae5a3c8df0ac2c559ae1c45b11d42fdf866558112bc`),
                 20,
-                Signature(`0x0ed498b867c33d316b468d817ba8238aec68541abd912cecc499f8e780a8cda` ~
-                          `f2692d0b8b04133a34716169a4b1d33d77c3e585357d8a2a2c48a772275255c01`)
-            ),
-
-            // Node 6
+                Signature(`0x0e45db90c589997b5dbea336bd98d2fa41aeedb9de773b74a8550ca11ce0ab52fd787c4518b78ab9ed73a3760741d557ac2aca631fc2796be86fcf391d3a6634`)),
             Enrollment(
-                Hash(`0x8c1561a4475df42afa0830da1f8a678ad4b1d82b6c610f7b03ce69b7e0fabcf` ~
-                     `537d48ecd0aee6f1cab14290a0fc6313c729edf928ff3576f8656f3b7be5670e0`),
-                Hash(`0xaf43c67d9dd0f53de3eaede63cdcda8643422d62205df0b5af65706ec28b372` ~
-                     `adb785ce681d559d7a7137a4494ccbab4658ce11ec75a8ec84be5b73590bffceb`),
+                Hash(`0x3a917147a39298356b4bc700c44957d8d766b33ccf68bd53b8ec22437d82ac33db409cf0b27c34baf6c9bd2a37d8d2e163eb61a071757819150298c78b51a330`),
+                Hash(`0xa0502960ddbe816729f60aeaa480c7924fb020d864deec6a9db778b8e56dd2ff8e987be748ff6ca0a43597ecb575da5d532696e376dc70bb4567b5b1fa512cb4`),
                 20,
-                Signature(`0x09474f489579c930dbac46f638f3202ac24407f1fa419c1d95be38ab474da29` ~
-                          `d7e3d4753b6b4ccdb35c2864be4195e83b7b8433ca1d27a57fb9f48a631001304`)
-            ),
-
-            // Node 5
+                Signature(`0x0afcc65a1f66efec2f190494d948f5ff39b0283cd8ed354b85ca8bd880b48aa2d79a36ace4d3097869dc009b8939fc83bdf940c8822c6931d5c09326aa746b31`)),
             Enrollment(
-                Hash(`0x94908ec79866cf54bb8e87b605e31ce0b5d7c3090f3498237d83edaca9c8ba2` ~
-                     `d3d180c572af46c1221fb81add163e14adf738df26e3679626e82113b9fe085b0`),
-                Hash(`0xa24b7e6843220d3454523ceb7f9b43f037e56a01d2bee82958b080dc6350eba` ~
-                     `c2da12b561cbd96c6fb3f5ae5a3c8df0ac2c559ae1c45b11d42fdf866558112bc`),
+                Hash(`0x80378d786d26ef24bb9f7fe3d8d0c642014652c13c77ee11c7b808c6e0df213b1b2da78bf07072b2dcdda9d1e02d95cdaa00e7f7b790014ccf0ea48e685aa3a1`),
+                Hash(`0xd0348a88f9b7456228e4df5689a57438766f4774d760776ec450605c82348c461db84587c2c9b01c67c8ed17f297ee4008424ad3e0e5039179719d7e9df297c1`),
                 20,
-                Signature(`0x0e4566eca30feb9ad47a65e7ff7e7ce1a7555ccedcf61e1143c2e5fddbec686` ~
-                          `6fd787c4518b78ab9ed73a3760741d557ac2aca631fc2796be86fcf391d3a6634`)
-            ),
-
-            // Node 2
+                Signature(`0x0ebf6f19cd0bcb369d3237061661573a2b6d975c2d32eda0863bd2622847348c2692d0b8b04133a34716169a4b1d33d77c3e585357d8a2a2c48a772275255c01`)),
             Enrollment(
-                Hash(`0xb20da9cfbda971f3f573f55eabcd677feaf12f7948e8994a97cdf9e570799b7` ~
-                     `1631e87bb9ebce0d6a402275adfb6e365fdb72139c18559a10df0e5fe4bae08eb`),
-                Hash(`0xa0502960ddbe816729f60aeaa480c7924fb020d864deec6a9db778b8e56dd2f` ~
-                     `f8e987be748ff6ca0a43597ecb575da5d532696e376dc70bb4567b5b1fa512cb4`),
+                Hash(`0xb954b65741a81c8869903a44b6858c570daa2f1b550e13458f4df24c271668ddf11a52eec663b72dfbb354192d570eb9734277df6feddf53554ed1e7df81724b`),
+                Hash(`0xaf43c67d9dd0f53de3eaede63cdcda8643422d62205df0b5af65706ec28b372adb785ce681d559d7a7137a4494ccbab4658ce11ec75a8ec84be5b73590bffceb`),
                 20,
-                Signature(`0x052ee1d975c49f19fd26b077740dcac399f174f40b5df1aba5f09ebea11faac` ~
-                          `fd79a36ace4d3097869dc009b8939fc83bdf940c8822c6931d5c09326aa746b31`)
-            ),
-
-            // Node 3
+                Signature(`0x0481968fc244690c7973a0df68cf28f42ec35823d334eabc4cc29d01662860fb7e3d4753b6b4ccdb35c2864be4195e83b7b8433ca1d27a57fb9f48a631001304`)),
             Enrollment(
-                Hash(`0xdb3931bd87d2cea097533d82be0a5e36c54fec8e5570790c3369bd8300c65a0` ~
-                     `3d76d12a74aa38ec3e6866fd64ae56091ed3cbc3ca278ae0c8265ab699ffe2d85`),
-                Hash(`0xdd1b9c62d4c62246ea124e5422d5a2e23d3ca9accb0eba0e46cd46708a4e7b4` ~
-                     `17f46df34dc2e3cba9a57b1dc35a66dfc2d5ef239ebeaaa00299232bc7e3b7bfa`),
+                Hash(`0xcb11dbc5864a63bc7cb6ea1ebc8485f80bae3e5cc95b8c1b6e6d3bdba73637a8f86089a92289e357c45e02ad73abecdd94e9986e8070b3bba5befed449855d50`),
+                Hash(`0xdd1b9c62d4c62246ea124e5422d5a2e23d3ca9accb0eba0e46cd46708a4e7b417f46df34dc2e3cba9a57b1dc35a66dfc2d5ef239ebeaaa00299232bc7e3b7bfa`),
                 20,
-                Signature(`0x0e0070e5951ef5be897cb593c4c57ce28b7529463f7e5644b1314ab7cc69fd6` ~
-                          `25c71e74382a24b7e644d32b0306fe3cf14ecd7de5635c70aa592f4721aa74fe2`)
-            ),
-        ],
+                Signature(`0x0723a0a7f353b76f8e95ee4122c413169f443936147ff14dfe18ee589726551f5c71e74382a24b7e644d32b0306fe3cf14ecd7de5635c70aa592f4721aa74fe2`))
+        ]
     },
     merkle_tree: GenesisMerkleTree,
     txs: [
@@ -195,12 +160,9 @@ unittest
 }
 
 private immutable Hash[] GenesisMerkleTree = [
-    Hash(`0x6314ce9bc41a7f5b98309c3a3d824647d7613b714c4e3ddbc1c5e9ae46db297` ~
-         `15c83127ce259a3851363bff36af2e1e9a51dfa15c36a77c9f8eba6826ff975bc`),
-    Hash(`0x7a5bfeb96f9caefa377cb9a7ffe3ea3dd59ea84d4a1c66304ab8c307a4f4770` ~
-         `6fe0aec2a73ce2b186a9f45641620995f8c7e4c157cee7940872d96d9b2f0f95c`),
-    Hash(`0x788c159d62b565655d9f725786c38e6802038ee73d7a9d187b3be1c7de95aa0` ~
-         `ba856bf81bb556d7448488e71f4b89ce6eba319d0536798308112416413289254`),
+    Hash(`0x8072b135e72dd84d59793d97839680f96300ec783bdc9786ee418a50eb40914f88a5de87e12df58d227bd454b08710a9b2fa9a84ee1f3bbc82bd00ac1f360c48`),
+    Hash(`0xf806b1fcc4173e6c132def50f0d4f6fce90b7a3964520f42133e2f7e7389949128262d42351eec08da45428f83f1c2c0aa65798445661eda77b8fb2388766dc0`),
+    Hash(`0x73585acc894828ca72d5a5d55cea406e665a7e8f768b14f1ce08c058a19ac52a87ab693f6cc8cd32fa98613c80c7a78411f5751c0670727c35022e33d1710131`)
 ];
 
 /// GCOQEOHAUFYUAC6G22FJ3GZRNLGVCCLESEJ2AXBIJ5BJNUVTAERPLRIJ

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -79,6 +79,15 @@ public string isInvalidReason (
         if (!sum_unspent.add(utxo_value.output.value))
             return "Transaction: Input overflow";
 
+        // note: this is strictly not necessary to be here, the Input's script
+        // should be evaluated for validity and then the Input could be kept
+        // until the unlock height becomes valid. Alternatively we could reject
+        // it here right away and force the party to send it again at the right
+        // time. However, we run into a risk if we ever implement caching of
+        // rejecting them if they're submitted too early.
+        if (height < utxo_value.unlock_height + input.unlock_age)
+            return "Transanction: Input's unlock age cannot be used for this block height";
+
         return null;
     }
 

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -51,6 +51,9 @@ public string isInvalidReason (
     if (tx.outputs.length == 0)
         return "Transaction: No output";
 
+    if (tx.height_lock > height)
+        return "Transaction: Not unlocked for this height";
+
     foreach (output; tx.outputs)
     {
         // disallow negative amounts
@@ -776,4 +779,36 @@ unittest
     // test for output overflow in Payment transaction
     assert(!thirdTx.isValid(&storage.peekUTXO, Height(0)),
         format("Tx having output overflow should not pass validation. tx: %s", thirdTx));
+}
+
+/// transaction-level absolute time lock
+unittest
+{
+    import ocean.core.Test;
+    scope storage = new TestUTXOSet;
+    KeyPair kp = KeyPair.random();
+
+    Transaction prev_tx = { outputs: [Output(Amount(100), kp.address)] };
+    storage.put(prev_tx);
+
+    Transaction tx = Transaction(
+        TxType.Payment, [Input(hashFull(prev_tx), 0)],
+        [Output(Amount(50), kp.address)]);
+
+    // effectively disabled lock
+    tx.height_lock = Height(0);
+    tx.inputs[0].signature = kp.secret.sign(hashFull(tx)[]);
+    test!"=="(tx.isInvalidReason(storage.getUTXOFinder(), Height(0)), null);
+    test!"=="(tx.isInvalidReason(storage.getUTXOFinder(), Height(1024)), null);
+
+    tx.height_lock = Height(10);
+    tx.inputs[0].signature = kp.secret.sign(hashFull(tx)[]);
+    test!"=="(tx.isInvalidReason(storage.getUTXOFinder(), Height(0)),
+        "Transaction: Not unlocked for this height");
+    test!"=="(tx.isInvalidReason(storage.getUTXOFinder(), Height(9)),
+        "Transaction: Not unlocked for this height");
+    test!"=="(tx.isInvalidReason(storage.getUTXOFinder(), Height(10)),
+        null);
+    test!"=="(tx.isInvalidReason(storage.getUTXOFinder(), Height(1024)),
+        null);
 }

--- a/source/agora/test/HeightLock.d
+++ b/source/agora/test/HeightLock.d
@@ -1,0 +1,64 @@
+/*******************************************************************************
+
+    Tests for the transaction-level absolute time lock.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.HeightLock;
+
+version (unittest):
+
+import agora.api.Validator;
+import agora.consensus.data.Transaction;
+import agora.test.Base;
+
+/// Ditto
+unittest
+{
+    TestConf conf = TestConf.init;
+    auto network = makeTestNetwork(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[0];
+
+    // height 1
+    auto txs = genesisSpendable().map!(txb => txb.sign()).array();
+    txs.each!(tx => node_1.putTransaction(tx));
+    network.expectBlock(Height(1), network.blocks[0].header);
+
+    const Height UnlockHeight_2 = Height(2);
+    auto unlock_2_txs = txs.map!(tx => TxBuilder(tx).sign(TxType.Payment,
+        UnlockHeight_2)).array();
+
+    const Height UnlockHeight_3 = Height(3);
+    auto unlock_3_txs = txs.map!(tx => TxBuilder(tx).sign(TxType.Payment,
+        UnlockHeight_3)).array();
+
+    assert(unlock_2_txs != unlock_3_txs);
+
+    // these should all be rejected, or alternatively accepted by the pool but
+    // not added to the block at height 2
+    unlock_3_txs.each!(tx => node_1.putTransaction(tx));
+
+    // should be accepted
+    unlock_2_txs.each!(tx => node_1.putTransaction(tx));
+
+    network.expectBlock(Height(2), network.blocks[0].header);
+
+    auto blocks = node_1.getBlocksFrom(2, 1);
+    assert(blocks.length == 1);
+
+    sort(unlock_2_txs);
+    assert(blocks[0].txs == unlock_2_txs);
+}

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -48,7 +48,7 @@ unittest
     auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();
-    scope(failure) network.printLogs();
+    //scope(failure) network.printLogs();
     network.waitForDiscovery();
 
     auto nodes = network.clients;
@@ -170,16 +170,16 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
+            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
         // 1
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
+            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
@@ -188,32 +188,32 @@ unittest
 
         // 2
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
+            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
         // 3
         QuorumConfig(6, [
+            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
         // 4
         QuorumConfig(6, [
+            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
         // 5
@@ -229,9 +229,9 @@ unittest
         // 6
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
+            WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
-            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
@@ -240,10 +240,10 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
+            WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
     ];
 
@@ -279,11 +279,11 @@ unittest
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE5.address]),
+            WK.Keys.NODE7.address]),
 
         // 1
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
+            WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
@@ -293,25 +293,15 @@ unittest
 
         // 2
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
-            WK.Keys.B.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE5.address,]),
-
-        // 3
-        QuorumConfig(6, [
-            WK.Keys.NODE2.address,
-            WK.Keys.NODE4.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
-        // 4
+        // 3
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
@@ -319,7 +309,17 @@ unittest
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
+            WK.Keys.NODE5.address]),
+
+        // 4
+        QuorumConfig(6, [
+            WK.Keys.NODE4.address,
+            WK.Keys.NODE6.address,
+            WK.Keys.B.address,
+            WK.Keys.NODE3.address,
+            WK.Keys.A.address,
+            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address]),
 
         // 5
         QuorumConfig(6, [
@@ -335,20 +335,20 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
+            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address]),
 
         // 7
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
+            WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
     ];
 

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -178,20 +178,20 @@ unittest
 
         // 1
         QuorumConfig(6, [
+            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address]),
+            WK.Keys.NODE7.address]),
 
         // 2
         QuorumConfig(6, [
+            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
-            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
@@ -220,8 +220,8 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
+            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
@@ -230,8 +230,8 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
+            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
@@ -277,9 +277,9 @@ unittest
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
-            WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address]),
+            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address]),
 
         // 1
         QuorumConfig(6, [
@@ -293,8 +293,8 @@ unittest
 
         // 2
         QuorumConfig(6, [
+            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
@@ -303,12 +303,12 @@ unittest
 
         // 3
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
+            WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
         // 4
@@ -323,7 +323,7 @@ unittest
 
         // 5
         QuorumConfig(6, [
-            WK.Keys.NODE4.address,
+            WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
@@ -334,7 +334,7 @@ unittest
         // 6
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
-            WK.Keys.NODE4.address,
+            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,

--- a/source/agora/test/UnlockAge.d
+++ b/source/agora/test/UnlockAge.d
@@ -1,0 +1,86 @@
+/*******************************************************************************
+
+    Tests for the input-level relative time lock.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.UnlockAge;
+
+version (unittest):
+
+import agora.api.Validator;
+import agora.consensus.data.Transaction;
+import agora.test.Base;
+
+/// Ditto
+unittest
+{
+    import std.conv;
+    TestConf conf = TestConf.init;
+    auto network = makeTestNetwork(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[0];
+
+    auto txs = genesisSpendable().map!(txb => txb.split(
+        WK.Keys.Genesis.address.repeat.take(8)).sign()).array;
+
+    // height 1, many Outputs
+    txs.each!(tx => node_1.putTransaction(tx));
+    network.expectBlock(Height(1), network.blocks[0].header);
+
+    auto split_up = txs
+        .map!(tx => iota(tx.outputs.length)
+            .map!(idx => TxBuilder(tx, cast(uint)idx))).array;
+
+    // if `unlock_age` is 3 then UTXO at height `1` which unlocks at height `2`
+    // will be spendable by this input at height `2 + 3 = 5`.
+    auto txs_0 = split_up[0].map!(txb => txb.sign()).array;
+    auto txs_1 = split_up[1].map!(txb => txb.sign()).array;
+    auto txs_2 = split_up[2].map!(txb => txb.sign()).array;
+    const uint UnlockAge_3 = 3;
+    auto age_3_txs = split_up[3].map!(txb => txb.sign(TxType.Payment,
+        Height(0), UnlockAge_3)).array();
+
+    age_3_txs.each!(tx => node_1.putTransaction(tx));  // rejected, wrong age
+    txs_0.each!(tx => node_1.putTransaction(tx));      // accepted
+    network.expectBlock(Height(2), network.blocks[0].header);
+    auto blocks = node_1.getBlocksFrom(2, 1);
+    assert(blocks.length == 1);
+    sort(txs_0);
+    assert(blocks[0].txs == txs_0);
+
+    age_3_txs.each!(tx => node_1.putTransaction(tx));  // rejected again
+    txs_1.each!(tx => node_1.putTransaction(tx));      // accepted
+    network.expectBlock(Height(3), network.blocks[0].header);
+    blocks = node_1.getBlocksFrom(3, 1);
+    assert(blocks.length == 1);
+    sort(txs_1);
+    assert(blocks[0].txs == txs_1);
+
+    age_3_txs.each!(tx => node_1.putTransaction(tx));  // rejected again
+    txs_2.each!(tx => node_1.putTransaction(tx));      // accepted
+    network.expectBlock(Height(4), network.blocks[0].header);
+    blocks = node_1.getBlocksFrom(4, 1);
+    assert(blocks.length == 1);
+    sort(txs_2);
+    assert(blocks[0].txs == txs_2);
+
+    age_3_txs.each!(tx => node_1.putTransaction(tx));  // finally accepted
+    network.expectBlock(Height(5), network.blocks[0].header);
+    blocks = node_1.getBlocksFrom(5, 1);
+    assert(blocks.length == 1);
+    sort(age_3_txs);
+    assert(blocks[0].txs == age_3_txs);
+}

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -345,13 +345,13 @@ private struct BlockHeaderFmt
 
 @safe unittest
 {
-    static immutable GenesisHStr = `Height: 0, Prev: 0x0000...0000, Root: 0x788c...9254, Enrollments: [
-{ utxo: 0x4688...a3ac, seed: 0x0a82...4328, cycles: 20, sig: 0x0cab...7422 }
-{ utxo: 0x4dde...e6ef, seed: 0xd034...97c1, cycles: 20, sig: 0x0ed4...5c01 }
-{ utxo: 0x8c15...70e0, seed: 0xaf43...fceb, cycles: 20, sig: 0x0947...1304 }
-{ utxo: 0x9490...85b0, seed: 0xa24b...12bc, cycles: 20, sig: 0x0e45...6634 }
-{ utxo: 0xb20d...08eb, seed: 0xa050...2cb4, cycles: 20, sig: 0x052e...6b31 }
-{ utxo: 0xdb39...2d85, seed: 0xdd1b...7bfa, cycles: 20, sig: 0x0e00...4fe2 }]`;
+    static immutable GenesisHStr = `Height: 0, Prev: 0x0000...0000, Root: 0x7358...0131, Enrollments: [
+{ utxo: 0x23f3...afbf, seed: 0x0a82...4328, cycles: 20, sig: 0x09ac...7422 }
+{ utxo: 0x3761...2000, seed: 0xa24b...12bc, cycles: 20, sig: 0x0e45...6634 }
+{ utxo: 0x3a91...a330, seed: 0xa050...2cb4, cycles: 20, sig: 0x0afc...6b31 }
+{ utxo: 0x8037...a3a1, seed: 0xd034...97c1, cycles: 20, sig: 0x0ebf...5c01 }
+{ utxo: 0xb954...724b, seed: 0xaf43...fceb, cycles: 20, sig: 0x0481...1304 }
+{ utxo: 0xcb11...5d50, seed: 0xdd1b...7bfa, cycles: 20, sig: 0x0723...4fe2 }]`;
     const actual = format("%s", BlockHeaderFmt(GenesisBlock.header));
     assert(GenesisHStr == actual, actual);
 }
@@ -384,13 +384,13 @@ private struct BlockFmt
 
 @safe unittest
 {
-    static immutable ResultStr = `Height: 0, Prev: 0x0000...0000, Root: 0x788c...9254, Enrollments: [
-{ utxo: 0x4688...a3ac, seed: 0x0a82...4328, cycles: 20, sig: 0x0cab...7422 }
-{ utxo: 0x4dde...e6ef, seed: 0xd034...97c1, cycles: 20, sig: 0x0ed4...5c01 }
-{ utxo: 0x8c15...70e0, seed: 0xaf43...fceb, cycles: 20, sig: 0x0947...1304 }
-{ utxo: 0x9490...85b0, seed: 0xa24b...12bc, cycles: 20, sig: 0x0e45...6634 }
-{ utxo: 0xb20d...08eb, seed: 0xa050...2cb4, cycles: 20, sig: 0x052e...6b31 }
-{ utxo: 0xdb39...2d85, seed: 0xdd1b...7bfa, cycles: 20, sig: 0x0e00...4fe2 }],
+    static immutable ResultStr = `Height: 0, Prev: 0x0000...0000, Root: 0x7358...0131, Enrollments: [
+{ utxo: 0x23f3...afbf, seed: 0x0a82...4328, cycles: 20, sig: 0x09ac...7422 }
+{ utxo: 0x3761...2000, seed: 0xa24b...12bc, cycles: 20, sig: 0x0e45...6634 }
+{ utxo: 0x3a91...a330, seed: 0xa050...2cb4, cycles: 20, sig: 0x0afc...6b31 }
+{ utxo: 0x8037...a3a1, seed: 0xd034...97c1, cycles: 20, sig: 0x0ebf...5c01 }
+{ utxo: 0xb954...724b, seed: 0xaf43...fceb, cycles: 20, sig: 0x0481...1304 }
+{ utxo: 0xcb11...5d50, seed: 0xdd1b...7bfa, cycles: 20, sig: 0x0723...4fe2 }],
 Transactions: 2
 Type : Freeze, Inputs: None
 Outputs (6):
@@ -436,13 +436,13 @@ private struct RangeFmt (R)
 {
     static immutable ResultStr = `
 ===============================================================================
-Height: 0, Prev: 0x0000...0000, Root: 0x788c...9254, Enrollments: [
-{ utxo: 0x4688...a3ac, seed: 0x0a82...4328, cycles: 20, sig: 0x0cab...7422 }
-{ utxo: 0x4dde...e6ef, seed: 0xd034...97c1, cycles: 20, sig: 0x0ed4...5c01 }
-{ utxo: 0x8c15...70e0, seed: 0xaf43...fceb, cycles: 20, sig: 0x0947...1304 }
-{ utxo: 0x9490...85b0, seed: 0xa24b...12bc, cycles: 20, sig: 0x0e45...6634 }
-{ utxo: 0xb20d...08eb, seed: 0xa050...2cb4, cycles: 20, sig: 0x052e...6b31 }
-{ utxo: 0xdb39...2d85, seed: 0xdd1b...7bfa, cycles: 20, sig: 0x0e00...4fe2 }],
+Height: 0, Prev: 0x0000...0000, Root: 0x7358...0131, Enrollments: [
+{ utxo: 0x23f3...afbf, seed: 0x0a82...4328, cycles: 20, sig: 0x09ac...7422 }
+{ utxo: 0x3761...2000, seed: 0xa24b...12bc, cycles: 20, sig: 0x0e45...6634 }
+{ utxo: 0x3a91...a330, seed: 0xa050...2cb4, cycles: 20, sig: 0x0afc...6b31 }
+{ utxo: 0x8037...a3a1, seed: 0xd034...97c1, cycles: 20, sig: 0x0ebf...5c01 }
+{ utxo: 0xb954...724b, seed: 0xaf43...fceb, cycles: 20, sig: 0x0481...1304 }
+{ utxo: 0xcb11...5d50, seed: 0xdd1b...7bfa, cycles: 20, sig: 0x0723...4fe2 }],
 Transactions: 2
 Type : Freeze, Inputs: None
 Outputs (6):
@@ -454,11 +454,11 @@ GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000),
 GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000),
 GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000)
 ====================
-Height: 1, Prev: 0x72e6...3b7d, Root: 0x07a8...acf4, Enrollments: [],
+Height: 1, Prev: 0xa4b7...9e21, Root: 0x6c02...2e3a, Enrollments: [],
 Transactions: 2
-Type : Payment, Inputs (1): 0xc378...d314:0x0fbf...ba74
+Type : Payment, Inputs (1): 0x7f87...1a84:0x01b2...18e4
 Outputs (1): GCOQ...LRIJ(61,000,000)
-Type : Payment, Inputs (1): 0xfca9...baf8:0x02da...95d1
+Type : Payment, Inputs (1): 0x82dd...11c3:0x09da...4e5b
 Outputs (1): GCOQ...LRIJ(61,000,000)`;
     import agora.utils.Test : genesisSpendable;
     const Block secondBlock = makeNewBlock(GenesisBlock,

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -454,11 +454,11 @@ GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000),
 GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000),
 GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000)
 ====================
-Height: 1, Prev: 0xa4b7...9e21, Root: 0x6c02...2e3a, Enrollments: [],
+Height: 1, Prev: 0xa4b7...9e21, Root: 0x71ec...647a, Enrollments: [],
 Transactions: 2
-Type : Payment, Inputs (1): 0x7f87...1a84:0x01b2...18e4
+Type : Payment, Inputs (1): 0x7f87...1a84:0x0008...5740
 Outputs (1): GCOQ...LRIJ(61,000,000)
-Type : Payment, Inputs (1): 0x82dd...11c3:0x09da...4e5b
+Type : Payment, Inputs (1): 0x82dd...11c3:0x0966...2734
 Outputs (1): GCOQ...LRIJ(61,000,000)`;
     import agora.utils.Test : genesisSpendable;
     const Block secondBlock = makeNewBlock(GenesisBlock,

--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -427,6 +427,7 @@ public struct TxBuilder
         Params:
             type = type of `Transaction`
             height_lock = the transaction-level height lock
+            unlock_age = the unlock age for each input in the transaction
 
         Returns:
             The finalized & signed `Transaction`.
@@ -434,7 +435,7 @@ public struct TxBuilder
     ***************************************************************************/
 
     public Transaction sign (TxType type = TxType.Payment,
-        Height height_lock = Height(0)) @safe nothrow
+        Height height_lock = Height(0), uint unlock_age = 0) @safe nothrow
     {
         assert(this.inputs.length, "Cannot sign input-less transaction");
         assert(this.data.outputs.length || this.leftover.value > Amount(0),
@@ -445,7 +446,7 @@ public struct TxBuilder
 
         // Finalize the transaction by adding inputs
         foreach (ref in_; this.inputs)
-            this.data.inputs ~= Input(in_.hash);
+            this.data.inputs ~= Input(in_.hash, Signature.init, unlock_age);
 
         // Add the refund tx, if needed
         if (this.leftover.value > Amount(0))

--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -426,19 +426,22 @@ public struct TxBuilder
 
         Params:
             type = type of `Transaction`
+            height_lock = the transaction-level height lock
 
         Returns:
             The finalized & signed `Transaction`.
 
     ***************************************************************************/
 
-    public Transaction sign (TxType type = TxType.Payment) @safe nothrow
+    public Transaction sign (TxType type = TxType.Payment,
+        Height height_lock = Height(0)) @safe nothrow
     {
         assert(this.inputs.length, "Cannot sign input-less transaction");
         assert(this.data.outputs.length || this.leftover.value > Amount(0),
                "Output-less transactions are not valid");
 
         this.data.type = type;
+        this.data.height_lock = height_lock;
 
         // Finalize the transaction by adding inputs
         foreach (ref in_; this.inputs)


### PR DESCRIPTION
This will be needed for Eltoo (https://github.com/bpfkorea/agora/issues/1267) and also for multi-hop payment channels.

Note that the execution engine itself **is not** in charge of checking the block height. The engine only cares about executing opcodes in the scope of the Transaction itself and the Output it is spending - it does not care about block heights. This allows transactions to be cached - otherwise a transaction's script would have to be re-evaluated at each new block height to determine if it's valid. There are many BIPs explaining how this mechanism works, if you're curious.

Fixes https://github.com/bpfkorea/agora/issues/243