### PR TITLE
Add additional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Additionally, the following are dependencies:
 - `openssl`:    Binary (to detect the version) and development library
 - `sqlite3`:    Development library
 - `zlib`:       Development library
+- `libunwind`:  Portable Exception handling and debugging
 
 Additionally, on OSX, `PKG_CONFIG_PATH` needs to be properly set to pick up `sqlite3` and `openssl`.
 Provided you installed those packages via `brew`, you can run the following command prior to building:


### PR DESCRIPTION
Noticed when building on Ubuntu now fails without libunwind.
On Ubuntu: `sudo apt install libunwind-dev`