### PR TITLE
Block header: Use time offset not timestamp

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -37,9 +37,9 @@ node:
   # is going to connect to, for example: http://0.0.0.0:8008
   # It can also be set to -1 do disable listening (default is -1)
   stats_listening_port: 9110
-  # The new block timestamp has to be greater than the previous block timestamp,
-  # but less than current time + block_timestamp_tolerance_secs
-  block_timestamp_tolerance_secs: 60
+  # The new block time offset has to be greater than the previous block time offset
+  # but less than current time + block_time_offset_tolerance_secs
+  block_time_offset_tolerance_secs: 60
   # The duration between requests for retrieving the latest blocks
   # from all other nodes
   block_catchup_interval_secs: 20

--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -268,7 +268,7 @@ public class BanManager
 
     /***************************************************************************
 
-        Get the un-ban unix timestamp of the provided address,
+        Get the un-ban unix time offset from Genesis timestamp of the provided address,
         or 0 if the address was never banned.
 
         Params:

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -165,9 +165,9 @@ public struct NodeConfig
     /// from all other nodes
     public Duration block_catchup_interval = 20.seconds;
 
-    /// The new block timestamp has to be greater than the previous block timestamp,
-    /// but less than current time + block_timestamp_tolerance
-    public Duration block_timestamp_tolerance = 60.seconds;
+    /// The new block time offset has to be greater than the previous block time offset,
+    /// but less than current time + block_time_offset_tolerance_secs
+    public Duration block_time_offset_tolerance = 60.seconds;
 }
 
 /// Validator config
@@ -428,7 +428,7 @@ private NodeConfig parseNodeConfig (Node* node, in CommandLine cmdln)
     string data_dir = get!(string, "node", "data_dir")(cmdln, node);
     auto port = get!(ushort, "node", "port")(cmdln, node);
     const stats_listening_port = opt!(ushort, "node", "stats_listening_port")(cmdln, node);
-    const block_timestamp_tolerance_secs = opt!(uint, "node", "block_timestamp_tolerance_secs")(cmdln, node);
+    const block_time_offset_tolerance_secs = opt!(uint, "node", "block_time_offset_tolerance_secs")(cmdln, node);
     const block_catchup_interval = opt!(uint, "node", "block_catchup_interval_secs")(cmdln, node);
 
     NodeConfig result = {
@@ -445,7 +445,7 @@ private NodeConfig parseNodeConfig (Node* node, in CommandLine cmdln)
             timeout : timeout,
             data_dir : data_dir,
             stats_listening_port : stats_listening_port,
-            block_timestamp_tolerance : block_timestamp_tolerance_secs.seconds,
+            block_time_offset_tolerance : block_time_offset_tolerance_secs.seconds,
             block_catchup_interval : block_catchup_interval.seconds,
     };
     return result;

--- a/source/agora/consensus/data/Params.d
+++ b/source/agora/consensus/data/Params.d
@@ -49,6 +49,7 @@ public immutable class ConsensusParams
     mixin ROProperty!("ValidatorTXFeeCut", "validator_tx_fee_cut");
     mixin ROProperty!("PayoutPeriod", "payout_period");
     mixin ROProperty!("SlashPenaltyAmount", "slash_penalty_amount");
+    mixin ROProperty!("GenesisTimestamp", "genesis_timestamp");
 
     /***************************************************************************
 
@@ -78,6 +79,7 @@ public immutable class ConsensusParams
         uint validator_cycle = 1008, uint max_quorum_nodes = 7,
         uint quorum_threshold = 80)
     {
+        const genesis_timestamp = 1609459200;  // 2021-01-01:00:00:00 GMT
         import agora.consensus.data.genesis.Test : GenesisBlock;
         import agora.utils.WellKnownKeys;
         ConsensusConfig config = {
@@ -92,6 +94,8 @@ public immutable class ConsensusParams
 /// Ditto
 public struct ConsensusConfig
 {
+    public ulong genesis_timestamp = 1609459200; // 2021-01-01:00:00:00 GMT
+
     /// The cycle length for a validator
     public uint validator_cycle = 1008;
 

--- a/source/agora/consensus/data/genesis/Coinnet.d
+++ b/source/agora/consensus/data/genesis/Coinnet.d
@@ -33,6 +33,7 @@ public immutable Block GenesisBlock =
         enrollments: Enrollments,
         validators:  BitField!ubyte(6),
         signature:   Signature.init,
+        time_offset: 0, // In subsequent blocks this will be the offset in seconds from Genesis time
     },
     txs: GenesisTransactions,
     merkle_tree: GenesisMerkleTree,

--- a/source/agora/consensus/data/genesis/Test.d
+++ b/source/agora/consensus/data/genesis/Test.d
@@ -51,7 +51,7 @@ public immutable Block GenesisBlock = {
         prev_block:  Hash.init,
         height:      Height(0),
         merkle_root: GenesisMerkleTree[$ - 1],
-        timestamp:   1596153600, // 2020.07.31 12:00:00AM
+        time_offset: 0, // In subsequent blocks this will be the offset in seconds from Genesis time
         validators:  BitField!ubyte(6),
         signature:   Signature.init,
 

--- a/source/agora/consensus/protocol/Data.d
+++ b/source/agora/consensus/protocol/Data.d
@@ -31,7 +31,7 @@ public struct ConsensusData
     public uint[] missing_validators;
 
     /// The block time that is being nominated / voted on
-    public ulong timestamp;
+    public ulong time_offset;
 }
 
 /// ConsensusData type testSymmetry check
@@ -66,7 +66,7 @@ unittest
         tx_set:  GenesisBlock.txs.map!(tx => tx.hashFull()).array,
         enrolls: [ record, record, ],
         missing_validators : [ 1, 3, 5 ],
-        timestamp: 12345678
+        time_offset: 12345678
     };
 
     testSymmetry(data);

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -177,7 +177,7 @@ public class FullNode : API
             immutable Block result = {
                 header: {
                     merkle_root: TESTNET.GenesisBlock.header.merkle_root,
-                    timestamp: TESTNET.GenesisBlock.header.timestamp,
+                    time_offset: TESTNET.GenesisBlock.header.time_offset,
                     validators: typeof(BlockHeader.validators)(config.node.limit_test_validators),
                     enrollments: TESTNET.GenesisBlock.header.enrollments[0 .. config.node.limit_test_validators],
                 },
@@ -204,7 +204,7 @@ public class FullNode : API
         this.fee_man = this.getFeeManager();
         this.ledger = new Ledger(params, this.utxo_set,
             this.storage, this.enroll_man, this.pool, this.fee_man, this.clock,
-            config.node.block_timestamp_tolerance, &this.onAcceptedBlock);
+            config.node.block_time_offset_tolerance, &this.onAcceptedBlock);
 
         // Make `BlockExternalizedHandler` from config
         foreach (address;

--- a/source/agora/test/BlockTimeConsensus.d
+++ b/source/agora/test/BlockTimeConsensus.d
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-    Tests the consensus algorithm on block timestamp creation
+    Tests the consensus algorithm on block time offset creation
 
     Copyright:
         Copyright (c) 2020 BOS Platform Foundation Korea
@@ -46,7 +46,6 @@ unittest
     ));
 
     const b0 = nodes[0].getBlocksFrom(0, 1)[0];
-    auto start_time = network.nodes[0].time();
 
     void checkHeight(Height height)
     {
@@ -54,8 +53,8 @@ unittest
             cast(ushort) (height - 1));
         network.setTimeFor(height);
         network.assertSameBlocks(height);
-        auto timestamp = nodes[0].getBlocksFrom(height, 1)[0].header.timestamp;
-        assert( timestamp == start_time + (conf.block_interval_sec)*height, "actual time: " ~ to!string(timestamp));
+        auto time_offset = nodes[0].getBlocksFrom(height, 1)[0].header.time_offset;
+        assert( time_offset == conf.block_interval_sec * height, "actual time offset in header for height " ~ height.to!string ~ ": " ~ to!string(time_offset));
     }
 
     // Check for adding blocks 1 to 4

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -113,7 +113,7 @@ unittest
             super(args);
             this.ledger = new PickyLedger(params, this.utxo_set, this.storage,
                 this.enroll_man, this.pool, this.fee_man, this.clock,
-                this.config.node.block_timestamp_tolerance, &this.onAcceptedBlock);
+                this.config.node.block_time_offset_tolerance, &this.onAcceptedBlock);
         }
 
         public override void putTransaction (Transaction tx) @safe

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -478,7 +478,7 @@ GCOQEOHA...LRIJ(61,000,000), GCOQEOHA...LRIJ(61,000,000), GCOQEOHA...LRIJ(61,000
 GCOQEOHA...LRIJ(61,000,000), GCOQEOHA...LRIJ(61,000,000), GCOQEOHA...LRIJ(61,000,000),
 GCOQEOHA...LRIJ(61,000,000), GCOQEOHA...LRIJ(61,000,000)
 ====================================================
-Height: 1, Prev: 0x5a96...8163, Root: 0xd437...e2c9, Enrollments: []
+Height: 1, Prev: 0x2451...7377, Root: 0xd437...e2c9, Enrollments: []
 Signature: 0x000000000000000000016f605ea9638d7bff58d2c0cc2467c18e38b36367be78000000000000000000016f605ea9638d7bff58d2c0cc2467c18e38b36367be78,
 Validators: [64],
 Random seed: [0x0000...0000],

--- a/tests/unit/BlockStorage.d
+++ b/tests/unit/BlockStorage.d
@@ -59,7 +59,7 @@ private void main ()
                 Output(Amount(1_000), WK.Keys[idx % 8].address)
             ]
         );
-        blocks ~= makeNewBlock(blocks[$ - 1], [tx], blocks[$ - 1].header.timestamp + 1, Hash.init);
+        blocks ~= makeNewBlock(blocks[$ - 1], [tx], blocks[$ - 1].header.time_offset + 1, Hash.init);
         block_hashes ~= hashFull(blocks[$ - 1].header);
         storage.saveBlock(blocks[$ - 1]);
     }

--- a/tests/unit/BlockStorageChecksum.d
+++ b/tests/unit/BlockStorageChecksum.d
@@ -55,7 +55,7 @@ private void writeBlocks (string path)
     foreach (block_idx; 0 .. BlockCount)
     {
         Transaction[8] txs;
-        auto block = makeNewBlock(blocks[$ - 1], txs[], blocks[$ - 1].header.timestamp + 1, Hash.init);
+        auto block = makeNewBlock(blocks[$ - 1], txs[], blocks[$ - 1].header.time_offset + 1, Hash.init);
         storage.saveBlock(block);
         blocks ~= block;
     }

--- a/tests/unit/BlockStorageMultiSig.d
+++ b/tests/unit/BlockStorageMultiSig.d
@@ -67,7 +67,7 @@ private void main ()
 
     void signBlockSig1 (Height h)
     {
-        block = makeNewBlock(prev_block, txs, prev_block.header.timestamp + 1, Hash.init);
+        block = makeNewBlock(prev_block, txs, prev_block.header.time_offset + 1, Hash.init);
         block.header.signature = SIG1;
         block.header.validators = BitField!ubyte(6);
         block.header.validators[1] = true;

--- a/tests/unit/BlockStorageMultiTx.d
+++ b/tests/unit/BlockStorageMultiTx.d
@@ -50,7 +50,7 @@ private void main ()
         .array();
     foreach (block_idx; 0 .. BlockCount)
     {
-        auto block = makeNewBlock(blocks[$ - 1], txs, blocks[$ - 1].header.timestamp, Hash.init);
+        auto block = makeNewBlock(blocks[$ - 1], txs, blocks[$ - 1].header.time_offset + 1, Hash.init);
         storage.saveBlock(block);
         blocks ~= block;
         // Prepare transactions for the next block


### PR DESCRIPTION
This will replace timestamp with an offset in seconds from the Genesis start time which is set in the ConsensusParams.