### PR TITLE
Refuse Enrollments if the public key is already present

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -597,33 +597,6 @@ public class EnrollmentManager
 
     /***************************************************************************
 
-        Restore validators' information from block
-
-        Params:
-            last_height = the latest block height
-            block = the block to update the validator set with
-            finder = the delegate to find UTXOs with
-            self_utxos = the UTXOs belonging to this node
-
-    ***************************************************************************/
-
-    public void restoreValidators (Height last_height, const ref Block block,
-        scope UTXOFinder finder, in UTXO[Hash] self_utxos)
-        @safe nothrow
-    {
-        assert(last_height >= block.header.height);
-        if (last_height - block.header.height < this.params.ValidatorCycle)
-        {
-            foreach (const ref enroll; block.header.enrollments)
-            {
-                this.addValidator(enroll, block.header.height, finder,
-                    self_utxos);
-            }
-        }
-    }
-
-    /***************************************************************************
-
         Get the public key of node that is used for a enrollment
 
         Returns:

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -237,9 +237,9 @@ public class ValidatorSet
         }
         catch (Exception ex)
         {
-            log.error("Exception occured on hasEnrollment: {}, " ~
+            log.fatal("Exception occured on hasEnrollment: {}, " ~
                 "Key for enrollment: {}", ex.msg, enroll_hash);
-            return false;
+            assert(0);
         }
     }
 
@@ -265,9 +265,9 @@ public class ValidatorSet
         }
         catch (Exception ex)
         {
-            log.error("Exception occured on hasEnrollment: {}, " ~
+            log.fatal("Exception occured on hasEnrollment: {}, " ~
                 "PublicKey for enrollment: {}", ex.msg, pubkey);
-            return false;
+            assert(0);
         }
     }
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -573,8 +573,10 @@ public class FullNode : API
     {
         this.endpoint_request_stats.increaseMetricBy!"agora_endpoint_calls_total"(1, "enroll_validator", "http");
 
-        if (this.enroll_man.addEnrollment(enroll, this.ledger.getBlockHeight(),
-            this.utxo_set.getUTXOFinder()))
+        UTXO utxo;
+        this.utxo_set.peekUTXO(enroll.utxo_key, utxo);
+        if (this.enroll_man.addEnrollment(enroll, utxo.output.address,
+            this.ledger.getBlockHeight(), this.utxo_set.getUTXOFinder()))
         {
             log.info("Accepted enrollment: {}", prettify(enroll));
             this.network.sendEnrollment(enroll);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -190,17 +190,13 @@ public class Ledger
                 block_count >= this.params.ValidatorCycle
                 ? Height(block_count - this.params.ValidatorCycle) : Height(0);
 
-            PublicKey pubkey = this.enroll_man.getEnrollmentPublicKey();
-            UTXO[Hash] utxos = this.utxo_set.getUTXOs(pubkey);
-
             // restore validator set from the blockchain.
             // using block_count, as the range is inclusive
             foreach (block_idx; min_height .. block_count)
             {
                 Block block;
                 this.storage.readBlock(block, block_idx);
-                this.enroll_man.restoreValidators(this.last_block.header.height,
-                    block, this.utxo_set.getUTXOFinder(), utxos);
+                this.updateValidatorSet(block);
             }
         }
 
@@ -401,13 +397,11 @@ public class Ledger
     protected void updateValidatorSet (const ref Block block) @safe
     {
         this.enroll_man.clearExpiredValidators(block.header.height);
-
+        PublicKey pubkey = this.enroll_man.getEnrollmentPublicKey();
+        UTXO[Hash] utxos = this.utxo_set.getUTXOs(pubkey);
         foreach (idx, ref enrollment; block.header.enrollments)
         {
             this.enroll_man.removeEnrollment(enrollment.utxo_key);
-
-            PublicKey pubkey = this.enroll_man.getEnrollmentPublicKey();
-            UTXO[Hash] utxos = this.utxo_set.getUTXOs(pubkey);
             if (auto r = this.enroll_man.addValidator(enrollment,
                 block.header.height, this.utxo_set.getUTXOFinder(), utxos))
             {

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -1,0 +1,209 @@
+/*******************************************************************************
+
+    Contains networking tests with multiple enrollments with different UTXOs.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.EnrollDifferentUTXOs;
+
+version (unittest):
+
+import agora.common.Amount;
+import agora.common.Config;
+import agora.common.Hash;
+import agora.common.crypto.Key;
+import agora.consensus.EnrollmentManager;
+import agora.consensus.data.Block;
+import agora.consensus.data.Enrollment;
+import agora.consensus.data.Transaction;
+import agora.test.Base;
+
+import core.stdc.time;
+import core.thread;
+import geod24.Registry;
+
+private class SameKeyValidator : TestValidatorNode
+{
+    /// Ctor
+    public this (Config config, Registry* reg, immutable(Block)[] blocks,
+                    ulong txs_to_nominate, shared(time_t)* cur_time)
+    {
+        super(config, reg, blocks, txs_to_nominate, cur_time);
+    }
+
+    /// Create an enrollment with new UTXO which is not yet used
+    public override Enrollment createEnrollmentData ()
+    {
+        Hash[] utxo_hashes;
+        auto utxos = this.utxo_set.getUTXOs(
+            this.config.validator.key_pair.address);
+        foreach (key, utxo; utxos)
+        {
+            if (utxo.type == TxType.Freeze &&
+                utxo.output.value.integral() >= Amount.MinFreezeAmount.integral())
+            {
+                utxo_hashes ~= key;
+            }
+        }
+
+        // Find a UTXO which is not used for the enrollments in Genesis block
+        Hash unused_utxo;
+        Hash[] enroll_keys;
+        assert(this.enroll_man.getEnrolledUTXOs(enroll_keys));
+        foreach (utxo; utxo_hashes)
+        {
+            if (!canFind(enroll_keys, utxo))
+            {
+                unused_utxo = utxo;
+                break;
+            }
+        }
+        assert(unused_utxo != Hash.init);
+
+        return this.enroll_man.createEnrollment(unused_utxo);
+    }
+}
+
+private class SameKeyNodeAPIManager : TestAPIManager
+{
+    ///
+    public this (immutable(Block)[] blocks, TestConf test_conf, time_t initial_time)
+    {
+        super(blocks, test_conf, initial_time);
+    }
+
+    /// See base class
+    public override void createNewNode (Config conf, string file, int line)
+    {
+        if (this.nodes.length == 0)
+        {
+            auto time = new shared(time_t)(this.initial_time);
+            auto api = RemoteAPI!TestAPI.spawn!SameKeyValidator(
+                conf, &this.reg, this.blocks, this.test_conf.txs_to_nominate,
+                time, conf.node.timeout);
+            this.reg.register(conf.node.address, api.tid());
+            this.nodes ~= NodePair(conf.node.address, api, time);
+        }
+        else
+            super.createNewNode(conf, file, line);
+    }
+}
+
+/// Situation: There are six validators enrolled in Genesis block. Right before
+///     the cycle ends, the first validator re-enrolls with another UTXO and
+///     other validators re-enrolls again with the same UTXO used in the current
+///     enrollments.
+/// Expectation: Enrolling with the different UTXO of first validator fails but
+///     trying re-enrolling with the UTXO succeeds after the cycle ends.
+unittest
+{
+    TestConf conf = {
+        extra_blocks : 16,
+        recurring_enrollment : false,
+    };
+
+    auto network = makeTestNetwork!SameKeyNodeAPIManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+    auto nodes = network.clients;
+
+    // Sanity check
+    assert(network.blocks[0].header.enrollments.length >= 1);
+    network.expectBlock(Height(16), network.blocks[0].header, 5.seconds);
+
+    // Discarded UTXOs (just to trigger block creation)
+    auto spendable = network.blocks[$ - 1].spendable().array;
+    auto txs = spendable[0 .. 4]
+        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
+        .array;
+
+    // 8 utxos for freezing, 24 utxos for creating a block later
+    txs ~= spendable[4].split(WK.Keys.NODE2.address.repeat(8)).sign();
+    txs ~= spendable[5].split(WK.Keys.Z.address.repeat(8)).sign();
+    txs ~= spendable[6].split(WK.Keys.Z.address.repeat(8)).sign();
+    txs ~= spendable[7].split(WK.Keys.Z.address.repeat(8)).sign();
+
+    // Block 17
+    txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(17), network.blocks[0].header, 5.seconds);
+
+    // Freeze builders
+    auto freezable = txs[$ - 4]
+        .outputs.length.iota
+        .takeExactly(8)
+        .map!(idx => TxBuilder(txs[$ - 4], cast(uint)idx));
+
+    // Create 8 freeze TXs
+    auto freeze_txs = freezable
+        .enumerate
+        .map!(pair => pair.value.refund(WK.Keys.NODE2.address)
+            .sign(TxType.Freeze))
+        .array;
+    assert(freeze_txs.length == 8);
+
+    // Block 18
+    freeze_txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(18), network.blocks[0].header, 5.seconds);
+
+    // Block 19
+    auto new_txs = txs[$ - 3]
+        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 3], cast(uint)idx))
+        .takeExactly(8)
+        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
+    new_txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(19), network.blocks[0].header, 5.seconds);
+
+    // Now we re-enroll the first validator with a new UTXO but it will fail
+    // because an enrollment with same public key of the first validator is
+    // already present in the validator set.
+    Enrollment new_enroll = nodes[0].createEnrollmentData();
+    nodes[0].enrollValidator(new_enroll);
+    Thread.sleep(3.seconds);  // enrollValidator() can take a while..
+    nodes.each!(node =>
+        retryFor(node.getEnrollment(new_enroll.utxo_key) == Enrollment.init, 1.seconds));
+
+    // Now we re-enroll other five validators
+    foreach (node; nodes[1 .. $])
+    {
+        Enrollment enroll = node.createEnrollmentData();
+        nodes[0].enrollValidator(enroll);
+        nodes.each!(node =>
+            retryFor(node.getEnrollment(enroll.utxo_key) == enroll, 5.seconds));
+    }
+
+    // Block 20
+    new_txs = txs[$ - 2]
+        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 2], cast(uint)idx))
+        .takeExactly(8)
+        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
+    new_txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(20), 5.seconds);
+    auto b20 = nodes[0].getBlocksFrom(20, 2)[0];
+    assert(b20.header.enrollments.length == 5);
+
+    // Now we retry re-enrolling the first validator with the new UTXO
+    nodes[0].enrollValidator(new_enroll);
+    nodes.each!(node =>
+        retryFor(node.getEnrollment(new_enroll.utxo_key) == new_enroll, 5.seconds));
+
+    // Block 21 created with the new enrollment
+    new_txs = txs[$ - 1]
+        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 1], cast(uint)idx))
+        .takeExactly(8)
+        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
+    new_txs.each!(tx => nodes[0].putTransaction(tx));
+    network.waitForPreimages(b20.header.enrollments, 1, 2.seconds);
+    network.expectBlock(Height(21), 5.seconds);
+    auto b21 = nodes[0].getBlocksFrom(21, 2)[0];
+    assert(b21.header.enrollments.length == 1);
+    assert(b21.header.enrollments[0] == new_enroll);
+}


### PR DESCRIPTION
We should refuse any Enrollment which would lead to the same public key being enrolled twice (despite the two UTXOs). In other words, enrollments from the same public key can not be accepted in an overlapped cycles. But, a validator can enroll with any UTXO after a validator cycle ends.

This PR is for that requirement. This contains network tests also.

Fixes #1310 