### PR TITLE
Only update validators after the Genesis Block

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -525,8 +525,8 @@ public class Ledger
 
     protected void updateValidatorSet (in Block block) @safe
     {
-        this.enroll_man.clearExpiredValidators(block.header.height);
         this.enroll_man.updateValidatorIndexMaps(Height(block.header.height));
+        this.enroll_man.clearExpiredValidators(block.header.height);
         PublicKey pubkey = this.enroll_man.getEnrollmentPublicKey();
         UTXO[Hash] utxos = this.utxo_set.getUTXOs(pubkey);
         foreach (idx, ref enrollment; block.header.enrollments)

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -525,8 +525,12 @@ public class Ledger
 
     protected void updateValidatorSet (in Block block) @safe
     {
-        this.enroll_man.updateValidatorIndexMaps(Height(block.header.height));
-        this.enroll_man.clearExpiredValidators(block.header.height);
+        if (block.header.height > 0)
+            this.enroll_man.updateValidatorIndexMaps(block.header.height);
+
+        if (block.header.height >= this.params.ValidatorCycle)
+            this.enroll_man.clearExpiredValidators(block.header.height);
+
         PublicKey pubkey = this.enroll_man.getEnrollmentPublicKey();
         UTXO[Hash] utxos = this.utxo_set.getUTXOs(pubkey);
         foreach (idx, ref enrollment; block.header.enrollments)


### PR DESCRIPTION
Trivial fix to prevent calls to update validators for Genesis block. Updated to clear the validators after updating the indexes to prevent logged errors at validator block cycle height multiples.