### PR TITLE
Nominating and checking validity for `ConsensusData` containing slashed validators

### DIFF
--- a/source/agora/consensus/SlashPolicy.d
+++ b/source/agora/consensus/SlashPolicy.d
@@ -1,0 +1,289 @@
+/*******************************************************************************
+
+    Manages the slashing policy for the misbehaving validators that do not
+    reveal their pre-images timely.
+
+    This class currently has two responsibilities:
+    - It determines when the misbehaving validators will be slashed -- in other
+        words, how many times of missing pre-images it will allow.
+    - It determines what the penalty is for misbehaving validators -- in other
+        words, How many BOAs it will impose on the misbehaving validators
+        as a penalty
+
+    All the validators should reveal their pre-images timely in order for
+    the network to maintain randomness. So we need a penalty as an incentive
+    to make validators reveal them regularly. So this class manages all the
+    policies for penalty and slashing.
+    See https://github.com/bpfkorea/agora/issues/1076.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.consensus.SlashPolicy;
+
+import agora.common.Amount;
+import agora.common.crypto.Key;
+import agora.common.Types;
+import agora.consensus.EnrollmentManager;
+import agora.consensus.data.Params;
+import agora.consensus.data.Enrollment;
+import agora.consensus.data.Params;
+import agora.consensus.data.PreImageInfo;
+import agora.consensus.data.Transaction;
+import agora.consensus.state.UTXODB;
+import agora.utils.Log;
+version (unittest) import agora.utils.Test;
+
+import std.exception;
+
+mixin AddLogger!();
+
+/*******************************************************************************
+
+    Manage the policy for slashing
+
+*******************************************************************************/
+
+public class SlashPolicy
+{
+    // The amount of a penalty
+    public immutable Amount penalty_amount;
+
+    // The address to get a penalty
+    public immutable PublicKey penalty_address;
+
+    // Enrollment manager
+    private EnrollmentManager enroll_man;
+
+    /***************************************************************************
+
+        Constructor
+
+        Params:
+            enroll_man = the EnrollmentManager
+            params = the consensus-critical constants
+
+    ***************************************************************************/
+
+    public this (EnrollmentManager enroll_man, immutable(ConsensusParams) params)
+    {
+        this.enroll_man = enroll_man;
+        // TODO: This should be set through ConsensusParams
+        this.penalty_amount = Amount(10_000L * 10_000_000L);
+        this.penalty_address = params.CommonsBudgetAddress;
+    }
+
+    /***************************************************************************
+
+        Get the validators that do not reveal their pre-images and will be
+        slashed through the consensus procoess.
+
+        Params:
+            missing_validators = will contain the validators
+            height = the desired block height to look up the validators for
+
+    ***************************************************************************/
+
+    public void getMissingValidators (ref uint[] missing_validators,
+        in Height height) @safe nothrow
+    {
+        missing_validators.length = 0;
+        () @trusted { assumeSafeAppend(missing_validators); }();
+
+        Hash[] keys;
+        if (!this.enroll_man.getEnrolledUTXOs(keys) || keys.length == 0)
+        {
+            log.fatal("Could not retrieve enrollments / no enrollments found");
+            assert(0);
+        }
+
+        foreach (idx, utxo_key; keys)
+        {
+            if (!this.hasRevealedPreimage(height, utxo_key))
+            {
+                missing_validators ~= cast(uint)idx;
+            }
+        }
+    }
+
+    /***************************************************************************
+
+        Get the random seed reduced from the preimages for the provided
+        block height.
+
+        Params:
+            height = the desired block height to look up the hash for
+
+        Returns:
+            the random seed
+
+    ***************************************************************************/
+
+    public Hash getRandomSeed (in Height height) @safe nothrow
+    {
+        Hash[] keys;
+        if (!this.enroll_man.getEnrolledUTXOs(keys) || keys.length == 0)
+        {
+            log.fatal("Could not retrieve enrollments / no enrollments found");
+            assert(0);
+        }
+
+        Hash[] valid_keys;
+        foreach (key; keys)
+        {
+            if (this.hasRevealedPreimage(height, key))
+                valid_keys ~= key;
+        }
+
+        return this.enroll_man.getRandomSeed(valid_keys, height);
+    }
+
+    /***************************************************************************
+
+        Check if a validator has a pre-image for the height
+
+        Params:
+            height = the desired block height to look up the hash for
+            utxo_key = the UTXO key idendifying a validator
+
+        Returns:
+            true if the validator has revealed its preimage for the provided
+                block height
+
+    ***************************************************************************/
+
+    private bool hasRevealedPreimage (in Height height, in Hash utxo_key)
+        @safe nothrow
+    {
+        auto preimage = this.enroll_man.getValidatorPreimage(utxo_key);
+        auto enrolled = this.enroll_man.getEnrolledHeight(preimage.enroll_key);
+        assert(height >= enrolled);
+        if (preimage.distance >= cast(ushort)(height - enrolled))
+            return true;
+        else
+            return false;
+    }
+}
+
+// Test for getting the candidates to be slashed due to missing pre-images
+unittest
+{
+    import agora.common.crypto.Schnorr;
+    import agora.common.Hash;
+    import agora.consensus.data.Transaction;
+    import agora.consensus.PreImage;
+    import agora.consensus.state.UTXOSet;
+
+    import std.algorithm;
+    import std.format;
+    import std.range;
+
+    scope utxo_set = new TestUTXOSet;
+    Hash[] utxo_hashes;
+
+    // genesisSpendable returns 8 outputs
+    auto pairs = iota(8).map!(idx => WK.Keys[idx]).array;
+    genesisSpendable()
+        .enumerate
+        .map!(tup => tup.value
+            .refund(pairs[tup.index].address)
+            .sign(TxType.Freeze))
+        .each!((tx) {
+            utxo_set.put(tx);
+            utxo_hashes ~= UTXO.getHash(tx.hashFull(), 0);
+        });
+
+    auto params = new immutable(ConsensusParams);
+    scope enroll_man = new EnrollmentManager(":memory:", WK.Keys.A, params);
+
+    // create 8 enrollments
+    Enrollment[] enrollments;
+    PreImageCache[] caches;
+    foreach (idx, kp; pairs)
+    {
+        auto pair = Pair.fromScalar(secretKeyToCurveScalar(kp.secret));
+        auto cycle = PreImageCycle(
+                0, 0,
+                PreImageCache(PreImageCycle.NumberOfCycles, params.ValidatorCycle),
+                PreImageCache(params.ValidatorCycle, 1));
+        const seed = cycle.populate(pair.v, true);
+        caches ~= cycle.preimages;
+        auto enroll = EnrollmentManager.makeEnrollment(
+            pair, utxo_hashes[idx], params.ValidatorCycle,
+            seed, idx);
+        assert(enroll_man.addEnrollment(enroll, kp.address, Height(1),
+                &utxo_set.peekUTXO));
+        enrollments ~= enroll;
+    }
+
+    // 8 validators(=enrollments) are enrolled at the height of 1
+    UTXO[Hash] self_utxos;
+    self_utxos[utxo_hashes[0]] = utxo_set[utxo_hashes[0]];
+    foreach (idx, enroll; enrollments)
+        assert(enroll_man.addValidator(enroll, pairs[idx].address, Height(1),
+            &utxo_set.peekUTXO, self_utxos) is null);
+    assert(enroll_man.validatorCount() == 8);
+
+    // create slashing manager
+    scope slash_man = new SlashPolicy(enroll_man, params);
+
+    // get all the validators and find index of the first and second validastors
+    uint first_validator;
+    uint second_validator;
+    Hash[] utxos;
+    assert(enroll_man.getEnrolledUTXOs(utxos));
+    foreach (idx, utxo; utxos)
+        if (utxo == enrollments[0].utxo_key)
+        {
+            first_validator = cast(uint)idx;
+            break;
+        }
+    foreach (idx, utxo; utxos)
+        if (utxo == enrollments[1].utxo_key)
+        {
+            second_validator = cast(uint)idx;
+            break;
+        }
+
+    // the first validator reveals a pre-image
+    PreImageInfo preimage_1 = PreImageInfo(
+        enrollments[0].utxo_key,
+        caches[0][$ - 2],
+        1
+    );
+    assert(hashFull(preimage_1.hash) == enrollments[0].random_seed);
+    enroll_man.addPreimage(preimage_1);
+    auto gotten_image = enroll_man.getValidatorPreimage(enrollments[0].utxo_key);
+    assert(preimage_1 == gotten_image);
+
+    // the second validator reveals a pre-image
+    PreImageInfo preimage_2 = PreImageInfo(
+        enrollments[1].utxo_key,
+        caches[1][$ - 2],
+        1
+    );
+    assert(hashFull(preimage_2.hash) == enrollments[1].random_seed);
+    enroll_man.addPreimage(preimage_2);
+    gotten_image = enroll_man.getValidatorPreimage(enrollments[1].utxo_key);
+    assert(preimage_2 == gotten_image);
+
+    // check missing pre-image at the current height of 2
+    uint[] missing_validators;
+    slash_man.getMissingValidators(missing_validators, Height(2));
+    assert(missing_validators.length == 6,
+            format!"Current missing preimage validaters: %s"
+                (missing_validators.length));
+    assert(missing_validators.find(first_validator).empty());
+    assert(missing_validators.find(second_validator).empty());
+
+    // get and check random seed
+    Hash preimage_root = slash_man.getRandomSeed(Height(2));
+    assert(preimage_root ==
+        hashMulti(hashMulti(Hash.init, preimage_1), preimage_2));
+}

--- a/source/agora/consensus/protocol/Data.d
+++ b/source/agora/consensus/protocol/Data.d
@@ -24,6 +24,10 @@ public struct ConsensusData
 
     /// The enrollments that are being nominated / voted on
     public Enrollment[] enrolls;
+
+    /// List of indices to the validator UTXO set which have not
+    /// revealed the preimage, aka missing preimage validators, or MPVs
+    public uint[] missing_validators;
 }
 
 /// ConsensusData type testSymmetry check
@@ -55,6 +59,7 @@ unittest
     {
         tx_set:  GenesisBlock.txs,
         enrolls: [ record, record, ],
+        missing_validators : [ 1, 3, 5 ],
     };
 
     testSymmetry(data);

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -280,6 +280,14 @@ extern(D):
             return false;
         }
 
+        // check whether the slashing related data is valid
+        if (auto msg = this.ledger.validateSlashingData(data))
+        {
+            log.fatal("tryNominate(): Invalid preimage data: {}. Data: {}",
+                    msg, data);
+            return false;
+        }
+
         return true;
     }
 
@@ -543,6 +551,14 @@ extern(D):
                 log.error("validateValue(): Validation failed: {}. Data: {}",
                     fail_reason, data);
                 return ValidationLevel.kInvalidValue;
+            }
+
+            if (auto fail_reason = this.ledger.validateSlashingData(data))
+            {
+                log.info("validateValue(): Preimage Validation failed, but " ~
+                    "return kMaybeValidValue. Reason: {}, Data: {}",
+                    fail_reason, data);
+                return ValidationLevel.kMaybeValidValue;
             }
         }
         catch (Exception ex)

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -1,0 +1,351 @@
+/*******************************************************************************
+
+    Contains tests for the validators not revealing their pre-images.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.MissingPreImageDetection;
+
+version (unittest):
+
+import agora.common.crypto.Key;
+import agora.common.Config;
+import agora.common.Hash;
+import agora.common.Serializer;
+import agora.common.Task;
+import agora.consensus.data.Block;
+import agora.consensus.data.Params;
+import agora.consensus.data.Enrollment;
+import agora.consensus.data.PreImageInfo;
+import agora.consensus.data.Transaction;
+import agora.consensus.EnrollmentManager;
+import agora.consensus.protocol.Data;
+import agora.network.Clock;
+import agora.network.NetworkManager;
+import agora.node.Ledger;
+import agora.utils.Test;
+import agora.test.Base;
+
+import scpd.types.Utils;
+import scpd.types.Stellar_SCP;
+
+import core.stdc.stdint;
+import core.stdc.time;
+import core.thread;
+
+import geod24.Registry;
+
+/*******************************************************************************
+
+    Verifies that the nodes have not generated a block at the given height.
+
+    Params:
+        clients = the nodes to be checked
+        height = the unexpected block height
+
+*******************************************************************************/
+
+private void unexpectBlock (Clients)(Clients clients, Height height)
+{
+    foreach (_; 0 .. 10)
+    {
+        clients.each!(node => retryFor(
+            node.getBlockHeight() < height, 1.seconds));
+        Thread.sleep(1.seconds);
+    }
+}
+
+private class MissingPreImageEM : EnrollmentManager
+{
+    ///
+    public this (string db_path, KeyPair key_pair,
+        immutable(ConsensusParams) params)
+    {
+        super(db_path, key_pair, params);
+    }
+
+    /// This does not reveal pre-images intentionally
+    public override bool getNextPreimage (out PreImageInfo preimage,
+        Height height) @safe
+    {
+        return false;
+    }
+}
+
+private class NoPreImageVN : TestValidatorNode
+{
+    ///
+    public this (Config config, Registry* reg, immutable(Block)[] blocks,
+        in TestConf test_conf, shared(time_t)* cur_time)
+    {
+        super(config, reg, blocks, test_conf, cur_time);
+    }
+
+    protected override EnrollmentManager getEnrollmentManager (
+        string data_dir, in ValidatorConfig validator_config,
+        immutable(ConsensusParams) params)
+    {
+        return new MissingPreImageEM(":memory:", validator_config.key_pair,
+            params);
+    }
+}
+
+// This specifies the bad behavior of nominators
+enum NominatorType
+{
+    MismatchingMPV,     // The missing preimage validators are faked
+    FalsePreImageRoot,  // The random seed is faked
+}
+
+private class BadNominator : TestNominator
+{
+    NominatorType bad_type;
+
+    /// Ctor
+    public this (immutable(ConsensusParams) params, Clock clock,
+        NetworkManager network, KeyPair key_pair, Ledger ledger,
+        TaskManager taskman, string data_dir, ulong txs_to_nominate,
+        shared(time_t)* curr_time, NominatorType bad_type)
+    {
+        this.bad_type = bad_type;
+        super(params, clock, network, key_pair, ledger, taskman,
+            data_dir, txs_to_nominate);
+    }
+
+extern (C++):
+
+    public override ValidationLevel validateValue (uint64_t slot_idx,
+        ref const(Value) value, bool nomination) nothrow
+    {
+        scope(failure) assert(0);
+        ValidationLevel ret;
+        () @trusted {
+            auto data = deserializeFull!ConsensusData(value[]);
+            if (this.bad_type == NominatorType.MismatchingMPV)
+            {
+                data.missing_validators.length = 0;
+                data.missing_validators ~= 2;
+            }
+            else
+            {
+                assert(0, format!"Invalid BadNominatorType: %s"
+                        (this.bad_type));
+            }
+            auto next_value = data.serializeFull().toVec();
+            ret = super.validateValue(slot_idx, next_value, nomination);
+        }();
+
+        return ret;
+    }
+}
+
+private class BadNominatingVN : TestValidatorNode
+{
+    NominatorType bad_type;
+
+    ///
+    public this (Config config, Registry* reg, immutable(Block)[] blocks,
+        in TestConf test_conf, shared(time_t)* cur_time,
+        NominatorType bad_type)
+    {
+        this.bad_type = bad_type;
+        super(config, reg, blocks, test_conf, cur_time);
+    }
+
+    ///
+    protected override TestNominator getNominator (
+        immutable(ConsensusParams) params, Clock clock,
+        NetworkManager network, KeyPair key_pair, Ledger ledger,
+        TaskManager taskman, string data_dir)
+    {
+        return new BadNominator(
+            params, clock, network, key_pair, ledger, taskman, data_dir,
+            this.txs_to_nominate, this.cur_time, this.bad_type);
+    }
+}
+
+/// Situation: There is a validator does not reveal a pre-image for
+///     the height after next.
+/// Expectation: The expected block has been generated.
+unittest
+{
+    static class BadAPIManager : TestAPIManager
+    {
+        ///
+        public this (immutable(Block)[] blocks, TestConf test_conf,
+            time_t initial_time)
+        {
+            super(blocks, test_conf, initial_time);
+        }
+
+        ///
+        public override void createNewNode (Config conf, string file, int line)
+        {
+            if (this.nodes.length == 5)
+            {
+                auto time = new shared(time_t)(this.initial_time);
+                auto api = RemoteAPI!TestAPI.spawn!NoPreImageVN(
+                    conf, &this.reg, this.blocks, this.test_conf,
+                    time, conf.node.timeout);
+                this.reg.register(conf.node.address, api.tid());
+                this.nodes ~= NodePair(conf.node.address, api, time);
+            }
+            else
+                super.createNewNode(conf, file, line);
+        }
+    }
+
+    TestConf conf = {
+        recurring_enrollment : false,
+    };
+    auto network = makeTestNetwork!BadAPIManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto spendable = network.blocks[$ - 1].spendable().array;
+
+    // discarded UTXOs (just to trigger block creation)
+    auto txs = spendable[0 .. 8].map!(txb => txb.sign()).array;
+
+    Thread.sleep(5.seconds);
+
+    // block 1
+    txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(1));
+}
+
+/// Situation: There is a validator does not reveal a pre-image for next
+//      height and the information is contained in a `ConsensusData`. But
+//      a bad nominator manipulates information about the missing preimage
+//      validators.
+/// Expectation: The expected block has been generated.
+unittest
+{
+    static class BadNominatingAPIManager : TestAPIManager
+    {
+        ///
+        public this (immutable(Block)[] blocks, TestConf test_conf,
+            time_t initial_time)
+        {
+            super(blocks, test_conf, initial_time);
+        }
+
+        ///
+        public override void createNewNode (Config conf, string file, int line)
+        {
+            if (this.nodes.length == 0)
+            {
+                auto time = new shared(time_t)(this.initial_time);
+                auto api = RemoteAPI!TestAPI.spawn!NoPreImageVN(
+                    conf, &this.reg, this.blocks, this.test_conf,
+                    time, conf.node.timeout);
+                this.reg.register(conf.node.address, api.tid());
+                this.nodes ~= NodePair(conf.node.address, api, time);
+            }
+            else if (this.nodes.length == 5)
+            {
+                auto time = new shared(time_t)(this.initial_time);
+                auto api = RemoteAPI!TestAPI.spawn!BadNominatingVN(
+                    conf, &this.reg, this.blocks, this.test_conf,
+                    time, NominatorType.MismatchingMPV, conf.node.timeout);
+                this.reg.register(conf.node.address, api.tid());
+                this.nodes ~= NodePair(conf.node.address, api, time);
+            }
+            else
+                super.createNewNode(conf, file, line);
+        }
+    }
+
+    TestConf conf = {
+        recurring_enrollment : false,
+    };
+    auto network = makeTestNetwork!BadNominatingAPIManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto spendable = network.blocks[$ - 1].spendable().array;
+
+    // discarded UTXOs (just to trigger block creation)
+    auto txs = spendable[0 .. 8].map!(txb => txb.sign()).array;
+
+    Thread.sleep(5.seconds);
+
+    // try to make block 1
+    txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(1));
+}
+
+/// Situation: There is a validator does not reveal a pre-image for next
+//      height and the information is contained in a `ConsensusData`. But
+//      two bad nominators manipulate information about the preimage root.
+/// Expectation: The expected block has not been generated.
+unittest
+{
+    static class BadNominatingAPIManager : TestAPIManager
+    {
+        ///
+        public this (immutable(Block)[] blocks, TestConf test_conf,
+            time_t initial_time)
+        {
+            super(blocks, test_conf, initial_time);
+        }
+
+        ///
+        public override void createNewNode (Config conf, string file, int line)
+        {
+            if (this.nodes.length == 0)
+            {
+                auto time = new shared(time_t)(this.initial_time);
+                auto api = RemoteAPI!TestAPI.spawn!NoPreImageVN(
+                    conf, &this.reg, this.blocks, this.test_conf,
+                    time, conf.node.timeout);
+                this.reg.register(conf.node.address, api.tid());
+                this.nodes ~= NodePair(conf.node.address, api, time);
+            }
+            else if (this.nodes.length >= 4)
+            {
+                auto time = new shared(time_t)(this.initial_time);
+                auto api = RemoteAPI!TestAPI.spawn!BadNominatingVN(
+                    conf, &this.reg, this.blocks, this.test_conf,
+                    time, NominatorType.FalsePreImageRoot, conf.node.timeout);
+                this.reg.register(conf.node.address, api.tid());
+                this.nodes ~= NodePair(conf.node.address, api, time);
+            }
+            else
+                super.createNewNode(conf, file, line);
+        }
+    }
+
+    TestConf conf = {
+        recurring_enrollment : false,
+    };
+    auto network = makeTestNetwork!BadNominatingAPIManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+    auto nodes = network.clients;
+    auto spendable = network.blocks[$ - 1].spendable().array;
+
+    // discarded UTXOs (just to trigger block creation)
+    auto txs = spendable[0 .. 8].map!(txb => txb.sign()).array;
+
+    Thread.sleep(5.seconds);
+
+    // try to make block 1
+    txs.each!(tx => nodes[0].putTransaction(tx));
+    unexpectBlock(nodes, Height(1));
+}


### PR DESCRIPTION
This is implementation about nominating and checking the validity for `ConsensusData` containing the merkleized `preimage_root` of all the preimages and the UTXO indices of validators that are missing to relay their pre-images.

This PR does not have some requirements as follows but the missing requirements will be added in other PRs soon.
* Check for `ConsensusData` which tries to melt a UTXO which is in the MPV
* Changing getRandomSeed

Part of #1076 