### PR TITLE
Notify Validator of invalid nominations

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -125,6 +125,10 @@ public extern (C++) class Nominator : SCPDriver
     /// Enrollment manager
     private EnrollmentManager enroll_man;
 
+    /// Delegate called when node's own nomination is invalid
+    extern (D) public void delegate(const ref ConsensusData data, const ref
+        string msg) @safe onInvalidNomination = null;
+
 extern(D):
 
     /***************************************************************************
@@ -297,6 +301,8 @@ extern(D):
         {
             log.fatal("tryNominate(): Invalid consensus data: {}. Data: {}",
                     msg, data);
+            if (this.onInvalidNomination)
+                this.onInvalidNomination(data, msg);
             return false;
         }
 
@@ -305,6 +311,8 @@ extern(D):
         {
             log.fatal("tryNominate(): Invalid preimage data: {}. Data: {}",
                     msg, data);
+            if (this.onInvalidNomination)
+                this.onInvalidNomination(data, msg);
             return false;
         }
 

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -651,6 +651,13 @@ public class Ledger
         }
     }
 
+    /// Error message describing the reason of validation failure
+    public static enum InvalidConsensusDataReason : string
+    {
+        NoTransactions = "Transaction set doesn't contain any transactions",
+        NotEnoughValidators = "Enrollment: Insufficient number of active validators",
+    }
+
     /***************************************************************************
 
         Check whether the consensus data is valid.
@@ -669,7 +676,7 @@ public class Ledger
         auto utxo_finder = this.utxo_set.getUTXOFinder();
 
         if (!data.tx_set.length)
-            return "Transaction set doesn't contain any transactions";
+            return InvalidConsensusDataReason.NoTransactions;
 
         foreach (const ref tx; data.tx_set)
         {
@@ -680,7 +687,7 @@ public class Ledger
         size_t active_enrollments = enroll_man.getValidatorCount(expect_height);
 
         if (data.enrolls.length + active_enrollments < Enrollment.MinValidatorCount)
-            return "Enrollment: Insufficient number of active validators";
+            return InvalidConsensusDataReason.NotEnoughValidators;
 
         foreach (const ref enroll; data.enrolls)
         {

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -234,7 +234,7 @@ public class Validator : FullNode, API
 
         if (this.enroll_man.isEnrolled(&this.utxo_set.peekUTXO))
             this.nominator.startNominatingTimer();
-        else if (this.config.validator.recurring_enrollment)
+        if (this.config.validator.recurring_enrollment)
             this.checkAndEnroll(this.ledger.getBlockHeight());
     }
 


### PR DESCRIPTION
This can be used as a self-test.
The example usage here makes sure all Validators keep track of the active Validator count and enroll if needed, asynchronously to the block creation.

Any thoughts?