### PR TITLE
FullNode: Introduce a simpler 'getBlock' function

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -146,6 +146,24 @@ public interface API
 
     /***************************************************************************
 
+        Expose blocks as a REST collection
+
+        API:
+            GET /blocks/:height
+
+        Params:
+            _height = The height of the block to return
+
+        Returns:
+            The block at height `_height`, or throw an `Exception` (404).
+
+    ***************************************************************************/
+
+    @path("/blocks/:height")
+    public const(Block) getBlock (ulong _height);
+
+    /***************************************************************************
+
         Get the array of hashes which form the merkle path
 
         API:

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -425,6 +425,14 @@ public class FullNode : API
             .take(min(max_blocks, MaxBatchBlocksSent)).array;
     }
 
+    /// GET: /blocks/:height
+    public override const(Block) getBlock (ulong height)  @safe
+    {
+        this.endpoint_request_stats
+            .increaseMetricBy!"agora_endpoint_calls_total"(1, "blocks", "http");
+        return this.ledger.getBlocksFrom(Height(height)).front();
+    }
+
     /// Start the StatsServer
     public void startStatsServer ()
     {


### PR DESCRIPTION
This can be useful for clients, as it does not rely on a query parameter,
unlike `getBlocksFrom`, which makes it unusable in certain contexts.