### PR TITLE
Stabilize quorum generator tests

### DIFF
--- a/source/agora/consensus/Quorum.d
+++ b/source/agora/consensus/Quorum.d
@@ -126,7 +126,7 @@ unittest
 {
     auto keys = getKeys(1);
     auto quorums = buildTestQuorums(Amount.MinFreezeAmount.only, keys,
-        hashFull(1), QuorumParams.init);
+        hashFull(1), QuorumParams.init, 0);
     verifyQuorumsSanity(quorums);
     verifyQuorumsIntersect(quorums);
     test!"=="(countNodeInclusions(quorums, keys), [1]);
@@ -137,7 +137,7 @@ unittest
 {
     auto keys = getKeys(2);
     auto quorums = buildTestQuorums(Amount.MinFreezeAmount.repeat(2), keys,
-        hashFull(1), QuorumParams.init);
+        hashFull(1), QuorumParams.init, 1);
     verifyQuorumsSanity(quorums);
     verifyQuorumsIntersect(quorums);
     test!"=="(countNodeInclusions(quorums, keys), [2, 2]);
@@ -148,7 +148,7 @@ unittest
 {
     auto keys = getKeys(3);
     auto quorums = buildTestQuorums(Amount.MinFreezeAmount.repeat(3), keys,
-        hashFull(1), QuorumParams.init);
+        hashFull(1), QuorumParams.init, 2);
     verifyQuorumsSanity(quorums);
     verifyQuorumsIntersect(quorums);
     test!"=="(countNodeInclusions(quorums, keys), [3, 3, 3]);
@@ -159,7 +159,7 @@ unittest
 {
     auto keys = getKeys(4);
     auto quorums = buildTestQuorums(Amount.MinFreezeAmount.repeat(4), keys,
-        hashFull(1), QuorumParams.init);
+        hashFull(1), QuorumParams.init, 3);
     verifyQuorumsSanity(quorums);
     verifyQuorumsIntersect(quorums);
     test!"=="(countNodeInclusions(quorums, keys), [4, 4, 4, 4]);
@@ -170,16 +170,16 @@ unittest
 {
     auto keys = getKeys(8);
     auto quorums_1 = buildTestQuorums(Amount.MinFreezeAmount.repeat(8), keys,
-        hashFull(1), QuorumParams.init);
+        hashFull(1), QuorumParams.init, 4);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
-    test!"=="(countNodeInclusions(quorums_1, keys), [8, 5, 6, 7, 7, 8, 7, 8]);
+    test!"=="(countNodeInclusions(quorums_1, keys), [7, 8, 7, 6, 8, 7, 7, 6]);
 
     auto quorums_2 = buildTestQuorums(Amount.MinFreezeAmount.repeat(8), keys,
-        hashFull(2), QuorumParams.init);
+        hashFull(2), QuorumParams.init, 5);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
-    test!"=="(countNodeInclusions(quorums_2, keys), [8, 6, 8, 6, 6, 7, 7, 8]);
+    test!"=="(countNodeInclusions(quorums_2, keys), [8, 6, 7, 7, 6, 8, 6, 8]);
 }
 
 // 16 nodes with equal stakes
@@ -187,18 +187,18 @@ unittest
 {
     auto keys = getKeys(16);
     auto quorums_1 = buildTestQuorums(Amount.MinFreezeAmount.repeat(16), keys,
-        hashFull(1), QuorumParams.init);
+        hashFull(1), QuorumParams.init, 6);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
     test!"=="(countNodeInclusions(quorums_1, keys),
-        [9, 6, 5, 8, 7, 9, 6, 7, 6, 5, 6, 6, 8, 5, 8, 11]);
+        [8, 6, 8, 3, 7, 8, 8, 8, 8, 7, 7, 4, 6, 8, 7, 9]);
 
     auto quorums_2 = buildTestQuorums(Amount.MinFreezeAmount.repeat(16), keys,
-        hashFull(2), QuorumParams.init);
+        hashFull(2), QuorumParams.init, 7);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
     test!"=="(countNodeInclusions(quorums_2, keys),
-        [5, 6, 8, 8, 6, 9, 8, 5, 9, 6, 8, 9, 7, 7, 5, 6]);
+        [6, 7, 8, 5, 6, 9, 8, 6, 7, 8, 9, 6, 9, 7, 5, 6]);
 }
 
 // 16 nodes with linearly ascending stakes
@@ -208,14 +208,14 @@ unittest
         .map!(idx => Amount(400000000000uL + (100000000000uL * idx)));
     auto keys = getKeys(16);
     auto quorums_1 = buildTestQuorums(amounts, keys, hashFull(1),
-        QuorumParams.init);
+        QuorumParams.init, 8);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
     test!"=="(countNodeInclusions(quorums_1, keys),
         [2, 5, 5, 6, 6, 6, 9, 4, 8, 7, 11, 9, 10, 5, 8, 11]);
 
     auto quorums_2 = buildTestQuorums(amounts, keys, hashFull(2),
-        QuorumParams.init);
+        QuorumParams.init, 9);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
     test!"=="(countNodeInclusions(quorums_2, keys),
@@ -229,18 +229,18 @@ unittest
     auto amounts = Amount(400000000000uL).repeat(16).array;
     amounts[0] = amounts[$ - 1] = Amount(400000000000uL * 14);
     auto quorums_1 = buildTestQuorums(amounts, keys, hashFull(1),
-        QuorumParams.init);
+        QuorumParams.init, 10);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
     test!"=="(countNodeInclusions(quorums_1, keys),
-        [16, 6, 3, 8, 5, 6, 5, 11, 5, 5, 4, 7, 4, 4, 7, 16]);
+        [16, 8, 5, 10, 6, 5, 4, 6, 6, 5, 4, 6, 4, 5, 6, 16]);
 
     auto quorums_2 = buildTestQuorums(amounts, keys, hashFull(2),
-        QuorumParams.init);
+        QuorumParams.init, 11);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
     test!"=="(countNodeInclusions(quorums_2, keys),
-        [16, 7, 5, 1, 4, 8, 3, 5, 6, 9, 7, 8, 6, 3, 8, 16]);
+        [16, 5, 8, 4, 4, 7, 6, 7, 3, 11, 6, 7, 3, 3, 6, 16]);
 }
 
 // 32 nodes where two nodes own 66% of the stake
@@ -250,24 +250,24 @@ unittest
     auto amounts = Amount(400000000000uL).repeat(32).array;
     amounts[0] = amounts[$ - 1] = Amount(400000000000uL * 30);
     auto quorums_1 = buildTestQuorums(amounts, keys, hashFull(1),
-        QuorumParams.init);
+        QuorumParams.init, 12);
     verifyQuorumsSanity(quorums_1);
     // verified to work but disabled because it runs slow with a
     // non-max threshold (~20 seconds)
     //verifyQuorumsIntersect(quorums_1);
     test!"=="(countNodeInclusions(quorums_1, keys),
-        [32, 5, 5, 6, 4, 5, 6, 8, 5, 6, 7, 2, 4, 5, 3, 10, 4, 7, 6, 5, 6, 3, 8,
-        6, 3, 6, 5, 5, 3, 6, 6, 32]);
+        [32, 7, 5, 5, 5, 4, 4, 6, 4, 3, 5, 6, 8, 3, 10, 7, 7, 6, 4, 6, 6, 4, 4,
+        5, 4, 3, 7, 4, 6, 6, 6, 32]);
 
     auto quorums_2 = buildTestQuorums(amounts, keys, hashFull(2),
-        QuorumParams.init);
+        QuorumParams.init, 13);
     verifyQuorumsSanity(quorums_2);
     // verified to work but disabled because it runs slow with a
     // non-max threshold (~20 seconds)
     //verifyQuorumsIntersect(quorums_2);
     test!"=="(countNodeInclusions(quorums_2, keys),
-        [31, 2, 8, 3, 5, 8, 1, 5, 7, 5, 5, 7, 6, 6, 9, 5, 3, 5, 3, 9, 7, 2, 3,
-        6, 5, 8, 3, 7, 8, 3, 8, 31]);
+        [31, 7, 5, 6, 6, 2, 3, 9, 3, 6, 8, 3, 7, 5, 7, 10, 5, 3, 5, 3, 5, 5, 6,
+        1, 7, 8, 6, 4, 4, 6, 7, 31]);
 }
 
 // 64 nodes where two nodes own 66% of the stake
@@ -277,26 +277,26 @@ unittest
     auto amounts = Amount(400000000000uL).repeat(64).array;
     amounts[0] = amounts[$ - 1] = Amount(400000000000uL * 62);
     auto quorums_1 = buildTestQuorums(amounts, keys, hashFull(1),
-        QuorumParams.init);
+        QuorumParams.init, 14);
     verifyQuorumsSanity(quorums_1);
     // verified to work but disabled because it runs slow with a
     // non-max threshold (~20 minutes)
     //verifyQuorumsIntersect(quorums_1);
     test!"=="(countNodeInclusions(quorums_1, keys),
-        [64, 6, 3, 3, 5, 5, 5, 9, 4, 3, 4, 9, 6, 5, 7, 4, 7, 4, 4, 6, 7, 6, 3,
-        6, 12, 6, 9, 4, 4, 9, 2, 4, 3, 5, 5, 5, 7, 4, 4, 6, 5, 5, 6, 6, 7, 6, 4,
-        4, 7, 5, 8, 3, 3, 4, 7, 5, 2, 4, 5, 5, 2, 4, 5, 62]);
+        [63, 2, 6, 5, 5, 2, 5, 6, 6, 4, 4, 1, 7, 8, 7, 5, 4, 5, 6, 5, 5, 6, 9,
+        1, 6, 5, 4, 11, 7, 9, 4, 4, 3, 7, 4, 5, 9, 4, 5, 4, 4, 4, 5, 5, 5, 5, 6,
+        7, 5, 2, 5, 4, 6, 4, 10, 3, 6, 4, 10, 6, 3, 4, 4, 63]);
 
     auto quorums_2 = buildTestQuorums(amounts, keys, hashFull(2),
-        QuorumParams.init);
+        QuorumParams.init, 15);
     verifyQuorumsSanity(quorums_2);
     // verified to work but disabled because it runs slow with a
     // non-max threshold (~20 minutes)
     //verifyQuorumsIntersect(quorums_2);
     test!"=="(countNodeInclusions(quorums_2, keys),
-        [61, 6, 4, 5, 5, 6, 5, 4, 1, 4, 6, 5, 5, 7, 3, 6, 3, 5, 6, 6, 3, 3, 3,
-        6, 7, 4, 3, 3, 6, 8, 6, 8, 7, 4, 2, 6, 5, 1, 5, 8, 4, 7, 9, 6, 4, 4, 4,
-        8, 4, 2, 5, 6, 8, 6, 2, 5, 10, 5, 4, 8, 8, 8, 8, 62]);
+        [61, 7, 5, 9, 5, 3, 3, 7, 7, 7, 5, 4, 4, 7, 5, 6, 4, 6, 4, 5, 6, 4, 4,
+        3, 4, 8, 6, 5, 6, 4, 4, 2, 8, 4, 3, 7, 4, 6, 5, 6, 5, 6, 6, 6, 4, 3, 3,
+        3, 6, 8, 7, 2, 4, 7, 3, 4, 8, 8, 7, 9, 5, 6, 3, 62]);
 }
 
 // 128 nodes where two nodes own 66% of the stake
@@ -306,30 +306,30 @@ unittest
     auto amounts = Amount(400000000000uL).repeat(128).array;
     amounts[0] = amounts[$ - 1] = Amount(400000000000uL * 126);
     auto quorums_1 = buildTestQuorums(amounts, keys, hashFull(1),
-        QuorumParams.init);
+        QuorumParams.init, 16);
     verifyQuorumsSanity(quorums_1);
     // not verified to work.
     //verifyQuorumsIntersect(quorums_1);
     test!"=="(countNodeInclusions(quorums_1, keys),
-        [124, 4, 8, 6, 4, 4, 2, 4, 4, 7, 5, 9, 4, 6, 3, 5, 3, 8, 6, 8, 3, 4, 8,
-        4, 4, 3, 6, 4, 3, 4, 5, 2, 6, 3, 6, 6, 6, 5, 3, 5, 9, 9, 4, 3, 4, 6, 3,
-        7, 3, 6, 6, 6, 4, 5, 7, 5, 8, 4, 3, 5, 3, 5, 6, 6, 5, 5, 7, 5, 6, 5, 6,
-        9, 9, 6, 10, 6, 6, 6, 7, 3, 8, 5, 3, 3, 2, 6, 5, 5, 3, 4, 5, 7, 3, 5, 5,
-        6, 5, 7, 2, 4, 7, 2, 6, 6, 5, 3, 5, 4, 5, 4, 4, 5, 6, 4, 5, 8, 5, 3, 4,
-        9, 6, 3, 6, 6, 5, 5, 6, 124]);
+        [124, 8, 5, 4, 7, 6, 3, 1, 7, 5, 2, 2, 4, 4, 4, 11, 3, 4, 3, 5, 5, 8, 6,
+        3, 6, 7, 4, 3, 4, 7, 6, 7, 8, 6, 4, 4, 7, 7, 6, 4, 6, 5, 6, 4, 4, 4, 4,
+        6, 4, 6, 3, 9, 5, 6, 2, 4, 4, 5, 3, 4, 6, 5, 2, 3, 4, 2, 5, 3, 3, 7, 5,
+        2, 5, 6, 5, 9, 10, 2, 7, 4, 5, 9, 6, 7, 4, 6, 4, 6, 6, 4, 6, 4, 6, 2, 6,
+        9, 8, 4, 4, 4, 7, 7, 7, 2, 6, 6, 6, 5, 8, 4, 7, 5, 2, 5, 7, 5, 6, 6, 7,
+        7, 4, 3, 3, 7, 6, 6, 5, 124]);
 
     auto quorums_2 = buildTestQuorums(amounts, keys, hashFull(2),
-        QuorumParams.init);
+        QuorumParams.init, 17);
     verifyQuorumsSanity(quorums_2);
     // not verified to work.
     //verifyQuorumsIntersect(quorums_2);
     test!"=="(countNodeInclusions(quorums_2, keys),
-        [124, 3, 3, 8, 10, 3, 6, 9, 6, 7, 8, 10, 3, 3, 1, 3, 7, 2, 8, 6, 4, 4,
-        6, 2, 10, 7, 6, 4, 6, 7, 6, 3, 6, 3, 3, 9, 3, 7, 9, 7, 5, 6, 5, 4, 8, 3,
-        2, 5, 8, 8, 6, 2, 7, 2, 5, 5, 5, 5, 2, 5, 6, 3, 4, 5, 7, 3, 8, 4, 4, 5,
-        3, 6, 8, 3, 4, 3, 7, 7, 7, 3, 3, 4, 5, 4, 3, 4, 9, 6, 5, 6, 5, 5, 3, 5,
-        3, 6, 4, 10, 6, 8, 6, 3, 6, 3, 12, 3, 4, 3, 6, 9, 2, 7, 4, 1, 5, 2, 3,
-        5, 5, 5, 3, 5, 4, 8, 5, 2, 7, 124]);
+        [124, 4, 5, 3, 10, 7, 4, 2, 2, 7, 3, 7, 5, 7, 3, 3, 5, 5, 4, 4, 4, 5, 9,
+        2, 7, 11, 7, 3, 7, 5, 3, 3, 6, 7, 7, 9, 4, 6, 8, 5, 3, 7, 7, 4, 5, 6, 7,
+        5, 3, 6, 3, 8, 3, 7, 7, 4, 4, 2, 5, 6, 4, 7, 3, 4, 6, 7, 5, 2, 11, 5, 3,
+        6, 8, 5, 5, 6, 5, 8, 3, 7, 7, 7, 3, 3, 1, 3, 4, 9, 2, 7, 3, 3, 6, 8, 4,
+        6, 5, 4, 5, 7, 9, 2, 3, 5, 5, 3, 6, 5, 7, 4, 6, 5, 3, 4, 8, 4, 5, 4, 5,
+        6, 3, 7, 5, 3, 4, 1, 9, 124]);
 }
 
 // using various different quorum parameter configurations
@@ -338,33 +338,33 @@ unittest
     QuorumParams qp_1 = { MaxQuorumNodes : 4, QuorumThreshold : 80 };
     auto keys = getKeys(10);
     auto quorums_1 = buildTestQuorums(Amount.MinFreezeAmount.repeat(10), keys,
-        hashFull(1), qp_1);
+        hashFull(1), qp_1, 18);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
     quorums_1.byValue.each!(qc => test!"<="(qc.nodes.length, 4));
     quorums_1.byValue.each!(qc => test!"=="(qc.threshold, 4));
     test!"=="(countNodeInclusions(quorums_1, keys),
-        [3, 3, 2, 4, 4, 3, 3, 8, 6, 4]);
+        [4, 2, 6, 4, 4, 4, 2, 5, 6, 3]);
 
     QuorumParams qp_2 = { MaxQuorumNodes : 8, QuorumThreshold : 80 };
     auto quorums_2 = buildTestQuorums(Amount.MinFreezeAmount.repeat(10), keys,
-        hashFull(1), qp_2);
+        hashFull(1), qp_2, 19);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
     quorums_2.byValue.each!(qc => test!"<="(qc.nodes.length, 8));
     quorums_2.byValue.each!(qc => test!"=="(qc.threshold, 7));
     test!"=="(countNodeInclusions(quorums_2, keys),
-        [8, 7, 3, 9, 8, 10, 8, 10, 10, 7]);
+        [7, 7, 5, 9, 9, 8, 7, 9, 10, 9]);
 
     QuorumParams qp_3 = { MaxQuorumNodes : 8, QuorumThreshold : 60 };
     auto quorums_3 = buildTestQuorums(Amount.MinFreezeAmount.repeat(10), keys,
-        hashFull(1), qp_3);
+        hashFull(1), qp_3, 20);
     verifyQuorumsSanity(quorums_3);
     verifyQuorumsIntersect(quorums_3);
     quorums_3.byValue.each!(qc => test!"<="(qc.nodes.length, 8));
     quorums_3.byValue.each!(qc => test!"=="(qc.threshold, 5));
     test!"=="(countNodeInclusions(quorums_3, keys),
-        [8, 7, 3, 9, 8, 10, 8, 10, 10, 7]);
+        [7, 8, 8, 9, 9, 9, 6, 9, 8, 7]);
 }
 
 version (unittest)
@@ -483,7 +483,7 @@ private NodeStake[] buildStakesDescending (const ref PublicKey filter,
 version (unittest)
 private QuorumConfig[PublicKey] buildTestQuorums (Range)(Range amounts,
     const(PublicKey)[] keys, const auto ref Hash rand_seed,
-    const auto ref QuorumParams params)
+    const auto ref QuorumParams params, int id)
 {
     assert(amounts.length == keys.length);
     QuorumConfig[PublicKey] quorums;
@@ -496,7 +496,17 @@ private QuorumConfig[PublicKey] buildTestQuorums (Range)(Range amounts,
             outputs: [Output(amount, keys[idx])]
         };
 
-        storage.put(tx);
+        // simulating our own UTXO hashes to make the tests stable
+        Hash txhash = hashMulti(id, idx, amount);
+        foreach (size_t out_idx, ref output_; tx.outputs)
+        {
+            Hash h = UTXO.getHash(txhash, out_idx);
+            UTXO v = {
+                type: tx.type,
+                output: output_
+            };
+            storage[txhash] = v;
+        }
     }
 
     Hash[] utxos = storage.keys;


### PR DESCRIPTION
The quorum generator tests will no longer fail whenever there is a change in the hashing algorithm of the transactions.