### PR TITLE
Serializer or code issue

### DIFF
--- a/source/agora/common/Serializer.d
+++ b/source/agora/common/Serializer.d
@@ -99,6 +99,43 @@ import std.meta;
 import std.range;
 import std.traits;
 
+import agora.common.Amount;
+import agora.common.Types;
+import agora.crypto.Hash;
+
+import std.stdio;
+
+struct Payload
+{
+    ulong x;
+    Amount y;
+
+    void serialize (scope SerializeDg dg) const @safe
+    {
+        serializePart(this.x, dg, CompactMode.No);
+        serializePart(this.y, dg, CompactMode.No);
+    }
+
+    static QT fromBinary (QT) (scope DeserializeDg dg, in DeserializerOptions opts) @safe
+    {
+        auto x = deserializeFull!ulong(dg, opts);
+        auto y = deserializeFull!Amount(dg, opts);
+        return QT(x, y);
+    }
+}
+
+unittest
+{
+    // setting x to 0 fixes it
+    Payload payload = { x : ulong.max, y : Amount(200) };
+    auto serialized = serializeFull(payload);
+
+    const DeserializerOptions opts = { maxLength : DefaultMaxLength, compact : CompactMode.No };
+    scope DeserializeDg dg = (size) @safe { return serialized; };
+
+    auto deserialized = deserializeFull!Payload(dg, opts);
+}
+
 /// Pedestrian usage of serialization
 unittest
 {


### PR DESCRIPTION
I get this:

```
[source/agora/common/Amount.d:62] Assertion thrown during test:
Module tests failed: agora.common.Serializer
core.exception.AssertError@source/agora/common/Amount.d(62)
```

It seems like there is a mismatch somewhere? VarInt being used even though it shouldn't? Because if I set the value of `x` to zero then the problem goes away..