### PR TITLE
ValidatorSet should use the respective cycle_length of each individual enrollment

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -1093,11 +1093,12 @@ unittest
     assert(man.addEnrollment(enroll, key_pair.address, Height(1),
             utxo_set.getUTXOFinder()));
 
-    assert(man.params.ValidatorCycle - 101 == 907); // Sanity check
     assert(man.getValidatorPreimage(utxo_hash) == PreImageInfo.init);
     assert(man.addValidator(enroll, key_pair.address, Height(2), &utxo_set.peekUTXO,
             utxos) is null);
-    auto preimage = PreImageInfo(utxo_hash, man.cycle.preimages[100], 907);
+    auto preimage = PreImageInfo(utxo_hash,
+                        man.cycle.preimages[(man.params.ValidatorCycle / 2) - 1],
+                        cast (ushort) man.params.ValidatorCycle / 2);
     assert(man.addPreimage(preimage));
     assert(man.getValidatorPreimage(utxo_hash) == preimage);
 }
@@ -1254,19 +1255,19 @@ unittest
     man.clearExpiredValidators(block_height);
     assert(man.getValidatorCount(block_height) == 3);  // not cleared yet
 
-    block_height = 1009; // valid block height : 2 <= H < 1010
+    block_height = params.ValidatorCycle + 1; // valid block height : 2 <= H < params.ValidatorCycle + 2
     man.clearExpiredValidators(block_height);
     assert(man.getValidatorCount(block_height) == 3);
 
-    block_height = 1010; // valid block height : 3 <= H < 1011
+    block_height = params.ValidatorCycle + 2; // valid block height : 3 <= H < params.ValidatorCycle + 3
     man.clearExpiredValidators(block_height);
     assert(man.getValidatorCount(block_height) == 2);
 
-    block_height = 1011; // valid block height : 4 <= H < 1012
+    block_height = params.ValidatorCycle + 3; // valid block height : 4 <= H < params.ValidatorCycle + 4
     man.clearExpiredValidators(block_height);
     assert(man.getValidatorCount(block_height) == 1);
 
-    block_height = 1012; // valid block height : 5 <= H < 1013
+    block_height = params.ValidatorCycle + 4; // valid block height : 5 <= H < params.ValidatorCycle + 5
     man.clearExpiredValidators(block_height);
     assert(man.getValidatorCount(block_height) == 0);
 }
@@ -1397,16 +1398,16 @@ unittest
 
     utxos.sort();  // must be sorted by enrollment key
     assert(man.getRandomSeed(utxos, Height(1)) ==
-        Hash(`0xc689b81d03b1793514fd0725930db06c3b1c1de6339073f82bb4ad39948877b8c1c8e72e1afba5f86419cc900cdbf46b50fed5e0e97c610dd82c98e81574424b`),
+        Hash(`0x32a615331f98bafa6944f188e4d65f1a7d9ed853b5ca384acec2aef39148c60980a592e8c7bc583389a0e4306c2bd557afd4998aa2daca1c4fc410011800732e`),
         man.getRandomSeed(utxos, Height(1)).to!string);
 
-    assert(man.getRandomSeed(utxos, Height(504)) ==
-        Hash(`0x49008dfc5c470b580146349a2fda59901914c37001507a31bf37252102675af31898c50331407f21015b4ae04606136b857955a2fd1b0f382c5a30339d24c88c`),
-        man.getRandomSeed(utxos, Height(504)).to!string);
+    assert(man.getRandomSeed(utxos, Height(params.ValidatorCycle / 2)) ==
+        Hash(`0x60ea0094ddac8664ad90982fab111ece752b676d3c640cdc53c1bbb6cd887c9032b00027a2cd25341aa5e7d6dafd4ccc0661b7adb28a8a551a81e20714ff27d8`),
+        man.getRandomSeed(utxos, Height(params.ValidatorCycle / 2)).to!string);
 
-    assert(man.getRandomSeed(utxos, Height(1008)) ==
-        Hash(`0xec51f4e21932ab7269ddbf461c4339dcdc493cb9f65941ebc816ff26e097fa07e2ee914e824b17b90c7a3640ac063148eaac56bb25a00c3934a13a16984ed546`),
-        man.getRandomSeed(utxos, Height(1008)).to!string);
+    assert(man.getRandomSeed(utxos, Height(params.ValidatorCycle)) ==
+        Hash(`0x98aee8a095ffc15a44ba5679d555a7873107a490d059b785776ec2b5860629cd767edd8ba3238855d66273d1479834bfee66bc23c70071039f9df0e2f0b2524e`),
+        man.getRandomSeed(utxos, Height(params.ValidatorCycle)).to!string);
 }
 
 // Tests for not consuming pre-images before being a validator

--- a/source/agora/consensus/data/Params.d
+++ b/source/agora/consensus/data/Params.d
@@ -97,7 +97,7 @@ public immutable class ConsensusParams
 
     /// Default for unittest, uses the test genesis block
     version (unittest) public this (
-        uint validator_cycle = 1008, uint max_quorum_nodes = 7,
+        uint validator_cycle = 20, uint max_quorum_nodes = 7,
         uint quorum_threshold = 80)
     {
         import agora.consensus.data.genesis.Test : GenesisBlock;

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -699,14 +699,14 @@ unittest
     enroll = createEnrollment(utxos[3], WK.Keys[3], seed_sources[utxos[3]],
         set.params.ValidatorCycle);
     assert(set.add(Height(9), &storage.peekUTXO, enroll, WK.Keys[3].address) is null);
-    set.clearExpiredValidators(Height(1016));
+    set.clearExpiredValidators(Height(set.params.ValidatorCycle + 8));
     keys.length = 0;
     assert(set.getEnrolledUTXOs(keys));
     assert(keys.length == 1);
     assert(keys[0] == utxos[3]);
 
     // add enrollment at the genesis block:
-    // validates blocks [1 .. 1008] inclusively
+    // validates blocks [1 .. set.params.ValidatorCycle] inclusively
     set.clearExpiredValidators(Height(long.max));  // clear all
     assert(set.count == 0);
     seed_sources[utxos[0]] = Scalar.random();
@@ -714,36 +714,36 @@ unittest
         set.params.ValidatorCycle);
     assert(set.add(Height(0), &storage.peekUTXO, enroll, WK.Keys[0].address) is null);
 
-    // not cleared yet at height 1007
-    set.clearExpiredValidators(Height(1007));
+    // not cleared yet at height set.params.ValidatorCycle - 1
+    set.clearExpiredValidators(Height(set.params.ValidatorCycle - 1));
     keys.length = 0;
     assert(set.count == 1);
     assert(set.getEnrolledUTXOs(keys));
     assert(keys.length == 1);
     assert(keys[0] == utxos[0]);
 
-    // cleared after block height 1008 was externalized
-    set.clearExpiredValidators(Height(1008));
+    // cleared after block height set.params.ValidatorCycle was externalized
+    set.clearExpiredValidators(Height(set.params.ValidatorCycle));
     assert(set.count == 0);
     assert(set.getEnrolledUTXOs(keys));
     assert(keys.length == 0);
 
-    // now try with validator for [1 .. 1009]
+    // now try with validator for [1 .. set.params.ValidatorCycle + 1]
     seed_sources[utxos[0]] = Scalar.random();
     enroll = createEnrollment(utxos[0], WK.Keys[0], seed_sources[utxos[0]],
         set.params.ValidatorCycle);
     assert(set.add(Height(1), &storage.peekUTXO, enroll, WK.Keys[0].address) is null);
 
-    // not cleared yet at height 1008
-    set.clearExpiredValidators(Height(1008));
+    // not cleared yet at height set.params.ValidatorCycle
+    set.clearExpiredValidators(Height(set.params.ValidatorCycle));
     keys.length = 0;
     assert(set.count == 1);
     assert(set.getEnrolledUTXOs(keys));
     assert(keys.length == 1);
     assert(keys[0] == utxos[0]);
 
-    // cleared after block height 1009 was externalized
-    set.clearExpiredValidators(Height(1009));
+    // cleared after block height set.params.ValidatorCycle was externalized
+    set.clearExpiredValidators(Height(set.params.ValidatorCycle + 1));
     assert(set.count == 0);
     assert(set.getEnrolledUTXOs(keys));
     assert(keys.length == 0);

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -217,6 +217,35 @@ public class ValidatorSet
 
     /***************************************************************************
 
+        In validatorSet DB, return the cycle length.
+
+        Params:
+            enroll_hash = key for an enrollment
+
+        Returns:
+            the cycle length, or `uint.max` if no matching key exists
+
+    ***************************************************************************/
+
+    public uint getCycleLength (in Hash enroll_hash) @trusted nothrow
+    {
+        try
+        {
+            auto results = this.db.execute("SELECT cycle_length FROM validator_set" ~
+                " WHERE key = ?", enroll_hash.toString());
+            if (!results.empty)
+                return results.oneValue!(uint);
+        }
+        catch (Exception ex)
+        {
+
+            log.error("ManagedDatabase operation error: {}", ex.msg);
+        }
+        return uint.max;
+    }
+
+    /***************************************************************************
+
         Check if a enrollment data exists in the validator set.
 
         Params:
@@ -317,19 +346,11 @@ public class ValidatorSet
 
     public void clearExpiredValidators (Height block_height) @safe nothrow
     {
-        // the smallest enrolled height would be 0 (genesis block),
-        // so the passed block height should be at minimum the
-        // size of the validator cycle
-        if (block_height < this.params.ValidatorCycle)
-            return;
-
         try
         {
             () @trusted {
                 this.db.execute("DELETE FROM validator_set WHERE " ~
-                    "enrolled_height <= ?",
-                    block_height - this.params.ValidatorCycle);
-
+                    "enrolled_height + cycle_length <= ?", block_height.value);
             }();
         }
         catch (Exception ex)
@@ -360,12 +381,11 @@ public class ValidatorSet
     {
         try
         {
-            const height = (block_height >= this.params.ValidatorCycle) ?
-                block_height - this.params.ValidatorCycle + 1 : 0;
             return () @trusted {
                 return this.db.execute(
-                    "SELECT count(*) FROM validator_set WHERE enrolled_height >= ?",
-                    height).oneValue!ulong;
+                    "SELECT count(*) FROM validator_set WHERE " ~
+                    "enrolled_height + cycle_length > ?",
+                    block_height.value).oneValue!ulong;
             }();
         }
         catch (Exception ex)
@@ -527,12 +547,13 @@ public class ValidatorSet
             return false;
         }
 
+        const validator_cycle = this.getCycleLength(preimage.enroll_key);
+
         // Ignore same height pre-image because validators will gossip them
         if (prev_preimage.distance == preimage.distance)
             return false;
 
-        if (auto reason = isInvalidReason(preimage, prev_preimage,
-            this.params.ValidatorCycle))
+        if (auto reason = isInvalidReason(preimage, prev_preimage, validator_cycle))
         {
             log.info("Invalid pre-image data: {}. Pre-image: {}",
                 reason, preimage);

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -80,6 +80,9 @@ public string isInvalidReason (const ref Enrollment enrollment,
         return Message;
     }
 
+    if (enrollment.cycle_length == 0 || enrollment.cycle_length == uint.max)
+        return "Enrollment: Invalid cycle length";
+
     return null;
 }
 

--- a/source/agora/consensus/validation/PreImage.d
+++ b/source/agora/consensus/validation/PreImage.d
@@ -86,7 +86,7 @@ unittest
     reverse(preimages);
 
     PreImageInfo prev_image = PreImageInfo(hashFull("abc"), preimages[0], 1);
-    auto params = new immutable(ConsensusParams)();
+    auto params = new immutable(ConsensusParams)(1008);
 
     // valid pre-image
     PreImageInfo new_image = PreImageInfo(hashFull("abc"), preimages[100], 101);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -717,8 +717,8 @@ unittest
     assert(blocks.length == 3);  // two blocks + genesis block
 
     /// now generate 98 more blocks to make it 100 + genesis block (101 total)
-    genBlockTransactions(98);
-    assert(ledger.getBlockHeight() == 100);
+    genBlockTransactions(17);
+    assert(ledger.getBlockHeight() == 19);
 
     blocks = ledger.getBlocksFrom(Height(0)).takeExactly(10);
     assert(blocks[0] == ledger.params.Genesis);
@@ -734,24 +734,24 @@ unittest
     assert(blocks[0].header.height == 1);
     assert(blocks.length == 10);
 
-    blocks = ledger.getBlocksFrom(Height(50)).takeExactly(10);
-    assert(blocks[0].header.height == 50);
+    blocks = ledger.getBlocksFrom(Height(5)).takeExactly(10);
+    assert(blocks[0].header.height == 5);
     assert(blocks.length == 10);
 
-    blocks = ledger.getBlocksFrom(Height(95)).take(10);  // only 6 left from here (block 100 included)
-    assert(blocks.front.header.height == 95);
-    assert(blocks.walkLength() == 6);
+    blocks = ledger.getBlocksFrom(Height(15)).take(10);  // only 6 left from here (block 100 included)
+    assert(blocks.front.header.height == 15);
+    assert(blocks.walkLength() == 5);
 
-    blocks = ledger.getBlocksFrom(Height(99)).take(10);  // only 2 left from here (ditto)
-    assert(blocks.front.header.height == 99);
+    blocks = ledger.getBlocksFrom(Height(18)).take(10);  // only 2 left from here (ditto)
+    assert(blocks.front.header.height == 18);
     assert(blocks.walkLength() == 2);
 
-    blocks = ledger.getBlocksFrom(Height(100)).take(10);  // only 1 block available
-    assert(blocks.front.header.height == 100);
+    blocks = ledger.getBlocksFrom(Height(19)).take(10);  // only 1 block available
+    assert(blocks.front.header.height == 19);
     assert(blocks.walkLength() == 1);
 
     // over the limit => return up to the highest block
-    assert(ledger.getBlocksFrom(Height(0)).take(1000).walkLength() == 101);
+    assert(ledger.getBlocksFrom(Height(0)).take(1000).walkLength() == 20);
 
     // higher index than available => return nothing
     assert(ledger.getBlocksFrom(Height(1000)).take(10).walkLength() == 0);
@@ -1261,7 +1261,7 @@ unittest
         assert(ledger.last_block == cast()next_block);
         utxos = ledger.utxo_set.getUTXOs(WK.Keys.Genesis.address);
         assert(utxos.length == 8);
-        utxos.each!(utxo => assert(utxo.unlock_height == 1009));
+        utxos.each!(utxo => assert(utxo.unlock_height == params.ValidatorCycle + 1));
         assert(ledger.enroll_man.getEnrolledUTXOs(keys));
         assert(keys.length == 0);
     }
@@ -1298,7 +1298,7 @@ unittest
     {
         auto key_pair = KeyPair.random();
         const blocks = genBlocksToIndex(key_pair, params.ValidatorCycle, params);
-        assert(blocks.length == 1009);  // +1 for genesis
+        assert(blocks.length == params.ValidatorCycle + 1);  // +1 for genesis
 
         scope ledger = new ThrowingLedger(
             key_pair, blocks.takeExactly(params.ValidatorCycle), params);
@@ -1415,7 +1415,7 @@ unittest
     import agora.consensus.data.PreImageInfo;
     import agora.consensus.PreImage;
 
-    auto params = new immutable(ConsensusParams)(10);
+    auto params = new immutable(ConsensusParams)();
     const(Block)[] blocks = [ GenesisBlock ];
     scope ledger = new TestLedger(WK.Keys.NODE2, blocks, params);
 
@@ -1473,7 +1473,7 @@ unittest
     ledger.forceCreateBlock();
     assert(ledger.getBlockHeight() == 3);
 
-    foreach (height; 4 .. 10)
+    foreach (height; 4 .. 20)
     {
         new_txs = genGeneralBlock(new_txs);
         assert(ledger.getBlockHeight() == Height(height));
@@ -1506,19 +1506,19 @@ unittest
         assert(stored_enroll == enrollments[idx]);
     }
 
-    // create the 10th block to make the `Enrollment`s enrolled
+    // create the 20th block to make the `Enrollment`s enrolled
     new_txs = genGeneralBlock(new_txs);
-    assert(ledger.getBlockHeight() == Height(10));
-    ledger.enroll_man.clearExpiredValidators(Height(10));
-    auto b10 = ledger.getBlocksFrom(Height(10))[0];
-    assert(b10.header.enrollments.length == 4);
+    assert(ledger.getBlockHeight() == Height(20));
+    ledger.enroll_man.clearExpiredValidators(Height(20));
+    auto b20 = ledger.getBlocksFrom(Height(20))[0];
+    assert(b20.header.enrollments.length == 4);
 
-    // block 11
+    // block 21
     new_txs = genGeneralBlock(new_txs);
-    assert(ledger.getBlockHeight() == Height(11));
+    assert(ledger.getBlockHeight() == Height(21));
 
     // check missing validators not revealing pre-images.
-    // there are three missing validators at the height of 11.
+    // there are three missing validators at the height of 21.
     auto temp_txs = genTransactions(new_txs);
     temp_txs.each!(tx => assert(ledger.acceptTransaction(tx)));
 


### PR DESCRIPTION
Currently, ValidatorSet uses the local parameters to validate and expire Enrollments. But enrollments can have different cycle lengths.

This revealed some tests use TestGenesis, which has enrollments with 20-block cycle length , but assume 1008-block cycle lengths. The default parameter for tests should be 20 to reflect the TestGenesis enrollments better.