### PR TITLE
Stop nominating immediately after externalize

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -352,13 +352,13 @@ public class Validator : FullNode, API
     protected final override void onAcceptedBlock (const ref Block block,
         bool validators_changed) @safe
     {
-        super.onAcceptedBlock(block, validators_changed);
+        assert(block.header.height >= this.last_shuffle_height);
 
         // block received either via externalize or getBlocksFrom(),
-        // we need to cancel any existing nominating rounds
+        // we need to cancel any existing nominating rounds.
+        // note: must be called before any context switch
         this.nominator.stopNominationRound(block.header.height);
-
-        assert(block.header.height >= this.last_shuffle_height);
+        super.onAcceptedBlock(block, validators_changed);
 
         const need_shuffle = block.header.height >=
             (this.last_shuffle_height + this.params.QuorumShuffleInterval);


### PR DESCRIPTION
There is a potential for a context switch here.

I'm not sure if this is related to #1364, but it's definitely a bug. We'll test it with #1364 next week.