### PR TITLE
[osx] Reproducible test-case for #1395 (vibe.d bug)

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -46,6 +46,11 @@ public struct NodeInfo
     public Set!string addresses;
 }
 
+struct LocalTime
+{
+    time_t time;
+}
+
 /*******************************************************************************
 
     Define the API a full node exposes to the world
@@ -241,5 +246,5 @@ public interface API
 
     ***************************************************************************/
 
-    public time_t getLocalTime ();
+    public LocalTime getLocalTime ();
 }

--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -157,9 +157,9 @@ public struct PublicKey
     public static PublicKey fromString (scope const(char)[] str) @trusted
     {
         const bin = Base32.decode(str);
-        assert(bin.length == 1 + PublicKey.Width + 2);
-        assert(bin[0] == VersionByte.AccountID);
-        assert(validate(bin[0 .. $ - 2], bin[$ - 2 .. $]));
+        enforce(bin.length == 1 + PublicKey.Width + 2);
+        enforce(bin[0] == VersionByte.AccountID);
+        enforce(validate(bin[0 .. $ - 2], bin[$ - 2 .. $]));
         return PublicKey(typeof(this.data)(bin[1 .. $ - 2]));
     }
 
@@ -430,9 +430,9 @@ public struct Seed
     public static Seed fromString (scope const(char)[] str)
     {
         const bin = Base32.decode(str);
-        assert(bin.length == 1 + Seed.Width + 2);
-        assert(bin[0] == VersionByte.Seed);
-        assert(validate(bin[0 .. $ - 2], bin[$ - 2 .. $]));
+        enforce(bin.length == 1 + Seed.Width + 2);
+        enforce(bin[0] == VersionByte.Seed);
+        enforce(validate(bin[0 .. $ - 2], bin[$ - 2 .. $]));
         return Seed(typeof(this.data)(bin[1 .. $ - 2]));
     }
 }

--- a/source/agora/network/Clock.d
+++ b/source/agora/network/Clock.d
@@ -72,7 +72,7 @@ public class Clock
     private long net_time_offset = 0;
 
     /// how often the clock should be synchronized with the network
-    public const Duration ClockSyncInterval = 1.minutes;
+    public const Duration ClockSyncInterval = 1.seconds;
 
     /// used to set timer for syncing
     private SetPeriodicTimer setPeriodicTimerDg;

--- a/source/agora/network/NetworkClient.d
+++ b/source/agora/network/NetworkClient.d
@@ -193,7 +193,7 @@ class NetworkClient
 
     ***************************************************************************/
 
-    public time_t getLocalTime () @trusted nothrow
+    public LocalTime getLocalTime () @trusted nothrow
     {
         return this.attemptRequest!(API.getLocalTime, Throw.No)(this.api);
     }

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -552,8 +552,13 @@ public class NetworkManager
 
             const req_start = this.clock.localTime();
             const node_time = node.getLocalTime();
+
             if (node_time == 0)
                 continue;  // request failed
+
+            log.info("Node time: {}", node_time);
+            if (node_time < 10)
+                assert(0);
 
             const req_delay = this.clock.localTime() - req_start;
             const dist_delay = req_delay / 2;  // divide evently
@@ -565,7 +570,6 @@ public class NetworkManager
         if (offsets.length >= threshold)
         {
             offsets.sort!((a, b) => a.offset < b.offset);
-            log.info("Net time offsets: {}", offsets);
             time_offset = offsets[$ / 2].offset;  // pick median
             return true;
         }

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -553,17 +553,17 @@ public class NetworkManager
             const req_start = this.clock.localTime();
             const node_time = node.getLocalTime();
 
-            if (node_time == 0)
+            if (node_time.time == 0)
                 continue;  // request failed
 
             log.info("Node time: {}", node_time);
-            if (node_time < 10)
+            if (node_time.time < 10)
                 assert(0);
 
             const req_delay = this.clock.localTime() - req_start;
             const dist_delay = req_delay / 2;  // divide evently
-            const offset = (node_time - dist_delay) - req_start;
-            offsets ~= TimeInfo(pk, node_time, req_delay, offset);
+            const offset = (node_time.time - dist_delay) - req_start;
+            offsets ~= TimeInfo(pk, node_time.time, req_delay, offset);
         }
 
         // we heard from at least one quorum slice

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -612,10 +612,10 @@ public class FullNode : API
     }
 
     /// GET /local_time
-    public override time_t getLocalTime () @safe nothrow
+    public override LocalTime getLocalTime () @safe nothrow
     {
         this.endpoint_request_stats.increaseMetricBy!"agora_endpoint_calls_total"(1, "local_time", "http");
-        return this.clock.localTime();
+        return LocalTime(this.clock.localTime());
     }
 
     /***************************************************************************

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -7,7 +7,7 @@ node:
 
   min_listeners: 3
   max_listeners: 10
-  address: 0.0.0.0
+  address: 127.0.0.1
   port:    1826
   retry_delay: 50
   max_retries: 25
@@ -48,11 +48,11 @@ banman:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-2:2826
-  - http://node-3:3826
-  - http://node-4:4826
-  - http://node-5:5826
-  - http://node-6:6826
+  - http://127.0.0.1:2826
+  - http://127.0.0.1:3826
+  - http://127.0.0.1:4826
+  - http://127.0.0.1:5826
+  - http://127.0.0.1:6826
 
 ################################################################################
 ##                               Logging options                              ##

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -6,7 +6,7 @@ node:
   testing: true
   min_listeners: 7
   max_listeners: 10
-  address: 0.0.0.0
+  address: 127.0.0.1
   port:    2826
   retry_delay: 50
   max_retries: 25
@@ -57,12 +57,12 @@ banman:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-0:1826
-  - http://node-3:3826
-  - http://node-4:4826
-  - http://node-5:5826
-  - http://node-6:6826
-  - http://node-7:7826
+  - http://127.0.0.1:1826
+  - http://127.0.0.1:3826
+  - http://127.0.0.1:4826
+  - http://127.0.0.1:5826
+  - http://127.0.0.1:6826
+  - http://127.0.0.1:7826
 
 ################################################################################
 ##                               Logging options                              ##

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -7,7 +7,7 @@ node:
 
   min_listeners: 7
   max_listeners: 10
-  address: 0.0.0.0
+  address: 127.0.0.1
   port:    3826
   retry_delay: 50
   max_retries: 25
@@ -58,12 +58,12 @@ banman:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-0:1826
-  - http://node-2:2826
-  - http://node-4:4826
-  - http://node-5:5826
-  - http://node-6:6826
-  - http://node-7:7826
+  - http://127.0.0.1:1826
+  - http://127.0.0.1:2826
+  - http://127.0.0.1:4826
+  - http://127.0.0.1:5826
+  - http://127.0.0.1:6826
+  - http://127.0.0.1:7826
 
 ################################################################################
 ##                               Logging options                              ##

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -7,7 +7,7 @@ node:
 
   min_listeners: 7
   max_listeners: 10
-  address: 0.0.0.0
+  address: 127.0.0.1
   port:    4826
   retry_delay: 50
   max_retries: 25
@@ -58,12 +58,12 @@ banman:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-0:1826
-  - http://node-2:2826
-  - http://node-3:3826
-  - http://node-5:5826
-  - http://node-6:6826
-  - http://node-7:7826
+  - http://127.0.0.1:1826
+  - http://127.0.0.1:2826
+  - http://127.0.0.1:3826
+  - http://127.0.0.1:5826
+  - http://127.0.0.1:6826
+  - http://127.0.0.1:7826
 
 ################################################################################
 ##                               Logging options                              ##

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -7,7 +7,7 @@ node:
 
   min_listeners: 7
   max_listeners: 10
-  address: 0.0.0.0
+  address: 127.0.0.1
   port:    5826
   retry_delay: 50
   max_retries: 25
@@ -58,12 +58,12 @@ banman:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-0:1826
-  - http://node-2:2826
-  - http://node-3:3826
-  - http://node-4:4826
-  - http://node-6:6826
-  - http://node-7:7826
+  - http://127.0.0.1:1826
+  - http://127.0.0.1:2826
+  - http://127.0.0.1:3826
+  - http://127.0.0.1:4826
+  - http://127.0.0.1:6826
+  - http://127.0.0.1:7826
 
 ################################################################################
 ##                               Logging options                              ##

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -7,7 +7,7 @@ node:
 
   min_listeners: 7
   max_listeners: 10
-  address: 0.0.0.0
+  address: 127.0.0.1
   port:    6826
   retry_delay: 50
   max_retries: 25
@@ -58,12 +58,12 @@ banman:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-0:1826
-  - http://node-2:2826
-  - http://node-3:3826
-  - http://node-4:4826
-  - http://node-5:5826
-  - http://node-7:7826
+  - http://127.0.0.1:1826
+  - http://127.0.0.1:2826
+  - http://127.0.0.1:3826
+  - http://127.0.0.1:4826
+  - http://127.0.0.1:5826
+  - http://127.0.0.1:7826
 
 ################################################################################
 ##                               Logging options                              ##

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -7,7 +7,7 @@ node:
 
   min_listeners: 7
   max_listeners: 10
-  address: 0.0.0.0
+  address: 127.0.0.1
   port:    7826
   retry_delay: 50
   max_retries: 25
@@ -58,12 +58,12 @@ banman:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-0:1826
-  - http://node-2:2826
-  - http://node-3:3826
-  - http://node-4:4826
-  - http://node-5:5826
-  - http://node-6:6826
+  - http://127.0.0.1:1826
+  - http://127.0.0.1:2826
+  - http://127.0.0.1:3826
+  - http://127.0.0.1:4826
+  - http://127.0.0.1:5826
+  - http://127.0.0.1:6826
 
 ################################################################################
 ##                               Logging options                              ##


### PR DESCRIPTION
This includes some commits which help reproduce the issue.

The last commit curiously gets rid of the bug. In it I replaced the return value of `getLocalTime()` from `time_t` to `struct { time_t }`. I didn't randomly come up with this workaround. I initially added several fields in this struct and populated them with some strings, just to see if they would end up getting corrupted. But instead the bug disappeared.

To reproduce the bug with commit 8b31aa9 (_Change logging_):

```
$ git checkout 8b31aa9
$ DFLAGS="-g --link-defaultlib-debug" dub build agora
```

Then, spawn 6 terminals and CD to each system integration test's directory:

```
$ cd agora/tests/system/node/7
$ cd agora/tests/system/node/6
$ cd agora/tests/system/node/5
$ cd agora/tests/system/node/4
$ cd agora/tests/system/node/3
$ cd agora/tests/system/node/2
```

Before running each test I highly recommend you always clear the cache:

```
$ rm -r -- tests/system/node/[0-9]/.cache
```

You don't need to start node 0 because that's the FullNode, it's not relevant to the test.

Then within each terminal you just have to run the node (do this once for each of the 6 nodes):

```
../../../../build/agora -c config.yaml
```

Then, build and run [faucet](https://github.com/bpfkorea/faucet):

```
$ ./bin/faucet http://127.0.0.1:2826
```

You just need to look into the first node output (node 7 in my case) to see what goes wrong. After running faucet eventually the node will crash with:

```
2020-12-02 19:46:22,266 Info [agora.network.NetworkManager] - Node time: 1606905982
sock error 54!
2020-12-02 19:46:22,872 Info [agora.network.NetworkManager] - Node time: 1
core.exception.AssertError@source/agora/network/NetworkManager.d(561): Assertion failure
```

I added this assert there. The node time should never be `1`. It can be `0` in case of request failure, or the node's local unix time. If you remove the assert you'll see that the values tend to be small but random.

Now, if you check out the last commit 73a6527 and you reproduce the steps above then the bug is gone and the above assertion does not trigger anymore.
