### PR TITLE
Reduce usage of rdmd in tests

### DIFF
--- a/ci/run.bat
+++ b/ci/run.bat
@@ -3,7 +3,9 @@ set AGORA_VERSION="HEAD"
 rem call dub test --skip-registry=all --compiler=%DC%
 call dub build --skip-registry=all --compiler=%DC% -c unittest -b unittest
 if %errorlevel% neq 0 exit /b %errorlevel%
-call rdmd --build-only --compiler=%DC% ./tests/runner.d --compiler=%DC% -cov
+rem call %DC% -i -run ./tests/runner.d %DC% -cov
+call %DC% -i ./tests/runner.d
+rem We should really run those tests, but they are currently broken
 if %errorlevel% neq 0 exit /b %errorlevel%
 call dub build --skip-registry=all --compiler=%DC%
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -13,7 +13,7 @@ dub build -c client --skip-registry=all --compiler=${DC}
 dub build -b unittest-cov -c unittest --skip-registry=all --compiler=${DC}
 
 # Run this after unit tests have proven to compile ok
-rdmd --compiler=${DC} ./tests/runner.d --compiler=${DC} -cov
+${DC} -i -run ./tests/runner.d ${DC} -cov
 
 export dchatty=true
 export dsinglethreaded=true

--- a/tests/runner.d
+++ b/tests/runner.d
@@ -30,18 +30,20 @@ private int main (string[] args)
 {
     size_t count;
 
+    const compiler = args.length > 1 ? args[1] : "ldc2";
     const importPaths = getImportPaths();
     const lflags = getLflags();
     if (!importPaths.length || !lflags.length)
         return 1;
-    const Args = ["rdmd", "-vcolumns", "-i=stdx"] ~ args[1 .. $] ~
+    const Args = [compiler, "-i", "-vcolumns" ] ~
+        args[(args.length >= 2) + 1 .. $] ~
         importPaths.map!(v => "-I" ~ v).array ~
         lflags.map!(v => "-L" ~ v).array;
 
     foreach (test; dirEntries(UnitPath, SpanMode.shallow))
     {
         writeln("Running test on ", test);
-        auto pp = pipeProcess(Args ~ test);
+        auto pp = pipeProcess(Args ~ [ "-run", test ]);
         if (pp.pid.wait() != 0)
         {
             pp.stdout.byLine.each!(a => writeln("[stdout]\t", a));


### PR DESCRIPTION
Since rdmd needs to call the compiler twice, it's quite slow.
Reduce its usage by directly using '-i -run' with the compiler instead.