### PR TITLE
Add the absolute block height to the stats

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -336,6 +336,8 @@ public class Ledger
         this.block_stats.increaseMetricBy!"agora_block_txs_total"(
             block.txs.length);
         this.block_stats.increaseMetricBy!"agora_block_externalized_total"(1);
+        this.block_stats.setMetricTo!"agora_block_height_counter"(
+            block.header.height.value);
         return true;
     }
 

--- a/source/agora/stats/Block.d
+++ b/source/agora/stats/Block.d
@@ -16,9 +16,9 @@ module agora.stats.Block;
 import agora.stats.Stats;
 
 ///
-///
 public struct BlockStatsValue
 {
+    public ulong agora_block_height_counter;
     public ulong agora_block_externalized_total;
     public ulong agora_block_enrollments_gauge;
     public ulong agora_block_txs_total;


### PR DESCRIPTION
This is more useful than the number of block externalized since start.
Fixes #1405