### PR TITLE
Allow a block to have between 1 and 1000 transactions

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -426,7 +426,7 @@ extern(D):
         const cur_height = this.ledger.getBlockHeight();
         if (envelope.statement.slotIndex <= cur_height)
         {
-            log.trace("Rejected envelope with outdated slot #{} (ledger: #{})",
+            log.trace("Ignoring envelope with outdated slot #{} (ledger: #{})",
                 envelope.statement.slotIndex, cur_height);
             return;  // slot was already externalized, ignore outdated message
         }
@@ -442,7 +442,7 @@ extern(D):
         }
 
         if (this.scp.receiveEnvelope(envelope) != SCP.EnvelopeState.VALID)
-            log.info("Rejected invalid envelope: {}", scpPrettify(&envelope));
+            log.trace("SCP indicated invalid envelope: {}", scpPrettify(&envelope));
     }
 
     /***************************************************************************

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -57,6 +57,11 @@ import core.time : msecs, seconds;
 
 mixin AddLogger!();
 
+// TODO: The block should probably have a size limit rather than a maximum
+//  number of transactions.
+//  But for now set a maximum number of transactions to a thousand
+enum MaxTransactionsPerBlock = 1000;
+
 /// Ditto
 public extern (C++) class Nominator : SCPDriver
 {
@@ -262,8 +267,8 @@ extern(D):
 
     protected bool prepareNominatingSet (out ConsensusData data) @safe
     {
-        this.ledger.prepareNominatingSet(data, 8);
-        if (data.tx_set.length != 8)
+        this.ledger.prepareNominatingSet(data, MaxTransactionsPerBlock);
+        if (data.tx_set.length < 1)
             return false;  // not ready to nominate yet
 
         // check whether the consensus data is valid before nominating it.

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -15,6 +15,7 @@ node:
   data_dir: .cache
 
   validator_cycle: 20
+  block_interval_sec: 5
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -16,6 +16,7 @@ node:
   data_dir: .cache
 
   validator_cycle: 20
+  block_interval_sec: 5
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -16,6 +16,7 @@ node:
   data_dir: .cache
 
   validator_cycle: 20
+  block_interval_sec: 5
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -16,6 +16,7 @@ node:
   data_dir: .cache
 
   validator_cycle: 20
+  block_interval_sec: 5
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -16,6 +16,7 @@ node:
   data_dir: .cache
 
   validator_cycle: 20
+  block_interval_sec: 5
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -16,6 +16,7 @@ node:
   data_dir: .cache
 
   validator_cycle: 20
+  block_interval_sec: 5
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/source/main.d
+++ b/tests/system/source/main.d
@@ -50,6 +50,7 @@ private void waitForDiscovery (API[] clients, Duration timeout)
 
 int main (string[] args)
 {
+    writefln("%s START SYSTEM TEST", PREFIX);
     if (args.length < 2)
     {
         writeln("%s You must enter addresses of the nodes to connect to.", PREFIX);
@@ -127,7 +128,7 @@ private void assertBlockHeight (const string[] addresses, ulong height)
             {
                 writefln("%s Client #%s is at block height %s", PREFIX, idx, getHeight);
                 const blocks = client.getBlocksFrom(0, 42);
-                writefln("%s Client #%s has blocks:\n%s", PREFIX, idx, blocks.map!prettify);
+                writefln("%s Client #%s has blocks:\n%s", PREFIX, idx, prettify(blocks));
                 writefln("%s ----------------------------------------", PREFIX);
                 assert(blocks.length == height + 1);
                 if (idx != 0)


### PR DESCRIPTION
Fixes issue #1356.
I also updated the ci test to use a `block_interval_sec` of 5. The test first only adds a single transaction so that the first block, after Genesis, will always have a single transaction. All nodes are then checked until they have height 1. Then I generate 8 more transactions and make sure block at height 2 is externalised by all the nodes.