### PR TITLE
Fixed: unable to terminate name-registry

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -92,6 +92,7 @@
             "name": "name-registry",
             "targetName": "name-registry",
             "mainSourceFile": "source/agora/registry/main.d",
+            "versions": [ "VibeHighEventPriority" ],
             "excludedSourceFiles": ["source/agora/cli/*", "source/agora/node/main.d"]
         },
         {


### PR DESCRIPTION
Name registry didn't terminate while pressing CTRL+C
due to the Vibe.d bug: https://github.com/vibe-d/vibe-core/issues/205

This is needed before for infra issue #99.