### PR TITLE
BlockStorage: Remove boolean-returning functions and embrace Exception

### DIFF
--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -366,8 +366,8 @@ public class BlockStorage : IBlockStorage
                 if (findex == this.file_index)
                     return true;
 
-                if (this.is_saving && !this.writeChecksum())
-                    assert(0);
+                if (this.is_saving)
+                    this.writeChecksum();
 
                 this.release();
             }
@@ -474,8 +474,7 @@ public class BlockStorage : IBlockStorage
 
         this.length += size_t.sizeof + block_size;
 
-        if (!this.writeChecksum())
-            throw new Exception("BlockStorage: Failed to write checksum");
+        this.writeChecksum();
 
         // add to index of height
         this.height_idx.insert(
@@ -554,9 +553,7 @@ public class BlockStorage : IBlockStorage
                 throw new Exception("failed to write block data size");
 
             this.length += size_t.sizeof + block_size;
-
-            if (!this.writeChecksum())
-                assert(0);
+            this.writeChecksum();
 
             return true;
         }
@@ -956,28 +953,15 @@ public class BlockStorage : IBlockStorage
         Read the file data, calculate checksum,
         and write checksum to file at start point
 
-        Returns:
-            true if the checksum was successful
-
     *******************************************************************************/
 
-    private bool writeChecksum () @trusted nothrow
+    private void writeChecksum () @trusted
     {
-        try
-        {
-            const ubyte[4] checksum = makeChecksum(
-                cast(ubyte[])this.file[ChecksumSize .. MapSize]);
+        const ubyte[4] checksum = makeChecksum(
+            cast(ubyte[])this.file[ChecksumSize .. MapSize]);
 
-            foreach (idx, val; checksum)
-                this.file[idx] = val;
-
-            return true;
-        }
-        catch (Exception ex)
-        {
-            log.error("BlockStorage.writeChecksum: {}", ex);
-            return false;
-        }
+        foreach (idx, val; checksum)
+            this.file[idx] = val;
     }
 }
 

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -1201,7 +1201,7 @@ private void testStorage (IBlockStorage storage)
     Hash[] block_hashes;
 
     blocks ~= GenesisBlock;
-    storage.saveBlock(GenesisBlock);
+    storage.load(GenesisBlock);
     block_hashes ~= hashFull(GenesisBlock.header);
     Transaction[] last_txs;
     Transaction[] txs;

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -70,16 +70,15 @@ public interface IBlockStorage
 
         Read the last block from the storage.
 
-        Params:
-            block = The last block
-
         Returns:
-            Returns true if success, otherwise returns false.
+            The block that has been read.
+
+        Throws:
+            If the block cannot be read.
 
     ***************************************************************************/
 
-    public bool readLastBlock (ref Block block);
-
+    public Block readLastBlock ();
 
     /***************************************************************************
 
@@ -331,24 +330,13 @@ public class BlockStorage : IBlockStorage
         return buildPath(this.root_path, format("B%012d.dat", index));
     }
 
-    /***************************************************************************
-
-        Read the last block from the storage.
-
-        Params:
-            block = will contain the block if the read was successful
-
-        Returns:
-            Returns true if success, otherwise returns false.
-
-    ***************************************************************************/
-
-    public override bool readLastBlock (ref Block block) @safe nothrow
+    /// Implement `IBlockStorage.readLastBlock`
+    public override Block readLastBlock () @safe
     {
         if (this.height_idx.length == 0)
-            return false;
+            throw new Exception("No block has been loaded yet");
 
-        return this.tryReadBlock(block, this.height_idx.back.height);
+        return this.readBlock(this.height_idx.back.height);
     }
 
     /***************************************************************************
@@ -1030,24 +1018,13 @@ public class MemBlockStorage : IBlockStorage
             assert(blk.length > 0);
     }
 
-    /***************************************************************************
-
-        Read the last block from array.
-
-        Params:
-            block = will contain the block if the read was successful
-
-        Returns:
-            Returns true if success, otherwise returns false.
-
-    ***************************************************************************/
-
-    public bool readLastBlock (ref Block block) @safe
+    /// Implement `IBlockStorage.readLastBlock`
+    public Block readLastBlock () @safe
     {
         if (this.height_idx.length == 0)
-            return false;
+            throw new Exception("No block has been loaded yet");
 
-        return this.tryReadBlock(block, this.height_idx.back.height);
+        return this.readBlock(this.height_idx.back.height);
     }
 
     /***************************************************************************

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -572,7 +572,14 @@ public class BlockStorage : IBlockStorage
     {
         try
         {
-            this.readBlockAtPosition(block, this.height_idx.findBlockPosition(height));
+            const block_pos = this.height_idx.findBlockPosition(height);
+            if (height != 0 && block_pos == 0)
+            {
+                log.trace("BlockStorage.readBlock({}): Couldn't find block at this height", height);
+                return false;
+            }
+
+            this.readBlockAtPosition(block, block_pos);
             return true;
         }
         catch (Exception ex)

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -657,10 +657,7 @@ public class FullNode : API
         if (this.ledger.getBlockHeight() < height)
             return null;
 
-        Block block;
-        if (!this.storage.tryReadBlock(block, height))
-            return null;
-
+        Block block = this.storage.readBlock(height);
         size_t index = block.findHashIndex(hash);
         if (index >= block.txs.length)
             return null;

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -162,8 +162,7 @@ public class Ledger
         this.storage.load(params.Genesis);
 
         // ensure latest checksum can be read
-        if (!this.storage.readLastBlock(this.last_block))
-            assert(0);
+        this.last_block = this.storage.readLastBlock();
         log.info("Last known block: #{} ({})", this.last_block.header.height,
                  this.last_block.header.hashFull());
         this.block_stats.setMetricTo!"agora_block_height_counter"(
@@ -356,12 +355,10 @@ public class Ledger
             log.error("Failed to update block: {}", prettify(block));
             return false;
         }
-        if (block.header.height == this.last_block.header.height
-            && !this.storage.readLastBlock(this.last_block))
-        {
-            log.error("Failed to update last_block");
-            return false;
-        }
+
+        if (block.header.height == this.last_block.header.height)
+            this.last_block = this.storage.readLastBlock();
+
         return true;
     }
 
@@ -448,8 +445,8 @@ public class Ledger
             || this.enroll_man.validatorCount() != old_count;
 
         // read back and cache the last block
-        if (externalized && !this.storage.readLastBlock(this.last_block))
-            assert(0, format!"Failed to read last block: %s"(prettify(this.last_block)));
+        if (externalized)
+            this.last_block = this.storage.readLastBlock();
 
         // Prepare maps for next block with maybe new enrollments
         log.trace("Storing active validators for next block using height {}.", block.header.height);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -169,8 +169,7 @@ public class Ledger
         this.block_stats.setMetricTo!"agora_block_height_counter"(
             this.last_block.header.height.value);
 
-        Block gen_block;
-        this.storage.readBlock(gen_block, Height(0));
+        Block gen_block = this.storage.readBlock(Height(0));
         if (gen_block != cast()params.Genesis)
             throw new Exception("Genesis block loaded from disk is " ~
                 "different from the one in the config file");
@@ -182,8 +181,7 @@ public class Ledger
 
             foreach (height; 0 .. this.last_block.header.height + 1)
             {
-                Block block;
-                this.storage.readBlock(block, Height(height));
+                Block block = this.storage.readBlock(Height(height));
                 this.acceptBlock(block, false);
                 this.last_block = block;
             }
@@ -203,8 +201,7 @@ public class Ledger
             // using block_count, as the range is inclusive
             foreach (block_idx; min_height .. block_count)
             {
-                Block block;
-                this.storage.readBlock(block, block_idx);
+                Block block = this.storage.readBlock(block_idx);
                 this.updateValidatorSet(block);
             }
         }
@@ -877,18 +874,10 @@ public class Ledger
     {
         start_height = min(start_height, this.getBlockHeight() + 1);
 
-        const(Block) readBlock (Height height)
-        {
-            Block block;
-            if (!this.storage.tryReadBlock(block, height))
-                assert(0);
-            return block;
-        }
-
         // Call to `Height.value` to work around
         // https://issues.dlang.org/show_bug.cgi?id=21583
         return iota(start_height.value, this.getBlockHeight() + 1)
-            .map!(idx => readBlock(Height(idx)));
+            .map!(idx => this.storage.readBlock(Height(idx)));
     }
 
     /***************************************************************************

--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -66,7 +66,7 @@ public struct Logger
                 assert(0,"\nplease make sure you are declaring the \nmixin AddLogger!(); statement on top, followed by:\nstatic this{}; followed by:\nstatic ~this{};");
                 return;
             }
-            mixin("this.logger." ~ call ~ "(args);");            
+            mixin("this.logger." ~ call ~ "(args);");
         }
         catch (Exception ex)
         {
@@ -225,17 +225,17 @@ unittest
     };
 
     // case 1
-    // the internal buffer size is greater than the length of the messages 
+    // the internal buffer size is greater than the length of the messages
     // that we are trying to log
     assert(get_log_output("01234") == "01234");
 
     // case 2
-    // the internal buffer size is equal to the length of the messages 
+    // the internal buffer size is equal to the length of the messages
     // that we are trying to log(there is a terminating newline)
     assert(get_log_output("012345") == "012345");
 
     // case 3
-    // the internal buffer size is smaller than the length of the messages 
+    // the internal buffer size is smaller than the length of the messages
     // that we are trying to log
     assert(get_log_output("0123456789") == "3456789");
 }

--- a/tests/unit/BlockStorage.d
+++ b/tests/unit/BlockStorage.d
@@ -68,7 +68,7 @@ private void main ()
     Block[] loaded_blocks;
     loaded_blocks.length = count;
     foreach (idx; 0 .. count)
-        storage.readBlock(loaded_blocks[idx], Height(idx));
+        loaded_blocks[idx] = storage.readBlock(Height(idx));
 
     // compare
     assert(equal(blocks, loaded_blocks));
@@ -79,16 +79,15 @@ private void main ()
 
     auto rnd = rndGen;
 
-    Block random_block;
     foreach (height; iota(count).randomCover(rnd))
     {
-        storage.readBlock(random_block, Height(height));
+        auto random_block = storage.readBlock(Height(height));
         assert(random_block.header.height == height);
     }
 
     foreach (idx; iota(count).randomCover(rnd))
     {
-        storage.readBlock(random_block, block_hashes[idx]);
+        auto random_block = storage.readBlock(block_hashes[idx]);
         assert(hashFull(random_block.header) == block_hashes[idx]);
     }
 
@@ -100,13 +99,13 @@ private void main ()
 
     foreach (height; iota(count).randomCover(rnd))
     {
-        other.readBlock(random_block, Height(height));
+        auto random_block = other.readBlock(Height(height));
         assert(random_block.header.height == height);
     }
 
     foreach (idx; iota(count).randomCover(rnd))
     {
-        other.readBlock(random_block, block_hashes[idx]);
+        auto random_block = other.readBlock(block_hashes[idx]);
         assert(hashFull(random_block.header) == block_hashes[idx]);
     }
 

--- a/tests/unit/BlockStorageChecksum.d
+++ b/tests/unit/BlockStorageChecksum.d
@@ -39,10 +39,8 @@ private void main ()
     BlockStorage storage = new BlockStorage(path);
     scope (exit) storage.release();
 
-    Block block;
-
     // Checksum detection test
-    assertThrown!Exception(storage.readBlock(block, Height(0)));
+    assertThrown!Exception(storage.readBlock(Height(0)));
 }
 
 /// Write the block data to disk

--- a/tests/unit/BlockStorageMultiSig.d
+++ b/tests/unit/BlockStorageMultiSig.d
@@ -82,20 +82,19 @@ private void main ()
     }());
 
     iota(0, BlockCount).each!(h => {
-        assert(storage.tryReadBlock(block, Height(h)));
+        block = storage.readBlock(Height(h));
         writeln(format!"block at height %s:\n%s\n\n"(h, prettify(block)));
         }());
 
-    Block block2;
     /// Update each block adding an updated block multisig and set validator 0
     /// as also signed
     iota(1, BlockCount).each!(h => {
-        storage.readBlock(block2, Height(h));
+        auto block2 = storage.readBlock(Height(h));
         assert(block2.header.validators[1] == true, format!"block at height %s:\n%s\n\n"(h, prettify(block2)));
         block2.header.signature = SIG2;
         block2.header.validators[0] = true;
         storage.updateBlockMultiSig(block2);
-        assert(storage.tryReadBlock(block, Height(h)));
+        block = storage.readBlock(Height(h));
         assert(block == block2, format!"read block at height %s:\n%s\n\n"(h, prettify(block)));
         assert(block.header.validators[0] == true, format!"block at height %s:\n%s\n\n"(h, prettify(block2)));
         assert(block.header.validators[1] == true, format!"block at height %s:\n%s\n\n"(h, prettify(block2)));

--- a/tests/unit/BlockStorageMultiTx.d
+++ b/tests/unit/BlockStorageMultiTx.d
@@ -64,7 +64,7 @@ private void main ()
     Block[] loaded_blocks;
     loaded_blocks.length = BlockCount + 1;
     foreach (idx; 0 .. BlockCount + 1)
-        storage.readBlock(loaded_blocks[idx], Height(idx));
+        loaded_blocks[idx] = storage.readBlock(Height(idx));
 
     // Finally compare every blocks
     assert(loaded_blocks == blocks);


### PR DESCRIPTION
It's pretty obvious that the Exception-less API has been completely misused, leading to a lot of places just using `assert(0)`.
In hindsight, it's also relatively pointless to optimize against Exceptions when we perform disk IO and (de)serialization.
So clean up the API by returning `Block` and using `Exception`.