### PR TITLE
Make BlockStorage.updateBlockMultiSig accepts the sig and bitfield

### DIFF
--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -45,11 +45,11 @@ public struct BlockHeader
     /// Hash of the previous block in the chain of blocks
     public Hash prev_block;
 
-    /// Block height (genesis is #0)
-    public Height height;
-
     /// The hash of the merkle root of the transactions
     public Hash merkle_root;
+
+    /// Hash of random seed of the preimages for this height
+    public Hash random_seed;
 
     /// Schnorr multisig of all validators which signed this block
     public Signature signature;
@@ -57,11 +57,11 @@ public struct BlockHeader
     /// Bitfield containing the validators' key indices which signed the block
     public BitField!ubyte validators;
 
+    /// Block height (genesis is #0)
+    public Height height;
+
     /// Enrolled validators
     public Enrollment[] enrollments;
-
-    /// Hash of random seed of the preimages for this height
-    public Hash random_seed;
 
     /// List of indices to the validator UTXO set which have not revealed the preimage
     public uint[] missing_validators;
@@ -173,12 +173,12 @@ public struct Block
         return Block(
             BlockHeader(
                 this.header.prev_block,
-                this.header.height,
                 this.header.merkle_root,
+                this.header.random_seed,
                 signature,
                 validators,
+                this.header.height,
                 this.header.enrollments.dup,
-                this.header.random_seed,
                 this.header.missing_validators.dup,
                 this.header.timestamp),
             // TODO: Optimize this by using dup for txs also

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -579,11 +579,7 @@ extern(D):
                     block_sig.signature, block_sig.height, block_sig.public_key);
                 return;
             }
-            if (!this.ledger.updateBlockMultiSig(signed_block))
-            {
-                log.error("Failed to update block with signature {} for block {} publicKey {}",
-                    block_sig.signature, block_sig.height, block_sig.public_key);
-            }
+            this.ledger.updateBlockMultiSig(signed_block);
         }
     }
 

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -383,10 +383,7 @@ public class BlockStorage : IBlockStorage
             if (this.height_idx.length > 0)
             {
                 last_pos = this.height_idx.back.position;
-
-                if (!this.readSizeT(last_pos, last_size))
-                    throw new Exception("BlockStorage: Failed to read a size_t");
-
+                last_size = this.readSizeT(last_pos);
                 this.length = last_pos + size_t.sizeof + last_size;
             }
             else
@@ -569,18 +566,16 @@ public class BlockStorage : IBlockStorage
 
         Params:
             pos = position of memory mapped file
-            value = type of `size_t`
 
         Returns:
-            Returns true if success, otherwise returns false.
+            The value read
 
     ***************************************************************************/
 
-    private bool readSizeT (size_t pos, ref size_t value) @trusted
+    private size_t readSizeT (size_t pos) @trusted
     {
         ubyte[] data = this.read(pos, pos+size_t.sizeof);
-        value = *cast(size_t*)(data.ptr);
-        return true;
+        return *cast(size_t*)(data.ptr);
     }
 
     /***************************************************************************

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -335,18 +335,13 @@ public class Ledger
 
     ***************************************************************************/
 
-    public bool updateBlockMultiSig (const ref Block block) @safe
+    public void updateBlockMultiSig (const ref Block block) @safe
     {
-        if (!this.storage.updateBlockMultiSig(block))
-        {
-            log.error("Failed to update block: {}", prettify(block));
-            return false;
-        }
+        this.storage.updateBlockSig(block.header.height, block.hashFull(),
+            block.header.signature, block.header.validators);
 
         if (block.header.height == this.last_block.header.height)
             this.last_block = this.storage.readLastBlock();
-
-        return true;
     }
 
     /***************************************************************************

--- a/tests/unit/BlockStorageMultiSig.d
+++ b/tests/unit/BlockStorageMultiSig.d
@@ -22,6 +22,7 @@ import agora.common.Types;
 import agora.consensus.data.Block;
 import agora.consensus.data.genesis.Test;
 import agora.consensus.data.Transaction;
+import agora.crypto.Hash;
 import agora.node.BlockStorage;
 import agora.utils.Test;
 import agora.utils.PrettyPrinter;
@@ -92,7 +93,7 @@ private void main ()
         assert(block2.header.validators[1] == true, format!"block at height %s:\n%s\n\n"(h, prettify(block2)));
         block2.header.signature = SIG2;
         block2.header.validators[0] = true;
-        storage.updateBlockMultiSig(block2);
+        storage.updateBlockSig(Height(h), block2.hashFull(), SIG2, block2.header.validators);
         block = storage.readBlock(Height(h));
         assert(block == block2, format!"read block at height %s:\n%s\n\n"(h, prettify(block)));
         assert(block.header.validators[0] == true, format!"block at height %s:\n%s\n\n"(h, prettify(block2)));

--- a/tests/unit/BlockStorageMultiSig.d
+++ b/tests/unit/BlockStorageMultiSig.d
@@ -87,7 +87,7 @@ private void main ()
 
     /// Update each block adding an updated block multisig and set validator 0
     /// as also signed
-    iota(1, BlockCount).each!(h => {
+    iota(1, BlockCount).each!((h) {
         auto block2 = storage.readBlock(Height(h));
         assert(block2.header.validators[1] == true, format!"block at height %s:\n%s\n\n"(h, prettify(block2)));
         block2.header.signature = SIG2;
@@ -99,5 +99,5 @@ private void main ()
         assert(block.header.validators[1] == true, format!"block at height %s:\n%s\n\n"(h, prettify(block2)));
         assert(block.header.signature == SIG2, format!"block at height %s:\n%s\n\n%s != %s"
             (h, prettify(block), block.header.signature, SIG2));
-    }());
+    });
 }


### PR DESCRIPTION
Instead of passing the whole block and serializing it,
just pass the fields to update along with the height
(to locate the block) and the hash (to check we have the right one).