### PR TITLE
The expectBlock should wait for all the validators

### DIFF
--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -180,13 +180,13 @@ unittest
     // create genesis block
     last_txs = genesisSpendable().map!(txb => txb.sign()).array();
     last_txs.each!(tx => node_validators[0].putTransaction(tx));
-    network.expectBlock(iota(1), Height(1));
+    network.expectBlock(iota(GenesisValidators), Height(1));
 
     // create 1 additional block and enough `tx`es
     auto txs = last_txs.map!(tx => TxBuilder(tx).sign()).array();
     // send it to one node
     txs.each!(tx => node_validators[0].putTransaction(tx));
-    network.expectBlock(iota(1), Height(2));
+    network.expectBlock(iota(GenesisValidators), Height(2));
     last_txs = txs;
 
     // the validator node has 2 blocks, but bad node pretends to have 3


### PR DESCRIPTION
The NetworkManager network unit test has been seen to be flakey when comparing the blocks. This PR will make sure all validators have all the block signatures before the `ClearFilter` is called which will mean the test should be reliable.