### PR TITLE
Update API docs

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -142,7 +142,6 @@ public interface API
 
     public const(Block)[] getBlocksFrom (ulong block_height, uint max_blocks);
 
-
     /***************************************************************************
 
         Get the array of hashes which form the merkle path
@@ -195,7 +194,7 @@ public interface API
 
     /***************************************************************************
 
-        Get validator's pre-image inforamtion
+        Get validator's pre-image information
 
         API:
             GET /preimage

--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -165,7 +165,7 @@ public interface API
         Enroll as a validator
 
         API:
-            PUT /enroll_validator
+            POST /enroll_validator
 
         Params:
             enroll = the Enrollment object, the information about an validator
@@ -216,7 +216,7 @@ public interface API
         Reveals a pre-image
 
         API:
-            PUT /receive_preimage
+            POST /receive_preimage
 
         Params:
             preimage = a PreImageInfo object which contains a hash and a height

--- a/source/agora/api/Validator.d
+++ b/source/agora/api/Validator.d
@@ -16,10 +16,10 @@
     as users are expected to use only one of them, not both in combination.
     A client either deal with a validator because it needs the validator API
     (only other validators so far), or needs the full node API and don't
-    care about the validators functions, and should not knoe about them as
+    care about the validators functions, and should not know about them as
     they also include many more dependencies.
 
-    `API` are defined as D interfaces, following what is done in Vibe.d.
+    `API`s are defined as D interfaces, following what is done in Vibe.d.
     Those interfaces can be read by a generator to build a client or a server.
     One such generator is Vibe.d's `vibe.web.rest`. `RestInterfaceClient`
     allows to query a REST API, while `registerRestInterface` will route queries

--- a/source/agora/api/Validator.d
+++ b/source/agora/api/Validator.d
@@ -92,7 +92,7 @@ public interface API : agora.api.FullNode.API
             envelope = Envelope to process (See Stellar_SCP)
 
         API:
-            PUT /receive_envelope
+            POST /receive_envelope
 
     ***************************************************************************/
 

--- a/source/agora/api/handler/BlockExternalizedHandler.d
+++ b/source/agora/api/handler/BlockExternalizedHandler.d
@@ -32,7 +32,6 @@ public interface BlockExternalizedHandler
 
     ***************************************************************************/
 
-    @method(HTTPMethod.POST)
     @path("/")
     public void pushBlock (const Block block);
 }

--- a/source/agora/api/handler/PreImageReceivedHandler.d
+++ b/source/agora/api/handler/PreImageReceivedHandler.d
@@ -32,7 +32,6 @@ public interface PreImageReceivedHandler
 
     ***************************************************************************/
 
-    @method(HTTPMethod.POST)
     @path("/")
     public void pushPreImage (const PreImageInfo preimage);
 }


### PR DESCRIPTION
I found this while working on the `Faucet API`. According to [vibe.web.rest](https://vibed.org/api/vibe.web.rest/),

> By default, the method and URI parts will be inferred from the method name by looking for a known prefix.

> Member functions that have no valid prefix default to 'POST'.

`enroll`, `receive`, and `push` are not known prefixes, so they are calling `HTTP POST`. This has been confirmed after testing with Wireshark. Similarly, methods do not have to be tagged if the default `HTTP POST` is desired.