### PR TITLE
Implement slashing protocol

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -702,12 +702,13 @@ public class EnrollmentManager
         foreach (const ref key; keys)
         {
             const preimage = this.validator_set.getPreimageAt(key, height);
-            // this should not happen. validators which didn't reveal the
-            // preimage should not be in the active validator set 'keys'.
+            // We could have a misbehaving validator that does not reveal
+            // its preimages in real world. In order to deal with the validator,
+            // We implement the slashing protocol.
             if (preimage == PreImageInfo.init)
             {
-                log.fatal("No preimage at height {} for validator key {}", height.value, key);
-                assert(0, "No preimage at expected height");
+                log.info("No preimage at height {} for validator key {}", height.value, key);
+                continue;
             }
             rand_seed = hashMulti(rand_seed, preimage);
         }

--- a/source/agora/consensus/SlashPolicy.d
+++ b/source/agora/consensus/SlashPolicy.d
@@ -143,7 +143,7 @@ public class SlashPolicy
                 valid_keys ~= key;
         }
 
-        // NOTE: The preimage root of `Hash.init` value is currently
+        // NOTE: The random seed of `Hash.init` value is currently
         // checked in the `validateSlashingData` function of `Ledger`.
         if (valid_keys.length == 0)
             return Hash.init;

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -59,6 +59,12 @@ public struct BlockHeader
     /// Enrolled validators
     public Enrollment[] enrollments;
 
+    /// Hash of random seed of the preimages for this this height
+    public Hash random_seed;
+
+    /// List of indices to the validator UTXO set which have not revealed the preimage
+    public uint[] missing_validators;
+
     /***************************************************************************
 
         Implements hashing support
@@ -78,6 +84,9 @@ public struct BlockHeader
         dg(this.merkle_root[]);
         foreach (enrollment; this.enrollments)
             hashPart(enrollment, dg);
+        dg(this.random_seed[]);
+        foreach (validator; this.missing_validators)
+            hashPart(validator, dg);
     }
 
     /***************************************************************************
@@ -99,6 +108,10 @@ public struct BlockHeader
         serializePart(this.enrollments.length, dg);
         foreach (enrollment; this.enrollments)
             serializePart(enrollment, dg);
+        dg(this.random_seed[]);
+        serializePart(this.missing_validators.length, dg);
+        foreach (validator; this.missing_validators)
+            serializePart(validator, dg);
     }
 }
 
@@ -117,9 +130,9 @@ unittest
         BlockHeader header = { merkle_root : tx.hashFull() };
 
         auto hash = hashFull(header);
-        auto exp_hash = Hash("0xc04f3226bdc07c6d3141e3ac14888cd3b4199d84877" ~
-            "e591927063af65e5f56b14f9236e764bacb980aed5acefb98981b221e5c99e" ~
-            "aaaf1100c87c250cec2f32c");
+        auto exp_hash = Hash("0xc49255b83a9e125377df3de687abd883dd57df98aa7" ~
+            "5bd5f26a7e7de89d78e2922fa426524aef0b7651467051736fb4c98e1d4737" ~
+            "b2c91cfa0b866a3fae8bec8");
         assert(hash == exp_hash);
     }();
 }

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -515,8 +515,10 @@ extern(D):
                 return;
             }
             const Block prev_block = blocks.front;
+            Hash random_seed = this.ledger.getExternalizedRandomSeed(
+                this.ledger.getBlockHeight(), con_data.missing_validators);
             const Block proposed_block = makeNewBlock(prev_block, con_data.tx_set,
-                con_data.enrolls);
+                con_data.enrolls, random_seed, con_data.missing_validators);
             const Signature signature = envelope.statement.pledges.confirm_.value_sig;
             const Height height = Height(envelope.statement.slotIndex);
             if (!this.addBlockSignature(public_key, proposed_block, signature, height))
@@ -705,8 +707,10 @@ extern(D):
         assert(!blocks.empty);
 
         const prev_block = blocks.front;
+        Hash random_seed = this.ledger.getExternalizedRandomSeed(
+                this.ledger.getBlockHeight(), con_data.missing_validators);
         const proposed_block = makeNewBlock(prev_block, con_data.tx_set,
-            con_data.enrolls);
+            con_data.enrolls, random_seed, con_data.missing_validators);
 
         Height height = proposed_block.header.height;
         const Signature signature = createBlockSignature(proposed_block);
@@ -866,7 +870,10 @@ extern(D):
             assert(!blocks.empty);  // should not happen
             const prev_block = blocks.front;
 
-            const block = makeNewBlock(prev_block, data.tx_set, data.enrolls);
+            Hash random_seed = this.ledger.getExternalizedRandomSeed(
+                this.ledger.getBlockHeight(), data.missing_validators);
+            const block = makeNewBlock(prev_block, data.tx_set, data.enrolls,
+                random_seed, data.missing_validators);
 
             // If we did not sign yet then add signature
             if (this.schnorr_pair.V !in this.slot_sigs[height])

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -220,6 +220,30 @@ public class ValidatorSet
 
     /***************************************************************************
 
+        Unenroll the enrollment with the given UTXO key from the validator set
+
+        Params:
+            utxo_key = the UTXO key of the enrollment data to unerno
+
+    ***************************************************************************/
+
+    public void unenroll (in Hash enroll_hash) @trusted nothrow
+    {
+        try
+        {
+            () @trusted {
+                this.db.execute("UPDATE validator_set SET active = ? WHERE key = ?",
+                    EnrollmentStatus.Expired, enroll_hash.toString());
+            }();
+        }
+        catch (Exception ex)
+        {
+            log.error("ManagedDatabase operation error: {}", ex.msg);
+        }
+    }
+
+    /***************************************************************************
+
         In validatorSet DB, return the enrolled block height.
 
         Params:

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -929,7 +929,14 @@ unittest
     enrollments ~= enroll1;
     enrollments ~= enroll2;
     enrollments.sort!("a.utxo_key < b.utxo_key");
-    auto block3 = makeNewTestBlock(block2, txs_3, enrollments);
+
+    auto preimage_root = Hash("0x47c993d409aa7d77651ecaa5a5d29e47a7aee609c7" ~
+                              "cb376f5f8ff2a868c738233a2df5ba11d635c8576a47" ~
+                              "3864fc1c8fd1469f4be80b853764da53f6a5b41661");
+    uint[] missing_validators = [];
+
+    auto block3 = makeNewTestBlock(block2, txs_3, enrollments, preimage_root,
+        missing_validators);
     assert(block3.isValid(block2.header.height, hashFull(block2.header), findUTXO,
         Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
     enrollments.sort!("a.utxo_key > b.utxo_key");
@@ -1061,7 +1068,14 @@ unittest
         Enrollment[] enrollments;
         enrollments ~= enroll1;
         enrollments.sort!("a.utxo_key < b.utxo_key");
-        auto block3 = makeNewTestBlock(block2, txs_3, enrollments);
+
+        auto preimage_root = Hash("0x47c993d409aa7d77651ecaa5a5d29e47a7aee609c7" ~
+                                  "cb376f5f8ff2a868c738233a2df5ba11d635c8576a47" ~
+                                  "3864fc1c8fd1469f4be80b853764da53f6a5b41661");
+        uint[] missing_validators = [];
+
+        auto block3 = makeNewTestBlock(block2, txs_3, enrollments, preimage_root,
+            missing_validators);
         assert(block3.header.enrollments.length == Enrollment.MinValidatorCount);
         assert(block3.isValid(block2.header.height, hashFull(block2.header),
             findUTXO, 0, genesis_validator_keys.length, checker, findGenesisEnrollments));

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -1224,7 +1224,10 @@ unittest
         {
             txs = last_txs.map!(tx => TxBuilder(tx).sign()).array();
             Enrollment[] no_enrollments = null;
+            uint[] no_missing_validator = null;
             last_block = makeNewTestBlock(blocks[$ - 1], txs, no_enrollments,
+                Hash.init,
+                no_missing_validator,
                 genesis_validator_keys[0 .. $ - 1], // last validator will not sign
                 (PublicKey k)
                 {

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -1,0 +1,148 @@
+/*******************************************************************************
+
+    Contains tests for re-routing part of the frozen UTXO of a slashed
+    validater to `CommonsBudget` address.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.SlashingMisbehavingValidator;
+
+version (unittest):
+
+import agora.common.crypto.Key;
+import agora.common.Config;
+import agora.common.Hash;
+import agora.consensus.data.Block;
+import agora.consensus.data.Params;
+import agora.consensus.data.PreImageInfo;
+import agora.consensus.data.Transaction;
+import agora.consensus.EnrollmentManager;
+import agora.consensus.state.UTXODB;
+import agora.network.NetworkManager;
+import agora.utils.Test;
+import agora.test.Base;
+
+import core.stdc.stdint;
+import core.stdc.time;
+import core.thread;
+
+import geod24.Registry;
+
+// This derived `EnrollmentManager` does not reveal any preimages
+// after enrollment.
+private class MissingPreImageEM : EnrollmentManager
+{
+    ///
+    public this (string db_path, KeyPair key_pair,
+        immutable(ConsensusParams) params)
+    {
+        super(db_path, key_pair, params);
+    }
+
+    /// This does not reveal pre-images intentionally
+    public override bool getNextPreimage (out PreImageInfo preimage,
+        Height height) @safe
+    {
+        return false;
+    }
+}
+
+// This derived TestValidatorNode does not reveal any preimages using the
+// `MissingPreImageEM` class
+private class NoPreImageVN : TestValidatorNode
+{
+    public static shared UTXOSet utxo_set;
+
+    ///
+    public this (Config config, Registry* reg, immutable(Block)[] blocks,
+        in TestConf test_conf, shared(time_t)* cur_time)
+    {
+        super(config, reg, blocks, test_conf, cur_time);
+    }
+
+    protected override EnrollmentManager getEnrollmentManager (
+        string data_dir, in ValidatorConfig validator_config,
+        immutable(ConsensusParams) params)
+    {
+        return new MissingPreImageEM(":memory:", validator_config.key_pair,
+            params);
+    }
+
+    protected override UTXOSet getUtxoSet(string data_dir)
+    {
+        this.utxo_set = cast(shared UTXOSet)super.getUtxoSet(data_dir);
+        return cast(UTXOSet)this.utxo_set;
+    }
+}
+
+/// Situation: A misbehaving validator does not reveal its preimages right after
+///     it's enrolled.
+/// Expectation: The information about the validator is stored in a block.
+///     The validator is un-enrolled and a part of its fund is refunded to the
+///     validators with the 10K of the fund going to the `CommonsBudget` address.
+unittest
+{
+    static class BadAPIManager : TestAPIManager
+    {
+        ///
+        public this (immutable(Block)[] blocks, TestConf test_conf,
+            time_t initial_time)
+        {
+            super(blocks, test_conf, initial_time);
+        }
+
+        ///
+        public override void createNewNode (Config conf, string file, int line)
+        {
+            if (this.nodes.length == 5)
+            {
+                auto time = new shared(time_t)(this.initial_time);
+                auto api = RemoteAPI!TestAPI.spawn!NoPreImageVN(
+                    conf, &this.reg, this.blocks, this.test_conf,
+                    time, conf.node.timeout);
+                this.reg.register(conf.node.address, api.tid());
+                this.nodes ~= NodePair(conf.node.address, api, time);
+            }
+            else
+                super.createNewNode(conf, file, line);
+        }
+    }
+
+    TestConf conf = {
+        recurring_enrollment : false,
+    };
+    auto network = makeTestNetwork!BadAPIManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto spendable = network.blocks[$ - 1].spendable().array;
+    auto utxo_set = cast(UTXOSet) NoPreImageVN.utxo_set;
+    auto bad_address = nodes[5].getPublicKey();
+
+    // discarded UTXOs (just to trigger block creation)
+    auto txs = spendable[0 .. 8].map!(txb => txb.sign()).array;
+
+    // wait for the preimage to be missed
+    Thread.sleep(5.seconds);
+
+    // block 1
+    txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(1));
+
+    // block 2
+    txs = txs.map!(tx => TxBuilder(tx).sign()).array();
+    txs.each!(tx => nodes[0].putTransaction(tx));
+    network.expectBlock(Height(2));
+    auto block2 = nodes[0].getBlocksFrom(2, 1)[0];
+    assert(block2.header.missing_validators.length == 1);
+}

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -331,12 +331,15 @@ private struct BlockHeaderFmt
     {
         try
         {
-            formattedWrite(sink, "Height: %d, Prev: %s, Root: %s, Enrollments: [%s]\nSignature: %s,\nValidators: %s",
+            formattedWrite(sink, "Height: %d, Prev: %s, Root: %s, Enrollments: [%s]\nSignature: %s,\nValidators: %s,\nRandom seed: [%s],\nSlashed validators: [%s]",
                 this.value.height.value, HashFmt(this.value.prev_block),
                 HashFmt(this.value.merkle_root),
                 this.value.enrollments.fold!((a, b) =>
                     format!"%s\n%s"(a, prettify(b)))(""),
-                this.value.signature, this.value.validators);
+                this.value.signature, this.value.validators,
+                HashFmt(this.value.random_seed),
+                this.value.missing_validators.fold!((a, b) =>
+                    format!"%s, %s"(a, prettify(b)))(""));
         }
         catch (Exception ex)
         {
@@ -355,7 +358,9 @@ private struct BlockHeaderFmt
 { utxo: 0xb20d...08eb, seed: 0xa050...2cb4, cycles: 20, sig: 0x052e...6b31 }
 { utxo: 0xdb39...2d85, seed: 0xdd1b...7bfa, cycles: 20, sig: 0x0e00...4fe2 }]
 Signature: 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
-Validators: [0]`;
+Validators: [0],
+Random seed: [0x0000...0000],
+Slashed validators: []`;
     const actual = format("%s", BlockHeaderFmt(GenesisBlock.header));
     assert(GenesisHStr == actual, actual);
 }
@@ -397,6 +402,8 @@ private struct BlockFmt
 { utxo: 0xdb39...2d85, seed: 0xdd1b...7bfa, cycles: 20, sig: 0x0e00...4fe2 }]
 Signature: 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
 Validators: [0],
+Random seed: [0x0000...0000],
+Slashed validators: [],
 Transactions: 2
 Type : Freeze, Inputs: None
 Outputs (6):
@@ -450,6 +457,8 @@ Height: 0, Prev: 0x0000...0000, Root: 0x788c...9254, Enrollments: [
 { utxo: 0xdb39...2d85, seed: 0xdd1b...7bfa, cycles: 20, sig: 0x0e00...4fe2 }]
 Signature: 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
 Validators: [0],
+Random seed: [0x0000...0000],
+Slashed validators: [],
 Transactions: 2
 Type : Freeze, Inputs: None
 Outputs (6):
@@ -461,9 +470,11 @@ GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000),
 GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000),
 GCOQ...LRIJ(61,000,000), GCOQ...LRIJ(61,000,000)
 ====================================================
-Height: 1, Prev: 0x72e6...3b7d, Root: 0x07a8...acf4, Enrollments: []
+Height: 1, Prev: 0xd053...80d8, Root: 0x07a8...acf4, Enrollments: []
 Signature: 0x000000000000000000016f605ea9638d7bff58d2c0cc2467c18e38b36367be78000000000000000000016f605ea9638d7bff58d2c0cc2467c18e38b36367be78,
 Validators: [64],
+Random seed: [0x0000...0000],
+Slashed validators: [],
 Transactions: 2
 Type : Payment, Inputs (1): 0xc378...d314:0x0fbf...ba74
 Outputs (1): GCOQ...LRIJ(61,000,000)

--- a/tests/unit/BlockStorage.d
+++ b/tests/unit/BlockStorage.d
@@ -62,7 +62,7 @@ private void main ()
         // We can use a random keypair because blocks are not validated
         // Use a key that is not used elsewhere.
         tx.inputs[0].signature = WK.Keys.X.secret.sign(hashFull(tx)[]);
-        blocks ~= makeNewBlock(blocks[$ - 1], [tx], null);
+        blocks ~= makeNewBlock(blocks[$ - 1], [tx], null, Hash.init, null);
         block_hashes ~= hashFull(blocks[$ - 1].header);
         storage.saveBlock(blocks[$ - 1]);
     }

--- a/tests/unit/BlockStorageChecksum.d
+++ b/tests/unit/BlockStorageChecksum.d
@@ -57,7 +57,7 @@ private void writeBlocks (string path)
     foreach (block_idx; 0 .. BlockCount)
     {
         Transaction[8] txs;
-        auto block = makeNewBlock(blocks[$ - 1], txs[], null);
+        auto block = makeNewBlock(blocks[$ - 1], txs[], null, Hash.init, null);
         storage.saveBlock(block);
         blocks ~= block;
     }

--- a/tests/unit/BlockStorageMultiTx.d
+++ b/tests/unit/BlockStorageMultiTx.d
@@ -51,7 +51,7 @@ private void main ()
         .array();
     foreach (block_idx; 0 .. BlockCount)
     {
-        auto block = makeNewBlock(blocks[$ - 1], txs, null);
+        auto block = makeNewBlock(blocks[$ - 1], txs, null, Hash.init, null);
         storage.saveBlock(block);
         blocks ~= block;
         // Prepare transactions for the next block


### PR DESCRIPTION
With this PR, we can add information about validators being slashed into the block. After the validators being slashed, the UTXOs of the validators are split into the validators' address and the `CommonsBudget` address.

This does *NOT* contain the validation check for the information yet. But it will be implemented soon. The feature of PR #1421 is the need for the next step, which is to maintain un-enrolled validators in the `ValidatorSet`.

Part of #1076 