### PR TITLE
BanManager: Only ban after 1k failed requests

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -80,7 +80,7 @@ validator:
 ################################################################################
 banman:
   # max failed requests until an address is banned
-  max_failed_requests: 10
+  max_failed_requests: 1000
   # the default duration of a ban
   ban_duration: 86400
 

--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -38,7 +38,7 @@ public class BanManager
     public struct Config
     {
         /// max failed requests until an address is banned
-        public size_t max_failed_requests = 10;
+        public size_t max_failed_requests = 1000;
 
         /// How long does a ban lasts, in seconds (default: 1 day)
         public Duration ban_duration = 1.days;

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -36,13 +36,6 @@ validator:
   registry_address: disabled
 
 ################################################################################
-##                         Ban manager configuration                          ##
-################################################################################
-banman:
-  max_failed_requests: 10
-  ban_duration: 86400
-
-################################################################################
 ##                               Node discovery                               ##
 ##                                                                            ##
 ## When the network first starts, we need to connect to some peers to learn   ##

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -42,13 +42,6 @@ validator:
   registry_address: disabled
 
 ################################################################################
-##                         Ban manager configuration                          ##
-################################################################################
-banman:
-  max_failed_requests: 10
-  ban_duration: 86400
-
-################################################################################
 ##                               Node discovery                               ##
 ##                                                                            ##
 ## When the network first starts, we need to connect to some peers to learn   ##

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -43,13 +43,6 @@ validator:
   registry_address: disabled
 
 ################################################################################
-##                         Ban manager configuration                          ##
-################################################################################
-banman:
-  max_failed_requests: 10
-  ban_duration: 86400
-
-################################################################################
 ##                               Node discovery                               ##
 ##                                                                            ##
 ## When the network first starts, we need to connect to some peers to learn   ##

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -43,13 +43,6 @@ validator:
   registry_address: disabled
 
 ################################################################################
-##                         Ban manager configuration                          ##
-################################################################################
-banman:
-  max_failed_requests: 10
-  ban_duration: 86400
-
-################################################################################
 ##                               Node discovery                               ##
 ##                                                                            ##
 ## When the network first starts, we need to connect to some peers to learn   ##

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -43,13 +43,6 @@ validator:
   registry_address: disabled
 
 ################################################################################
-##                         Ban manager configuration                          ##
-################################################################################
-banman:
-  max_failed_requests: 10
-  ban_duration: 86400
-
-################################################################################
 ##                               Node discovery                               ##
 ##                                                                            ##
 ## When the network first starts, we need to connect to some peers to learn   ##

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -43,13 +43,6 @@ validator:
   registry_address: disabled
 
 ################################################################################
-##                         Ban manager configuration                          ##
-################################################################################
-banman:
-  max_failed_requests: 10
-  ban_duration: 86400
-
-################################################################################
 ##                               Node discovery                               ##
 ##                                                                            ##
 ## When the network first starts, we need to connect to some peers to learn   ##

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -43,13 +43,6 @@ validator:
   registry_address: disabled
 
 ################################################################################
-##                         Ban manager configuration                          ##
-################################################################################
-banman:
-  max_failed_requests: 10
-  ban_duration: 86400
-
-################################################################################
 ##                               Node discovery                               ##
 ##                                                                            ##
 ## When the network first starts, we need to connect to some peers to learn   ##


### PR DESCRIPTION
Currently the BanManager is a tad too eager to ban nodes,
which is causing many issues, both in the live system and
the test-suite. While the underlying reason it's getting banned
might persist and still trigger the ban, it is much likely
to be less spurious with a higher limit.