### PR TITLE
Fix 1661, 1440: Refund output of freezing tx shouldn't be frozen

### DIFF
--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
 
     Contains validation routines for transactions

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -61,7 +61,7 @@ public string isInvalidReason (
     if (tx.lock_height > height)
         return "Transaction: Not unlocked for this height";
 
-    foreach (output; tx.outputs)
+    foreach (idx, output; tx.outputs)
     {
         // disallow negative amounts
         if (!output.value.isValid())
@@ -70,6 +70,13 @@ public string isInvalidReason (
         // disallow 0 amount
         if (output.value == Amount(0))
             return "Transaction: Value of output is 0";
+
+        // Each output of a freezing transaction must have at least
+        // `Amount.MinFreezeAmount`, save for the first one which
+        // will be considered a refund if it is less than that.
+        if (tx.type == TxType.Freeze && idx > 0 &&
+            output.value < Amount.MinFreezeAmount)
+            return "Transaction: All non-refund outputs must be over the minimum freezing amount";
     }
 
     const tx_hash = hashFull(tx);

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1942,10 +1942,6 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
 
     auto all_configs = validator_configs.chain(full_node_configs).array;
 
-    immutable string gen_block_hex = GenesisBlock
-        .serializeFull()
-        .toHexString();
-
     const test_start_time = time(null);
     foreach (ref conf; all_configs)
         conf.node.testing = true;

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -232,3 +232,42 @@ unittest
     node_1.putTransaction(backup_tx);
     network.expectBlock(Height(3));  // new block finally created
 }
+
+// Ensure that when creating a frozen UTXO, the refund is not frozen too
+// See https://github.com/bpfkorea/agora/issues/1440
+unittest
+{
+    TestConf conf = { txs_to_nominate: 1 };
+    auto network = makeTestNetwork(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    // Create a freezing tx with two outputs:
+    // 1) A refund of 1k
+    // 2) A very large frozen amount (60.999k)
+    Amount freezeAmount = network.blocks[0].txs[1].outputs[0].value;
+    // Must be under Amount.MinFreezeAmount so that the refund isn't frozen
+    freezeAmount.mustSub(1_000.coins);
+    auto tx = network.blocks[0].spendable
+        .map!(txb => txb
+              .draw(freezeAmount, WK.Keys.AA.address.only).sign(TxType.Freeze)
+        ).front;
+
+    assert(tx.outputs.length == 2);
+    network.clients[0].putTransaction(tx);
+
+    // Wait for the block to be created
+    network.expectBlock(Height(1));
+    const b1 = network.clients[0].getBlock(1);
+    assert(b1.txs.length == 1);
+
+    // Now spend the refund transaction
+    auto tx2 = TxBuilder(b1.txs[0], 0).sign();
+    assert(tx2.outputs.length == 1);
+
+    network.clients[0].putTransaction(tx2);
+    network.expectBlock(Height(2));
+    assert(network.clients[0].getBlock(2).txs.length == 1);
+}

--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -462,7 +462,7 @@ public struct TxBuilder
 
         // Add the refund tx, if needed
         if (this.leftover.value > Amount(0))
-            this.data.outputs ~= this.leftover;
+            this.data.outputs = [ this.leftover ] ~ this.data.outputs;
 
         this.data.payload = DataPayload(data);
 
@@ -740,11 +740,11 @@ unittest
     // 488M / 3
     const Amount ExpectedAmount      = Amount(162_666_666_6666_666L);
 
-    assert(result.outputs[0].value == ExpectedAmount);
     assert(result.outputs[1].value == ExpectedAmount);
     assert(result.outputs[2].value == ExpectedAmount);
+    assert(result.outputs[3].value == ExpectedAmount);
     // The first output is the remainder
-    assert(result.outputs[3].value == Amount(2));
+    assert(result.outputs[0].value == Amount(2));
 }
 
 /// Test with one output key
@@ -777,7 +777,7 @@ unittest
     assert(result.outputs.length == 4);
 
     assert(equal!((in Output outp, in KeyPair b) => outp.address == b.address)(
-               result.outputs, [ WK.Keys.A, WK.Keys.B, WK.Keys.C, WK.Keys.Z ]));
+               result.outputs, [ WK.Keys.Z, WK.Keys.A, WK.Keys.B, WK.Keys.C ]));
 }
 
 /// Test with a range of tuples


### PR DESCRIPTION
The fix for #1661 is necessary to make #1440 possible, so the two are in this PR.
CC @MichaelKim20 