### PR TITLE
Fix send-tx client to use Schnorr

### DIFF
--- a/source/agora/cli/client/SendTxProcess.d
+++ b/source/agora/cli/client/SendTxProcess.d
@@ -191,7 +191,10 @@ public int sendTxProcess (string[] args, ref string[] outputs,
         [Output(Amount(op.amount), PublicKey.fromString(op.address))]
     };
 
-    auto signature = key_pair.secret.sign(hashFull(tx)[]);
+    import agora.common.crypto.Schnorr;
+    auto kp = () @trusted { return secretKeyToCurveScalar(key_pair.secret); }();
+    Pair pair = Pair(kp, kp.toPoint());
+    auto signature = sign(pair, tx);
     tx.inputs[0].unlock = genKeyUnlock(signature);
 
     if (op.dump)


### PR DESCRIPTION
Example of using Schnorr signing using the [LockType.Lock](https://github.com/bpfkorea/agora/blob/9aee9d750a572be2e93e2497e63038af09cd407d/source/agora/script/Lock.d#L61) locks in the genesis block:

```
$ dub build -c client
$ ./build/agora-client sendtx -i "0.0.0.0" -p 2826 -t "0xb3aaf405f53560a6f6d5dd9dd83d7b031da480c0640a2897f2e2562c4670dfe84552d84daf5b1b7c63ce249d06bf54747cc5fdc98178a932fff99ab1372e873b"  -a 2000 -d "GDDGBCGFG7R6XH6F7IVDZ6WXO5SZRUN5PLTEZPVQEZH33FFNQECYMQ2E" -k "SCT4KKJNYLTQO4TVDPVJQZEONTVVW66YLRWAINWI3FZDY7U4JS4JJEI4" -n 0
```

And on the node side:

```
2020-12-23 12:12:49,450 Info [agora.node.FullNode] - Accepted transaction: { type: TxType.Payment, inputs: [{ utxo: 0x533f664df20aa5f3f657bea7073c9fdbe930c3887db8c57ddb2efd258c3bfddf644b645f3c399996bd4d97dbb17138e1b670d254d3518959d97793ef27c55e2e, unlock: { bytes: [177, 62, 60, 234, 68, 201, 191, 71, 27, 217, 15, 89, 55, 148, 214, 18, 253, 108, 231, 230, 154, 43, 217, 8, 66, 50, 113, 15, 154, 223, 209, 31, 167, 211, 34, 51, 192, 228, 142, 200, 137, 181, 227, 212, 203, 43, 24, 109, 206, 216, 131, 163, 147, 151, 129, 248, 91, 197, 105, 179, 118, 236, 115, 2] }, unlock_age: 0 }], outputs: [{ value: 2000, lock: { type: LockType.Key, bytes: [198, 96, 136, 197, 55, 227, 235, 159, 197, 250, 42, 60, 250, 215, 119, 101, 152, 209, 189, 122, 230, 76, 190, 176, 38, 79, 189, 148, 173, 129, 5, 134] } }], payload: , lock_height: 0 }
2020-12-23 12:12:50,74 Info [agora.consensus.protocol.Nominator] - Nomination started at 1608693170
2020-12-23 12:12:50,74 Info [agora.consensus.protocol.Nominator] - agora.consensus.protocol.Nominator.Nominator.nominate(): Proposing tx set for slot 1
```

Works as intended.