### PR TITLE
Update Shnorr signature datastructs during startup

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -526,6 +526,7 @@ public class Ledger
     protected void updateValidatorSet (in Block block) @safe
     {
         this.enroll_man.clearExpiredValidators(block.header.height);
+        this.enroll_man.updateValidatorIndexMaps(Height(block.header.height));
         PublicKey pubkey = this.enroll_man.getEnrollmentPublicKey();
         UTXO[Hash] utxos = this.utxo_set.getUTXOs(pubkey);
         foreach (idx, ref enrollment; block.header.enrollments)


### PR DESCRIPTION
'key_to_index' and 'index_to_key' were not filled in for the entire
cycle length during validator start up

fixes: #1703