### PR TITLE
Flash: Propagate payment failure down the path

### DIFF
--- a/source/agora/flash/API.d
+++ b/source/agora/flash/API.d
@@ -178,6 +178,7 @@ public interface FlashAPI
             chan_id = an existing channel ID
             seq_id = the new sequence ID
             secrets = the secrets the proposer wishes to disclose
+            rev_htlcs = the htlcs the proposer wishes to drop
             peer_nonce = the nonce the calling peer will use
             block_height = the block height of the calling node. This is needed
                 in order to properly resolve any pending HTLCs in the channel.
@@ -193,7 +194,8 @@ public interface FlashAPI
     ***************************************************************************/
 
     public Result!PublicNonce proposeUpdate (in Hash chan_id, in uint seq_id,
-        in Hash[] secrets, in PublicNonce peer_nonce, in Height block_height);
+        in Hash[] secrets, in Hash[] rev_htlcs, in PublicNonce peer_nonce,
+        in Height block_height);
 
     /***************************************************************************
 

--- a/source/agora/flash/OnionPacket.d
+++ b/source/agora/flash/OnionPacket.d
@@ -282,5 +282,5 @@ unittest
 
 /// OnionPacket payment router
 public alias PaymentRouter =
-    void delegate (in Hash chan_id, in Hash payment_hash, in Amount amount,
+    bool delegate (in Hash chan_id, in Hash payment_hash, in Amount amount,
         in Height lock_height, in OnionPacket packet);

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -551,7 +551,7 @@ unittest
     // the utxo the funding tx will spend (only relevant to the funder)
     const bob_utxo = UTXO.getHash(hashFull(txs[1]), 0);
     const bob_charlie_chan_id = bob.openNewChannel(
-        bob_utxo, Amount(10_000), Settle_1_Blocks, charlie_pk);
+        bob_utxo, Amount(6_000), Settle_1_Blocks, charlie_pk);
     writefln("Bob Charlie channel ID: %s", bob_charlie_chan_id);
 
     // await bob & bob channel funding transaction
@@ -565,16 +565,16 @@ unittest
     /+++++++++++++++++++++++++++++++++++++++++++++/
 
     // begin off-chain transactions
-    auto inv_1 = charlie.createNewInvoice(Amount(5_000), time_t.max, "payment 1");
+    auto inv_1 = charlie.createNewInvoice(Amount(4_000), time_t.max, "payment 1");
 
     // here we assume bob sent the invoice to alice through some means,
     // e.g. QR code. Alice scans it and proposes the payment.
     // it has a direct channel to bob so it uses it.
     alice.payInvoice(inv_1);
 
-    // wait until the invoice is done (should payInvoice() be blocking?)
-    writefln("Sleeping for 7 seconds..");
-    Thread.sleep(7.seconds);
+    // Second payment attempt should fail because of insufficient funds
+    auto inv_2 = charlie.createNewInvoice(Amount(4_000), time_t.max, "payment 2");
+    alice.payInvoice(inv_2);
 
     //
     writefln("Beginning bob => charlie collaborative close..");


### PR DESCRIPTION
If a node on the path fails to route the payment
the already created HTLCs should unwind.

Part of #1623 