### PR TITLE
Not slash when there are not enough validators

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -763,6 +763,8 @@ public class Ledger
             return fail_reason;
 
         size_t active_enrollments = enroll_man.getValidatorCount(expect_height);
+        assert(active_enrollments >= data.missing_validators.length);
+        active_enrollments -= data.missing_validators.length;
 
         if (data.enrolls.length + active_enrollments < Enrollment.MinValidatorCount)
             return InvalidConsensusDataReason.NotEnoughValidators;


### PR DESCRIPTION
If there are not enough validators after some validators are slashed, we must not slash misbehaving validators. Instead, we can wait for the validators to reveal their pre-images again or other enrollment to be requested.

Part of #1551 

The original requirement of the issue is that validators do not slash themselves. The requirement could be handled in other PR.