### PR TITLE
Move `pushBlock` call out of ctor into `start` function

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -197,9 +197,9 @@ public class EnrollmentManager
         if (keys.length == 0)
             log.error("No Active validator public keys at height {}", height);
 
+        log.trace("Update validator lookup maps at height {}: {}", height, keys);
         foreach (idx, key; keys)
         {
-            log.trace("Update validator lookup maps at height {} for index {} pubkey {}", height, idx, key);
             const K = Point(key[]);
             this.key_to_index[height][K] = idx;
             this.index_to_key[height][idx] = K;

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -114,9 +114,6 @@ public class FullNode : API
     /// Network of connected nodes
     protected NetworkManager network;
 
-    /// Reusable exception object
-    protected RestException exception;
-
     /// Transaction pool
     protected TransactionPool pool;
 
@@ -205,8 +202,6 @@ public class FullNode : API
         this.ledger = new Ledger(params, this.utxo_set,
             this.storage, this.enroll_man, this.pool, this.fee_man, this.clock,
             config.node.block_timestamp_tolerance, &this.onAcceptedBlock);
-        this.exception = new RestException(
-            400, Json("The query was incorrect"), string.init, int.init);
 
         // Make `BlockExternalizedHandler` from config
         foreach (address;

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -221,11 +221,6 @@ public class FullNode : API
             this.transaction_handlers[address] = this.network
                 .getTransactionReceivedHandler(address);
 
-        // Special case
-        // Block externalized handler is set and push for Genesis block.
-        if (this.block_handlers.length > 0 && this.getBlockHeight() == 0)
-            this.pushBlock(this.params.Genesis);
-
         Utils.getCollectorRegistry().addCollector(&this.collectAppStats);
         Utils.getCollectorRegistry().addCollector(&this.collectStats);
         enum build_version = import(VersionFileName);
@@ -252,6 +247,11 @@ public class FullNode : API
         this.startPeriodicDiscovery();
         this.startPeriodicCatchup();
         this.startStatsServer();
+
+        // Special case
+        // Block externalized handler is set and push for Genesis block.
+        if (this.block_handlers.length > 0 && this.getBlockHeight() == 0)
+            this.pushBlock(this.params.Genesis);
     }
 
     /// Returns an already instantiated version of the BanManager

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -267,7 +267,7 @@ public class FullNode : API
 
     ***************************************************************************/
 
-    private void startPeriodicDiscovery ()
+    protected void startPeriodicDiscovery ()
     {
         this.taskman.runTask(
         ()

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -269,8 +269,6 @@ public class FullNode : API
 
     private void startPeriodicDiscovery ()
     {
-        import core.time;
-
         this.taskman.runTask(
         ()
         {

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -222,13 +222,14 @@ public class Validator : FullNode, API
     public override void start ()
     {
         this.started = true;
+        // Note: Switching the next two lines leads to test failure
+        // It should not, and this needs to be fixed eventually
         this.network.startPeriodicNameRegistration();
-        this.startPeriodicDiscovery();
-        this.startStatsServer();
+        super.start();
+
         this.clock.startSyncing();
         this.taskman.setTimer(this.config.validator.preimage_reveal_interval,
             &this.checkRevealPreimage, Periodic.Yes);
-        this.startPeriodicCatchup();
 
         if (this.config.admin.enabled)
             this.admin_interface.start();
@@ -245,7 +246,7 @@ public class Validator : FullNode, API
 
     ***************************************************************************/
 
-    private void startPeriodicDiscovery ()
+    protected override void startPeriodicDiscovery ()
     {
         this.taskman.runTask(
         ()

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -76,7 +76,6 @@ import core.atomic : atomicLoad, atomicStore;
 import core.exception;
 import core.runtime;
 import core.stdc.time;
-import core.stdc.stdlib : abort;
 
 /* The following imports are frequently needed in tests */
 
@@ -135,8 +134,7 @@ void testAssertHandler (string file, ulong line, string msg) nothrow
             cast(int) exc_name.length, exc_name.ptr,
             cast(int) file.length, file.ptr, line, cast(int) msg.length, msg.ptr);
     }
-    // TODO: Using `abort` here would give use a core dump,
-    // but this gives us a stack trace.
+    // We still want a stack trace, so throw anyway
     throw new AssertError(msg, file, line);
 }
 


### PR DESCRIPTION
Removing IO in ctor is always a good thing. Here we move a network request from the node ctor and into the `start` function, which is also de-duplicated to make the code more straightforward.