### PR TITLE
Upgrade README and Github actions to LDC v1.25.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: |
             mkdir -p $HOME/dlang && wget https://dlang.org/install.sh -O $HOME/dlang/install.sh
             chmod +x $HOME/dlang/install.sh
-            $HOME/dlang/install.sh install ldc-1.24.0
+            $HOME/dlang/install.sh install ldc-1.25.0
       - run:
           name: Install libsodium
           command: |
@@ -44,13 +44,13 @@ jobs:
       - run:
           name: Check virtual method offset
           command: |
-            source $HOME/dlang/ldc-1.24.0/activate
+            source $HOME/dlang/ldc-1.25.0/activate
             ci/check_vtable_test.d
           no_output_timeout: 10m
       - run:
           name: Build & test docker image
           command: |
-            source $HOME/dlang/ldc-1.24.0/activate
+            source $HOME/dlang/ldc-1.25.0/activate
             ci/system_integration_test.d
             # Work around druntime setting the permissions to 600..
             # Need to iterate on the directory to avoid 'list arguments too long'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,14 +22,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-18.04, macOS-10.15, windows-2019 ]
-        dc: [ ldc-master, ldc-1.24.0 ]
+        dc: [ ldc-master, ldc-1.25.0 ]
         # Define job-specific parameters
         include:
           # By default, don't generate artifacts for push
           - { artifacts: false }
           # Only generate when the latest ldc is used
           # IMPORTANT: Update this when the compiler support is changed!
-          - { dc: ldc-1.24.0, artifacts: true }
+          - { dc: ldc-1.25.0, artifacts: true }
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ and add it to your `.bashrc`, `.zshrc`, etc...
 
 ```console
 # Install the LDC compiler (you might want to use a newer version)
-curl https://dlang.org/install.sh | bash -s ldc-1.24.0
+curl https://dlang.org/install.sh | bash -s ldc-1.25.0
 # Add LDC to the $PATH
-source ~/dlang/ldc-1.24.0/activate
+source ~/dlang/ldc-1.25.0/activate
 # Clone this repository
 git clone https://github.com/bpfkorea/agora.git
 # Use the git root as working directory


### PR DESCRIPTION
The only thing missing is upgrading the Docker image,
but for this we first need to upgrade the Alpine packages.