### PR TITLE
Fix #1297: Make Enrollments valid for nomination on only a single block height

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -923,6 +923,17 @@ public class EnrollmentManager
     {
         this.validator_set.removeAll();
     }
+
+    /***************************************************************************
+
+        Returns: A delegate to query past Enrollments
+
+    ***************************************************************************/
+
+    public EnrollmentFinder getEnrollmentFinder () @trusted nothrow
+    {
+        return &this.validator_set.findRecentEnrollment;
+    }
 }
 
 /// tests for member functions of EnrollmentManager

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -1025,7 +1025,7 @@ unittest
     assert(man.getEnrollments(enrolls, Height(9)).length == 0);
 
     // clear up all validators
-    man.clearExpiredValidators(Height(1018));
+    man.validator_set.removeAll();
 
     // Reverse ordering
     ordered_enrollments.sort!("a.utxo_key > b.utxo_key");

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -116,7 +116,8 @@ public class ValidatorSet
         const ref Enrollment enroll, PublicKey pubkey) @safe nothrow
     {
         // check validaty of the enrollment data
-        if (auto reason = isInvalidReason(enroll, finder))
+        if (auto reason = isInvalidReason(enroll, finder,
+                                    block_height, &this.findRecentEnrollment))
             return reason;
 
         // check if already exists

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -443,8 +443,8 @@ public class Ledger
         const next_height = Height(this.getBlockHeight() + 1);
         auto utxo_finder = this.utxo_set.getUTXOFinder();
 
-        this.enroll_man.getEnrollments(data.enrolls,
-            Height(this.getBlockHeight()));
+        this.enroll_man.getEnrollments(data.enrolls, this.getBlockHeight(),
+                                                    &this.utxo_set.peekUTXO);
 
         // get information about validators not revealing a preimage timely
         this.slash_man.getMissingValidators(data.missing_validators,
@@ -1131,7 +1131,7 @@ unittest
     // Check if there are any unregistered enrollments
     Enrollment[] unreg_enrollments;
     assert(ledger.enroll_man.getEnrollments(unreg_enrollments,
-        ledger.getBlockHeight()) is null);
+        ledger.getBlockHeight(), &ledger.utxo_set.peekUTXO) is null);
     auto block_4 = ledger.getBlocksFrom(Height(4));
     enrollments.sort!("a.utxo_key < b.utxo_key");
     assert(block_4[0].header.enrollments == enrollments);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -175,7 +175,8 @@ public class Ledger
                         last_read_block.header.hashFull,
                         this.utxo_set.getUTXOFinder(),
                         active_enrollments,
-                        &this.payload_checker.check))
+                        &this.payload_checker.check,
+                        this.enroll_man.getEnrollmentFinder()))
                         throw new Exception(
                             "A block loaded from disk is invalid: " ~
                             fail_reason);
@@ -543,7 +544,8 @@ public class Ledger
             this.last_block.header.hashFull,
             this.utxo_set.getUTXOFinder(),
             active_enrollments,
-            &this.payload_checker.check);
+            &this.payload_checker.check,
+            this.enroll_man.getEnrollmentFinder());
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -463,7 +463,7 @@ public class Validator : FullNode, API
             log.trace("Sending Enrollment at height {} for {} cycles with {}",
                 block_height, this.params.ValidatorCycle, enroll_key);
             this.network.sendEnrollment(
-                this.enroll_man.createEnrollment(enroll_key));
+                this.enroll_man.createEnrollment(enroll_key, Height(block_height + 1)));
         }
     }
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1562,7 +1562,14 @@ public class TestValidatorNode : Validator, TestAPI
             }
         }
         assert(utxo_hashes.length > 0, format!"No frozen utxo for %s"(pubkey));
-        return this.enroll_man.createEnrollment(utxo_hashes[0]);
+
+        const enroll_height = this.enroll_man.getEnrolledHeight(utxo_hashes[0]);
+        // The first height at which the enrollment can be enrolled.
+        const avail_height = enroll_height == ulong.max ?
+                                this.ledger.getBlockHeight() + 1 :
+                                enroll_height + this.params.ValidatorCycle;
+        return this.enroll_man.createEnrollment(utxo_hashes[0],
+                                                    Height(avail_height));
     }
 
 

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -67,7 +67,7 @@ private class SameKeyValidator : TestValidatorNode
         }
         assert(unused_utxo != Hash.init);
 
-        return this.enroll_man.createEnrollment(unused_utxo);
+        return this.enroll_man.createEnrollment(unused_utxo, this.ledger.getBlockHeight());
     }
 }
 

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -172,9 +172,9 @@ unittest
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
+            WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address]),
+            WK.Keys.NODE7.address]),
 
         // 1
         QuorumConfig(6, [
@@ -192,36 +192,36 @@ unittest
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
+            WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
         // 3
         QuorumConfig(6, [
+            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
-            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
         // 4
         QuorumConfig(6, [
+            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address]),
+            WK.Keys.NODE7.address]),
 
         // 5
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
+            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
@@ -229,11 +229,11 @@ unittest
         // 6
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
+            WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
         // 7
@@ -275,15 +275,15 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
+            WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
 
         // 1
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
+            WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
@@ -295,16 +295,16 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
-            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
-            WK.Keys.NODE5.address,]),
+            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address]),
 
         // 3
         QuorumConfig(6, [
             WK.Keys.NODE2.address,
-            WK.Keys.NODE4.address,
+            WK.Keys.NODE6.address,
             WK.Keys.B.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
@@ -323,10 +323,10 @@ unittest
 
         // 5
         QuorumConfig(6, [
+            WK.Keys.NODE2.address,
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
-            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
@@ -347,8 +347,8 @@ unittest
             WK.Keys.NODE4.address,
             WK.Keys.NODE6.address,
             WK.Keys.B.address,
-            WK.Keys.NODE3.address,
             WK.Keys.A.address,
+            WK.Keys.NODE7.address,
             WK.Keys.NODE5.address]),
     ];
 

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -63,3 +63,116 @@ unittest
     // Check if all validators in genesis are enrolled again
     assert(blocks[blocks.length - 1].header.enrollments.length == blocks[0].header.enrollments.length);
 }
+
+// Recurring enrollment with wrong `random_seed`
+// When nodes reach the end of their validation cycle, they will try to
+// re-enroll with the same commitment in the GenesisBlock (ie. Height(0))
+// They should not be able to enroll and no new block should be created.
+unittest
+{
+    import agora.consensus.EnrollmentManager;
+    import agora.consensus.data.Enrollment;
+    import agora.consensus.data.Params;
+    import agora.consensus.data.Block;
+    import agora.common.Hash;
+    import agora.common.Config;
+    import agora.common.crypto.Key;
+    import geod24.Registry;
+    import core.stdc.time;
+    import std.exception;
+    import core.exception : AssertError;
+
+    // Will always try to enroll with PreImage at Height(0)
+    static class BadEnrollmentManager : EnrollmentManager
+    {
+        public this (string db_path, KeyPair key_pair,
+            immutable(ConsensusParams) params)
+        {
+            super(db_path, key_pair, params);
+        }
+
+        public override Enrollment createEnrollment ( in Hash utxo,
+            Height height ) @safe nothrow
+        {
+            return super.createEnrollment(utxo, Height(0));
+        }
+    }
+
+    static class BadValidator : TestValidatorNode
+    {
+        public this (Config config, Registry* reg, immutable(Block)[] blocks,
+            in TestConf test_conf, shared(time_t)* cur_time)
+        {
+            super(config, reg, blocks, test_conf, cur_time);
+        }
+
+        protected override EnrollmentManager getEnrollmentManager (
+            string data_dir, in ValidatorConfig validator_config,
+            immutable(ConsensusParams) params)
+        {
+            return new BadEnrollmentManager(":memory:",
+                validator_config.key_pair, params);
+        }
+    }
+
+    static class BadAPIManager : TestAPIManager
+    {
+        public this (immutable(Block)[] blocks, TestConf test_conf,
+            time_t initial_time)
+        {
+            super(blocks, test_conf, initial_time);
+        }
+
+        public override void createNewNode (Config conf, string file = __FILE__,
+            int line = __LINE__)
+        {
+            if (conf.validator.enabled)
+                this.addNewNode!BadValidator(conf, file, line);
+            else
+                this.addNewNode!TestFullNode(conf, file, line);
+        }
+    }
+
+    TestConf conf = {
+        quorum_threshold : 100
+    };
+    auto network = makeTestNetwork!BadAPIManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[0];
+
+    // Get the genesis block, make sure it's the only block externalized
+    auto blocks = node_1.getBlocksFrom(0, 2);
+    assert(blocks.length == 1);
+
+    Transaction[] txs;
+
+    void createAndExpectNewBlock (Height new_block_height)
+    {
+        // create enough tx's for a single block
+        txs = blocks[new_block_height - 1].spendable().map!(txb => txb.sign())
+            .array();
+
+        // send it to one node
+        txs.each!(tx => node_1.putTransaction(tx));
+
+        network.expectBlock(new_block_height, blocks[0].header);
+
+        // add next block
+        blocks ~= node_1.getBlocksFrom(new_block_height, 1);
+    }
+
+    // create GenesisValidatorCycle - 1 blocks
+    foreach (block_idx; 1 .. GenesisValidatorCycle)
+    {
+        createAndExpectNewBlock(Height(block_idx));
+    }
+
+    // Try creating one last block, should fail
+    assertThrown!AssertError(createAndExpectNewBlock(
+        Height(GenesisValidatorCycle)));
+}

--- a/tests/system/dub.json
+++ b/tests/system/dub.json
@@ -3,8 +3,8 @@
     "targetType": "executable",
     "targetPath": "build",
     "dflags": [ "-i" ],
-    "libs-posix": [ "sodium" ],
-    "libs-windows": [ "libsodium" ],
+    "libs-posix": [ "sodium", "sqlite3" ],
+    "libs-windows": [ "libsodium", "libsqlite3" ],
     "versions": 
     [
         "Have_base32",


### PR DESCRIPTION
With this, `PreImage`s are consumed not by new enrollments but by new blocks. Commitments in new enrollments should be the `PreImage` that would be revealed on the height that Enrollment would be available.

More background info at https://github.com/bpfkorea/agora/issues/1297