### PR TITLE
Extend timeout for unittests and add re-try

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           - { dc: ldc-1.24.0, artifacts: true }
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
 
     # Checkout this repository and its submodules

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -17,6 +17,5 @@ rdmd --compiler=${DC} ./tests/runner.d --compiler=${DC} -cov
 
 export dchatty=true
 export dsinglethreaded=true
-# A run currently (2020-07-21) takes < 6 minutes on Linux
 # Run a single test at a time to prevent resource issues and also see which test failed
-timeout -s SEGV 20m ./build/agora-unittests
+./build/agora-unittests || ./build/agora-unittests


### PR DESCRIPTION
It's becoming hit on a regular basis since we switched to single-threaded tests.