### PR TITLE
Shut down timers while shutting down Agora

### DIFF
--- a/ci/system_integration_test.d
+++ b/ci/system_integration_test.d
@@ -24,7 +24,7 @@ immutable BuildImg = [ "docker", "build", "--build-arg", `DUB_OPTIONS=-b cov`,
                        "-t", "agora", RootPath, ];
 immutable TestContainer = [ "docker", "run", "agora", "--help", ];
 immutable DockerComposeUp = [ "docker-compose", "-f", ComposeFile, "up", "--abort-on-container-exit", ];
-immutable DockerComposeDown = [ "docker-compose", "-f", ComposeFile, "down", ];
+immutable DockerComposeDown = [ "docker-compose", "-f", ComposeFile, "down", "-t", "30", ];
 immutable DockerComposeLogs = [ "docker-compose", "-f", ComposeFile, "logs", "-t", ];
 immutable RunIntegrationTests = [ "dub", "--root", IntegrationPath, "--",
                                     "http://127.0.0.1:4000",

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -573,18 +573,18 @@ public class NetworkManager
     }
 
     /// Periodically registers network addresses
-    public void startPeriodicNameRegistration ()
+    public ITimer startPeriodicNameRegistration ()
     {
         this.registry_client = this.getNameRegistryClient(
             this.validator_config.registry_address, 2.seconds);
         if (this.registry_client is null)
-            return;
+            return null;
 
         this.onRegisterName();  // avoid delay
         // we re-register in every 2 minutes, in order to cope with the situation below
         // 1. network registry server is restarted
         // 2. client running agora node acquired some new IPs
-        this.taskman.setTimer(2.minutes, &this.onRegisterName, Periodic.Yes);
+        return this.taskman.setTimer(2.minutes, &this.onRegisterName, Periodic.Yes);
     }
 
     /// Discover the network, connect to all required peers

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -224,11 +224,12 @@ public class Validator : FullNode, API
         this.started = true;
         // Note: Switching the next two lines leads to test failure
         // It should not, and this needs to be fixed eventually
-        this.network.startPeriodicNameRegistration();
+        this.timers ~= this.network.startPeriodicNameRegistration();
         super.start();
 
         this.clock.startSyncing();
-        this.taskman.setTimer(this.config.validator.preimage_reveal_interval,
+        this.timers ~= this.taskman.setTimer(
+            this.config.validator.preimage_reveal_interval,
             &this.checkRevealPreimage, Periodic.Yes);
 
         if (this.config.admin.enabled)
@@ -253,7 +254,7 @@ public class Validator : FullNode, API
         {
             void discover () { this.network.discover(this.required_peer_keys); }
             discover();  // avoid delay
-            this.taskman.setTimer(5.seconds, &discover, Periodic.Yes);
+            this.timers ~= this.taskman.setTimer(5.seconds, &discover, Periodic.Yes);
         });
     }
 
@@ -420,7 +421,7 @@ public class Validator : FullNode, API
                     time_offset);
             },
             (Duration duration, void delegate() cb) nothrow @trusted
-                { this.taskman.setTimer(duration, cb, Periodic.Yes); });
+                { this.timers ~= this.taskman.setTimer(duration, cb, Periodic.Yes); });
     }
 
     /***************************************************************************

--- a/tests/system/docker-compose.yml
+++ b/tests/system/docker-compose.yml
@@ -78,5 +78,11 @@ services:
   faucet:
     image: "bpfk/faucet:latest"
     depends_on:
+      - node-0
+      - node-2
+      - node-3
+      - node-4
+      - node-5
+      - node-6
       - node-7
     command: http://node-7:7826


### PR DESCRIPTION
While this is unlikely to affect the live system,
it might have an effect in unittest where restarting nodes frequently fails.