### PR TITLE
Ensure that nodes don't slash themselves

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -823,6 +823,34 @@ public class EnrollmentManager
         return PublicKey(this.key_pair.V[]);
     }
 
+    /***************************************************************************
+
+        Get the index of this node's enrollment in the sorted enrolled UTXOs
+
+        Returns:
+            the index of the enrollment, or ulong.max if this node is not
+            enrolled as a validator.
+
+    ***************************************************************************/
+
+    public ulong getIndexOfEnrollment () @safe nothrow
+    {
+        if (this.enroll_key == Hash.init)
+            return ulong.max;
+
+        Hash[] utxo_keys;
+        if (!this.validator_set.getEnrolledUTXOs(utxo_keys))
+            assert(0);
+
+        foreach (idx, key; utxo_keys)
+            if (key == this.enroll_key)
+                return idx;
+
+        log.fatal("Index of the node's enrollment not found. Enrollment: {}",
+            this.enroll_key);
+        assert(0);
+    }
+
     /// Returns: true if this validator is currently enrolled
     public bool isEnrolled (scope UTXOFinder finder) nothrow @safe
     {

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -415,9 +415,6 @@ public class EnrollmentManager
 
     public Enrollment createEnrollment (in Hash utxo, Height height) @safe nothrow
     {
-        // K, frozen UTXO hash
-        this.enroll_key = utxo;
-
         // X, final seed data and preimages of hashes
         const seed = this.cycle.getPreImage(this.key_pair.v, height);
         const enroll = makeEnrollment(

--- a/source/agora/consensus/SlashPolicy.d
+++ b/source/agora/consensus/SlashPolicy.d
@@ -233,6 +233,9 @@ public class SlashPolicy
     private bool hasRevealedPreimage (in Height height, in Hash utxo_key)
         @safe nothrow
     {
+        if (utxo_key == this.enroll_man.getEnrollmentKey())
+            return true;
+
         auto preimage = this.enroll_man.getValidatorPreimage(utxo_key);
         auto enrolled = this.enroll_man.getEnrolledHeight(preimage.enroll_key);
         assert(height >= enrolled);
@@ -264,6 +267,13 @@ public class SlashPolicy
         if (!this.enroll_man.getEnrolledUTXOs(keys) || keys.length == 0)
         {
             log.fatal("Could not retrieve enrollments / no enrollments found");
+            assert(0);
+        }
+
+        auto enroll_index = this.enroll_man.getIndexOfEnrollment();
+        if (enroll_index != ulong.max && !missing_validators.find(enroll_index).empty)
+        {
+            log.fatal("The node is slashing itself.");
             assert(0);
         }
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -808,6 +808,12 @@ extern(D):
                 return ValidationLevel.kInvalidValue;
             }
 
+            if (this.ledger.checkSelfSlashing(data))
+            {
+                log.error("validateValue(): Slasing itself");
+                return ValidationLevel.kInvalidValue;
+            }
+
             if (auto fail_reason = this.ledger.validateSlashingData(data))
             {
                 log.info("validateValue(): Preimage Validation failed, but " ~

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -769,8 +769,39 @@ public class Ledger
 
     public string validateSlashingData (in ConsensusData data) @safe
     {
+        if (checkSelfSlashing(data))
+        {
+            log.fatal("The node is slashing itself.");
+            assert(0);
+        }
+
         return this.slash_man.isInvalidPreimageRootReason(this.getBlockHeight(),
                 data.missing_validators);
+    }
+
+    /***************************************************************************
+
+        Check if the consensus data has the information that is slashing
+        a node itself
+
+        Params:
+            data = consensus data
+
+        Returns:
+            true if the consensus data has the information that is slashing
+            a node itself.
+
+    ***************************************************************************/
+
+    public bool checkSelfSlashing(in ConsensusData data) @safe nothrow
+    {
+        auto enroll_index = this.enroll_man.getIndexOfEnrollment();
+        if (enroll_index != ulong.max &&
+            !data.missing_validators.find(enroll_index).empty)
+        {
+            return true;
+        }
+        return false;
     }
 
     /***************************************************************************


### PR DESCRIPTION
This code terminates a node that is trying to slash itself, which is decided by the discussion with @Geod24.
The `agora.test.EnrollDifferentUTXOs` network test in the second commit fails without the first commit which removes the statements saving enrollment information into the `EnrollmentManager` before consensus.

Fixes #1551 