### PR TITLE
Dockerfile: Copy the correct ldc-runtime in the runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ RUN AGORA_VERSION=${AGORA_VERSION} dub build --skip-registry=all --compiler=ldc2
 # Uses edge as we need the same `ldc-runtime` as the LDC that compiled Agora,
 # and `bpfk/agora-builder:latest` uses edge.
 FROM alpine:edge
-RUN apk --no-cache add ldc-runtime llvm-libunwind libgcc libsodium libstdc++ sqlite-libs
+COPY --from=Builder /root/packages/ /root/packages/
+RUN apk --no-cache add --allow-untrusted -X /root/packages/build/ ldc-runtime=1.25.1-r0 \
+    && rm -rf /root/packages/
+RUN apk --no-cache add llvm-libunwind libgcc libsodium libstdc++ sqlite-libs
 COPY --from=Builder /root/agora/build/agora /usr/local/bin/agora
 WORKDIR /agora/
 ENTRYPOINT [ "/usr/local/bin/agora" ]


### PR DESCRIPTION
```
We were compiling with the right compiler,
but since we were using the vanilla runtime,
we didn't get the fix we put in our fork.
```