### PR TITLE
Reduce MaxBatchBlocksSent to 20

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -70,7 +70,7 @@ import core.time;
 mixin AddLogger!();
 
 /// Maximum number of blocks that will be sent in a call to getBlocksFrom()
-private enum uint MaxBatchBlocksSent = 1000;
+private enum uint MaxBatchBlocksSent = 20;
 
 /*******************************************************************************
 


### PR DESCRIPTION
Old value of 1000 is too much.
Even if block size is limited to 1MB, it makes 1GB of data per request.