### PR TITLE
Change banning to info

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -223,7 +223,7 @@ public class BanManager
 
     public void banUntil (Address address, time_t banned_until) @safe nothrow
     {
-        log.trace("BanManager: Address {} banned until {}", address, banned_until);
+        log.info("BanManager: Address {} banned until {}", address, banned_until);
         this.get(address).banned_until = banned_until;
     }
 


### PR DESCRIPTION
No distinction for validator nodes yet. Might do it in the future.

Fixes #1540