### PR TITLE
Simplify the generation of many blocks in unit tests

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1860,7 +1860,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
         conf.node.genesis_start_time = genesis_start_time;
     }
 
-    immutable(Block)[] blocks = generateBlocks(GenesisBlock,
+    immutable(Block)[] blocks = generateExtraBlocks(GenesisBlock,
         test_conf.extra_blocks);
 
     auto net = new APIManager(blocks, test_conf, genesis_start_time);
@@ -1909,7 +1909,7 @@ public const(Block)[] getAllBlocks (TestAPI node)
 
 *******************************************************************************/
 
-private immutable(Block)[] generateBlocks (
+private immutable(Block)[] generateExtraBlocks (
     ref immutable Block gen_block, size_t count)
 {
     const(Block)[] blocks = [gen_block];

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -61,7 +61,7 @@ unittest
 
     // Make 3 more blocks in new cycle
     network.generateBlocks(iota(GenesisValidators),
-        Height(GenesisValidatorCycle + 3), Height(GenesisValidatorCycle));
+        Height(GenesisValidatorCycle + 3));
 }
 
 // Test for re-enroll before the validator cycle ends

--- a/source/agora/test/ManyBlocks.d
+++ b/source/agora/test/ManyBlocks.d
@@ -1,12 +1,11 @@
 /*******************************************************************************
 
-    Contains the simplest possible block creating test
+    Testing generastion of many blocks with re-enrolling every cycle
 
-    This is useful as a starting point for creating more complext test-cases,
-    or just to test new behavior with the simplest creation of blocks.
+    This is useful as a starting point for testing many blocks can be created.
 
     Run via:
-    $ dtest=agora.test.Simple dub test
+    $ dtest=agora.test.ManyBlocks dub test
 
     Copyright:
         Copyright (c) 2020 BOS Platform Foundation Korea
@@ -17,18 +16,19 @@
 
 *******************************************************************************/
 
-module agora.test.Simple;
+module agora.test.ManyBlocks;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.consensus.data.Transaction;
 import agora.test.Base;
 
 /// Simple test
 unittest
 {
-    TestConf conf = TestConf.init;
+    TestConf conf = {
+        txs_to_nominate : 1,
+        quorum_threshold : 100
+    };
     auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();
@@ -38,8 +38,7 @@ unittest
     auto nodes = network.clients;
     auto node_1 = nodes[0];
 
-    auto txes = genesisSpendable().map!(txb => txb.sign()).array();
-    txes.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1));
-
+    auto target_height = Height(101);
+    network.generateBlocks(target_height);
+    network.assertSameBlocks(target_height);
 }

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -60,7 +60,7 @@ void manyValidators (size_t validators)
 
     // Generate the last block of cycle with Genesis validators
     network.generateBlocks(iota(GenesisValidators),
-        Height(GenesisValidatorCycle), Height(0));
+        Height(GenesisValidatorCycle));
 
     // make sure outsiders are up to date
     network.expectBlock(iota(GenesisValidators, validators),
@@ -73,8 +73,7 @@ void manyValidators (size_t validators)
                 idx, node.getValidatorCount(), validators)));
 
     // first validated block using all nodes
-    network.generateBlocks(iota(validators), Height(GenesisValidatorCycle + 1),
-        Height(GenesisValidatorCycle));
+    network.generateBlocks(iota(validators), Height(GenesisValidatorCycle + 1));
 }
 
 /// 8 nodes

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -88,7 +88,7 @@ unittest
 
     // verify that consensus can still be reached by the leftover validators
     network.generateBlocks(iota(GenesisValidators, nodes.length),
-        Height(GenesisValidatorCycle + 1), Height(GenesisValidatorCycle));
+        Height(GenesisValidatorCycle + 1));
 
     // force wake up
     nodes.takeExactly(GenesisValidators).each!(node =>

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -159,7 +159,7 @@ unittest
 
      // Generate the last block of cycle with Genesis validators
     network.generateBlocks(iota(GenesisValidators),
-        Height(GenesisValidatorCycle), Height(0));
+        Height(GenesisValidatorCycle));
 
     // make sure outsiders are up to date
     network.expectBlock(iota(GenesisValidators, validators),
@@ -259,14 +259,14 @@ unittest
 
     // create 19 blocks with all validators (1 short of end of 2nd cycle)
     network.generateBlocks(iota(validators),
-        Height((2 * GenesisValidatorCycle) - 1), Height(GenesisValidatorCycle));
+        Height((2 * GenesisValidatorCycle) - 1));
 
     // Re-enroll
     iota(validators).each!(idx => network.enroll(idx));
 
     // Generate the last block of cycle with Genesis validators
     network.generateBlocks(iota(validators),
-        Height(2 * GenesisValidatorCycle), Height(GenesisValidatorCycle));
+        Height(2 * GenesisValidatorCycle));
 
     // these changed compared to quorums_2 due to the new enrollments
     // which use a different preimage

--- a/source/agora/test/QuorumShuffle.d
+++ b/source/agora/test/QuorumShuffle.d
@@ -46,31 +46,21 @@ unittest
 
     const keys = network.nodes.map!(node => node.client.getPublicKey()).array;
 
-    Height enrolledHeight (ulong height)
-    {
-        Height enrolledHeight = Height(((height - 1) / GenesisValidatorCycle)
-            * GenesisValidatorCycle);
-        log.trace("enrolledHeight = {}", enrolledHeight);
-        return enrolledHeight;
-    }
-
     QuorumConfig[] checkQuorum (Height height) {
         if (height > 0) // if not Genesis block
         {
             if (height % GenesisValidatorCycle == 0) {
-                log.trace("generateBlocks to height {}, enrollments from {}",
-                    height - 1, enrolledHeight(height - 1));
-                network.generateBlocks(Height(height - 1),
-                    enrolledHeight(Height(height - 1)));
+                log.trace("generateBlocks to height {}", height - 1);
+                network.generateBlocks(Height(height - 1));
                 log.trace("re-enrolling at height {}", height);
                 iota(0, GenesisValidators).each!(idx => network.enroll(idx));
                 log.trace("generateBlocks to height {}", height);
-                network.generateBlocks(Height(height), enrolledHeight(height));
+                network.generateBlocks(Height(height));
             }
             else
             {
                 log.trace("generateBlocks to height {}", height);
-                network.generateBlocks(Height(height), enrolledHeight(height));
+                network.generateBlocks(Height(height));
             }
         }
         log.trace("checkQuorum for height {}", height);

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -110,7 +110,7 @@ unittest
 
     // Block 21 with the new validators in the set B
     network.generateBlocks(iota(GenesisValidators, cast(size_t) nodes.length),
-        Height(GenesisValidatorCycle + 1), Height(GenesisValidatorCycle));
+        Height(GenesisValidatorCycle + 1));
 }
 
 /// Situation: A validator is stopped and wiped clean after the block height


### PR DESCRIPTION
This is a simple change now that we have auto re-enrollment. 