### PR TITLE
Periodic catchup improvement

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -322,7 +322,10 @@ public class FullNode : API
 
     protected bool acceptBlock(const ref Block block) @trusted
     {
-        return this.ledger.acceptBlock(block);
+        // Attempt to add block to the ledger (it may be there by other means)
+        this.ledger.acceptBlock(block);
+        // We return if height in ledger is reached for this block to prevent fetching again
+        return this.ledger.getBlockHeight() >= block.header.height;
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -287,7 +287,8 @@ public class Validator : FullNode, API
         if (auto err = this.ledger.validateBlock(block))
         {
             log.error("Block failed to validate: {}", err);
-            return false;
+            // Maybe the block was already added to the ledger
+            return this.ledger.getBlockHeight() >= block.header.height;
         }
         auto sig = this.nominator.createBlockSignature(block);
         auto multi_sig = Sig.fromBlob(block.header.signature);


### PR DESCRIPTION
When running ci system tests I have seen that the following can occur:
Periodic catchup will trigger fetching blocks from another node from the current height in the ledger.
If the first block in the received blocks is considered invalid, because it is already in the ledger, then it tries to fetch blocks from all the other nodes, even though it will fail for the same reason.

