### PR TITLE
The leftover part of slashed UTXO becomes melting

### DIFF
--- a/source/agora/consensus/state/UTXODB.d
+++ b/source/agora/consensus/state/UTXODB.d
@@ -252,6 +252,8 @@ unittest
     import agora.consensus.data.Transaction;
     import agora.consensus.data.UTXO;
 
+    import TESTNET = agora.consensus.data.genesis.Test;
+
     KeyPair[] key_pairs = [KeyPair.random, KeyPair.random];
 
     auto utxo_set = new UTXOSet(":memory:");
@@ -262,7 +264,7 @@ unittest
         [Input(Hash.init, 0)],
         [Output(Amount.MinFreezeAmount, key_pairs[0].address)]
     );
-    utxo_set.updateUTXOCache(tx1, Height(0));
+    utxo_set.updateUTXOCache(tx1, Height(0), TESTNET.CommonsBudgetAddress);
     Hash hash1 = hashFull(tx1);
     auto utxo_hash = UTXO.getHash(hash1, 0);
 
@@ -276,7 +278,7 @@ unittest
         [Input(Hash.init, 0)],
         [Output(Amount(100_000 * 10_000_000L), key_pairs[0].address)]
     );
-    utxo_set.updateUTXOCache(tx2, Height(0));
+    utxo_set.updateUTXOCache(tx2, Height(0), TESTNET.CommonsBudgetAddress);
 
     // create the third transaction
     Transaction tx3 = Transaction(
@@ -284,7 +286,7 @@ unittest
         [Input(Hash.init, 0)],
         [Output(Amount.MinFreezeAmount, key_pairs[1].address)]
     );
-    utxo_set.updateUTXOCache(tx3, Height(0));
+    utxo_set.updateUTXOCache(tx3, Height(0), TESTNET.CommonsBudgetAddress);
 
     // test for getting UTXOs for the first KeyPair
     utxos = utxo_set.getUTXOs(key_pairs[0].address);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -498,7 +498,8 @@ public class Ledger
     {
         const height = block.header.height;
         // add the new UTXOs
-        block.txs.each!(tx => this.utxo_set.updateUTXOCache(tx, height));
+        block.txs.each!(tx => this.utxo_set.updateUTXOCache(tx, height,
+            this.params.CommonsBudgetAddress));
 
         // remove the TXs from the Pool
         block.txs.each!(tx => this.pool.remove(tx));
@@ -538,8 +539,8 @@ public class Ledger
                     Output(remain_amount, utxo_value.output.address),
                 ],
             };
-            this.utxo_set.updateUTXOCache(
-                slashing_tx, block.header.height, true);
+            this.utxo_set.updateUTXOCache(slashing_tx, block.header.height,
+                this.params.CommonsBudgetAddress);
         }
     }
 


### PR DESCRIPTION
The leftover part of slashed UTXO either should remain frozen or become melting while the funds going to the CommonsBudget address is melted immediately. It would be better that the leftover part will be melting because the two outputs can be handled in a transaction.

Fixes #1487 