### PR TITLE
Issue1319 add block sig part5

### DIFF
--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -728,6 +728,7 @@ version (unittest)
     {
         import agora.common.crypto.Schnorr;
         import agora.common.crypto.ECC;
+        import std.format;
 
         auto validators = BitField!ubyte(keys.length);
         Signature[] sigs;
@@ -755,7 +756,7 @@ version (unittest)
             keys.enumerate.each!((idx, key) => validatorSign(idx, key));
         } catch (Exception e)
         {
-            log.error("Unit test signing error: {}", e);
+            assert(0, format!"Unit test signing error: %s"(e));
         }
         // Create new block with updates
         block.header.validators = validators;

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -329,7 +329,8 @@ public class ValidatorSet
             pub_keys.length = 0;
             assumeSafeAppend(pub_keys);
             auto results = this.db.execute("SELECT public_key FROM validator_set
-                WHERE enrolled_height < ? ORDER BY public_key ASC", height.value);
+                WHERE enrolled_height < ? AND active = ? ORDER BY public_key ASC",
+                    height.value, EnrollmentStatus.Active);
             foreach (row; results)
                 pub_keys ~= PublicKey.fromString(row.peek!(char[])(0));
             return true;

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -17,6 +17,9 @@ import agora.common.Amount;
 import agora.common.Hash;
 import agora.common.Set;
 import agora.common.Types;
+import agora.common.crypto.ECC;
+import agora.common.crypto.Key;
+import agora.common.crypto.Schnorr;
 import agora.consensus.data.Block;
 import agora.consensus.data.DataPayload;
 import agora.consensus.data.Enrollment;
@@ -73,9 +76,14 @@ version (unittest)
         prev_height = the height of the direct ancestor of this block
         prev_hash = the hash of the direct ancestor of this block
         findUTXO = delegate to find the referenced unspent UTXOs with
+        checkPayload = delegate for checking data payload
         active_enrollments = the number of enrollments that do not expire
             at the next block height (prev_height + 1).
-        checkPayload = delegate for checking data payload
+        enrolled_validators = the number of validators enrolled at this height
+        getValidatorAtIndex = delegate to provide validator Point K for
+            given height and index into map
+        getCommitmentNonce = delegate to provide the commitment Nonce of the
+            validator given by it's Point K
 
     Returns:
         `null` if the block is valid, a string explaining the reason it
@@ -84,22 +92,32 @@ version (unittest)
 *******************************************************************************/
 
 public string isInvalidReason (const ref Block block, Height prev_height,
-    in Hash prev_hash, scope UTXOFinder findUTXO,
-    size_t active_enrollments, scope PayloadChecker checkPayload,
-    scope EnrollmentFinder findEnrollment) nothrow @safe
+    in Hash prev_hash, scope UTXOFinder findUTXO, scope PayloadChecker checkPayload,
+    scope EnrollmentFinder findEnrollment, size_t active_enrollments, size_t enrolled_validators,
+    Point delegate (Height, ulong) nothrow @safe getValidatorAtIndex,
+    Point delegate (const ref Point) nothrow @safe getCommitmentNonce,
+    string file = __FILE__, size_t line = __LINE__) nothrow @safe
 {
     import std.algorithm;
+    import std.string;
+    import std.conv;
 
-    if (block.header.height > prev_height + 1)
-        return "Block: Height is above expected height";
-    if (block.header.height < prev_height + 1)
-        return "Block: Height is under expected height";
+    if (block.header.height == 0)
+        return "Block: Genesis block should be validated using isGenesisBlockInvalidReason";
+
+    if (block.header.height != prev_height + 1)
+        return "Block: Height is not one more than previous block";
 
     if (block.header.prev_block != prev_hash)
         return "Block: Header.prev_block does not match previous block";
 
     if (block.txs.length == 0)
         return "Block: Must contain at least one transaction";
+
+    log.trace("Number of validators still active next block will be {}. New enrollments this block {}",
+        active_enrollments, block.header.enrollments.length);
+    if (block.header.enrollments.length + active_enrollments < Enrollment.MinValidatorCount)
+        return "Block: Insufficient number of active validators";
 
     if (!block.txs.isSorted())
         return "Block: Transactions are not sorted";
@@ -117,8 +135,6 @@ public string isInvalidReason (const ref Block block, Height prev_height,
     if (!isStrictlyMonotonic!"a.utxo_key < b.utxo_key"(block.header.enrollments))
         return "Block: The enrollments are not sorted in ascending order";
 
-    if (block.header.enrollments.length + active_enrollments < Enrollment.MinValidatorCount)
-        return "Enrollment: Insufficient number of active validators";
 
     /// FIXME: Use a proper type and sensible memory allocation pattern
     version (all)
@@ -143,6 +159,57 @@ public string isInvalidReason (const ref Block block, Height prev_height,
             return fail_reason;
     }
 
+    Point sum_K;
+    Point sum_R;
+    const Scalar challenge = hashFull(block);
+
+    log.trace("Validators expected to sign this block is {}", enrolled_validators);
+    foreach (idx; 0 .. enrolled_validators)
+    {
+        const K = getValidatorAtIndex(block.header.height, idx);
+        log.trace("idx {} PublicKey: {}", idx, PublicKey(K[]));
+        if (K == Point.init)
+        {
+            log.trace("[{}:{}] idx #{}: Validator {} not found for height {}",
+                file, line, idx, PublicKey(K[]), block.header.height);
+            return "Block: Couldn't find a Validator for the given index "
+                ~ to!string(idx) ~ " at height " ~ to!string(block.header.height.value);
+        }
+        if (!block.header.validators[idx])
+        {
+            log.trace("[{}:{}] idx #{}: Validator {} has not yet signed block height {}",
+                file, line, idx, PublicKey(K[]), block.header.height);
+            continue;  // this validator hasn't signed yet
+        }
+
+        const CR = getCommitmentNonce(K);  // commited R
+        log.trace("Commited R for validator {} is {}", PublicKey(K[]), CR);
+        if (CR == Point.init)
+            return "Block: Couldn't find commitment for this validator";
+        Point R = CR + challenge.toPoint();
+        sum_K = sum_K == Point.init ? K : (sum_K + K);
+        sum_R = sum_R == Point.init ? R : (sum_R + R);
+    }
+    if (sum_K == Point.init)
+    {
+        log.error("[{}:{}] Block: Not able to check the multi sig schnorr signature for any of the {} active validators at height {}",
+            file, line, active_enrollments, block.header.height);
+        return "Block: Not enough info to verify schnorr signature at height " ~ to!string(block.header.height.value);
+    }
+    Sig blockSig_Rs = Sig.fromBlob(block.header.signature);
+    if (sum_R != blockSig_Rs.R)
+    {
+        log.error("[{}:{}] Block: Height {} has invalid schnorr signature - sum of R not matching signature R. " ~
+            "enrolled_validators is {} bitmask is {}.",
+            file, line, block.header.height, enrolled_validators, block.header.validators);
+        return "Block: Invalid schnorr signature - sum of R not matching sig";
+    }
+    if (!multiSigVerify(block.header.signature, sum_K, challenge))
+    {
+        log.error("[{}:{}] Block: Invalid schnorr signature for {} active validators",
+            file, line, block.header.validators.length);
+        return "Block: Invalid schnorr signature";
+    }
     return null;
 }
 
@@ -279,8 +346,8 @@ unittest
 
     // don't accept block height 0 from the network
     block.header.height = 0;
-    assert(block.isNotValid(Height(0), Hash.init, null, Enrollment.MinValidatorCount,
-        checker, findGenesisEnrollments));
+    assert(block.isNotValid(Height(0), Hash.init, null,
+        Enrollment.MinValidatorCount, Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
 
     // height check
     block.header.height = 1;
@@ -481,32 +548,60 @@ public bool isGenesisBlockValid (const ref Block genesis_block)
     return isGenesisBlockInvalidReason(genesis_block) is null;
 }
 
-/// Ditto but returns `bool` and logs reason if fails, only usable in unittests
-version (unittest)
-public bool isValid (const ref Block block, Height prev_height,
-    Hash prev_hash, scope UTXOFinder findUTXO,
-    size_t active_enrollments, scope PayloadChecker checkPayload,
-    scope EnrollmentFinder findEnrollment, ulong enrollment_cycle = 0,
-    string file = __FILE__, size_t line = __LINE__) nothrow @safe
-{
-    string reason = isInvalidReason(block, prev_height, prev_hash, findUTXO,
-        active_enrollments, checkPayload, findEnrollment);
-    if (reason !is null)
-        log.trace("[{}:{}] block height {} is invalid: {}",
-            file, line, block.header.height, reason);
-    return reason is null;
-}
 
-/// Ditto but returns `bool`, only usable in unittests
 version (unittest)
-public bool isNotValid (const ref Block block, Height prev_height,
-    Hash prev_hash, scope UTXOFinder findUTXO,
-    size_t active_enrollments, scope PayloadChecker checkPayload,
-    scope EnrollmentFinder findEnrollment) nothrow @safe
 {
-    string reason = isInvalidReason(block, prev_height, prev_hash, findUTXO,
-        active_enrollments, checkPayload, findEnrollment);
-    return reason !is null;
+    SecretKey lookupSecretKeyFromPoint (Point point) @trusted nothrow
+    {
+        return genesis_validator_keys
+            .find!(key => key.address == PublicKey(point[]))[0].secret;
+    }
+
+    public string isValidcheck (const ref Block block, Height prev_height,
+        Hash prev_hash, scope UTXOFinder findUTXO,
+        size_t active_enrollments, size_t enrolled_validators, scope PayloadChecker checkPayload,
+        scope EnrollmentFinder findEnrollment, ulong enrollment_cycle = 0,
+        string file = __FILE__, size_t line = __LINE__) nothrow @safe
+    {
+        return isInvalidReason(block, prev_height, prev_hash, findUTXO,
+            checkPayload, findEnrollment, active_enrollments, enrolled_validators,
+            (Height h, ulong i) @safe nothrow
+            {
+                return Point(genesis_validator_keys[i].address[]);
+            },
+            (const ref Point key) @trusted nothrow
+            {
+                return Scalar(hashMulti(
+                    secretKeyToCurveScalar(lookupSecretKeyFromPoint(key)),
+                    "consensus.signature.noise", enrollment_cycle))
+                    .toPoint();
+            });
+    }
+
+    /// Ditto but returns `bool` and logs reason if fails, only usable in unittests
+    public bool isValid (const ref Block block, Height prev_height,
+        Hash prev_hash, scope UTXOFinder findUTXO,
+        size_t active_enrollments, size_t enrolled_validators, scope PayloadChecker checkPayload,
+        scope EnrollmentFinder findEnrollment, ulong enrollment_cycle = 0,
+        string file = __FILE__, size_t line = __LINE__) nothrow @safe
+    {
+        string reason = isValidcheck(block, prev_height, prev_hash, findUTXO,
+            active_enrollments, enrolled_validators, checkPayload, findEnrollment, enrollment_cycle);
+        if (reason !is null)
+            log.trace("[{}:{}] block height {} is invalid: {}",
+                file, line, block.header.height, reason);
+        return reason is null;
+    }
+
+    /// Ditto but returns `bool`, only usable in unittests
+    public bool isNotValid (const ref Block block, Height prev_height,
+        Hash prev_hash, scope UTXOFinder findUTXO,
+        size_t active_enrollments, size_t enrolled_validators, scope PayloadChecker checkPayload,
+        scope EnrollmentFinder findEnrollment, ulong enrollment_cycle = 0) nothrow @safe
+    {
+        return isValidcheck(block, prev_height, prev_hash, findUTXO,
+            active_enrollments, enrolled_validators, checkPayload, findEnrollment, enrollment_cycle) !is null;
+    }
 }
 
 /// Returns: EnrollmentFinder for GenesisBlock, a delegate to query enrollments
@@ -557,24 +652,24 @@ unittest
 
     // height check
     assert(block.isValid(GenesisBlock.header.height, gen_hash, findUTXO,
-        Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
     block.header.height = 100;
     assert(block.isNotValid(GenesisBlock.header.height, gen_hash, findUTXO,
-        Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        Enrollment.MinValidatorCount, genesis_validator_keys.length,  checker, findGenesisEnrollments));
 
     block.header.height = GenesisBlock.header.height + 1;
     assert(block.isValid(GenesisBlock.header.height, gen_hash, findUTXO,
-        Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        Enrollment.MinValidatorCount, genesis_validator_keys.length,  checker, findGenesisEnrollments));
 
     /// .prev_block check
     block.header.prev_block = block.header.hashFull();
     assert(block.isNotValid(GenesisBlock.header.height, gen_hash, findUTXO,
-        Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
     block.header.prev_block = gen_hash;
     assert(block.isValid(GenesisBlock.header.height, gen_hash, findUTXO,
-        Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
     /// Check consistency of `txs` field
     {
@@ -582,34 +677,34 @@ unittest
 
         block.txs = saved_txs[0 .. $ - 1];
         assert(block.isNotValid(GenesisBlock.header.height, gen_hash, findUTXO,
-            Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+            Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
         block.txs = (saved_txs ~ saved_txs).sort.array;
         assert(block.isNotValid(GenesisBlock.header.height, gen_hash, findUTXO,
-            Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+            Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
         block.txs = saved_txs;
         assert(block.isValid(GenesisBlock.header.height, gen_hash, findUTXO,
-            Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+            Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
         /// Txs sorting check
         block.txs.reverse;
         assert(block.isNotValid(GenesisBlock.header.height, gen_hash, findUTXO,
-            Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+            Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
         block.txs.reverse;
         assert(block.isValid(GenesisBlock.header.height, gen_hash, findUTXO,
-            Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+            Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
     }
 
     /// no matching utxo => fail
     utxos.clear();
     assert(block.isNotValid(GenesisBlock.header.height, gen_hash, findUTXO,
-        Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
     GenesisBlock.txs.each!(tx => utxos.put(tx));
     assert(block.isValid(GenesisBlock.header.height, gen_hash, findUTXO,
-        Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
     utxos.clear();  // genesis is spent
     auto prev_txs = block.txs;
@@ -618,7 +713,7 @@ unittest
     auto prev_block = block;
     block = block.makeNewTestBlock(prev_txs.map!(tx => TxBuilder(tx).sign()));
     assert(block.isValid(prev_block.header.height, prev_block.header.hashFull(),
-        findUTXO, Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        findUTXO, Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
     assert(prev_txs.length > 0);  // sanity check
     foreach (tx; prev_txs)
@@ -626,11 +721,11 @@ unittest
         // one utxo missing from the set => fail
         utxos.storage.remove(UTXO.getHash(tx.hashFull(), 0));
         assert(block.isNotValid(prev_block.header.height, prev_block.header.hashFull(),
-            findUTXO, Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+            findUTXO, Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
         utxos.put(tx);
         assert(block.isValid(prev_block.header.height, prev_block.header.hashFull(),
-            findUTXO, Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+            findUTXO, Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
     }
 
     // the key is hashMulti(hash(prev_tx), index)
@@ -665,7 +760,7 @@ unittest
     // consumed all utxo => fail
     block = GenesisBlock.makeNewTestBlock(genesisSpendable().map!(txb => txb.sign()));
     assert(block.isValid(GenesisBlock.header.height, GenesisBlock.header.hashFull(),
-            findNonSpent, Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        findNonSpent, Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
     // All `payment` utxos have been consumed
     assert(GenesisBlock.txs[0].type == TxType.Freeze);
@@ -679,37 +774,37 @@ unittest
     double_spend[$ - 1] = double_spend[$ - 2];
     block = makeNewTestBlock(GenesisBlock, double_spend);
     assert(block.isNotValid(GenesisBlock.header.height, GenesisBlock.header.hashFull(),
-            findNonSpent, Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+            findNonSpent, Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
     // we stopped validation due to a double-spend
     assert(used_set.length == double_spend.length - 1);
 
     block = GenesisBlock.makeNewTestBlock(prev_txs.map!(tx => TxBuilder(tx).sign()));
     assert(block.isValid(GenesisBlock.header.height, GenesisBlock.header.hashFull(),
-        findUTXO, Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        findUTXO, Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
     // modify the last hex byte of the merkle root
     block.header.merkle_root[][$ - 1]++;
 
     assert(block.isNotValid(GenesisBlock.header.height, GenesisBlock.header.hashFull(),
-        findUTXO, Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        findUTXO, Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
     // now restore it back to what it was
     block.header.merkle_root[][$ - 1]--;
     assert(block.isValid(GenesisBlock.header.height, GenesisBlock.header.hashFull(),
-        findUTXO, Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        findUTXO, Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
     const last_root = block.header.merkle_root;
 
     block = GenesisBlock.makeNewTestBlock(prev_txs.enumerate.map!(en =>
         TxBuilder(en.value).split(WK.Keys.byRange().take(en.index + 1).map!(k => k.address)).sign()));
 
     assert(block.isValid(GenesisBlock.header.height, GenesisBlock.header.hashFull(),
-        findUTXO, Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        findUTXO, Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
     // the previous merkle root should not match the new txs
     block.header.merkle_root = last_root;
     assert(block.isNotValid(GenesisBlock.header.height, GenesisBlock.header.hashFull(),
-        findUTXO, Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        findUTXO, Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 }
 
 ///
@@ -739,7 +834,7 @@ unittest
 
     auto block1 = makeNewTestBlock(GenesisBlock, txs_1);
     assert(block1.isValid(GenesisBlock.header.height, gen_hash, findUTXO,
-        Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        genesis_validator_keys.length, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
     foreach (ref tx; txs_1)
         utxo_set.put(tx);
@@ -782,7 +877,7 @@ unittest
 
     auto block2 = makeNewTestBlock(block1, txs_2);
     assert(block2.isValid(block1.header.height, hashFull(block1.header), findUTXO,
-        Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        genesis_validator_keys.length, genesis_validator_keys.length, checker, findGenesisEnrollments));
     foreach (ref tx; txs_2)
         utxo_set.put(tx);
 
@@ -825,14 +920,14 @@ unittest
     enrollments ~= enroll1;
     enrollments ~= enroll2;
     enrollments.sort!("a.utxo_key < b.utxo_key");
-    auto block3 = makeNewBlock(block2, txs_3, enrollments);
+    auto block3 = makeNewTestBlock(block2, txs_3, enrollments);
     assert(block3.isValid(block2.header.height, hashFull(block2.header), findUTXO,
-        Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
     enrollments.sort!("a.utxo_key > b.utxo_key");
     findUTXO = utxo_set.getUTXOFinder();
     // Block: The enrollments are not sorted in ascending order
     assert(block3.isNotValid(block2.header.height, hashFull(block2.header), findUTXO,
-        Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        Enrollment.MinValidatorCount, Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
 }
 
 /// test that there must always exist active validators
@@ -862,7 +957,7 @@ unittest
 
     auto block1 = makeNewTestBlock(GenesisBlock, txs_1);
     assert(block1.isValid(GenesisBlock.header.height, gen_hash, findUTXO,
-        Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
 
     foreach (ref tx; txs_1)
         utxo_set.put(tx);
@@ -896,7 +991,7 @@ unittest
 
     auto block2 = makeNewTestBlock(block1, txs_2);
     assert(block2.isValid(block1.header.height, hashFull(block1.header), findUTXO,
-        Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
+        Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
     foreach (ref tx; txs_2)
         utxo_set.put(tx);
 
@@ -923,7 +1018,7 @@ unittest
         auto block3 = makeNewTestBlock(block2, txs_3);
         assert(block3.header.enrollments.length == 0);
         assert(block3.isNotValid(block2.header.height, hashFull(block2.header),
-            findUTXO, 0, checker, findGenesisEnrollments));
+            findUTXO, 0, 0, checker, findGenesisEnrollments));
     }
 
     // When all existing validators expire at the new block height but the number of enrollments
@@ -957,10 +1052,10 @@ unittest
         Enrollment[] enrollments;
         enrollments ~= enroll1;
         enrollments.sort!("a.utxo_key < b.utxo_key");
-        auto block3 = makeNewBlock(block2, txs_3, enrollments);
+        auto block3 = makeNewTestBlock(block2, txs_3, enrollments);
         assert(block3.header.enrollments.length == Enrollment.MinValidatorCount);
         assert(block3.isValid(block2.header.height, hashFull(block2.header),
-                                    findUTXO, 0, checker, findGenesisEnrollments));
+            findUTXO, 0, genesis_validator_keys.length, checker, findGenesisEnrollments));
     }
 
     // When there are still active validators at the new block height,
@@ -984,10 +1079,10 @@ unittest
         assert(block3.header.enrollments.length == 0);
 
         assert(block3.isNotValid(block2.header.height, hashFull(block2.header),
-            findUTXO, 0, checker, findGenesisEnrollments));
+            findUTXO, 0, Enrollment.MinValidatorCount, checker, findGenesisEnrollments));
 
         findUTXO = utxo_set.getUTXOFinder();
-        assert(block3.isValid(block2.header.height, hashFull(block2.header),
-                            findUTXO, 1, checker, findGenesisEnrollments));
+        assert(block3.isValid(block2.header.height, hashFull(block2.header), findUTXO,
+            Enrollment.MinValidatorCount, genesis_validator_keys.length, checker, findGenesisEnrollments));
     }
 }

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -64,6 +64,8 @@ version (unittest)
 /// Ditto
 public class Ledger
 {
+    import agora.common.crypto.ECC : Point;
+
     /// data storage for all the blocks
     private IBlockStorage storage;
 
@@ -169,14 +171,23 @@ public class Ledger
                 {
                     const active_enrollments = enroll_man.getValidatorCount(
                         block.header.height);
+                    const enrolled_validators = enroll_man.getCountOfValidators(
+                        block.header.height);
                     log.trace("Active validator count = {}", active_enrollments);
                     if (auto fail_reason = block.isInvalidReason(
                         last_read_block.header.height,
                         last_read_block.header.hashFull,
                         this.utxo_set.getUTXOFinder(),
-                        active_enrollments,
                         &this.payload_checker.check,
-                        this.enroll_man.getEnrollmentFinder()))
+                        this.enroll_man.getEnrollmentFinder(),
+                        active_enrollments,
+                        enrolled_validators,
+                        &this.enroll_man.getValidatorAtIndex,
+                        (const ref Point key) @safe nothrow
+                        {
+                            const PK = PublicKey(key[]);
+                            return this.enroll_man.getCommitmentNonce(PK);
+                        }))
                         throw new Exception(
                             "A block loaded from disk is invalid: " ~
                             fail_reason);
@@ -234,6 +245,27 @@ public class Ledger
         return this.acceptBlock(block);
     }
 
+    version (unittest)
+    private bool externalize (ConsensusData data,
+        string file = __FILE__, size_t line = __LINE__)
+        @trusted
+    {
+        import agora.utils.Test : WK;
+
+        auto next_block = Height(this.last_block.header.height + 1);
+        KeyPair[] public_keys = iota(0, this.enroll_man.getCountOfValidators(next_block))
+            .map!(idx => PublicKey(this.enroll_man.getValidatorAtIndex(next_block, idx)[]))
+            .map!(K => WK.Keys[K])
+            .array();
+        const block = makeNewTestBlock(this.last_block, data.tx_set,
+            data.enrolls, public_keys,
+            (PublicKey pubkey)
+            {
+                return 0;   // This is the number of re-enrollments (currently always 0 in these tests)
+            });
+        return this.acceptBlock(block, file, line);
+    }
+
     /***************************************************************************
 
         Add a block to the ledger.
@@ -248,9 +280,12 @@ public class Ledger
 
     ***************************************************************************/
 
-    public bool acceptBlock (const ref Block block) @safe
+    public bool acceptBlock (const ref Block block,
+        string file = __FILE__, size_t line = __LINE__) @safe
     {
-        if (auto fail_reason = this.validateBlock(block))
+        if (auto fail_reason = block.header.height == 0
+            ? block.isGenesisBlockInvalidReason()
+            : this.validateBlock(block, file, line))
         {
             log.trace("Rejected block: {}: {}", fail_reason, block.prettify());
             return false;
@@ -569,17 +604,22 @@ public class Ledger
 
     ***************************************************************************/
 
-    public string validateBlock (const ref Block block) nothrow @safe
+    public string validateBlock (const ref Block block,
+        string file = __FILE__, size_t line = __LINE__) nothrow @safe
     {
-        size_t active_enrollments = enroll_man.getValidatorCount(
-                block.header.height);
-
         return block.isInvalidReason(this.last_block.header.height,
             this.last_block.header.hashFull,
             this.utxo_set.getUTXOFinder(),
-            active_enrollments,
             &this.payload_checker.check,
-            this.enroll_man.getEnrollmentFinder());
+            this.enroll_man.getEnrollmentFinder(),
+            this.enroll_man.getValidatorCount(block.header.height),
+            this.enroll_man.getCountOfValidators(block.header.height),
+            &this.enroll_man.getValidatorAtIndex,
+            (const ref Point key) @safe nothrow
+            {
+                const PK = PublicKey(key[]);
+                return this.enroll_man.getCommitmentNonce(PK);
+            }, file, line);
     }
 
     /***************************************************************************
@@ -681,12 +721,13 @@ public class Ledger
 version (unittest)
 {
     /// simulate block creation as if a nomination and externalize round completed
-    private void forceCreateBlock (Ledger ledger)
+    private void forceCreateBlock (Ledger ledger,
+        string file = __FILE__, size_t line = __LINE__)
     {
         ConsensusData data;
         ledger.prepareNominatingSet(data, Block.TxsInTestBlock);
         assert(data.tx_set.length == Block.TxsInTestBlock);
-        assert(ledger.onExternalized(data));
+        assert(ledger.externalize(data, file, line));
     }
 
     /// A `Ledger` with sensible defaults for `unittest` blocks
@@ -1461,11 +1502,12 @@ unittest
             .array;
     }
 
-    Transaction[] genGeneralBlock (Transaction[] txs)
+    Transaction[] genGeneralBlock (Transaction[] txs,
+        string file = __FILE__, size_t line = __LINE__)
     {
         auto new_txs = genTransactions(txs);
         new_txs.each!(tx => assert(ledger.acceptTransaction(tx)));
-        ledger.forceCreateBlock();
+        ledger.forceCreateBlock(file, line);
         return new_txs;
     }
 
@@ -1544,6 +1586,7 @@ unittest
     new_txs = genGeneralBlock(new_txs);
     assert(ledger.getBlockHeight() == Height(10));
     ledger.enroll_man.clearExpiredValidators(Height(10));
+    ledger.enroll_man.updateValidatorIndexMaps(Height(11));
     auto b10 = ledger.getBlocksFrom(Height(10))[0];
     assert(b10.header.enrollments.length == 4);
 

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -1,0 +1,150 @@
+/*******************************************************************************
+
+    Contains Byzantine node tests, which refuse to co-operate in the
+    SCP consensus protocol in various ways.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.InvalidBlockSigByzantine;
+
+version (unittest):
+
+import agora.api.Validator;
+import agora.common.Config;
+import agora.common.Task;
+import agora.common.Types;
+import agora.common.crypto.Key;
+import agora.common.crypto.Schnorr;
+import agora.consensus.data.Block;
+import agora.consensus.EnrollmentManager;
+import agora.consensus.data.Params;
+import agora.consensus.data.Transaction;
+import agora.consensus.data.ValidatorBlockSig;
+import agora.consensus.protocol.Data;
+import agora.consensus.protocol.Nominator;
+import agora.network.Clock;
+import agora.network.NetworkClient;
+import agora.network.NetworkManager;
+import agora.node.Ledger;
+import agora.test.Base;
+import agora.utils.SCPPrettyPrinter;
+import agora.utils.Log;
+import agora.utils.PrettyPrinter;
+
+
+import scpd.types.Stellar_SCP;
+import scpd.types.Stellar_types : NodeID;
+
+import geod24.Registry;
+
+import std.algorithm;
+import std.exception;
+import std.format;
+import std.range;
+import std.stdio;
+
+import core.exception;
+import core.stdc.inttypes;
+import core.stdc.time;
+import core.thread;
+import core.atomic;
+
+mixin AddLogger!();
+
+private extern(C++) class BadBlockSigningNominator : TestNominator
+{
+    extern(D) this (immutable(ConsensusParams) params,
+        Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
+        EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
+    {
+        super(params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
+            this.txs_to_nominate);
+    }
+
+    // As byzantine we will not sign envelope to make sure we test rejection of gossiped signature when bad
+    override public void signEnvelope (ref SCPEnvelope envelope)
+    {
+        // Do nothing
+    }
+
+    // Byzantine node will gossip bad signature for block
+    extern(D) override protected void gossipBlockSignature(ValidatorBlockSig block_sig) nothrow
+    {
+        super.gossipBlockSignature(ValidatorBlockSig(block_sig.height, block_sig.public_key,
+            Signature.fromString("0x0000000011111111000000001111111100000000111111110000000011111111" ~
+                "0000000011111111000000001111111100000000111111110000000011111111")));
+    }
+}
+
+/// node which refuses to co-operate: doesn't sign or signs with invalid envelope or block signature
+private class ByzantineNode () : TestValidatorNode
+{
+    mixin ForwardCtor!();
+
+    protected override TestNominator getNominator (immutable(ConsensusParams) params,
+        Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
+        EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
+    {
+        return new BadBlockSigningNominator(params, clock, network, key_pair, ledger,
+            enroll_man, taskman, data_dir);
+    }
+}
+
+/// create some nodes depending which will not sign or will sign with invalid signature
+private class ByzantineManager (size_t byzantine_bad_multisig_count = 0) : TestAPIManager
+{
+    ///
+    public this (immutable(Block)[] blocks, TestConf test_conf, time_t genesis_start_time)
+    {
+        super(blocks, test_conf, genesis_start_time);
+    }
+
+    public override void createNewNode (Config conf,
+        string file = __FILE__, int line = __LINE__)
+    {
+        if (this.nodes.length < byzantine_bad_multisig_count)
+        {
+            assert(conf.validator.enabled);
+            log.trace("Create node {} as Bad block signer", this.nodes.length);
+            this.addNewNode!(ByzantineNode!())(conf, file, line);
+        }
+        else
+        {
+            log.trace("Create node {} as normal validator", this.nodes.length);
+            super.createNewNode(conf, file, line);
+        }
+    }
+}
+
+/// MultiSig test: One node signs with an invalid block signature.
+/// The block should only have 5 / 6 block signatures added
+unittest
+{
+    TestConf conf = { quorum_threshold : 51 , txs_to_nominate : 1 };
+    auto network = makeTestNetwork!(ByzantineManager!(1))(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+    auto nodes = network.clients;
+    auto last_node = nodes[$ - 1];
+    assert(last_node.getQuorumConfig().threshold == 4); // We should need 4 nodes
+    auto txes = genesisSpendable().map!(txb => txb.sign()).array();
+    txes.each!(tx => last_node.putTransaction(tx));
+    network.expectBlock([1,2,3,4,5], Height(1));
+    auto block = last_node.getAllBlocks()[1];
+    assert(!block.header.validators[0],
+        format!"The first validator signed with an invalid block signature so should not be included. mask=%s"
+        (block.header.validators));
+    [1,2,3,4,5].each!(i =>
+        assert(block.header.validators[i],
+            format!"The validator #%s signed with a valid block signature so should be included. mask=%s"
+                (i, block.header.validators)));
+}

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -38,7 +38,7 @@ import core.time;
 ///
 unittest
 {
-    TestConf conf = { outsider_validators : 2,
+    TestConf conf = { outsider_validators : 3,
         txs_to_nominate : 0,  // zero allows any number of txs for nomination
         recurring_enrollment : false,
     };

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -34,9 +34,9 @@ unittest
 {
     TestConf conf = {
         timeout : 10.seconds,
-        outsider_validators : 2,
+        outsider_validators : 3,
         txs_to_nominate : 0, // zero allows any number of txs for nomination
-        recurring_enrollment : false,
+        recurring_enrollment : false
     };
     auto network = makeTestNetwork(conf);
     network.start();
@@ -72,7 +72,7 @@ unittest
             format!"Expected block height %s but outsider %s has height %s."
                 (GenesisValidatorCycle - 1, idx, node.getBlockHeight())));
 
-    // Now we enroll two new validators.
+    // Now we enroll the set B validators.
     set_b.enumerate.each!((idx, _) => network.enroll(GenesisValidators + idx));
 
     // Block 20, After this the Genesis block enrolled validators will be expired.


### PR DESCRIPTION
Final part of Issue #1319. This adds block signature validation and checking for more than half signing before the block is externalized. Late signatures after this will still be added so that ideally 100% signing can be acheived for blocks.