### PR TITLE
Only send Scalar s in block signatures as point R can be derived

### DIFF
--- a/source/agora/common/crypto/ECC.d
+++ b/source/agora/common/crypto/ECC.d
@@ -155,6 +155,10 @@ public struct Scalar
         import ocean.text.convert.Formatter : ocean_format = format;
         assert(phobos_format("%s", s) == "**SCALAR**");
         assert(ocean_format("{}", s) == "**SCALAR**");
+
+        import vibe.data.json;
+        assert(s.serializeToJsonString() == "\"**SCALAR**\"",
+            s.serializeToJsonString());
     }
 
     /// Vibe.d deserialization
@@ -245,6 +249,12 @@ public struct Scalar
         if (!ret.isValid)
             assert(0, "libsodium generated invalid Point from valid Scalar!");
         return ret;
+    }
+
+    /// Convenience overload to allow this to be converted to a BitBlob
+    public const(ubyte)[] opSlice () const @safe pure nothrow @nogc
+    {
+        return this.data[];
     }
 
     /***************************************************************************

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -489,6 +489,7 @@ public class EnrollmentManager
 
         Params:
             key = the public key to look up
+            height = height of block the R will be used to check the signature
 
         Returns:
             The `R` used in the signature of the Enrollment,
@@ -496,15 +497,17 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public Point getCommitmentNonce (const ref PublicKey key) @trusted nothrow
+    public Point getCommitmentNonce (const ref PublicKey key, Height height) @trusted nothrow
     {
-        return this.validator_set.getCommitmentNonce(key);
+        return this.validator_set.getCommitmentNonce(key, height);
     }
 
     /***************************************************************************
 
         Get the r that was used to sign the enrollment of this validator node
 
+        Params:
+            height = height of block that r will sign
         Returns:
             The initial `r` used when signing the Enrollment
 

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -755,7 +755,7 @@ version (unittest)
         import std.format;
 
         auto validators = BitField!ubyte(keys.length);
-        Signature[] sigs;
+        Sig[] sigs;
 
         // challenge = Hash(block) to Scalar
         const Scalar challenge = hashFull(block);
@@ -769,10 +769,10 @@ version (unittest)
             const Scalar r = rc + challenge; // make it unique each challenge
             const Pair R = Pair.fromScalar(r);
             const K = Point(key.address[]);
-            auto sig = multiSigSign(R, v, challenge);
-            log.trace("multiSigTestBlock: cycle {} index {} Commited R for validator {} is \n{} \nsig is {}",
+            Scalar sig = multiSigSign(r, v, challenge);
+            log.trace("multiSigTestBlock: cycle {} index {}. (R, s) for validator {} is ({}, {})",
                 cycleForValidator(key.address), i, key.address, rc.toPoint(), sig);
-            sigs ~= sig;
+            sigs ~= Sig(R.V, sig);
             validators[i] = true;
         }
         try
@@ -784,7 +784,7 @@ version (unittest)
         }
         // Create new block with updates
         block.header.validators = validators;
-        block.header.signature = multiSigCombine(sigs);
+        block.header.signature = multiSigCombine(sigs).toBlob();
         return block;
     }
 }

--- a/source/agora/consensus/data/ValidatorBlockSig.d
+++ b/source/agora/consensus/data/ValidatorBlockSig.d
@@ -19,6 +19,46 @@ import agora.common.crypto.ECC;
 import agora.common.crypto.Key;
 import agora.common.crypto.Schnorr;
 
+import std.format;
+
+/*******************************************************************************
+
+    The `s` of a Schnorr signature (R, s) needs to be transferred via vibe.d to
+    other nodes in the clear print format. SigScalar is used to enable this.
+
+*******************************************************************************/
+
+public struct SigScalar
+{
+    public Scalar data;
+
+    public this (typeof(this.data) data) @safe @nogc nothrow
+    {
+        this.data = data;
+    }
+
+    public Scalar asScalar() const @safe @nogc nothrow
+    {
+        return this.data;
+    }
+
+    public string toString () const @safe
+    {
+        return data.toString(PrintMode.Clear);
+    }
+
+    // If we are sending this via vibe.d then it needs to be in the clear
+    string toRepresentation() const @safe
+    {
+        return this.data.toString(PrintMode.Clear);
+    }
+
+    static SigScalar fromRepresentation(in char[] str) @safe
+    {
+        return SigScalar(Scalar.fromString(str));
+    }
+}
+
 /*******************************************************************************
 
     Define Validator Block Signature information
@@ -33,9 +73,20 @@ public struct ValidatorBlockSig
     /// The public key of the validator
     public PublicKey public_key;
 
-    /// The block signature for the validator
-    public Signature signature;
+    /// The block signature as s of Sig (R, s) for the validator
+    public SigScalar signature;
 
+    public this (Height height, PublicKey public_key, SigScalar signature) @safe @nogc nothrow
+    {
+        this.height = height;
+        this.public_key = public_key;
+        this.signature = signature;
+    }
+
+    public this (Height height, PublicKey public_key, Scalar signature) @safe @nogc nothrow
+    {
+        this(height, public_key, SigScalar(signature));
+    }
 }
 
 unittest
@@ -46,11 +97,13 @@ unittest
 
     Height height = Height(100);
     PublicKey public_key = PublicKey.fromString(`GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW`);
-    Signature signature = Signature("0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f637780e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778");
-    ValidatorBlockSig sig = {
-        height: height,
-        public_key: public_key,
-        signature: signature,
-    };
+    Scalar signature = Scalar("0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778");
+    ValidatorBlockSig sig = ValidatorBlockSig(height, public_key, signature);
     testSymmetry(sig);
+
+    import vibe.data.json;
+    assert(sig.serializeToJsonString() == "{\"height\":\"100\"," ~
+        "\"public_key\":\"GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFW\"," ~
+        "\"signature\":\"0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778\"}",
+        sig.serializeToJsonString());
 }

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -234,10 +234,10 @@ public class Ledger
                         active_enrollments,
                         enrolled_validators,
                         &this.enroll_man.getValidatorAtIndex,
-                        (const ref Point key) @safe nothrow
+                        (const ref Point key, const Height height) @safe nothrow
                         {
                             const PK = PublicKey(key[]);
-                            return this.enroll_man.getCommitmentNonce(PK);
+                            return this.enroll_man.getCommitmentNonce(PK, height);
                         },
                         last_read_block.header.timestamp,
                         cast(ulong) this.clock.networkTime(),
@@ -746,10 +746,10 @@ public class Ledger
             this.enroll_man.getValidatorCount(block.header.height),
             this.enroll_man.getCountOfValidators(block.header.height),
             &this.enroll_man.getValidatorAtIndex,
-            (const ref Point key) @safe nothrow
+            (const ref Point key, const Height height) @safe nothrow
             {
                 const PK = PublicKey(key[]);
-                return this.enroll_man.getCommitmentNonce(PK);
+                return this.enroll_man.getCommitmentNonce(PK, block.header.height);
             },
             this.last_block.header.timestamp,
             cast(ulong) this.clock.networkTime(),
@@ -888,7 +888,10 @@ version (unittest)
         ConsensusData data;
         ledger.prepareNominatingSet(data, Block.TxsInTestBlock);
         assert(data.tx_set.length == Block.TxsInTestBlock);
-        assert(ledger.externalize(data, file, line));
+        if (!ledger.externalize(data, file, line))
+        {
+            assert(0, format!"Failure in unit test. Block %s should have been externalized!"(ledger.getBlockHeight() + 1));
+        }
     }
 
     /// A `Ledger` with sensible defaults for `unittest` blocks

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -20,6 +20,7 @@ import agora.api.Validator;
 import agora.common.Config;
 import agora.common.Task;
 import agora.common.Types;
+import agora.common.crypto.ECC;
 import agora.common.crypto.Key;
 import agora.common.crypto.Schnorr;
 import agora.consensus.data.Block;
@@ -58,33 +59,60 @@ import core.atomic;
 
 mixin AddLogger!();
 
+private enum ByzantineReason
+{
+    BadCommitmentR,
+    BadSignature
+}
+
 private extern(C++) class BadBlockSigningNominator : TestNominator
 {
+    private ByzantineReason reason;
+
     extern(D) this (immutable(ConsensusParams) params,
         Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir, ulong test_start_time)
+        EnrollmentManager enroll_man, TaskManager taskman, string data_dir, ByzantineReason reason, ulong test_start_time)
     {
+        this.reason = reason;
         super(params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
             this.txs_to_nominate, test_start_time);
     }
 
-    // As byzantine we will not sign envelope to make sure we test rejection of gossiped signature when bad
-    override public void signEnvelope (ref SCPEnvelope envelope)
+    extern(D) override protected Sig createBlockSignature(const Block block) @trusted nothrow
     {
-        // Do nothing
+        import agora.common.crypto.Schnorr;
+        import agora.common.crypto.ECC;
+        import agora.common.Hash;
+        import agora.utils.Test : WK;
+
+        // challenge = Hash(block) to Scalar
+        const Scalar challenge = hashFull(block);
+        final switch (reason)
+        {
+            case ByzantineReason.BadCommitmentR:
+                const Scalar rc = Scalar.random(); // This is normally the enrollment commitment
+                const Scalar r = rc + challenge;
+                const Point R = r.toPoint();
+                return Sig(R, multiSigSign(r, this.schnorr_pair.v, challenge));
+            case ByzantineReason.BadSignature:
+                const Scalar rc = Scalar(hashMulti(secretKeyToCurveScalar(WK.Keys.NODE2.secret),
+                "consensus.signature.noise", 0));
+                const Scalar r = rc + challenge;
+                const Point R = r.toPoint();
+                // Sign with random in place of validator secret key
+                const wrong_scalar_v = Scalar.random();
+                return Sig(R, multiSigSign(r, wrong_scalar_v, challenge));
+        }
     }
 
-    // Byzantine node will gossip bad signature for block
-    extern(D) override protected void gossipBlockSignature(ValidatorBlockSig block_sig) nothrow
+    extern(D) override protected void verifyBlock (const Block signed_block)
     {
-        super.gossipBlockSignature(ValidatorBlockSig(block_sig.height, block_sig.public_key,
-            Signature.fromString("0x0000000011111111000000001111111100000000111111110000000011111111" ~
-                "0000000011111111000000001111111100000000111111110000000011111111")));
+        // Do nothing for this byzantine node
     }
 }
 
-/// node which refuses to co-operate: doesn't sign or signs with invalid envelope or block signature
-private class ByzantineNode () : TestValidatorNode
+/// node which refuses to co-operate: signs with invalid R or block signature
+private class ByzantineNode (ByzantineReason reason) : TestValidatorNode
 {
     mixin ForwardCtor!();
 
@@ -93,12 +121,12 @@ private class ByzantineNode () : TestValidatorNode
         EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
     {
         return new BadBlockSigningNominator(params, clock, network, key_pair, ledger,
-            enroll_man, taskman, data_dir, this.test_start_time);
+            enroll_man, taskman, data_dir, reason, this.test_start_time);
     }
 }
 
 /// create some nodes depending which will not sign or will sign with invalid signature
-private class ByzantineManager (size_t byzantine_bad_multisig_count = 0) : TestAPIManager
+private class ByzantineManager (ByzantineReason reason) : TestAPIManager
 {
     ///
     public this (immutable(Block)[] blocks, TestConf test_conf, time_t genesis_start_time)
@@ -109,11 +137,11 @@ private class ByzantineManager (size_t byzantine_bad_multisig_count = 0) : TestA
     public override void createNewNode (Config conf,
         string file = __FILE__, int line = __LINE__)
     {
-        if (this.nodes.length < byzantine_bad_multisig_count)
+        if (this.nodes.length < 1)  // Use first node as byzantine
         {
             assert(conf.validator.enabled);
             log.trace("Create node {} as Bad block signer", this.nodes.length);
-            this.addNewNode!(ByzantineNode!())(conf, file, line);
+            this.addNewNode!(ByzantineNode!(reason))(conf, file, line);
         }
         else
         {
@@ -127,23 +155,46 @@ private class ByzantineManager (size_t byzantine_bad_multisig_count = 0) : TestA
 /// The block should only have 5 / 6 block signatures added
 unittest
 {
-    TestConf conf = { quorum_threshold : 51 , txs_to_nominate : 1 };
-    auto network = makeTestNetwork!(ByzantineManager!(1))(conf);
+    TestConf conf = { quorum_threshold : 83 , txs_to_nominate : 1 };
+    auto network = makeTestNetwork!(ByzantineManager!(ByzantineReason.BadSignature))(conf);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
     network.waitForDiscovery();
     auto nodes = network.clients;
     auto last_node = nodes[$ - 1];
-    assert(last_node.getQuorumConfig().threshold == 4); // We should need 4 nodes
+    assert(last_node.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => last_node.putTransaction(tx));
     network.expectBlock([1,2,3,4,5], Height(1));
-    auto block = last_node.getAllBlocks()[1];
+    assertValidatorsBitmask(last_node.getAllBlocks()[1]);
+}
+
+/// MultiSig test: One node signs with a valid block signature using incorrect R.
+/// The block should only have 5 / 6 block signatures added
+unittest
+{
+    TestConf conf = { quorum_threshold : 83 , txs_to_nominate : 1 };
+    auto network = makeTestNetwork!(ByzantineManager!(ByzantineReason.BadCommitmentR))(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+    auto nodes = network.clients;
+    auto last_node = nodes[$ - 1];
+    assert(last_node.getQuorumConfig().threshold == 5); // We should need 5 nodes
+    auto txes = genesisSpendable().map!(txb => txb.sign()).array();
+    txes.each!(tx => last_node.putTransaction(tx));
+    network.expectBlock([1,2,3,4,5], Height(1));
+    assertValidatorsBitmask(last_node.getAllBlocks()[1]);
+}
+
+private void assertValidatorsBitmask (const Block block)
+{
     assert(!block.header.validators[0],
         format!"The first validator signed with an invalid block signature so should not be included. mask=%s"
         (block.header.validators));
-    [1,2,3,4,5].each!(i =>
+    iota(1, 6).each!(i =>
         assert(block.header.validators[i],
             format!"The validator #%s signed with a valid block signature so should be included. mask=%s"
                 (i, block.header.validators)));

--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -76,14 +76,14 @@ struct SCPStatement {
 
         static struct _confirm_t {
             SCPBallot ballot;
-            uint512 value_sig;  // (R ,s) is 64 bytes
+            uint256 value_sig;  // used for Scalar of Signature for this ballot
             uint32_t nPrepared;
             uint32_t nCommit;
             uint32_t nH;
             Hash quorumSetHash;
         }
 
-        static assert(_confirm_t.sizeof == 176);
+        static assert(_confirm_t.sizeof == 144);
 
         static struct _externalize_t {
             SCPBallot commit;
@@ -259,7 +259,7 @@ struct SCPStatement {
     _pledges_t pledges;
 }
 
-static assert(SCPStatement.sizeof == 232);
+static assert(SCPStatement.sizeof == 200);
 static assert(Signature.sizeof == 64);
 
 struct SCPEnvelope {
@@ -267,7 +267,7 @@ struct SCPEnvelope {
   Signature signature;
 }
 
-static assert(SCPEnvelope.sizeof == 296);
+static assert(SCPEnvelope.sizeof == 264);
 
 struct SCPQuorumSet {
     import agora.common.Hash;
@@ -339,3 +339,4 @@ static assert(SCPQuorumSet.sizeof == 56);
 
 /// From SCPDriver, here for convenience
 public alias SCPQuorumSetPtr = shared_ptr!SCPQuorumSet;
+

--- a/source/scpp/src/xdr/Stellar-SCP.h
+++ b/source/scpp/src/xdr/Stellar-SCP.h
@@ -177,7 +177,7 @@ struct SCPStatement {
     };
     struct _confirm_t {
       SCPBallot ballot{};
-      uint512 value_sig{};
+      uint256 value_sig{};
       uint32 nPrepared{};
       uint32 nCommit{};
       uint32 nH{};
@@ -192,7 +192,7 @@ struct SCPStatement {
                typename _quorumSetHash_T,
                typename = typename
                std::enable_if<std::is_constructible<SCPBallot, _ballot_T>::value
-                              && std::is_constructible<uint512, _value_sig_T>::value
+                              && std::is_constructible<uint256, _value_sig_T>::value
                               && std::is_constructible<uint32, _nPrepared_T>::value
                               && std::is_constructible<uint32, _nCommit_T>::value
                               && std::is_constructible<uint32, _nH_T>::value

--- a/source/scpp/src/xdr/Stellar-SCP.x
+++ b/source/scpp/src/xdr/Stellar-SCP.x
@@ -51,7 +51,7 @@ struct SCPStatement
         struct
         {
             SCPBallot ballot;   // b
-            uint512 value_sig;  // Bosagora added to sign ballot (R, s) 64 bytes
+            uint256 value_sig;  // Bosagora added to sign ballot (only 32 bytes as Scalar)
             uint32 nPrepared;   // p.n
             uint32 nCommit;     // c.n
             uint32 nH;          // h.n


### PR DESCRIPTION
Fixes issue #1482 