### PR TITLE
tests: add option to skip printing logs on failure

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -137,6 +137,9 @@ void testAssertHandler (string file, ulong line, string msg) nothrow
     throw new AssertError(msg, file, line);
 }
 
+/// Skip printing out per-node logs ony agora/test/* failures
+shared bool no_logs = false;
+
 /// Custom unnitest runner as a workaround for multi-threading issue:
 /// Agora unittests spawn threads, which allocate. The Ocean tests
 /// inspect GC stats for memory allocation changes, and potentially fail
@@ -161,6 +164,7 @@ private UnitTestResult customModuleUnitTester ()
 
     //
     const chatty = !!("dchatty" in environment);
+    no_logs = !!("dnologs" in environment);
     const all_single_threaded = !!("dsinglethreaded" in environment);
     auto filter = environment.get("dtest").toLower();
     size_t filtered;
@@ -886,6 +890,9 @@ public class TestAPIManager
 
     public void printLogs (string file = __FILE__, int line = __LINE__)
     {
+        if (no_logs)
+            return;
+
         synchronized  // make sure logging output is not interleaved
         {
             writeln("---------------------------- START OF LOGS ----------------------------");


### PR DESCRIPTION
A common workflow I use is this:

- Do my work
- Keep rebasing, splitting and moving code
- Ensure each commit is atomic and passes the test-suite

The last part is more difficult than it should be because of the excessive logs we have when tests fail. When I'm trying to make sure each commit is atomic I run the entire test-suite with the `dchatty=1` flag. This shows me the list of files that fail. 

But the excessive node logs of failing tests drown out that list of files that were tested so they become hard to find in the giant screen log in the terminal. The ideal approach would be:

- Disable node logs (implemented in this PR) and run with `dchatty=1`
- After the tests finish collect all the failing modules
- For each failing module run the tests individually with `dtest=agora.test.FailingModule` to get the full log and fix each test accordingly.

That's where `dnologs=1` in this PR helps with.