### PR TITLE
Set the value for block height on startup

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -155,6 +155,8 @@ public class Ledger
             assert(0);
         log.info("Last known block: #{} ({})", this.last_block.header.height,
                  this.last_block.header.hashFull());
+        this.block_stats.setMetricTo!"agora_block_height_counter"(
+            this.last_block.header.height.value);
 
         Block gen_block;
         this.storage.readBlock(gen_block, Height(0));


### PR DESCRIPTION
Otherwise, the value is not present in the stats until the first block is externalized
after a restart happens.