### PR TITLE
Implement time-lock opcodes in the execution engine

### DIFF
--- a/source/agora/script/Engine.d
+++ b/source/agora/script/Engine.d
@@ -509,6 +509,21 @@ public class Engine
 
                 break;
 
+            case OP.VERIFY_UNLOCK_AGE:
+                if (stack.count() < 1)
+                    return "VERIFY_UNLOCK_AGE opcode requires an unlock age on the stack";
+
+                const age_bytes = stack.pop();
+                if (age_bytes.length != uint.sizeof)
+                    return "VERIFY_UNLOCK_AGE unlock age must be a 4-byte number";
+
+                const uint unlock_age = littleEndianToNative!uint(
+                    age_bytes[0 .. uint.sizeof]);
+                if (unlock_age > input.unlock_age)
+                    return "VERIFY_UNLOCK_AGE unlock age of input is too low";
+
+                break;
+
             case OP.INVALID:
                 return "Script panic while executing OP.INVALID opcode";
 
@@ -975,6 +990,54 @@ unittest
             [ubyte(OP.VERIFY_HEIGHT_LOCK), ubyte(OP.TRUE)]),
         Unlock.init, tx_10, Input.init),
         "VERIFY_HEIGHT_LOCK opcode requires a lock height on the stack");
+}
+
+// OP.VERIFY_UNLOCK_AGE
+unittest
+{
+    const age_9 = nativeToLittleEndian(uint(9));
+    const age_10 = nativeToLittleEndian(uint(10));
+    const age_11 = nativeToLittleEndian(uint(11));
+    const age_overflow = nativeToLittleEndian(ulong.max);
+
+    scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
+    const Input input_10 = Input(Hash.init, 0, 10 /* unlock_age */);
+    const Input input_11 = Input(Hash.init, 0, 11 /* unlock_age */);
+    test!("==")(engine.execute(
+        Lock(LockType.Script,
+            toPushOpcode(age_9)
+            ~ [ubyte(OP.VERIFY_UNLOCK_AGE), ubyte(OP.TRUE)]),
+        Unlock.init, Transaction.init, input_10),
+        null);
+    test!("==")(engine.execute(
+        Lock(LockType.Script,
+            toPushOpcode(age_10)
+            ~ [ubyte(OP.VERIFY_UNLOCK_AGE), ubyte(OP.TRUE)]),
+        Unlock.init, Transaction.init, input_10),  // input with matching unlock age
+        null);
+    test!("==")(engine.execute(
+        Lock(LockType.Script,
+            toPushOpcode(age_11)
+            ~ [ubyte(OP.VERIFY_UNLOCK_AGE), ubyte(OP.TRUE)]),
+        Unlock.init, Transaction.init, input_10),
+        "VERIFY_UNLOCK_AGE unlock age of input is too low");
+    test!("==")(engine.execute(
+        Lock(LockType.Script,
+            toPushOpcode(age_11)
+            ~ [ubyte(OP.VERIFY_UNLOCK_AGE), ubyte(OP.TRUE)]),
+        Unlock.init, Transaction.init, input_11),  // input with matching unlock age
+        null);
+    test!("==")(engine.execute(
+        Lock(LockType.Script,
+            toPushOpcode(age_overflow)
+            ~ [ubyte(OP.VERIFY_UNLOCK_AGE), ubyte(OP.TRUE)]),
+        Unlock.init, Transaction.init, input_10),
+        "VERIFY_UNLOCK_AGE unlock age must be a 4-byte number");
+    test!("==")(engine.execute(
+        Lock(LockType.Script,
+            [ubyte(OP.VERIFY_UNLOCK_AGE), ubyte(OP.TRUE)]),
+        Unlock.init, Transaction.init, input_10),
+        "VERIFY_UNLOCK_AGE opcode requires an unlock age on the stack");
 }
 
 // LockType.Key (Native P2PK - Pay to Public Key), consumes 33 bytes

--- a/source/agora/script/Engine.d
+++ b/source/agora/script/Engine.d
@@ -23,6 +23,7 @@ module agora.script.Engine;
 import agora.common.crypto.ECC;
 import Schnorr = agora.common.crypto.Schnorr;
 import agora.common.Hash;
+import agora.common.Types : Height;
 import agora.consensus.data.Transaction;
 import agora.script.Lock;
 import agora.script.Opcodes;
@@ -493,6 +494,21 @@ public class Engine
                     return "VERIFY_SIG signature failed validation";
                 break;
 
+            case OP.VERIFY_HEIGHT_LOCK:
+                if (stack.count() < 1)
+                    return "VERIFY_HEIGHT_LOCK opcode requires a lock height on the stack";
+
+                const height_bytes = stack.pop();
+                if (height_bytes.length != ulong.sizeof)
+                    return "VERIFY_HEIGHT_LOCK height lock must be an 8-byte number";
+
+                const Height height_lock = Height(littleEndianToNative!ulong(
+                    height_bytes[0 .. ulong.sizeof]));
+                if (height_lock > tx.height_lock)
+                    return "VERIFY_HEIGHT_LOCK height lock of transaction is too low";
+
+                break;
+
             case OP.INVALID:
                 return "Script panic while executing OP.INVALID opcode";
 
@@ -912,6 +928,53 @@ unittest
             ~ [ubyte(32)] ~ kp.V[]
             ~ [ubyte(OP.VERIFY_SIG)]), Unlock([ubyte(OP.TRUE)]), tx, Input.init),
         null);
+}
+
+// OP.VERIFY_HEIGHT_LOCK
+unittest
+{
+    const height_9 = nativeToLittleEndian(ulong(9));
+    const height_10 = nativeToLittleEndian(ulong(10));
+    const height_11 = nativeToLittleEndian(ulong(11));
+
+    scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
+    const Transaction tx_10 = { height_lock : Height(10) };
+    const Transaction tx_11 = { height_lock : Height(11) };
+    test!("==")(engine.execute(
+        Lock(LockType.Script,
+            toPushOpcode(height_9)
+            ~ [ubyte(OP.VERIFY_HEIGHT_LOCK), ubyte(OP.TRUE)]),
+        Unlock.init, tx_10, Input.init),
+        null);
+    test!("==")(engine.execute(
+        Lock(LockType.Script,
+            toPushOpcode(height_10)
+            ~ [ubyte(OP.VERIFY_HEIGHT_LOCK), ubyte(OP.TRUE)]),
+        Unlock.init, tx_10, Input.init),  // tx with matching unlock height
+        null);
+    test!("==")(engine.execute(
+        Lock(LockType.Script,
+            toPushOpcode(height_11)
+            ~ [ubyte(OP.VERIFY_HEIGHT_LOCK), ubyte(OP.TRUE)]),
+        Unlock.init, tx_10, Input.init),
+        "VERIFY_HEIGHT_LOCK height lock of transaction is too low");
+    test!("==")(engine.execute(
+        Lock(LockType.Script,
+            toPushOpcode(height_11)
+            ~ [ubyte(OP.VERIFY_HEIGHT_LOCK), ubyte(OP.TRUE)]),
+        Unlock.init, tx_11, Input.init),  // tx with matching unlock height
+        null);
+    test!("==")(engine.execute(
+        Lock(LockType.Script,
+            toPushOpcode(nativeToLittleEndian(ubyte(9)))
+            ~ [ubyte(OP.VERIFY_HEIGHT_LOCK), ubyte(OP.TRUE)]),
+        Unlock.init, tx_10, Input.init),
+        "VERIFY_HEIGHT_LOCK height lock must be an 8-byte number");
+    test!("==")(engine.execute(
+        Lock(LockType.Script,
+            [ubyte(OP.VERIFY_HEIGHT_LOCK), ubyte(OP.TRUE)]),
+        Unlock.init, tx_10, Input.init),
+        "VERIFY_HEIGHT_LOCK opcode requires a lock height on the stack");
 }
 
 // LockType.Key (Native P2PK - Pay to Public Key), consumes 33 bytes

--- a/source/agora/script/Opcodes.d
+++ b/source/agora/script/Opcodes.d
@@ -98,16 +98,21 @@ public enum OP : ubyte
     /// Transaction's `height_lock` is greater than or equal to this value.
     VERIFY_HEIGHT_LOCK = 0x59,
 
+    /// Verify the time lock of the associated spending Input. Expects a
+    /// 4-byte unsigned integer as the unlock age on the stack, and verifies
+    /// that the Input's `unlock_age` is greater than or equal to this value.
+    VERIFY_UNLOCK_AGE = 0x5A,
+
     /// Pops two items from the stack. The two items must be a Point (Schnorr),
     /// and a Signature. If the items cannot be deserialized as a Point and
     /// Signature, the script validation fails.
     /// The signature is then validated using Schnorr, if the signature is
     /// valid then `TRUE` is pushed to the stack.
-    CHECK_SIG = 0x5A,
+    CHECK_SIG = 0x5B,
 
     /// Ditto, but instead of pushing the result to the stack it will cause the
     /// script execution to fail if the signature is invalid
-    VERIFY_SIG = 0x5B,
+    VERIFY_SIG = 0x5C,
 }
 
 /*******************************************************************************

--- a/source/agora/script/Opcodes.d
+++ b/source/agora/script/Opcodes.d
@@ -93,16 +93,21 @@ public enum OP : ubyte
     /// execution to fail if the two items are not equal to each other.
     VERIFY_EQUAL = 0x58,
 
+    /// Verify the height lock of a spending Transaction. Expects an 8-byte
+    /// unsigned integer as the height on the stack, and verifies that the
+    /// Transaction's `height_lock` is greater than or equal to this value.
+    VERIFY_HEIGHT_LOCK = 0x59,
+
     /// Pops two items from the stack. The two items must be a Point (Schnorr),
     /// and a Signature. If the items cannot be deserialized as a Point and
     /// Signature, the script validation fails.
     /// The signature is then validated using Schnorr, if the signature is
     /// valid then `TRUE` is pushed to the stack.
-    CHECK_SIG = 0x59,
+    CHECK_SIG = 0x5A,
 
     /// Ditto, but instead of pushing the result to the stack it will cause the
     /// script execution to fail if the signature is invalid
-    VERIFY_SIG = 0x5A,
+    VERIFY_SIG = 0x5B,
 }
 
 /*******************************************************************************


### PR DESCRIPTION
This previously required:

- https://github.com/bpfkorea/agora/pull/1291
- https://github.com/bpfkorea/agora/pull/1339

This does not yet integrate the engine with Agora, that will be part of another PR.