### PR TITLE
Test: Respect environment variable values

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -15,8 +15,8 @@ dub build -b unittest-cov -c unittest --skip-registry=all --compiler=${DC}
 # Run this after unit tests have proven to compile ok
 rdmd --compiler=${DC} ./tests/runner.d --compiler=${DC} -cov
 
-export dchatty=1
-export dsinglethreaded=1
+export dchatty=true
+export dsinglethreaded=true
 # A run currently (2020-07-21) takes < 6 minutes on Linux
 # Run a single test at a time to prevent resource issues and also see which test failed
 timeout -s SEGV 20m ./build/agora-unittests

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -139,7 +139,7 @@ void testAssertHandler (string file, ulong line, string msg) nothrow
 }
 
 /// Skip printing out per-node logs ony agora/test/* failures
-shared bool no_logs = false;
+shared bool no_logs;
 
 /// Custom unnitest runner as a workaround for multi-threading issue:
 /// Agora unittests spawn threads, which allocate. The Ocean tests
@@ -152,6 +152,7 @@ private UnitTestResult customModuleUnitTester ()
     import std.process;
     import std.string;
     import std.uni;
+    import std.conv;
     import core.atomic;
     import core.sync.semaphore;
     import core.thread.osthread;
@@ -164,9 +165,12 @@ private UnitTestResult customModuleUnitTester ()
     assertHandler = &testAssertHandler;
 
     //
-    const chatty = !!("dchatty" in environment);
-    no_logs = !!("dnologs" in environment);
-    const all_single_threaded = !!("dsinglethreaded" in environment);
+    const chatty = ("dchatty" in environment) ?
+        to!bool(environment["dchatty"]) : false;
+    no_logs = ("dnologs" in environment) ?
+        to!bool(environment["dnologs"]) : false;
+    const all_single_threaded = ("dsinglethreaded" in environment) ?
+        to!bool(environment["dsinglethreaded"]) : false;
     auto filter = environment.get("dtest").toLower();
     size_t filtered;
 


### PR DESCRIPTION
We used to only check for existence of the variables. "dchatty=0 dub test" would still be chatty.