### PR TITLE
Link system tests with sqlite3

### DIFF
--- a/tests/system/dub.json
+++ b/tests/system/dub.json
@@ -3,8 +3,8 @@
     "targetType": "executable",
     "targetPath": "build",
     "dflags": [ "-i" ],
-    "libs-posix": [ "sodium" ],
-    "libs-windows": [ "libsodium" ],
+    "libs-posix": [ "sodium", "sqlite3" ],
+    "libs-windows": [ "libsodium", "libsqlite3" ],
     "versions": 
     [
         "Have_base32",


### PR DESCRIPTION
[This](https://app.circleci.com/pipelines/github/bpfkorea/agora/5317/workflows/acd127b1-d13a-4ac5-86d8-3c24780a7360/jobs/5624) shows that system test now depend on sqlite somehow.