### PR TITLE
Config: move preimage_reveal_interval to Validator config

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -69,6 +69,8 @@ validator:
   # Whether or not the Validator will enroll automatically at the startup or
   # at the end of Validator cycle
   recurring_enrollment: true
+  # How often (in seconds) we should check for pre-images to reveal
+  preimage_reveal_interval: 10
 
 ################################################################################
 ##                         Ban manager configuration                          ##

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -225,7 +225,7 @@ public class Validator : FullNode, API
         this.startPeriodicDiscovery();
         this.startStatsServer();
         this.clock.startSyncing();
-        this.taskman.setTimer(this.config.node.preimage_reveal_interval,
+        this.taskman.setTimer(this.config.validator.preimage_reveal_interval,
             &this.checkRevealPreimage, Periodic.Yes);
         this.network.startPeriodicCatchup(this.ledger);
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1782,7 +1782,6 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             max_quorum_nodes : test_conf.max_quorum_nodes,
             quorum_threshold : test_conf.quorum_threshold,
             quorum_shuffle_interval : test_conf.quorum_shuffle_interval,
-            preimage_reveal_interval : 1.seconds,  // check revealing frequently
             block_interval_sec : test_conf.block_interval_sec,
             min_listeners : test_conf.min_listeners == 0
                 ? (GenesisValidators + test_conf.full_nodes) - 1
@@ -1824,7 +1823,8 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             key_pair : key_pair,
             addresses_to_register : [self_address],
             registry_address : test_conf.registry_address,
-            recurring_enrollment : test_conf.recurring_enrollment
+            recurring_enrollment : test_conf.recurring_enrollment,
+            preimage_reveal_interval : 1.seconds,  // check revealing frequently
         };
 
         Config conf =


### PR DESCRIPTION
Because this number is only relevant for validators,
as they are the only ones revealing pre-images.