### PR TITLE
Engine: Implement support for threshold signatures

### DIFF
--- a/source/agora/script/Engine.d
+++ b/source/agora/script/Engine.d
@@ -434,6 +434,19 @@ public class Engine
                 stack.push(payload);
                 break;
 
+            case OP.PUSH_NUM_1: .. case OP.PUSH_NUM_5:
+                static const ubyte[1] OneByte = [0];
+                if (!stack.canPush(OneByte))
+                    return "Stack overflow while executing PUSH_NUM_*";
+
+                // note: must be GC-allocated!
+                // todo: replace with preallocated values just like
+                // `TrueValue` and `FalseValue`
+                const ubyte[] number
+                    = [cast(ubyte)((opcode + 1) - OP.PUSH_NUM_1)];
+                stack.push(number);
+                break;
+
             case OP.DUP:
                 if (stack.empty)
                     return "DUP opcode requires an item on the stack";

--- a/source/agora/script/Engine.d
+++ b/source/agora/script/Engine.d
@@ -544,9 +544,6 @@ public class Engine
 
                 break;
 
-            case OP.INVALID:
-                return "Script panic while executing OP.INVALID opcode";
-
             default:
                 assert(0);  // should have been handled
             }
@@ -900,16 +897,6 @@ version (unittest)
     // sensible defaults
     private const TestStackMaxTotalSize = 16_384;
     private const TestStackMaxItemSize = 512;
-}
-
-// OP.INVALID
-unittest
-{
-    scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
-    test!("==")(engine.execute(
-        Lock(LockType.Script, [OP.INVALID]), Unlock.init, Transaction.init,
-            Input.init),
-        "Script panic while executing OP.INVALID opcode");
 }
 
 // OP.DUP

--- a/source/agora/script/Opcodes.d
+++ b/source/agora/script/Opcodes.d
@@ -36,10 +36,6 @@ import std.traits : EnumMembers;
 
 public enum OP : ubyte
 {
-    /// Executing this is an error and will cause script execution to fail.
-    /// Purposefully located first to default OPs to errors.
-    INVALID = 0x50,
-
     /// Used to encode a small data push to the stack (up to 75 bytes),
     /// may be used with `case PUSH_BYTES_1: .. case PUSH_BYTES_64:` syntax.
     PUSH_BYTES_1 = 0x01,

--- a/source/agora/script/Opcodes.d
+++ b/source/agora/script/Opcodes.d
@@ -122,6 +122,27 @@ public enum OP : ubyte
     /// script execution to fail if the signature is invalid
     VERIFY_SIG = 0x60,
 
+    /// Supports non-interactive threshold multi-signatures. A combination
+    /// of `N / M` is supported where `N <= M` and where the number of keys
+    /// and signatures does not exceed 5.
+    /// Pops an item from the stock which is the count of public keys that
+    /// should be read from the stack. It pops those public keys, and then
+    /// pops another item which is the number of required signatures.
+    /// Then it pops that many signatures from the stack. Then it walks through
+    /// all the public keys and validates the signatures in sequence. If a
+    /// key did not validate, it's removed from the internal list. If we've
+    /// ran out of keys and the number of valid signatures is less than
+    /// the required amount it means signature validation has failed.
+    /// It pushes the result of validation to the tack.
+    /// The keys and signatures must be placed in the same order on the stack.
+    /// Supports up to 5 public keys total as the signature validation is not
+    /// as efficient as alternative implementations such as MuSig.
+    CHECK_MULTI_SIG = 0x61,
+
+    /// Ditto, but instead of pushing the result to the stack it will cause the
+    /// script execution to fail if the signature is invalid
+    VERIFY_MULTI_SIG = 0x62,
+
     /// Expects a new sequence ID on the stack and an expected sequence ID
     /// on the stack. Verifies `sequence_id >= expected_id`, and adds
     /// `sequence_id` to the signature hash. The matching Input is blanked

--- a/source/agora/script/Opcodes.d
+++ b/source/agora/script/Opcodes.d
@@ -57,67 +57,79 @@ public enum OP : ubyte
     /// This opcode may be reserved for a future PUSH_DATA_4.
     // OP_RESERVED_1 = 0x4E,
 
+    /// Pushes `1` to `5` to the stack. To be used with counts for some opcodes
+    /// such as `CHECK_SEQ_SIG`.
+    PUSH_NUM_1 = 0x4F,
+    /// Ditto
+    PUSH_NUM_2 = 0x50,
+    /// Ditto
+    PUSH_NUM_3 = 0x51,
+    /// Ditto
+    PUSH_NUM_4 = 0x52,
+    /// Ditto
+    PUSH_NUM_5 = 0x53,
+
     /// Pushes True onto the stack. Used by conditional opcodes.
     /// Additionally if after lock + unlock script execution the only
     /// value on the stack is TRUE, the script will be considered valid.
     /// Any other value (FALSE or otherwise) on the top of the stack
     /// after execution will cause the script to fail.
-    TRUE = 0x4F,
+    TRUE = 0x54,
 
     /// Pushes False onto the stack. Used by conditional opcodes.
     FALSE = 0x00,
 
     /// Conditionals
-    IF = 0x51,
-    NOT_IF = 0x52,
-    ELSE = 0x53,
-    END_IF = 0x54,
+    IF = 0x55,
+    NOT_IF = 0x56,
+    ELSE = 0x57,
+    END_IF = 0x58,
 
     /// Pop the top item on the stack, hash it, and push the hash to the stack.
     /// Note that the item being hashed is a byte array.
-    HASH = 0x55,
+    HASH = 0x59,
 
     /// Duplicate the item on the stack. Equivalent to `value = pop()` and
     /// `push(value); push(value);`
-    DUP = 0x56,
+    DUP = 0x5A,
 
     /// Pops two items from the stack. Checks that the items are equal to each
     /// other, and pushes either `TRUE` or `FALSE` to the stack.
-    CHECK_EQUAL = 0x57,
+    CHECK_EQUAL = 0x5B,
 
     /// Ditto, but instead of pushing to the stack it will cause the script
     /// execution to fail if the two items are not equal to each other.
-    VERIFY_EQUAL = 0x58,
+    VERIFY_EQUAL = 0x5C,
 
     /// Verify the height lock of a spending Transaction. Expects an 8-byte
     /// unsigned integer as the height on the stack, and verifies that the
     /// Transaction's `lock_height` is greater than or equal to this value.
-    VERIFY_LOCK_HEIGHT = 0x59,
+    VERIFY_LOCK_HEIGHT = 0x5D,
 
     /// Verify the time lock of the associated spending Input. Expects a
     /// 4-byte unsigned integer as the unlock age on the stack, and verifies
     /// that the Input's `unlock_age` is greater than or equal to this value.
-    VERIFY_UNLOCK_AGE = 0x5A,
+    VERIFY_UNLOCK_AGE = 0x5E,
 
     /// Pops two items from the stack. The two items must be a Point (Schnorr),
     /// and a Signature. If the items cannot be deserialized as a Point and
     /// Signature, the script validation fails.
     /// The signature is then validated using Schnorr, if the signature is
     /// valid then `TRUE` is pushed to the stack.
-    CHECK_SIG = 0x5B,
+    CHECK_SIG = 0x5F,
 
     /// Ditto, but instead of pushing the result to the stack it will cause the
     /// script execution to fail if the signature is invalid
-    VERIFY_SIG = 0x5C,
+    VERIFY_SIG = 0x60,
 
     /// Expects a new sequence ID on the stack and an expected sequence ID
     /// on the stack. Verifies `sequence_id >= expected_id`, and adds
     /// `sequence_id` to the signature hash. The matching Input is blanked
     /// to implement floating transactions, as defined in Eltoo.
-    CHECK_SEQ_SIG = 0x5D,
+    CHECK_SEQ_SIG = 0x63,
 
     /// Ditto
-    VERIFY_SEQ_SIG = 0x5E,
+    VERIFY_SEQ_SIG = 0x64,
 }
 
 /*******************************************************************************
@@ -165,7 +177,7 @@ pure nothrow @safe @nogc unittest
 {
     OP op;
     assert(0x00.toOPCode(op) && op == OP.FALSE);
-    assert(0x55.toOPCode(op) && op == OP.HASH);
+    assert(0x59.toOPCode(op) && op == OP.HASH);
     assert(!255.toOPCode(op));
     assert(1.toOPCode(op) && op == OP.PUSH_BYTES_1);
     assert(32.toOPCode(op) && op == cast(OP)32);

--- a/source/agora/script/Script.d
+++ b/source/agora/script/Script.d
@@ -140,6 +140,9 @@ public string validateScript (in ScriptType type, in ubyte[] opcodes,
             bytes.popFrontN(payload_size);
             break;
 
+        case OP.PUSH_NUM_1: .. case OP.PUSH_NUM_5:
+            break;
+
         default:
             break;
         }
@@ -174,6 +177,10 @@ unittest
     // only pushes are allowed for unlock
     test!"=="(validateScript(ScriptType.Unlock, [OP.FALSE], StackMaxItemSize,
         result),
+        null);
+    test!"=="(validateScript(ScriptType.Unlock,
+        [OP.PUSH_NUM_1, OP.PUSH_NUM_2, OP.PUSH_NUM_3, OP.PUSH_NUM_4, OP.PUSH_NUM_5],
+        StackMaxItemSize, result),
         null);
     test!"=="(validateScript(ScriptType.Unlock, [OP.PUSH_BYTES_1, 1],
         StackMaxItemSize, result), null);

--- a/source/agora/script/Script.d
+++ b/source/agora/script/Script.d
@@ -183,9 +183,6 @@ unittest
 
     test!"=="(validateScript(ScriptType.Lock, [255], StackMaxItemSize, result),
         "Script contains an unrecognized opcode");
-    // OP.INVALID is only semantically invalid
-    test!"=="(validateScript(ScriptType.Lock, [OP.INVALID], StackMaxItemSize,
-        result), null);
 
     // PUSH_BYTES_*
     test!"=="(validateScript(ScriptType.Lock, [1], StackMaxItemSize, result),


### PR DESCRIPTION
See https://github.com/bpfkorea/agora/issues/1428 for more info. If we don't get MuSig support in the Wallet soon then this is the scheme we should be using by default.

Fixes https://github.com/bpfkorea/agora/issues/1428