### PR TITLE
NetworkManager: Filter our own key

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -185,7 +185,18 @@ public class NetworkManager
 
             const is_validator = key != PublicKey.init;
             if (is_validator)
+            {
+                if (key == this.outer.validator_config.key_pair.address)
+                {
+                    // either we connected to ourself, or someone else is pretending
+                    // to be us
+                    this.outer.connection_tasks.remove(address);
+                    this.outer.banman.ban(address);
+                    return;
+                }
+
                 log.info("Found new Validator: {} (key: {})", address, key);
+            }
             else
                 log.info("Found new FullNode: {}", address);
 

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -4,7 +4,7 @@
 node:
   # Run using test GenesisBlock and should use test addresses
   testing: true
-  min_listeners: 7
+  min_listeners: 6
   max_listeners: 10
   address: 0.0.0.0
   port:    2826

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -4,8 +4,7 @@
 node:
   # Run using test GenesisBlock and should use test addresses
   testing: true
-
-  min_listeners: 7
+  min_listeners: 6
   max_listeners: 10
   address: 0.0.0.0
   port:    3826

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -4,8 +4,7 @@
 node:
   # Run using test GenesisBlock and should use test addresses
   testing: true
-
-  min_listeners: 7
+  min_listeners: 6
   max_listeners: 10
   address: 0.0.0.0
   port:    4826

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -4,8 +4,7 @@
 node:
   # Run using test GenesisBlock and should use test addresses
   testing: true
-
-  min_listeners: 7
+  min_listeners: 6
   max_listeners: 10
   address: 0.0.0.0
   port:    5826

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -4,8 +4,7 @@
 node:
   # Run using test GenesisBlock and should use test addresses
   testing: true
-
-  min_listeners: 7
+  min_listeners: 6
   max_listeners: 10
   address: 0.0.0.0
   port:    6826

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -4,8 +4,7 @@
 node:
   # Run using test GenesisBlock and should use test addresses
   testing: true
-
-  min_listeners: 7
+  min_listeners: 6
   max_listeners: 10
   address: 0.0.0.0
   port:    7826


### PR DESCRIPTION
Something I've noticed during the Flash work. It's not an ideal solution as we should filter connecting to ourselves on the connection level. But at least it might help with the test-suite.