### PR TITLE
Refactor `getRandomSeed` function

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -883,14 +883,7 @@ public class Ledger
 
     public Hash getValidatorRandomSeed (Height height) nothrow
     {
-        Hash[] keys;
-        if (!this.enroll_man.getEnrolledUTXOs(keys) || keys.length == 0)
-        {
-            log.fatal("Could not retrieve enrollments / no enrollments found");
-            assert(0);
-        }
-
-        return this.enroll_man.getRandomSeed(keys, height);
+        return this.enroll_man.getRandomSeed(height);
     }
 
     /***************************************************************************
@@ -912,7 +905,7 @@ public class Ledger
     public Hash getExternalizedRandomSeed (in Height height,
         const ref uint[] missing_validators) @safe nothrow
     {
-        return this.slash_man.getExternalizedRandomSeed(height,
+        return this.enroll_man.getExternalizedRandomSeed(height,
             missing_validators);
     }
 
@@ -1060,7 +1053,7 @@ public class Ledger
 
     public Hash getRandomSeed() nothrow @safe
     {
-        return this.slash_man.getRandomSeed(this.last_block.header.height);
+        return this.enroll_man.getRandomSeed(this.last_block.header.height);
     }
 }
 

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -172,7 +172,7 @@ public class Validator : FullNode, API
             assert(0);
         }
 
-        const rand_seed = this.enroll_man.getRandomSeed(keys, height);
+        const rand_seed = this.enroll_man.getRandomSeed(height);
         qc = buildQuorumConfig(this.config.validator.key_pair.address,
             keys, this.utxo_set.getUTXOFinder(), rand_seed,
             this.quorum_params);

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1650,7 +1650,7 @@ public class TestValidatorNode : Validator, TestAPI
     {
         Hash[] utxos;
         assert(this.enroll_man.getEnrolledUTXOs(utxos) && utxos.length > 0);
-        const rand_seed = this.enroll_man.getRandomSeed(utxos, height);
+        const rand_seed = this.enroll_man.getRandomSeed(height);
         QuorumConfig[] quorums;
         foreach (pub_key; pub_keys)
             quorums ~= buildQuorumConfig(pub_key, utxos,


### PR DESCRIPTION
There are two `getRandomSeed` functions in the `EnrollmentManager` and `SlashPolicy` classes, which is unnecessary and confusing. We should only use the function in the `EnrollmentManager`. So this PR refactor the functions.