### PR TITLE
regenerateQuorums: Get block height instead of using Height(0)

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -100,7 +100,7 @@ public class Validator : FullNode, API
 
         // currently we are not saving preimage info,
         // we only have the commitment in the genesis block
-        this.regenerateQuorums(Height(0));
+        this.regenerateQuorums(this.ledger.getBlockHeight());
 
         this.admin_interface = new AdminInterface(config,
             this.config.validator.key_pair, this.clock);


### PR DESCRIPTION
If `getRandomSeed` returns `Hash.init`, then the generated quorum for the node is in an invalid state.

The current quorum generator is called with `Height(0)`, even though the restarted node's ledger may be newer than this.

Fixes #1663 