### PR TITLE
Implement pushTransaction for the transaction received handler

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -116,3 +116,6 @@ event_handlers:
   # URLs to push a data when a pre-image is updated. (path is "/preimage_received")
   preimage_received:
     - http://127.0.0.1:3836/preimage_received
+  # URLs to push a data when a transaction is updated. (path is "/transaction_received")
+  transaction_received:
+    - http://127.0.0.1:3836/transaction_received

--- a/source/agora/api/handler/TransactionReceivedHandler.d
+++ b/source/agora/api/handler/TransactionReceivedHandler.d
@@ -1,0 +1,37 @@
+/*******************************************************************************
+
+    Definitions of the TransactionReceivedHandler
+
+    Copyright:
+        Copyright (c) 2019-2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.api.handler.TransactionReceivedHandler;
+
+import agora.consensus.data.Transaction;
+
+import vibe.web.rest;
+import vibe.http.common;
+
+public interface TransactionReceivedHandler
+{
+// The REST generator requires @safe methods
+@safe:
+
+    /***************************************************************************
+
+        Push a transaction in JSON format with HTTP POST
+
+        API:
+            See config.event_handlers.transaction_received_handler_addresses
+
+    ***************************************************************************/
+
+    @path("/")
+    public void pushTransaction (const Transaction tx);
+}

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -229,6 +229,9 @@ public struct EventHandlerConfig
 
     /// URLs to push a data when a pre-image is updated
     public immutable string[] preimage_updated_handler_addresses;
+
+    /// URLs to push a data when a transaction is received
+    public immutable string[] transaction_received_handler_addresses;
 }
 
 /// Parse the command-line arguments and return a GetoptResult
@@ -753,7 +756,9 @@ private EventHandlerConfig parserEventHandlers (Node* node, in CommandLine c)
         block_externalized_handler_addresses:
             assumeUnique(parseSequence(*node, "block_externalized")),
         preimage_updated_handler_addresses:
-            assumeUnique(parseSequence(*node, "preimage_received"))
+            assumeUnique(parseSequence(*node, "preimage_received")),
+        transaction_received_handler_addresses:
+            assumeUnique(parseSequence(*node, "transaction_received")),
     };
 
     return handlers;
@@ -772,6 +777,7 @@ noexist_event_handlers:
         auto conf = parserEventHandlers("event_handlers" in node, cmdln);
         assert(conf.block_externalized_handler_addresses.length == 0);
         assert(conf.preimage_updated_handler_addresses.length == 0);
+        assert(conf.transaction_received_handler_addresses.length == 0);
     }
 
     // If the nodes and values exist
@@ -783,10 +789,13 @@ event_handlers:
     - http://127.0.0.1:3836
   preimage_received:
     - http://127.0.0.1:3836
+  transaction_received:
+    - http://127.0.0.1:3836
 `;
         auto node = Loader.fromString(conf_example).load();
         auto conf = parserEventHandlers("event_handlers" in node, cmdln);
         assert(conf.block_externalized_handler_addresses == [ `http://127.0.0.1:3836` ]);
         assert(conf.preimage_updated_handler_addresses == [ `http://127.0.0.1:3836` ]);
+        assert(conf.transaction_received_handler_addresses == [ `http://127.0.0.1:3836` ]);
     }
 }

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -25,6 +25,7 @@ module agora.network.NetworkManager;
 import agora.api.Validator;
 import agora.api.handler.BlockExternalizedHandler;
 import agora.api.handler.PreImageReceivedHandler;
+import agora.api.handler.TransactionReceivedHandler;
 import agora.common.BanManager;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
@@ -1177,6 +1178,34 @@ public class NetworkManager
         settings.httpClientSettings.readTimeout = this.node_config.timeout;
 
         return new RestInterfaceClient!PreImageReceivedHandler(settings);
+    }
+
+    /***************************************************************************
+
+        Instantiates a client object implementing `TransactionReceivedHandler`
+
+        In the default implementation, this returns a `TransactionReceivedHandler`
+
+        Params:
+            address = The address (IPv4, IPv6, hostname) of target Server
+        Returns:
+            A TransactionReceivedHandler to communicate with the server
+            at `address`
+
+    ***************************************************************************/
+
+    public TransactionReceivedHandler getTransactionReceivedHandler
+        (Address address)
+    {
+        import vibe.http.client;
+
+        auto settings = new RestInterfaceSettings;
+        settings.baseURL = URL(address);
+        settings.httpClientSettings = new HTTPClientSettings;
+        settings.httpClientSettings.connectTimeout = this.node_config.timeout;
+        settings.httpClientSettings.readTimeout = this.node_config.timeout;
+
+        return new RestInterfaceClient!TransactionReceivedHandler(settings);
     }
 }
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1135,6 +1135,7 @@ public class TestNetworkManager : NetworkManager
 {
     import agora.api.handler.BlockExternalizedHandler;
     import agora.api.handler.PreImageReceivedHandler;
+    import agora.api.handler.TransactionReceivedHandler;
 
     ///
     public Registry* registry;
@@ -1210,6 +1211,13 @@ public class TestNetworkManager : NetworkManager
 
     ///
     protected final override PreImageReceivedHandler getPreimageReceivedHandler
+        (Address address)
+    {
+        assert(0, "Not supported");
+    }
+
+    ///
+    protected final override TransactionReceivedHandler getTransactionReceivedHandler
         (Address address)
     {
         assert(0, "Not supported");


### PR DESCRIPTION
To allow Stoa to build its transaction pool it needs to know when transactions are added to the pool.
This allows it to set the incoming address by adding 'transaction_received_handler_addresses' to the setting.
Received a transaction push only valid a transaction.

Related to #1403 