### PR TITLE
Decouple TxBuilder from WellKnownKeys

### DIFF
--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -595,22 +595,22 @@ public struct TxBuilder
     private Transaction data;
 }
 
-    /***************************************************************************
+/***************************************************************************
 
-        Takes a block object and filters the payment outputs
-        into a range of `TxBuilder` objects.
+    Takes a block object and filters the payment outputs
+    into a range of `TxBuilder` objects.
 
-        Note that the outputs may not be spendable anymore if other
-        blocks have been externalized after this block.
+    Note that the outputs may not be spendable anymore if other
+    blocks have been externalized after this block.
 
-        Params:
-            block = a `Block` object
+    Params:
+        block = a `Block` object
 
-        Returns:
-            A range of `TxBuilder`s which reference each Payment output of
-            the input block
+    Returns:
+        A range of `TxBuilder`s which reference each Payment output of
+        the input block
 
-    ***************************************************************************/
+***************************************************************************/
 
 public auto spendable (const ref Block block) @safe pure nothrow
 {


### PR DESCRIPTION
`TxBuilder` could only be used with the well-known keypairs. Now, a transaction can be signed with not-yet-known keypairs.
If one wants to use not-yet-known keypairs, then they can call `signTx`.

Fixes #1348