### PR TITLE
Use `std.traits.Parameters` in the test-suite to make `Nominator` / `getNominator` more DRY

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -140,9 +140,9 @@ extern(D):
 
         Params:
             params = consensus params
+            key_pair = the key pair of this node
             clock = clock instance
             network = the network manager for gossiping SCP messages
-            key_pair = the key pair of this node
             ledger = needed for SCP state restoration & block validation
             enroll_man = used to look up the commitment & preimages
             taskman = used to run timers
@@ -150,8 +150,8 @@ extern(D):
 
     ***************************************************************************/
 
-    public this (immutable(ConsensusParams) params, Clock clock,
-        NetworkManager network, KeyPair key_pair, Ledger ledger,
+    public this (immutable(ConsensusParams) params, KeyPair key_pair,
+        Clock clock, NetworkManager network, Ledger ledger,
         EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
     {
         this.params = params;

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -387,7 +387,7 @@ public class Validator : FullNode, API
         Ledger ledger, EnrollmentManager enroll_man, TaskManager taskman)
     {
         return new Nominator(
-            this.params, clock, network, this.config.validator.key_pair, ledger,
+            this.params, this.config.validator.key_pair, clock, network, ledger,
             enroll_man, taskman, this.config.node.data_dir);
     }
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1624,13 +1624,12 @@ public class TestValidatorNode : Validator, TestAPI
     }
 
     /// Returns an instance of a TestNominator with customizable behavior
-    protected override TestNominator getNominator (Clock clock,
-        NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
-        TaskManager taskman)
+    protected override TestNominator getNominator (
+        Parameters!(Validator.getNominator) args)
     {
         return new TestNominator(
-            this.params, this.config.validator.key_pair, clock, network, ledger,
-            enroll_man, taskman, this.config.node.data_dir,
+            this.params, this.config.validator.key_pair, args,
+            this.config.node.data_dir,
             this.txs_to_nominate, this.test_start_time);
     }
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -95,6 +95,8 @@ public import std.format;
 public import std.range;
 // To print messages to the screen while debugging a test
 public import std.stdio;
+// Make inheriting much easier
+public import std.traits : Parameters;
 
 // Convenience constants
 public const size_t GenesisValidators = GenesisBlock.header.enrollments.count();
@@ -442,9 +444,9 @@ private final class LocalRestTimer : ITimer
 public class TestBanManager : BanManager
 {
     /// Ctor
-    public this (Config conf, Clock clock, cstring data_dir)
+    public this (Parameters!(BanManager.__ctor) args)
     {
-        super(conf, clock, data_dir);
+        super(args);
     }
 
     /// no-op
@@ -465,14 +467,12 @@ extern(D):
     protected ulong test_start_time;
 
     ///
-    public this (immutable(ConsensusParams) params, Clock clock,
-        NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
+    public this (Parameters!(Nominator.__ctor) args,
         ulong txs_to_nominate, ulong test_start_time)
     {
-        this.test_start_time = test_start_time;
+        super(args);
         this.txs_to_nominate = txs_to_nominate;
-        super(params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir);
+        this.test_start_time = test_start_time;
     }
 
     protected override ulong getExpectedBlockTime () @safe @nogc nothrow pure
@@ -1122,10 +1122,9 @@ public class TestAPIManager
 public class TestNetworkClient : NetworkClient
 {
     /// See NetworkClient ctor
-    public this (TaskManager taskman, BanManager banman, Address address,
-        ValidatorAPI api, Duration retry, size_t max_retries)
+    public this (Parameters!(NetworkClient.__ctor) args)
     {
-        super(taskman, banman, address, api, retry, max_retries);
+        super(args);
     }
 
     /***************************************************************************
@@ -1170,11 +1169,10 @@ public class TestNetworkManager : NetworkManager
     public Registry* registry;
 
     /// Constructor
-    public this (Config config, Metadata metadata,
-        TaskManager taskman, Clock clock, Registry* reg)
+    public this (Parameters!(NetworkManager.__ctor) args, Registry* reg)
     {
+        super(args);
         this.registry = reg;
-        super(config, metadata, taskman, clock);
     }
 
     /// No "http://" in unittests, we just use the string as-is
@@ -1671,10 +1669,9 @@ public class TestValidatorNode : Validator, TestAPI
 public mixin template ForwardCtor ()
 {
     ///
-    public this (Config config, Registry* reg, immutable(Block)[] blocks,
-        in TestConf test_conf, shared(time_t)* cur_time)
+    public this (Parameters!(typeof(super).__ctor) args)
     {
-        super(config, reg, blocks, test_conf, cur_time);
+        super(args);
     }
 }
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1629,7 +1629,7 @@ public class TestValidatorNode : Validator, TestAPI
         TaskManager taskman)
     {
         return new TestNominator(
-            this.params, clock, network, this.config.validator.key_pair, ledger,
+            this.params, this.config.validator.key_pair, clock, network, ledger,
             enroll_man, taskman, this.config.node.data_dir,
             this.txs_to_nominate, this.test_start_time);
     }

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -73,12 +73,12 @@ private extern(C++) class ByzantineNominator : TestNominator
 
     extern(D) this (immutable(ConsensusParams) params,
         Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir, ByzantineReason reason,
-        ulong test_start_time)
+        EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
+        ulong txs_to_nominate, ulong test_start_time, ByzantineReason reason)
     {
         this.reason = reason;
         super(params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
-            this.txs_to_nominate, this.test_start_time);
+            txs_to_nominate, test_start_time);
     }
 
     // override signing with Byzantine behaviour of not signing or signing with invalid signature
@@ -111,7 +111,7 @@ class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new ByzantineNominator(
             this.params, clock, network, this.config.validator.key_pair, ledger,
             enroll_man, taskman, this.config.node.data_dir,
-            reason, this.test_start_time);
+            this.txs_to_nominate, this.test_start_time, reason);
     }
 }
 

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -105,7 +105,7 @@ class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         TaskManager taskman)
     {
         return new ByzantineNominator(
-            this.params, clock, network, this.config.validator.key_pair, ledger,
+            this.params, this.config.validator.key_pair, clock, network, ledger,
             enroll_man, taskman, this.config.node.data_dir,
             this.txs_to_nominate, this.test_start_time, reason);
     }
@@ -167,7 +167,7 @@ private class SpyingValidator : TestValidatorNode
         TaskManager taskman)
     {
         return new SpyNominator(
-            this.params, clock, network, this.config.validator.key_pair,
+            this.params, this.config.validator.key_pair, clock, network,
             ledger, enroll_man, taskman, this.config.node.data_dir,
             this.txs_to_nominate, this.test_start_time, this.envelope_type_counts);
     }

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -100,13 +100,12 @@ class ByzantineNode (ByzantineReason reason) : TestValidatorNode
 {
     mixin ForwardCtor!();
 
-    protected override TestNominator getNominator (Clock clock,
-        NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
-        TaskManager taskman)
+    protected override TestNominator getNominator (
+        Parameters!(TestValidatorNode.getNominator) args)
     {
         return new ByzantineNominator(
-            this.params, this.config.validator.key_pair, clock, network, ledger,
-            enroll_man, taskman, this.config.node.data_dir,
+            this.params, this.config.validator.key_pair, args,
+            this.config.node.data_dir,
             this.txs_to_nominate, this.test_start_time, reason);
     }
 }
@@ -162,13 +161,12 @@ private class SpyingValidator : TestValidatorNode
     }
 
     ///
-    protected override TestNominator getNominator (Clock clock,
-        NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
-        TaskManager taskman)
+    protected override TestNominator getNominator (
+        Parameters!(TestValidatorNode.getNominator) args)
     {
         return new SpyNominator(
-            this.params, this.config.validator.key_pair, clock, network,
-            ledger, enroll_man, taskman, this.config.node.data_dir,
+            this.params, this.config.validator.key_pair, args,
+            this.config.node.data_dir,
             this.txs_to_nominate, this.test_start_time, this.envelope_type_counts);
     }
 }

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -125,8 +125,8 @@ private class SpyNominator : TestNominator
     public this (immutable(ConsensusParams) params, Clock clock,
         NetworkManager network, KeyPair key_pair, Ledger ledger,
         EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
-        ulong txs_to_nominate, shared(time_t)* curr_time,
-        shared(EnvelopeTypeCounts)* envelope_type_counts, ulong test_start_time)
+        ulong txs_to_nominate, ulong test_start_time,
+        shared(EnvelopeTypeCounts)* envelope_type_counts)
     {
         this.envelope_type_counts = envelope_type_counts;
         super(params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
@@ -177,8 +177,7 @@ private class SpyingValidator : TestValidatorNode
         return new SpyNominator(
             this.params, clock, network, this.config.validator.key_pair,
             ledger, enroll_man, taskman, this.config.node.data_dir,
-            this.txs_to_nominate, this.cur_time, this.envelope_type_counts,
-            this.test_start_time);
+            this.txs_to_nominate, this.test_start_time, this.envelope_type_counts);
     }
 }
 

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -71,14 +71,10 @@ private extern(C++) class ByzantineNominator : TestNominator
 {
     private ByzantineReason reason;
 
-    extern(D) this (immutable(ConsensusParams) params,
-        Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
-        ulong txs_to_nominate, ulong test_start_time, ByzantineReason reason)
+    extern(D) this (Parameters!(typeof(super).__ctor) args, ByzantineReason reason)
     {
+        super(args);
         this.reason = reason;
-        super(params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
-            txs_to_nominate, test_start_time);
     }
 
     // override signing with Byzantine behaviour of not signing or signing with invalid signature
@@ -122,15 +118,11 @@ private class SpyNominator : TestNominator
     private NodeID[][SCPStatementType.max + 1] nodes_received;
 
     /// Ctor
-    public this (immutable(ConsensusParams) params, Clock clock,
-        NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
-        ulong txs_to_nominate, ulong test_start_time,
+    public this (Parameters!(typeof(super).__ctor) args,
         shared(EnvelopeTypeCounts)* envelope_type_counts)
     {
+        super(args);
         this.envelope_type_counts = envelope_type_counts;
-        super(params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
-        txs_to_nominate, test_start_time);
     }
 
     public override void receiveEnvelope (scope ref const(SCPEnvelope) envelope) @trusted

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -102,8 +102,6 @@ private extern(C++) class ByzantineNominator : TestNominator
 /// node which refuses to co-operate: doesn't sign or signs with invalid signature
 class ByzantineNode (ByzantineReason reason) : TestValidatorNode
 {
-    ByzantineReason reason;
-
     mixin ForwardCtor!();
 
     protected override TestNominator getNominator (Clock clock,
@@ -113,7 +111,7 @@ class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new ByzantineNominator(
             this.params, clock, network, this.config.validator.key_pair, ledger,
             enroll_man, taskman, this.config.node.data_dir,
-            this.reason, this.test_start_time);
+            reason, this.test_start_time);
     }
 }
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -265,8 +265,8 @@ unittest
         /// Ctor
         public this (immutable(ConsensusParams) params, Clock clock,
             NetworkManager network, KeyPair key_pair, Ledger ledger,
-            EnrollmentManager enroll_man, TaskManager taskman, string data_dir, ulong txs_to_nominate,
-            shared(time_t)* curr_time, shared(size_t)* countPtr, ulong test_start_time)
+            EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
+            ulong txs_to_nominate, ulong test_start_time, shared(size_t)* countPtr)
         {
             this.runCount = countPtr;
             super(params, clock, network, key_pair, ledger, enroll_man, taskman,
@@ -310,8 +310,7 @@ unittest
             return new BadNominator(
                 this.params, clock, network, this.config.validator.key_pair,
                 ledger, enroll_man, taskman, this.config.node.data_dir,
-                this.txs_to_nominate, this.cur_time, this.runCount,
-                this.test_start_time);
+                this.txs_to_nominate, this.test_start_time, this.runCount);
         }
     }
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -299,13 +299,12 @@ unittest
         }
 
         ///
-        protected override TestNominator getNominator (Clock clock,
-            NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
-            TaskManager taskman)
+        protected override TestNominator getNominator (
+            Parameters!(TestValidatorNode.getNominator) args)
         {
             return new BadNominator(
-                this.params, this.config.validator.key_pair, clock, network,
-                ledger, enroll_man, taskman, this.config.node.data_dir,
+                this.params, this.config.validator.key_pair, args,
+                this.config.node.data_dir,
                 this.txs_to_nominate, this.test_start_time, this.runCount);
         }
     }

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -263,14 +263,10 @@ unittest
         private shared(size_t)* runCount;
 
         /// Ctor
-        public this (immutable(ConsensusParams) params, Clock clock,
-            NetworkManager network, KeyPair key_pair, Ledger ledger,
-            EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
-            ulong txs_to_nominate, ulong test_start_time, shared(size_t)* countPtr)
+        public this (Parameters!(TestNominator.__ctor) args, shared(size_t)* countPtr)
         {
+            super(args);
             this.runCount = countPtr;
-            super(params, clock, network, key_pair, ledger, enroll_man, taskman,
-                data_dir, txs_to_nominate, test_start_time);
         }
 
         ///

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -304,7 +304,7 @@ unittest
             TaskManager taskman)
         {
             return new BadNominator(
-                this.params, clock, network, this.config.validator.key_pair,
+                this.params, this.config.validator.key_pair, clock, network,
                 ledger, enroll_man, taskman, this.config.node.data_dir,
                 this.txs_to_nominate, this.test_start_time, this.runCount);
         }

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -69,14 +69,10 @@ private extern(C++) class BadBlockSigningNominator : TestNominator
 {
     private ByzantineReason reason;
 
-    extern(D) this (immutable(ConsensusParams) params,
-        Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
-        ulong txs_to_nominate, ulong test_start_time, ByzantineReason reason)
+    extern(D) this (Parameters!(TestNominator.__ctor) args, ByzantineReason reason)
     {
+        super(args);
         this.reason = reason;
-        super(params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
-            txs_to_nominate, test_start_time);
     }
 
     extern(D) override protected Sig createBlockSignature(const Block block) @trusted nothrow

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -118,7 +118,7 @@ private class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         TaskManager taskman)
     {
         return new BadBlockSigningNominator(
-            this.params, clock, network, this.config.validator.key_pair, ledger,
+            this.params, this.config.validator.key_pair, clock, network, ledger,
             enroll_man, taskman, this.config.node.data_dir,
             this.txs_to_nominate, this.test_start_time, reason);
     }

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -113,13 +113,12 @@ private class ByzantineNode (ByzantineReason reason) : TestValidatorNode
 {
     mixin ForwardCtor!();
 
-    protected override BadBlockSigningNominator getNominator (Clock clock,
-        NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
-        TaskManager taskman)
+    protected override BadBlockSigningNominator getNominator (
+        Parameters!(TestValidatorNode.getNominator) args)
     {
         return new BadBlockSigningNominator(
-            this.params, this.config.validator.key_pair, clock, network, ledger,
-            enroll_man, taskman, this.config.node.data_dir,
+            this.params, this.config.validator.key_pair, args,
+            this.config.node.data_dir,
             this.txs_to_nominate, this.test_start_time, reason);
     }
 }

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -71,11 +71,12 @@ private extern(C++) class BadBlockSigningNominator : TestNominator
 
     extern(D) this (immutable(ConsensusParams) params,
         Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir, ByzantineReason reason, ulong test_start_time)
+        EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
+        ulong txs_to_nominate, ulong test_start_time, ByzantineReason reason)
     {
         this.reason = reason;
         super(params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
-            this.txs_to_nominate, test_start_time);
+            txs_to_nominate, test_start_time);
     }
 
     extern(D) override protected Sig createBlockSignature(const Block block) @trusted nothrow
@@ -123,7 +124,7 @@ private class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new BadBlockSigningNominator(
             this.params, clock, network, this.config.validator.key_pair, ledger,
             enroll_man, taskman, this.config.node.data_dir,
-            reason, this.test_start_time);
+            this.txs_to_nominate, this.test_start_time, reason);
     }
 }
 

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -132,13 +132,12 @@ private class BadNominatingVN : TestValidatorNode
     }
 
     ///
-    protected override TestNominator getNominator (Clock clock,
-        NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
-        TaskManager taskman)
+    protected override TestNominator getNominator (
+        Parameters!(TestValidatorNode.getNominator) args)
     {
         return new BadNominator(
-            this.params, this.config.validator.key_pair, clock, network, ledger,
-            enroll_man, taskman, this.config.node.data_dir,
+            this.params, this.config.validator.key_pair, args,
+            this.config.node.data_dir,
             this.txs_to_nominate, this.test_start_time);
     }
 }

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -137,7 +137,7 @@ private class BadNominatingVN : TestValidatorNode
         TaskManager taskman)
     {
         return new BadNominator(
-            this.params, clock, network, this.config.validator.key_pair, ledger,
+            this.params, this.config.validator.key_pair, clock, network, ledger,
             enroll_man, taskman, this.config.node.data_dir,
             this.txs_to_nominate, this.test_start_time);
     }

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -101,8 +101,7 @@ private class BadNominator : TestNominator
     public this (immutable(ConsensusParams) params, Clock clock,
         NetworkManager network, KeyPair key_pair, Ledger ledger,
         EnrollmentManager enroll_man, TaskManager taskman,
-        string data_dir, ulong txs_to_nominate,
-        shared(time_t)* curr_time, ulong test_start_time)
+        string data_dir, ulong txs_to_nominate, ulong test_start_time)
     {
         super(params, clock, network, key_pair, ledger, enroll_man, taskman,
             data_dir, txs_to_nominate, test_start_time);
@@ -144,7 +143,7 @@ private class BadNominatingVN : TestValidatorNode
         return new BadNominator(
             this.params, clock, network, this.config.validator.key_pair, ledger,
             enroll_man, taskman, this.config.node.data_dir,
-            this.txs_to_nominate, this.cur_time, this.test_start_time);
+            this.txs_to_nominate, this.test_start_time);
     }
 }
 

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -98,13 +98,9 @@ private class NoPreImageVN : TestValidatorNode
 private class BadNominator : TestNominator
 {
     /// Ctor
-    public this (immutable(ConsensusParams) params, Clock clock,
-        NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman,
-        string data_dir, ulong txs_to_nominate, ulong test_start_time)
+    public this (Parameters!(TestNominator.__ctor) args)
     {
-        super(params, clock, network, key_pair, ledger, enroll_man, taskman,
-            data_dir, txs_to_nominate, test_start_time);
+        super(args);
     }
 
 extern (C++):

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -77,13 +77,12 @@ unittest
         mixin ForwardCtor!();
 
         ///
-        protected override CustomNominator getNominator (Clock clock,
-            NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
-            TaskManager taskman)
+        protected override CustomNominator getNominator (
+            Parameters!(TestValidatorNode.getNominator) args)
         {
             return new CustomNominator(
-                this.params, this.config.validator.key_pair, clock, network,
-                ledger, enroll_man, taskman, this.config.node.data_dir,
+                this.params, this.config.validator.key_pair, args,
+                this.config.node.data_dir,
                 this.txs_to_nominate, this.test_start_time);
         }
     }

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -57,7 +57,7 @@ unittest
         public this (immutable(ConsensusParams) params, Clock clock,
             NetworkManager network, KeyPair key_pair, Ledger ledger,
             EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
-            ulong txs_to_nominate, shared(time_t)* curr_time, ulong test_start_time)
+            ulong txs_to_nominate, ulong test_start_time)
         {
             super(params, clock, network, key_pair, ledger, enroll_man, taskman,
                 data_dir, txs_to_nominate, test_start_time);
@@ -88,7 +88,7 @@ unittest
             return new CustomNominator(
                 this.params, clock, network, this.config.validator.key_pair,
                 ledger, enroll_man, taskman, this.config.node.data_dir,
-                this.txs_to_nominate, this.cur_time, this.test_start_time);
+                this.txs_to_nominate, this.test_start_time);
         }
     }
 

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -82,7 +82,7 @@ unittest
             TaskManager taskman)
         {
             return new CustomNominator(
-                this.params, clock, network, this.config.validator.key_pair,
+                this.params, this.config.validator.key_pair, clock, network,
                 ledger, enroll_man, taskman, this.config.node.data_dir,
                 this.txs_to_nominate, this.test_start_time);
         }

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -54,13 +54,9 @@ unittest
     extern (D):
 
         /// Ctor
-        public this (immutable(ConsensusParams) params, Clock clock,
-            NetworkManager network, KeyPair key_pair, Ledger ledger,
-            EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
-            ulong txs_to_nominate, ulong test_start_time)
+        public this (Parameters!(TestNominator.__ctor) args)
         {
-            super(params, clock, network, key_pair, ledger, enroll_man, taskman,
-                data_dir, txs_to_nominate, test_start_time);
+            super(args);
         }
 
     extern (C++):

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -63,10 +63,11 @@ private extern(C++) class DoesNotExternalizeBlockNominator : TestNominator
 {
     extern(D) this (immutable(ConsensusParams) params,
         Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir, ulong test_start_time)
+        EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
+        ulong txs_to_nominate, ulong test_start_time)
     {
         super(params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
-            this.txs_to_nominate, test_start_time);
+            txs_to_nominate, test_start_time);
     }
 
     public override void valueExternalized (uint64_t slot_idx, ref const(Value) value) nothrow
@@ -92,7 +93,7 @@ private class TestNode () : TestValidatorNode
         return new DoesNotExternalizeBlockNominator(
             this.params, clock, network, this.config.validator.key_pair, ledger,
             enroll_man, taskman, this.config.node.data_dir,
-            this.test_start_time);
+            this.txs_to_nominate, this.test_start_time);
     }
 }
 

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -87,7 +87,7 @@ private class TestNode () : TestValidatorNode
         TaskManager taskman)
     {
         return new DoesNotExternalizeBlockNominator(
-            this.params, clock, network, this.config.validator.key_pair, ledger,
+            this.params, this.config.validator.key_pair, clock, network, ledger,
             enroll_man, taskman, this.config.node.data_dir,
             this.txs_to_nominate, this.test_start_time);
     }

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -82,13 +82,12 @@ private class TestNode () : TestValidatorNode
 {
     mixin ForwardCtor!();
 
-    protected override TestNominator getNominator (Clock clock,
-        NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
-        TaskManager taskman)
+    protected override TestNominator getNominator (
+        Parameters!(TestValidatorNode.getNominator) args)
     {
         return new DoesNotExternalizeBlockNominator(
-            this.params, this.config.validator.key_pair, clock, network, ledger,
-            enroll_man, taskman, this.config.node.data_dir,
+            this.params, this.config.validator.key_pair, args,
+            this.config.node.data_dir,
             this.txs_to_nominate, this.test_start_time);
     }
 }

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -61,13 +61,9 @@ mixin AddLogger!();
 
 private extern(C++) class DoesNotExternalizeBlockNominator : TestNominator
 {
-    extern(D) this (immutable(ConsensusParams) params,
-        Clock clock, NetworkManager network, KeyPair key_pair, Ledger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
-        ulong txs_to_nominate, ulong test_start_time)
+    extern(D) this (Parameters!(TestNominator.__ctor) args)
     {
-        super(params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
-            txs_to_nominate, test_start_time);
+        super(args);
     }
 
     public override void valueExternalized (uint64_t slot_idx, ref const(Value) value) nothrow

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -114,13 +114,12 @@ unittest
         mixin ForwardCtor!();
 
         ///
-        protected override ReNominator getNominator (Clock clock,
-            NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
-            TaskManager taskman)
+        protected override ReNominator getNominator (
+            Parameters!(TestValidatorNode.getNominator) args)
         {
             return new ReNominator(
-                this.params, this.config.validator.key_pair, clock, network,
-                ledger, enroll_man, taskman, this.config.node.data_dir,
+                this.params, this.config.validator.key_pair, args,
+                this.config.node.data_dir,
                 this.txs_to_nominate, this.test_start_time);
         }
     }

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -119,7 +119,7 @@ unittest
             TaskManager taskman)
         {
             return new ReNominator(
-                this.params, clock, network, this.config.validator.key_pair,
+                this.params, this.config.validator.key_pair, clock, network,
                 ledger, enroll_man, taskman, this.config.node.data_dir,
                 this.txs_to_nominate, this.test_start_time);
         }

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -85,13 +85,9 @@ unittest
     static class ReNominator : TestNominator
     {
         /// Ctor
-        public this (immutable(ConsensusParams) params, Clock clock,
-            NetworkManager network, KeyPair key_pair, Ledger ledger,
-            EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
-            ulong txs_to_nominate, ulong test_start_time)
+        public this (Parameters!(TestNominator.__ctor) args)
         {
-            super(params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
-                txs_to_nominate, test_start_time);
+            super(args);
         }
 
         ///

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -218,7 +218,7 @@ unittest
             TaskManager taskman)
         {
             return new SocialDistancingNominator(
-                this.params, clock, network, this.config.validator.key_pair,
+                this.params, this.config.validator.key_pair, clock, network,
                 ledger, enroll_man, taskman, this.config.node.data_dir,
                 this.txs_to_nominate, this.test_start_time);
         }

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -191,13 +191,9 @@ unittest
 {
     static class SocialDistancingNominator : TestNominator
     {
-        public this (immutable(ConsensusParams) params, Clock clock,
-            NetworkManager network, KeyPair key_pair, Ledger ledger,
-            EnrollmentManager enroll_man, TaskManager taskman, string data_dir,
-            ulong txs_to_nominate, ulong test_start_time)
+        public this (Parameters!(typeof(super).__ctor) args)
         {
-            super(params, clock, network, key_pair, ledger, enroll_man, taskman, data_dir,
-            txs_to_nominate, test_start_time);
+            super(args);
         }
 
         protected override bool prepareNominatingSet (out ConsensusData data) @safe

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -213,13 +213,12 @@ unittest
             super(config, reg, blocks, test_conf, cur_time);
         }
         ///
-        protected override TestNominator getNominator (Clock clock,
-            NetworkManager network, Ledger ledger, EnrollmentManager enroll_man,
-            TaskManager taskman)
+        protected override TestNominator getNominator (
+            Parameters!(TestValidatorNode.getNominator) args)
         {
             return new SocialDistancingNominator(
-                this.params, this.config.validator.key_pair, clock, network,
-                ledger, enroll_man, taskman, this.config.node.data_dir,
+                this.params, this.config.validator.key_pair, args,
+                this.config.node.data_dir,
                 this.txs_to_nominate, this.test_start_time);
         }
 


### PR DESCRIPTION
Was working on some changes in the nominator and I kept on having errors everywhere.
So I was looking for ways to clear that up, when I noticed I must not be the only one, given the variety of errors in the parameters being passed :)