### PR TITLE
Remove some single-use functions from NetworkManager

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -57,7 +57,7 @@ import core.stdc.stdint;
 import core.stdc.stdlib : abort;
 import core.stdc.time;
 
-import std.algorithm : max, map;
+import std.algorithm : each, max, map;
 import std.conv;
 import std.format;
 import std.path : buildPath;
@@ -1005,7 +1005,7 @@ extern(D):
             // deep-dup as SCP stores pointers to memory on the stack
             env.statement.pledges = deserializeFull!(SCPStatement._pledges_t)(
                 serializeFull(env.statement.pledges));
-            this.network.gossipEnvelope(env);
+            this.network.validators().each!(v => v.client.sendEnvelope(env));
 
             // Per SCP rules, once we CONFIRM a NOMINATE; we can't
             // nominate new values. Keep track of the biggest slot_idx we confirmed

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -46,8 +46,6 @@ import agora.utils.InetUtils;
 import agora.utils.Log;
 import agora.utils.Utility;
 
-import scpd.types.Stellar_SCP;
-
 import vibe.http.common;
 import vibe.web.rest;
 
@@ -1011,20 +1009,6 @@ public class NetworkManager
     {
         return new NetworkClient(taskman, banman, address, api, retry,
             max_retries);
-    }
-
-    /***************************************************************************
-
-        Gossips the SCPEnvelope to the network of connected validators.
-
-        Params:
-            envelope = the SCPEnvelope to gossip to the network.
-
-    ***************************************************************************/
-
-    public void gossipEnvelope (SCPEnvelope envelope)
-    {
-        this.validators().each!(v => v.client.sendEnvelope(envelope));
     }
 
     /***************************************************************************

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -28,7 +28,6 @@ import agora.api.handler.PreImageReceivedHandler;
 import agora.api.handler.TransactionReceivedHandler;
 import agora.common.BanManager;
 import agora.consensus.data.Block;
-import agora.consensus.data.Enrollment;
 import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.ValidatorBlockSig;
 import agora.common.crypto.Key;
@@ -1025,29 +1024,6 @@ public class NetworkManager
         log.trace("Gossip block signature {} for height #{} node {}",
             block_sig.signature, block_sig.height , block_sig.public_key);
         this.validators().each!(v => v.client.sendBlockSignature(block_sig));
-    }
-
-    /***************************************************************************
-
-        Sends the enrollment request to all the listeners.
-
-        Params:
-            enroll = the enrollment data to send
-
-    ***************************************************************************/
-
-    public void sendEnrollment (Enrollment enroll) @safe
-    {
-        foreach (ref node; this.peers[])
-        {
-            if (this.banman.isBanned(node.client.address))
-            {
-                log.trace("Not sending to {} as it's banned", node.client.address);
-                continue;
-            }
-
-            node.client.sendEnrollment(enroll);
-        }
     }
 
     /***************************************************************************

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -38,7 +38,6 @@ import agora.common.Metadata;
 import agora.common.Set;
 import agora.common.Task;
 import agora.common.Hash;
-import agora.consensus.data.Transaction;
 import agora.network.Clock;
 import agora.network.NetworkClient;
 import agora.node.Ledger;
@@ -1012,29 +1011,6 @@ public class NetworkManager
     {
         return new NetworkClient(taskman, banman, address, api, retry,
             max_retries);
-    }
-
-    /***************************************************************************
-
-        Gossips the transaction to all the listeners.
-
-        Params:
-            tx = the transaction to gossip
-
-    ***************************************************************************/
-
-    public void gossipTransaction (Transaction tx) @safe
-    {
-        foreach (ref node; this.peers[])
-        {
-            if (this.banman.isBanned(node.client.address))
-            {
-                log.trace("Not sending to {} as it's banned", node.client.address);
-                continue;
-            }
-
-            node.client.sendTransaction(tx);
-        }
     }
 
     /***************************************************************************

--- a/source/agora/network/NetworkManager.d
+++ b/source/agora/network/NetworkManager.d
@@ -28,7 +28,6 @@ import agora.api.handler.PreImageReceivedHandler;
 import agora.api.handler.TransactionReceivedHandler;
 import agora.common.BanManager;
 import agora.consensus.data.Block;
-import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.ValidatorBlockSig;
 import agora.common.crypto.Key;
 import agora.common.Config;
@@ -1024,29 +1023,6 @@ public class NetworkManager
         log.trace("Gossip block signature {} for height #{} node {}",
             block_sig.signature, block_sig.height , block_sig.public_key);
         this.validators().each!(v => v.client.sendBlockSignature(block_sig));
-    }
-
-    /***************************************************************************
-
-        Sends the pre-image to all the listeners.
-
-        Params:
-            preimage = the pre-image information to send
-
-    ***************************************************************************/
-
-    public void sendPreimage (PreImageInfo preimage) @safe
-    {
-        foreach (ref node; this.peers[])
-        {
-            if (this.banman.isBanned(node.client.address))
-            {
-                log.trace("Not sending to {} as it's banned", node.client.address);
-                continue;
-            }
-
-            node.client.sendPreimage(preimage);
-        }
     }
 
     /***************************************************************************

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -648,7 +648,7 @@ public class FullNode : API
             this.ledger.getBlockHeight(), this.utxo_set.getUTXOFinder()))
         {
             log.info("Accepted enrollment: {}", prettify(enroll));
-            this.network.sendEnrollment(enroll);
+            this.network.peers.each!(p => p.client.sendEnrollment(enroll));
         }
     }
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -393,7 +393,7 @@ public class FullNode : API
         if (this.ledger.acceptTransaction(tx))
         {
             log.info("Accepted transaction: {} ({})", prettify(tx), tx_hash);
-            this.network.gossipTransaction(tx);
+            this.network.peers[].each!(p => p.client.sendTransaction(tx));
             this.pushTransaction(tx);
         }
     }

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -668,7 +668,7 @@ public class FullNode : API
         if (this.enroll_man.addPreimage(preimage))
         {
             log.info("Accepted preimage: {}", prettify(preimage));
-            this.network.sendPreimage(preimage);
+            this.network.peers.each!(p => p.client.sendPreimage(preimage));
             this.pushPreImage(preimage);
         }
     }

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -499,7 +499,7 @@ public class Validator : FullNode, API
             this.ledger.getBlockHeight()))
         {
             this.enroll_man.addPreimage(preimage);
-            this.network.sendPreimage(preimage);
+            this.network.peers.each!(p => p.client.sendPreimage(preimage));
             this.pushPreImage(preimage);
         }
     }

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -44,6 +44,8 @@ import agora.utils.PrettyPrinter;
 
 import scpd.types.Stellar_SCP;
 
+import std.algorithm : each;
+
 import core.stdc.stdlib : abort;
 import core.stdc.time;
 import core.time;
@@ -543,8 +545,8 @@ public class Validator : FullNode, API
         {
             log.trace("Sending Enrollment at height {} for {} cycles with {}",
                 block_height, this.params.ValidatorCycle, enroll_key);
-            this.network.sendEnrollment(
-                this.enroll_man.createEnrollment(enroll_key, block_height + 1));
+            this.network.peers.each!(p => p.client.sendEnrollment(
+                this.enroll_man.createEnrollment(enroll_key, block_height + 1)));
         }
     }
 


### PR DESCRIPTION
See each commit for details. This reduces dependencies between modules, ensuring that NetworkManager is used to send the same message to a set of peer, but not giving `NetworkManager` knowledge of every message type to send.
The "banned" messages were removed, as if a node is banned, it should not be in the list of peers to begin with.