### PR TITLE
Re-enable parallel GC

### DIFF
--- a/source/agora/utils/Workarounds.d
+++ b/source/agora/utils/Workarounds.d
@@ -25,10 +25,3 @@ version (CRuntime_Musl)
         Runtime.traceHandler = &libunwindDefaultTraceHandler;
     }
 }
-
-/**
- * Workaround for segfault similar (or identical) to https://github.com/dlang/dub/issues/1812
- * https://dlang.org/changelog/2.087.0.html#gc_parallel
- */
-static if (__VERSION__ >= 2087)
-    extern(C) __gshared string[] rt_options = [ "gcopt=parallel:0" ];


### PR DESCRIPTION
It should work, as the oldest supported version is LDC v1.20, which has the fix.