### PR TITLE
Fix #1388: Allow Agora to restart

### DIFF
--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -942,6 +942,12 @@ public class MemBlockStorage : IBlockStorage
     /// No-op: MemBlockStorage does no I/O
     public override bool load (const ref Block genesis)
     {
+        // Allow `load` to be called multiple times
+        // This is useful when wanting to simulate persistence
+        // in a network integration test.
+        if (this.blocks.length)
+            return true;
+
         if (this._to_load.length == 0)
             return this.saveBlock(genesis);
 

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -181,7 +181,7 @@ public class Ledger
             }
             ManagedDatabase.commitBatch();
         }
-        else
+        else if (this.enroll_man.validatorCount() == 0)
         {
             // +1 because the genesis block counts as one
             const ulong block_count = this.last_block.header.height + 1;

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -404,12 +404,12 @@ public class Ledger
         foreach (idx, ref enrollment; block.header.enrollments)
         {
             UTXO utxo;
-            auto utxo_finder = this.utxo_set.getUTXOFinder();
-            assert(utxo_finder(enrollment.utxo_key, utxo));
+            if (!this.utxo_set.peekUTXO(enrollment.utxo_key, utxo))
+                assert(0);
 
             this.enroll_man.removeEnrollment(enrollment.utxo_key);
             if (auto r = this.enroll_man.addValidator(enrollment, utxo.output.address,
-                block.header.height, this.utxo_set.getUTXOFinder(), utxos))
+                block.header.height, &this.utxo_set.peekUTXO, utxos))
             {
                 log.fatal("Error while adding a new validator: {}", r);
                 log.fatal("Enrollment #{}: {}", idx, enrollment);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -129,6 +129,8 @@ public class Ledger
         // ensure latest checksum can be read
         if (!this.storage.readLastBlock(this.last_block))
             assert(0);
+        log.info("Last known block: #{} ({})", this.last_block.header.height,
+                 this.last_block.header.hashFull());
 
         Block gen_block;
         this.storage.readBlock(gen_block, Height(0));

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -130,7 +130,7 @@ public class Validator : FullNode, API
         this.last_shuffle_height = height;
 
         // we're not enrolled and don't care about quorum sets
-        if (!this.enroll_man.isEnrolled(this.utxo_set.getUTXOFinder()))
+        if (!this.enroll_man.isEnrolled(&this.utxo_set.peekUTXO))
         {
             this.nominator.stopNominatingTimer();
             this.qc = QuorumConfig.init;
@@ -231,7 +231,7 @@ public class Validator : FullNode, API
         if (this.config.admin.enabled)
             this.admin_interface.start();
 
-        if (this.enroll_man.isEnrolled(this.utxo_set.getUTXOFinder()))
+        if (this.enroll_man.isEnrolled(&this.utxo_set.peekUTXO))
             this.nominator.startNominatingTimer();
         else if (this.config.validator.recurring_enrollment)
             this.checkAndEnroll(this.ledger.getBlockHeight());
@@ -329,7 +329,7 @@ public class Validator : FullNode, API
         return new Clock((out long time_offset)
             {
                 // not enrolled - no need to synchronize clocks
-                if (!this.enroll_man.isEnrolled(this.utxo_set.getUTXOFinder()))
+                if (!this.enroll_man.isEnrolled(&this.utxo_set.peekUTXO))
                     return false;
 
                 return this.network.getNetTimeOffset(this.qc.threshold,

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -756,13 +756,12 @@ public class TestAPIManager
         if (conf.validator.enabled)
         {
             api = RemoteAPI!TestAPI.spawn!TestValidatorNode(conf, &this.reg,
-                this.blocks, this.test_conf.txs_to_nominate, time,
-                conf.node.timeout, file, line);
+                this.blocks, this.test_conf, time, conf.node.timeout, file, line);
         }
         else
         {
             api = RemoteAPI!TestAPI.spawn!TestFullNode(conf, &this.reg,
-                this.blocks, time, conf.node.timeout, file, line);
+                this.blocks, this.test_conf, time, conf.node.timeout, file, line);
         }
 
         this.reg.register(conf.node.address, api.tid());
@@ -1468,7 +1467,7 @@ public class TestFullNode : FullNode, TestAPI
 
     ///
     public this (Config config, Registry* reg, immutable(Block)[] blocks,
-        shared(time_t)* cur_time)
+        in TestConf test_conf, shared(time_t)* cur_time)
     {
         this.registry = reg;
         this.blocks = blocks;
@@ -1527,11 +1526,11 @@ public class TestValidatorNode : Validator, TestAPI
 
     ///
     public this (Config config, Registry* reg, immutable(Block)[] blocks,
-        ulong txs_to_nominate, shared(time_t)* cur_time)
+        in TestConf test_conf, shared(time_t)* cur_time)
     {
         this.registry = reg;
         this.blocks = blocks;
-        this.txs_to_nominate = txs_to_nominate;
+        this.txs_to_nominate = test_conf.txs_to_nominate;
         this.cur_time = cur_time;
         super(config);
     }
@@ -1607,9 +1606,9 @@ public mixin template ForwardCtor ()
 {
     ///
     public this (Config config, Registry* reg, immutable(Block)[] blocks,
-        in ulong txs_to_nominate, shared(time_t)* cur_time)
+        in TestConf test_conf, shared(time_t)* cur_time)
     {
-        super(config, reg, blocks, txs_to_nominate, cur_time);
+        super(config, reg, blocks, test_conf, cur_time);
     }
 }
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -751,21 +751,24 @@ public class TestAPIManager
 
     public void createNewNode (Config conf, string file = __FILE__, int line = __LINE__)
     {
-        RemoteAPI!TestAPI api;
-        auto time = new shared(time_t)(this.initial_time);
         if (conf.validator.enabled)
-        {
-            api = RemoteAPI!TestAPI.spawn!TestValidatorNode(conf, &this.reg,
-                this.blocks, this.test_conf, time, conf.node.timeout, file, line);
-        }
+            this.addNewNode!TestValidatorNode(conf, file, line);
         else
-        {
-            api = RemoteAPI!TestAPI.spawn!TestFullNode(conf, &this.reg,
-                this.blocks, this.test_conf, time, conf.node.timeout, file, line);
-        }
+            this.addNewNode!TestFullNode(conf, file, line);
+    }
+
+    /// Convenience templated function to be called from overriding classes
+    public TestAPI addNewNode (NodeType : TestAPI) (
+        Config conf, string file = __FILE__, int line = __LINE__)
+    {
+        auto time = new shared(time_t)(this.initial_time);
+        auto api = RemoteAPI!TestAPI.spawn!NodeType(conf, &this.reg,
+            this.blocks, this.test_conf, time,
+            conf.node.timeout, file, line);
 
         this.reg.register(conf.node.address, api.tid());
         this.nodes ~= NodePair(conf.node.address, api, time);
+        return api;
     }
 
     /***************************************************************************

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1602,6 +1602,17 @@ public class TestValidatorNode : Validator, TestAPI
     }
 }
 
+/// Convenience mixin for deriving classes
+public mixin template ForwardCtor ()
+{
+    ///
+    public this (Config config, Registry* reg, immutable(Block)[] blocks,
+        in ulong txs_to_nominate, shared(time_t)* cur_time)
+    {
+        super(config, reg, blocks, txs_to_nominate, cur_time);
+    }
+}
+
 /// Describes a network topology for testing purpose
 public enum NetworkTopology
 {

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1580,7 +1580,7 @@ public class TestValidatorNode : Validator, TestAPI
             (out long time_offset)
             {
                 // not enrolled - no need to synchronize clocks
-                if (!this.enroll_man.isEnrolled(this.utxo_set.getUTXOFinder()))
+                if (!this.enroll_man.isEnrolled(&this.utxo_set.peekUTXO))
                     return false;
 
                 return this.network.getNetTimeOffset(this.qc.threshold,

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -101,11 +101,8 @@ private extern(C++) class ByzantineNominator : TestNominator
 class ByzantineNode (ByzantineReason reason) : TestValidatorNode
 {
     ByzantineReason reason;
-    public this (Config config, Registry* reg, immutable(Block)[] blocks,
-        ulong txs_to_nominate, shared(time_t)* cur_time)
-    {
-        super(config, reg, blocks, txs_to_nominate, cur_time);
-    }
+
+    mixin ForwardCtor!();
 
     protected override TestNominator getNominator (immutable(ConsensusParams) params,
         Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -200,15 +200,11 @@ private class ByzantineManager (bool addSpyValidator = false,
             assert(conf.validator.enabled);
             RemoteAPI!TestAPI node;
             if (this.nodes.length < byzantine_not_signing_count)
-                node = RemoteAPI!TestAPI.spawn!(ByzantineNode!(ByzantineReason.NotSigningEnvelope))(
-                    conf, &this.reg, this.blocks, this.test_conf, time,
-                    conf.node.timeout);
+                this.addNewNode!(ByzantineNode!(ByzantineReason.NotSigningEnvelope))
+                    (conf, file, line);
             else
-                node = RemoteAPI!TestAPI.spawn!(ByzantineNode!(ByzantineReason.BadSigningEnvelope))(
-                    conf, &this.reg, this.blocks, this.test_conf, time,
-                    conf.node.timeout);
-            this.reg.register(conf.node.address, node.ctrl.tid());
-            this.nodes ~= NodePair(conf.node.address, node, time);
+                this.addNewNode!(ByzantineNode!(ByzantineReason.BadSigningEnvelope))
+                    (conf, file, line);
         }
         else
             // Add spying validator as last node

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -159,11 +159,11 @@ private class SpyingValidator : TestValidatorNode
 
     /// Ctor
     public this (Config config, Registry* reg, immutable(Block)[] blocks,
-                    ulong txs_to_nominate, shared(time_t)* cur_time,
-                    shared(EnvelopeTypeCounts)* envelope_type_counts)
+        in TestConf test_conf, shared(time_t)* cur_time,
+        shared(EnvelopeTypeCounts)* envelope_type_counts)
     {
         this.envelope_type_counts = envelope_type_counts;
-        super(config, reg, blocks, txs_to_nominate, cur_time);
+        super(config, reg, blocks, test_conf, cur_time);
     }
 
     ///
@@ -201,11 +201,11 @@ private class ByzantineManager (bool addSpyValidator = false,
             RemoteAPI!TestAPI node;
             if (this.nodes.length < byzantine_not_signing_count)
                 node = RemoteAPI!TestAPI.spawn!(ByzantineNode!(ByzantineReason.NotSigningEnvelope))(
-                    conf, &this.reg, this.blocks, this.test_conf.txs_to_nominate, time,
+                    conf, &this.reg, this.blocks, this.test_conf, time,
                     conf.node.timeout);
             else
                 node = RemoteAPI!TestAPI.spawn!(ByzantineNode!(ByzantineReason.BadSigningEnvelope))(
-                    conf, &this.reg, this.blocks, this.test_conf.txs_to_nominate, time,
+                    conf, &this.reg, this.blocks, this.test_conf, time,
                     conf.node.timeout);
             this.reg.register(conf.node.address, node.ctrl.tid());
             this.nodes ~= NodePair(conf.node.address, node, time);
@@ -217,7 +217,7 @@ private class ByzantineManager (bool addSpyValidator = false,
                 auto time = new shared(time_t)(this.initial_time);
                 assert(conf.validator.enabled);
                 auto node = RemoteAPI!TestAPI.spawn!SpyingValidator(
-                    conf, &this.reg, this.blocks, this.test_conf.txs_to_nominate,
+                    conf, &this.reg, this.blocks, this.test_conf,
                     time, &envelope_type_counts);
                 this.reg.register(conf.node.address, node.ctrl.tid());
                 this.nodes ~= NodePair(conf.node.address, node, time);

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -33,9 +33,9 @@ private class SameKeyValidator : TestValidatorNode
 {
     /// Ctor
     public this (Config config, Registry* reg, immutable(Block)[] blocks,
-                    ulong txs_to_nominate, shared(time_t)* cur_time)
+        in TestConf test_conf, shared(time_t)* cur_time)
     {
-        super(config, reg, blocks, txs_to_nominate, cur_time);
+        super(config, reg, blocks, test_conf, cur_time);
     }
 
     /// Create an enrollment with new UTXO which is not yet used
@@ -86,7 +86,7 @@ private class SameKeyNodeAPIManager : TestAPIManager
         {
             auto time = new shared(time_t)(this.initial_time);
             auto api = RemoteAPI!TestAPI.spawn!SameKeyValidator(
-                conf, &this.reg, this.blocks, this.test_conf.txs_to_nominate,
+                conf, &this.reg, this.blocks, this.test_conf,
                 time, conf.node.timeout);
             this.reg.register(conf.node.address, api.tid());
             this.nodes ~= NodePair(conf.node.address, api, time);

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -205,7 +205,7 @@ unittest
                 auto time = new shared(time_t)(this.initial_time);
                 assert(conf.validator.enabled);
                 auto node = RemoteAPI!TestAPI.spawn!TestNode(
-                    conf, &this.reg, this.blocks, this.test_conf.txs_to_nominate,
+                    conf, &this.reg, this.blocks, this.test_conf,
                     time, conf.node.timeout);
                 this.reg.register(conf.node.address, node.ctrl.tid());
                 this.nodes ~= NodePair(conf.node.address, node, time);
@@ -295,11 +295,11 @@ unittest
 
         /// Ctor
         public this (Config config, Registry* reg, immutable(Block)[] blocks,
-                     ulong txs_to_nominate, shared(time_t)* cur_time,
-                     shared(size_t)* countPtr)
+            in TestConf test_conf, shared(time_t)* cur_time,
+            shared(size_t)* countPtr)
         {
             this.runCount = countPtr;
-            super(config, reg, blocks, txs_to_nominate, cur_time);
+            super(config, reg, blocks, test_conf, cur_time);
         }
 
         ///
@@ -332,7 +332,7 @@ unittest
             {
                 auto time = new shared(time_t)(this.initial_time);
                 auto api = RemoteAPI!TestAPI.spawn!MisbehavingValidator(
-                    conf, &this.reg, this.blocks, this.test_conf.txs_to_nominate,
+                    conf, &this.reg, this.blocks, this.test_conf,
                     time, &this.runCount, conf.node.timeout);
                 this.reg.register(conf.node.address, api.tid());
                 this.nodes ~= NodePair(conf.node.address, api, time);

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -179,12 +179,7 @@ unittest
     {
         private size_t count;
 
-        ///
-        public this (Config config, Registry* reg, immutable(Block)[] blocks,
-            ulong txs_to_nominate, shared(time_t)* cur_time)
-        {
-            super(config, reg, blocks, txs_to_nominate, cur_time);
-        }
+        mixin ForwardCtor!();
 
         public override void receivePreimage (PreImageInfo preimage)
         {

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -77,12 +77,7 @@ unittest
 
     static class CustomValidator : TestValidatorNode
     {
-        /// Ctor
-        public this (Config config, Registry* reg, immutable(Block)[] blocks,
-                     ulong txs_to_nominate, shared(time_t)* cur_time)
-        {
-            super(config, reg, blocks, txs_to_nominate, cur_time);
-        }
+        mixin ForwardCtor!();
 
         ///
         protected override CustomNominator getNominator (

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -107,7 +107,7 @@ unittest
             {
                 auto time = new shared(time_t)(this.initial_time);
                 auto api = RemoteAPI!TestAPI.spawn!CustomValidator(
-                    conf, &this.reg, this.blocks, this.test_conf.txs_to_nominate,
+                    conf, &this.reg, this.blocks, this.test_conf,
                     time, conf.node.timeout);
                 this.reg.register(conf.node.address, api.tid());
                 this.nodes ~= NodePair(conf.node.address, api, time);

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -64,12 +64,7 @@ unittest
     /// node which returns bad blocks
     static class BadNode : TestFullNode
     {
-        ///
-        public this (Config config, Registry* reg, immutable(Block)[] blocks,
-            shared(time_t)* cur_time)
-        {
-            super(config, reg, blocks, cur_time);
-        }
+        mixin ForwardCtor!();
 
         /// return phony blocks
         public override const(Block)[] getBlocksFrom (ulong block_height,
@@ -142,17 +137,17 @@ unittest
             if (conf.validator.enabled)
             {
                 api = RemoteAPI!TestAPI.spawn!TestValidatorNode(
-                    conf, &this.reg, this.blocks, this.test_conf.txs_to_nominate,
+                    conf, &this.reg, this.blocks, this.test_conf,
                     time, conf.node.timeout);
             }
             else
             {
                 if (this.nodes.length == 6)  // 7th good FN, 8th bad FN
                     api = RemoteAPI!TestAPI.spawn!TestFullNode(conf,
-                        &this.reg, this.blocks, time, conf.node.timeout);
+                        &this.reg, this.blocks, this.test_conf, time, conf.node.timeout);
                 else
                     api = RemoteAPI!TestAPI.spawn!BadNode(conf,
-                        &this.reg, this.blocks, time, conf.node.timeout);
+                        &this.reg, this.blocks, this.test_conf, time, conf.node.timeout);
             }
 
             this.reg.register(conf.node.address, api.tid());

--- a/source/agora/test/Restart.d
+++ b/source/agora/test/Restart.d
@@ -16,8 +16,14 @@ module agora.test.Restart;
 version (unittest):
 
 import agora.api.Validator;
-import agora.consensus.data.Transaction;
+import agora.common.Config;
+import agora.consensus.data.Block;
+import agora.consensus.data.Params;
 import agora.test.Base;
+
+import geod24.Registry;
+
+import core.stdc.time;
 
 /// A test that stops and restarts a node
 unittest
@@ -38,6 +44,91 @@ unittest
 
     // Now shut down & restart one node
     auto restartMe = nodes[$-1];
+    network.restart(restartMe);
+    network.waitForDiscovery();
+    network.expectBlock(Height(1));
+}
+
+/// Node which has a persistent Ledger (restart always clear the local state)
+private class PersistentNode : TestValidatorNode
+{
+    import agora.consensus.EnrollmentManager;
+    import agora.consensus.state.UTXODB;
+    import agora.node.BlockStorage;
+
+    mixin ForwardCtor!();
+
+    ///
+    private static UTXOSet utxo_set_saved;
+    ///
+    private static EnrollmentManager em_saved;
+    ///
+    private static IBlockStorage blockstorage_saved;
+
+    ///
+    protected override IBlockStorage getBlockStorage (string data_dir) @system
+    {
+        if (blockstorage_saved is null)
+            blockstorage_saved = super.getBlockStorage(data_dir);
+        return blockstorage_saved;
+    }
+
+    ///
+    protected override UTXOSet getUtxoSet (string data_dir)
+    {
+        if (utxo_set_saved is null)
+            utxo_set_saved = super.getUtxoSet(data_dir);
+        return utxo_set_saved;
+    }
+
+    ///
+    protected override EnrollmentManager getEnrollmentManager (
+        string data_dir, in ValidatorConfig validator_config,
+        immutable(ConsensusParams) params)
+    {
+        if (em_saved is null)
+            em_saved = super.getEnrollmentManager(data_dir, validator_config, params);
+        return em_saved;
+    }
+}
+
+private class WithPersistentNodeAPIManager : TestAPIManager
+{
+    ///
+    public this (immutable(Block)[] blocks, TestConf test_conf, time_t genesis_start_time)
+    {
+        super(blocks, test_conf, genesis_start_time);
+    }
+
+    public override void createNewNode (Config conf,
+        string file = __FILE__, int line = __LINE__)
+    {
+        if (conf.validator.enabled)
+            this.addNewNode!PersistentNode(conf, file, line);
+        else
+            super.createNewNode(conf, file, line);
+    }
+}
+
+/// Stops and restarts a node with a pre-existing state
+unittest
+{
+    TestConf conf = TestConf.init;
+    auto network = makeTestNetwork!WithPersistentNodeAPIManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[0];
+
+    auto txes = genesisSpendable().map!(txb => txb.sign()).array();
+    txes.each!(tx => node_1.putTransaction(tx));
+    network.expectBlock(Height(1));
+
+    // Now shut down & restart one node
+    auto restartMe = nodes[$-1];
+    scope(failure) restartMe.printLog();
     network.restart(restartMe);
     network.waitForDiscovery();
     network.expectBlock(Height(1));

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -142,8 +142,7 @@ unittest
             {
                 auto time = new shared(time_t)(this.initial_time);
                 auto api = RemoteAPI!TestAPI.spawn!ReValidator(
-                    conf, &this.reg, this.blocks,
-                    this.test_conf.txs_to_nominate, time);
+                    conf, &this.reg, this.blocks, this.test_conf, time);
                 this.reg.register(conf.node.address, api.tid());
                 this.nodes ~= NodePair(conf.node.address, api, time);
                 assert(conf.validator.enabled);

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -113,12 +113,7 @@ unittest
 
     static class ReValidator : TestValidatorNode
     {
-        /// Ctor
-        public this (Config config, Registry* reg, immutable(Block)[] blocks,
-                     ulong txs_to_nominate, shared(time_t)* cur_time)
-        {
-            super(config, reg, blocks, txs_to_nominate, cur_time);
-        }
+        mixin ForwardCtor!();
 
         ///
         protected override TestNominator getNominator (


### PR DESCRIPTION
First commit should be fairly obvious. Second and third one attempt to address this issue:
```
2020-11-28 21:22:48,94 Info [SCP] - LocalNode::LocalNode@GDNOD qSet: 204980
2020-11-28 21:22:48,94 Info [agora.consensus.SCPEnvelopeStore] - Loading database from: .cache/scp_envelopes.dat
core.exception.AssertError@source/agora/consensus/EnrollmentManager.d(649): UTXO for validator not found!
```