### PR TITLE
Check validation for slashing information in a block

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -215,6 +215,24 @@ public interface API
 
     /***************************************************************************
 
+        Get validators' pre-image information
+
+        API:
+            GET /preimages
+
+        Params:
+            start_height = the starting enrolled height to begin retrieval from
+            end_height = the end enrolled height to finish retrieval to
+
+        Returns:
+            preimages' information of the validators
+
+    ***************************************************************************/
+
+    public PreImageInfo[] getPreimages (ulong start_height, ulong end_height);
+
+    /***************************************************************************
+
         Reveals a pre-image
 
         API:

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -785,6 +785,35 @@ public class EnrollmentManager
 
     /***************************************************************************
 
+        Add pre-images for enrolled validators
+
+        Params:
+            preimages = the pre-images to add
+
+        Returns:
+            true if preimages was added successfully
+
+    ***************************************************************************/
+
+    public bool addPreimages (const PreImageInfo[] preimages) @safe nothrow
+    {
+        foreach (image; preimages)
+        {
+            auto stored_image =
+                this.validator_set.getPreimage(image.enroll_key);
+            if (stored_image == PreImageInfo.init ||
+                stored_image.distance >= image.distance)
+                continue;
+
+            if (!this.validator_set.addPreimage(image))
+                return false;
+        }
+
+        return true;
+    }
+
+    /***************************************************************************
+
         Get the public key of node that is used for a enrollment
 
         Returns:

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -748,6 +748,26 @@ public class EnrollmentManager
 
     /***************************************************************************
 
+        Get validators' pre-image information
+
+        Params:
+            start_height = the starting enrolled height to begin retrieval from
+            end_height = the end enrolled height to finish retrieval to
+
+        Returns:
+            preimages' information of the validators
+
+    ***************************************************************************/
+
+    public PreImageInfo[] getValidatorPreimages (Height start_height,
+        Height end_height) @safe nothrow
+    {
+        return this.validator_set.getPreimages(start_height,
+            end_height);
+    }
+
+    /***************************************************************************
+
         Add a pre-image information to a validator data
 
         Params:

--- a/source/agora/consensus/SlashPolicy.d
+++ b/source/agora/consensus/SlashPolicy.d
@@ -213,11 +213,6 @@ public class SlashPolicy
                 valid_keys ~= key;
         }
 
-        // TODO: This should not happen in fact, which situation will be handled
-        // in issue #1444. (https://github.com/bpfkorea/agora/issues/1444)
-        if (valid_keys.length == 0)
-            return Hash.init;
-
         return this.enroll_man.getRandomSeed(valid_keys, height);
     }
 

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -497,7 +497,7 @@ public Block makeNewBlock (Transactions)(const ref Block prev_block,
 /// only used in unittests with defualt block signing with the genesis validators
 version (unittest)
 {
-    import agora.utils.Test : WK;
+    import agora.utils.Test;
 
     public KeyPair[] genesis_validator_keys = [
         WK.Keys.NODE2,
@@ -519,6 +519,9 @@ version (unittest)
         ulong delegate (PublicKey) cycleForValidator = (PublicKey k) => defaultCycleZero(k),
         ulong timestamp = ulong.max) @safe nothrow
     {
+        if (random_seed == Hash.init)
+            random_seed = getTestRandomSeed();
+
         // the timestamp passed to makeNewBlock should really be
         // prev_block.header.timestamp + ConsensusParams.BlockInterval instead of
         // prev_block.header.timestamp + 1

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -582,6 +582,48 @@ public class ValidatorSet
 
     /***************************************************************************
 
+        Get validators' pre-image information
+
+        Params:
+            start_height = the starting enrolled height to begin retrieval from
+            end_height = the end enrolled height to finish retrieval to
+
+        Returns:
+            preimages' information of the validators
+
+    ***************************************************************************/
+
+    public PreImageInfo[] getPreimages (Height start_height,
+        Height end_height) @trusted nothrow
+    {
+        PreImageInfo[] preimages;
+
+        try
+        {
+            auto results = this.db.execute("SELECT key, preimage, distance " ~
+                "FROM validator_set WHERE enrolled_height >= ? AND " ~
+                "enrolled_height <= ?",
+                start_height, end_height);
+
+            foreach (row; results)
+            {
+                Hash enroll_key = Hash(row.peek!(char[])(0));
+                Hash preimage = Hash(row.peek!(char[])(1));
+                ushort distance = row.peek!ushort(2);
+                preimages ~= PreImageInfo(enroll_key, preimage, distance);
+            }
+        }
+        catch (Exception ex)
+        {
+            log.error("Exception occured on getPreimages: {}, heights " ~
+                "[{}..{}]", ex.msg, start_height, end_height);
+        }
+
+        return preimages;
+    }
+
+    /***************************************************************************
+
         Get validator's pre-image for the given block height from the
         validator set
 

--- a/source/agora/network/NetworkClient.d
+++ b/source/agora/network/NetworkClient.d
@@ -372,6 +372,29 @@ class NetworkClient
 
     /***************************************************************************
 
+        Get the array of pre-images starting from the `enrolled_height`.
+
+        Params:
+            start_height = the starting enrolled height to begin retrieval from
+            end_height = the end enrolled height to finish retrieval to
+
+        Returns:
+            the array of preimages of validators enrolling from `enrolled_height`
+            to `end_height`
+
+            If the request failed, returns an empty array
+
+    ***************************************************************************/
+
+    public PreImageInfo[] getPreimages (ulong start_height,
+        ulong end_height) nothrow
+    {
+        return this.attemptRequest!(API.getPreimages, Throw.No)(this.api,
+            start_height, end_height);
+    }
+
+    /***************************************************************************
+
         Attempt a request up to 'this.max_retries' attempts, and make the task
         wait this.retry_delay between each attempt.
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -680,6 +680,14 @@ public class FullNode : API
         return this.enroll_man.getValidatorPreimage(enroll_key);
     }
 
+    /// GET: /preimages_from
+    public override PreImageInfo[] getPreimages (ulong start_height,
+        ulong end_height) @safe nothrow
+    {
+        return this.enroll_man.getValidatorPreimages(Height(start_height),
+            Height(end_height)).array();
+    }
+
     /// GET /local_time
     public override time_t getLocalTime () @safe nothrow
     {

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -34,6 +34,7 @@ import agora.consensus.data.Block;
 import agora.consensus.protocol.Data;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Params;
+import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.Transaction;
 import agora.consensus.state.UTXODB;
 import agora.consensus.EnrollmentManager;
@@ -92,6 +93,12 @@ public class Ledger
 
     /// Enrollment manager
     private EnrollmentManager enroll_man;
+
+    /// Property for Enrollment manager
+    @property public EnrollmentManager enrollment_manager() @safe
+    {
+        return this.enroll_man;
+    }
 
     /// Slashing policy manager
     private SlashPolicy slash_man;

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -100,8 +100,8 @@ private class SameKeyNodeAPIManager : TestAPIManager
 unittest
 {
     TestConf conf = {
-        extra_blocks : 16,
-        recurring_enrollment : false,
+        txs_to_nominate : 0, // zero allows any number of txs for nomination
+        recurring_enrollment : false
     };
 
     auto network = makeTestNetwork!SameKeyNodeAPIManager(conf);
@@ -111,7 +111,8 @@ unittest
     network.waitForDiscovery();
     auto nodes = network.clients;
 
-    // Sanity check
+    // generate 16 blocks
+    network.generateBlocks(Height(16));
     assert(network.blocks[0].header.enrollments.length >= 1);
     network.expectBlock(Height(16), network.blocks[0].header, 5.seconds);
 
@@ -129,7 +130,7 @@ unittest
 
     // Block 17
     txs.each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(17), network.blocks[0].header, 5.seconds);
+    network.expectBlock(Height(17), network.blocks[0].header, 10.seconds);
 
     // Freeze builders
     auto freezable = txs[$ - 4]

--- a/source/agora/test/RestoreSlashingInfo.d
+++ b/source/agora/test/RestoreSlashingInfo.d
@@ -1,0 +1,89 @@
+/*******************************************************************************
+
+    Contains tests for re-routing part of the frozen UTXO of a slashed
+    validater to `CommonsBudget` address.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.RestoreSlashingInfo;
+
+version (unittest):
+
+import agora.api.FullNode;
+import agora.common.crypto.Key;
+import agora.consensus.data.Enrollment;
+import agora.consensus.data.Transaction;
+import agora.test.Base;
+
+/// Situation: There are six validators enrolled in Genesis block. Right before
+///     the cycle ends, the new validators enrolls. After one more block
+///     being made, the validators restart and lose their data.
+/// Expectation: The validators catch up all the block with the right slashing
+///     information.
+unittest
+{
+    TestConf conf = {
+        timeout : 10.seconds,
+        outsider_validators : 3,
+        txs_to_nominate : 0, // zero allows any number of txs for nomination
+        recurring_enrollment : false
+    };
+    auto network = makeTestNetwork(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto set_a = network.clients[0 .. GenesisValidators];
+    auto set_b = network.clients[GenesisValidators .. $];
+
+    // generate 18 blocks, 2 short of the enrollments expiring.
+    network.generateBlocks(Height(GenesisValidatorCycle - 2));
+
+    const keys = network.nodes.map!(node => node.client.getPublicKey())
+        .dropExactly(GenesisValidators).takeExactly(conf.outsider_validators)
+        .array;
+
+    auto blocks = nodes[0].getAllBlocks();
+
+    // Block 19 we add the freeze utxos for set_b validators
+    // prepare frozen outputs for outsider validators to enroll
+    blocks[0].spendable().drop(1)
+        .map!(txb => txb
+            .split(keys).sign(TxType.Freeze))
+        .each!(tx => set_a[0].putTransaction(tx));
+
+    network.generateBlocks(Height(GenesisValidatorCycle - 1));
+
+    // wait for other nodes to get to same block height
+    set_b.enumerate.each!((idx, node) =>
+        retryFor(node.getBlockHeight() == GenesisValidatorCycle - 1, 2.seconds,
+            format!"Expected block height %s but outsider %s has height %s."
+                (GenesisValidatorCycle - 1, idx, node.getBlockHeight())));
+
+    // Now we enroll the set B validators.
+    set_b.enumerate.each!((idx, _) => network.enroll(GenesisValidators + idx));
+
+    // Block 20, After this the Genesis block enrolled validators will be expired.
+    network.generateBlocks(iota(nodes.length), Height(GenesisValidatorCycle));
+
+    // Sanity check
+    auto b20 = set_a[0].getBlocksFrom(GenesisValidatorCycle, 1)[0];
+    assert(b20.header.enrollments.length == conf.outsider_validators);
+
+    // Block 21
+    network.generateBlocks(iota(nodes.length), Height(GenesisValidatorCycle + 1));
+
+    // Now restarting the validators in the set B, all the data of those
+    // validators has been wiped out.
+    set_b.each!(node => network.restart(node));
+    network.expectBlock(Height(GenesisValidatorCycle + 1));
+}

--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -657,6 +657,12 @@ public auto genesisSpendable () @safe pure nothrow
     return GenesisBlock.spendable;
 }
 
+/// Get random seed for making new block
+public Hash getTestRandomSeed () @safe nothrow
+{
+    return hashFull(Hash.init);
+}
+
 ///
 @safe nothrow unittest
 {


### PR DESCRIPTION
We've added information about slashed validators into a block like `random_seed` and `missing_validators`. So, when a new block is being made, we should check the validity of the slashing information. There could be a situation where preimages needed for validation are missing like in the catch-up process. So we should be able to get the preimages from the network. 

Fixes #1444 