### PR TITLE
Drop support for LDC v1.23.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-18.04, macOS-10.15, windows-2019 ]
-        dc: [ ldc-master, ldc-1.24.0, ldc-1.23.0 ]
+        dc: [ ldc-master, ldc-1.24.0 ]
         # Define job-specific parameters
         include:
           # By default, don't generate artifacts for push


### PR DESCRIPTION
It fails frequently on Mac OSX and LDC v1.25.0 is around the corner.