### PR TITLE
Document and simplify dependency injection

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -94,9 +94,8 @@ public class Validator : FullNode, API
         this.quorum_params = QuorumParams(this.params.MaxQuorumNodes,
             this.params.QuorumThreshold);
 
-        this.nominator = this.getNominator(this.params, this.clock,
-            this.network, this.config.validator.key_pair, this.ledger,
-            this.enroll_man, this.taskman, this.config.node.data_dir);
+        this.nominator = this.getNominator(
+            this.clock, this.network, this.ledger, this.enroll_man, this.taskman);
         this.nominator.onInvalidNomination = &this.invalidNominationHandler;
 
         // currently we are not saving preimage info,
@@ -310,26 +309,23 @@ public class Validator : FullNode, API
         simulate byzantine nodes.
 
         Params:
-            params = consensus params
             clock = Clock instance
             network = the network manager for gossiping SCPEnvelopes
-            key_pair = the key pair of the node
             ledger = Ledger instance
             enroll_man = Enrollment manager
             taskman = the task manager
-            data_dir = path to the data directory
 
         Returns:
             An instance of a `Nominator`
 
     ***************************************************************************/
 
-    protected Nominator getNominator (immutable(ConsensusParams) params,
-        Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
+    protected Nominator getNominator (Clock clock, NetworkManager network,
+        Ledger ledger, EnrollmentManager enroll_man, TaskManager taskman)
     {
-        return new Nominator(params, clock, network, key_pair, ledger,
-            enroll_man, taskman, data_dir);
+        return new Nominator(
+            this.params, clock, network, this.config.validator.key_pair, ledger,
+            enroll_man, taskman, this.config.node.data_dir);
     }
 
     /***************************************************************************

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1395,34 +1395,33 @@ private mixin template TestNodeMixin ()
         output.put("======================================================================\n\n");
     }
 
-    protected override IBlockStorage getBlockStorage (string data_dir) @system
+    protected override IBlockStorage getBlockStorage () @system
     {
         return new MemBlockStorage(this.blocks);
     }
 
     /// Used by the node
-    public override Metadata getMetadata (string _unused) @system
+    public override Metadata getMetadata () @system
     {
         return new MemMetadata();
     }
 
     /// Return a transaction pool backed by an in-memory SQLite db
-    public override TransactionPool getPool (string) @system
+    public override TransactionPool getPool () @system
     {
         return new TransactionPool(":memory:");
     }
 
     /// Return a UTXO set backed by an in-memory SQLite db
-    protected override UTXOSet getUtxoSet (string data_dir)
+    protected override UTXOSet getUtxoSet ()
     {
         return new UTXOSet(":memory:");
     }
 
     /// Return a FeeManager backed by an in-memory SQLite db
-    protected override FeeManager getFeeManager (string data_dir,
-        immutable(ConsensusParams) params)
+    protected override FeeManager getFeeManager ()
     {
-        return new FeeManager(":memory:", params);
+        return new FeeManager(":memory:", this.params);
     }
 
     /// Return a LocalRest-backed task manager
@@ -1433,18 +1432,18 @@ private mixin template TestNodeMixin ()
 
     /// Return an instance of the custom TestNetworkManager
     protected override NetworkManager getNetworkManager (
-        in Config config, Metadata metadata, TaskManager taskman, Clock clock)
+        Metadata metadata, TaskManager taskman, Clock clock)
     {
         assert(taskman !is null);
-        return new TestNetworkManager(config, metadata, taskman, clock, this.registry);
+        return new TestNetworkManager(
+            this.config, metadata, taskman, clock, this.registry);
     }
 
     /// Return an enrollment manager backed by an in-memory SQLite db
-    protected override EnrollmentManager getEnrollmentManager (
-        string data_dir, in ValidatorConfig validator_config,
-        immutable(ConsensusParams) params)
+    protected override EnrollmentManager getEnrollmentManager ()
     {
-        return new EnrollmentManager(":memory:", validator_config.key_pair, params);
+        return new EnrollmentManager(
+            ":memory:", this.config.validator.key_pair, this.params);
     }
 
     /// Get the active validator count for the current block height
@@ -1623,12 +1622,14 @@ public class TestValidatorNode : Validator, TestAPI
     }
 
     /// Returns an instance of a TestNominator with customizable behavior
-    protected override TestNominator getNominator (
-        immutable(ConsensusParams) params, Clock clock, NetworkManager network,
-        KeyPair key_pair, Ledger ledger, EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
+    protected override TestNominator getNominator (Clock clock,
+        NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
+        TaskManager taskman)
     {
-        return new TestNominator(params, clock, network, key_pair, ledger,
-            enroll_man, taskman, data_dir, this.txs_to_nominate, this.test_start_time);
+        return new TestNominator(
+            this.params, clock, network, this.config.validator.key_pair, ledger,
+            enroll_man, taskman, this.config.node.data_dir,
+            this.txs_to_nominate, this.test_start_time);
     }
 
     /// Provides a unittest-adjusted clock source for the node

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -106,12 +106,14 @@ class ByzantineNode (ByzantineReason reason) : TestValidatorNode
 
     mixin ForwardCtor!();
 
-    protected override TestNominator getNominator (immutable(ConsensusParams) params,
-        Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
+    protected override TestNominator getNominator (Clock clock,
+        NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
+        TaskManager taskman)
     {
-        return new ByzantineNominator(params, clock, network, key_pair, ledger,
-            enroll_man, taskman, data_dir, reason, test_start_time);
+        return new ByzantineNominator(
+            this.params, clock, network, this.config.validator.key_pair, ledger,
+            enroll_man, taskman, this.config.node.data_dir,
+            this.reason, this.test_start_time);
     }
 }
 
@@ -170,14 +172,15 @@ private class SpyingValidator : TestValidatorNode
     }
 
     ///
-    protected override TestNominator getNominator (
-        immutable(ConsensusParams) params, Clock clock,
-        NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
+    protected override TestNominator getNominator (Clock clock,
+        NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
+        TaskManager taskman)
     {
         return new SpyNominator(
-            params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
-            this.txs_to_nominate, this.cur_time, this.envelope_type_counts, this.test_start_time);
+            this.params, clock, network, this.config.validator.key_pair,
+            ledger, enroll_man, taskman, this.config.node.data_dir,
+            this.txs_to_nominate, this.cur_time, this.envelope_type_counts,
+            this.test_start_time);
     }
 }
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -303,14 +303,15 @@ unittest
         }
 
         ///
-        protected override TestNominator getNominator (
-            immutable(ConsensusParams) params, Clock clock,
-            NetworkManager network, KeyPair key_pair, Ledger ledger,
-            EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
+        protected override TestNominator getNominator (Clock clock,
+            NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
+            TaskManager taskman)
         {
             return new BadNominator(
-                params, clock, network, key_pair, ledger, enroll_man, taskman,
-                data_dir, this.txs_to_nominate, this.cur_time, this.runCount, this.test_start_time);
+                this.params, clock, network, this.config.validator.key_pair,
+                ledger, enroll_man, taskman, this.config.node.data_dir,
+                this.txs_to_nominate, this.cur_time, this.runCount,
+                this.test_start_time);
         }
     }
 

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -116,12 +116,14 @@ private class ByzantineNode (ByzantineReason reason) : TestValidatorNode
 {
     mixin ForwardCtor!();
 
-    protected override TestNominator getNominator (immutable(ConsensusParams) params,
-        Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
+    protected override BadBlockSigningNominator getNominator (Clock clock,
+        NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
+        TaskManager taskman)
     {
-        return new BadBlockSigningNominator(params, clock, network, key_pair, ledger,
-            enroll_man, taskman, data_dir, reason, this.test_start_time);
+        return new BadBlockSigningNominator(
+            this.params, clock, network, this.config.validator.key_pair, ledger,
+            enroll_man, taskman, this.config.node.data_dir,
+            reason, this.test_start_time);
     }
 }
 

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -88,12 +88,10 @@ private class NoPreImageVN : TestValidatorNode
         super(config, reg, blocks, test_conf, cur_time);
     }
 
-    protected override EnrollmentManager getEnrollmentManager (
-        string data_dir, in ValidatorConfig validator_config,
-        immutable(ConsensusParams) params)
+    protected override EnrollmentManager getEnrollmentManager ()
     {
-        return new MissingPreImageEM(":memory:", validator_config.key_pair,
-            params);
+        return new MissingPreImageEM(
+            ":memory:", this.config.validator.key_pair, params);
     }
 }
 
@@ -139,13 +137,13 @@ private class BadNominatingVN : TestValidatorNode
     }
 
     ///
-    protected override TestNominator getNominator (
-        immutable(ConsensusParams) params, Clock clock,
-        NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
+    protected override TestNominator getNominator (Clock clock,
+        NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
+        TaskManager taskman)
     {
         return new BadNominator(
-            params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
+            this.params, clock, network, this.config.validator.key_pair, ledger,
+            enroll_man, taskman, this.config.node.data_dir,
             this.txs_to_nominate, this.cur_time, this.test_start_time);
     }
 }

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -81,14 +81,14 @@ unittest
         mixin ForwardCtor!();
 
         ///
-        protected override CustomNominator getNominator (
-            immutable(ConsensusParams) params, Clock clock,
-            NetworkManager network, KeyPair key_pair, Ledger ledger,
-            EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
+        protected override CustomNominator getNominator (Clock clock,
+            NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
+            TaskManager taskman)
         {
             return new CustomNominator(
-                params, clock, network, key_pair, ledger, enroll_man, taskman,
-                data_dir, this.txs_to_nominate, this.cur_time, this.test_start_time);
+                this.params, clock, network, this.config.validator.key_pair,
+                ledger, enroll_man, taskman, this.config.node.data_dir,
+                this.txs_to_nominate, this.cur_time, this.test_start_time);
         }
     }
 

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -85,12 +85,14 @@ private class TestNode () : TestValidatorNode
 {
     mixin ForwardCtor!();
 
-    protected override TestNominator getNominator (immutable(ConsensusParams) params,
-        Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
+    protected override TestNominator getNominator (Clock clock,
+        NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
+        TaskManager taskman)
     {
-        return new DoesNotExternalizeBlockNominator(params, clock, network, key_pair, ledger,
-            enroll_man, taskman, data_dir, this.test_start_time);
+        return new DoesNotExternalizeBlockNominator(
+            this.params, clock, network, this.config.validator.key_pair, ledger,
+            enroll_man, taskman, this.config.node.data_dir,
+            this.test_start_time);
     }
 }
 

--- a/source/agora/test/Restart.d
+++ b/source/agora/test/Restart.d
@@ -69,37 +69,34 @@ private class PersistentNode : TestValidatorNode
     private static FeeManager fee_man;
 
     ///
-    protected override IBlockStorage getBlockStorage (string data_dir) @system
+    protected override IBlockStorage getBlockStorage () @system
     {
         if (blockstorage_saved is null)
-            blockstorage_saved = super.getBlockStorage(data_dir);
+            blockstorage_saved = super.getBlockStorage();
         return blockstorage_saved;
     }
 
     ///
-    protected override UTXOSet getUtxoSet (string data_dir)
+    protected override UTXOSet getUtxoSet ()
     {
         if (utxo_set_saved is null)
-            utxo_set_saved = super.getUtxoSet(data_dir);
+            utxo_set_saved = super.getUtxoSet();
         return utxo_set_saved;
     }
 
     ///
-    protected override EnrollmentManager getEnrollmentManager (
-        string data_dir, in ValidatorConfig validator_config,
-        immutable(ConsensusParams) params)
+    protected override EnrollmentManager getEnrollmentManager ()
     {
         if (em_saved is null)
-            em_saved = super.getEnrollmentManager(data_dir, validator_config, params);
+            em_saved = super.getEnrollmentManager();
         return em_saved;
     }
 
     ///
-    protected override FeeManager getFeeManager (string data_dir,
-        immutable(ConsensusParams) params)
+    protected override FeeManager getFeeManager ()
     {
         if (fee_man is null)
-            fee_man = super.getFeeManager(data_dir, params);
+            fee_man = super.getFeeManager();
         return fee_man;
     }
 

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -118,14 +118,14 @@ unittest
         mixin ForwardCtor!();
 
         ///
-        protected override TestNominator getNominator (
-            immutable(ConsensusParams) params, Clock clock,
-            NetworkManager network, KeyPair key_pair, Ledger ledger,
-            EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
+        protected override ReNominator getNominator (Clock clock,
+            NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
+            TaskManager taskman)
         {
             return new ReNominator(
-                params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
-                    this.txs_to_nominate, this.test_start_time);
+                this.params, clock, network, this.config.validator.key_pair,
+                ledger, enroll_man, taskman, this.config.node.data_dir,
+                this.txs_to_nominate, this.test_start_time);
         }
     }
 

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -67,17 +67,15 @@ private class NoPreImageVN : TestValidatorNode
         super(config, reg, blocks, test_conf, cur_time);
     }
 
-    protected override EnrollmentManager getEnrollmentManager (
-        string data_dir, in ValidatorConfig validator_config,
-        immutable(ConsensusParams) params)
+    protected override EnrollmentManager getEnrollmentManager ()
     {
-        return new MissingPreImageEM(":memory:", validator_config.key_pair,
-            params);
+        return new MissingPreImageEM(
+            ":memory:", this.config.validator.key_pair, params);
     }
 
-    protected override UTXOSet getUtxoSet(string data_dir)
+    protected override UTXOSet getUtxoSet()
     {
-        this.utxo_set = cast(shared UTXOSet)super.getUtxoSet(data_dir);
+        this.utxo_set = cast(shared UTXOSet)super.getUtxoSet();
         return cast(UTXOSet)this.utxo_set;
     }
 }

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -106,12 +106,10 @@ unittest
             super(config, reg, blocks, test_conf, cur_time);
         }
 
-        protected override EnrollmentManager getEnrollmentManager (
-            string data_dir, in ValidatorConfig validator_config,
-            immutable(ConsensusParams) params)
+        protected override EnrollmentManager getEnrollmentManager ()
         {
-            return new BadEnrollmentManager(":memory:",
-                validator_config.key_pair, params);
+            return new BadEnrollmentManager(
+                ":memory:", this.config.validator.key_pair, params);
         }
     }
 


### PR DESCRIPTION
```
Since many places already relied on accessing the config object directly,
make it a guarantee that it'll be filled, as well as the consensus parameters.
It also allows to remove the oddity of requiring a ValidatorConfig to be
passed to a FullNode.
```