### PR TITLE
Make agora work with dub v1.24

### DIFF
--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -18,13 +18,8 @@
 
 module agora.node.main;
 
-/// Workaround for issue likely related to dub #225,
-/// expects a main() function and invokes it after unittesting.
-version (unittest)
-{
-    import agora.utils.Workarounds;
-    void main () { }
-}
+// TODO: Remove those two lines when compatibility for dub < v1.24 is dropped
+version (unittest) {}
 else:
 
 import agora.common.Config;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -58,6 +58,7 @@ import agora.registry.NameRegistryImpl;
 import agora.utils.Log;
 import agora.utils.PrettyPrinter;
 public import agora.utils.Utility : retryFor;
+import agora.utils.Workarounds;
 import agora.api.FullNode : NodeInfo, NetworkState;
 import agora.api.Validator : ValidatorAPI = API;
 
@@ -103,6 +104,10 @@ shared static this()
 {
     Runtime.extendedModuleUnitTester = &customModuleUnitTester;
 }
+
+/// Workaround for issue likely related to dub #225,
+/// expects a main() function and invokes it after unittesting.
+void main () { }
 
 void testAssertHandler (string file, ulong line, string msg) nothrow
 {


### PR DESCRIPTION
Since dub v1.24, 'mainSourceFiles' from other configurations are not included.
This means that dub now fails to link when running 'dub test', as there's no main.