### PR TITLE
NetworkManager: Remove buggy getAddress/isOurOwnAddress

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -720,8 +720,7 @@ public class NetworkManager
 
     private bool shouldEstablishConnection (Address address)
     {
-        return !this.isOurOwnAddress(address) &&
-            !this.banman.isBanned(address) &&
+        return !this.banman.isBanned(address) &&
             address !in this.connected_peers &&
             address !in this.connection_tasks &&
             address !in this.todo_addresses;
@@ -740,12 +739,10 @@ public class NetworkManager
         if (this.shouldEstablishConnection(address))
             this.todo_addresses.put(address);
 
-        // we do not include our own address in list of known,
-        // however we do included banned addresses.
-        // reasoning: while *we* cannot establish a connection with
+        // We include banned addresses in known address,
+        // because while *we* cannot establish a connection with
         // a node it's possible other nodes in the network might be able to.
-        if (!this.isOurOwnAddress(address))
-            this.known_addresses.put(address);
+        this.known_addresses.put(address);
     }
 
     /***************************************************************************
@@ -1157,35 +1154,6 @@ public class NetworkManager
         log.trace("Gossip block signature {} for height #{} node {}",
             block_sig.signature, block_sig.height , block_sig.public_key);
         this.validators().each!(v => v.client.sendBlockSignature(block_sig));
-    }
-
-    /***************************************************************************
-
-        Params:
-            address = the address to check against ours
-
-        Returns:
-            true if the given address matches our own
-
-    ***************************************************************************/
-
-    private bool isOurOwnAddress (Address address)
-    {
-        return address == this.getAddress();
-    }
-
-    /***************************************************************************
-
-        Returns:
-            the address of this node (can be overriden in unittests)
-
-    ***************************************************************************/
-
-    protected string getAddress ()
-    {
-        // allocates, called infrequently though
-        return format("http://%s:%s", this.node_config.address,
-            this.node_config.port);
     }
 
     /***************************************************************************

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1194,12 +1194,6 @@ public class TestNetworkManager : NetworkManager
         this.nregistry = nreg;
     }
 
-    /// No "http://" in unittests, we just use the string as-is
-    protected final override string getAddress ()
-    {
-        return this.node_config.address;
-    }
-
     ///
     protected final override TestAPI getClient (Address address,
         Duration timeout)

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -30,7 +30,7 @@ unittest
     foreach (key, node; network.nodes)
     {
         auto addresses = node.client.getNodeInfo().addresses.keys;
-        assert(addresses.sort.uniq.count == GenesisValidators - 1,
+        assert(addresses.sort.uniq.count == GenesisValidators,
                format("Node %s has %d peers: %s", key, addresses.length, addresses));
     }
 }
@@ -54,7 +54,7 @@ unittest
     foreach (key, node; network.nodes)
     {
         auto addresses = node.client.getNodeInfo().addresses.keys;
-        assert(addresses.sort.uniq.count == 9,
+        assert(addresses.sort.uniq.count == 10,
                format("Node %s has %d peers: %s", key, addresses.length, addresses));
     }
 }
@@ -76,7 +76,7 @@ unittest
     foreach (key, node; network.nodes)
     {
         auto addresses = node.client.getNodeInfo().addresses.keys;
-        assert(addresses.sort.uniq.count == 5,
+        assert(addresses.sort.uniq.count == 6,
                format("Node %s has %d peers: %s", key, addresses.length, addresses));
     }
 }

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -101,7 +101,7 @@ unittest
     // current validators and previous validators except themselves.
     set_b.each!(node =>
         retryFor(node.getNodeInfo().addresses.length ==
-            GenesisValidators + conf.outsider_validators - 1,
+            GenesisValidators + conf.outsider_validators,
             5.seconds));
 
     // Make all the validators of the set A disable to respond


### PR DESCRIPTION
```
isOurOwnAddress was not working as intended, since it relied on getAddress,
which itself relied on the config value of 'node.address', which is not
our own address, but rather a netmask of interfaces to listen to.
The most value for this field is actually '0.0.0.0',
meaning we're listening on all available interfaces,
so we would never attempt to connect to 0.0.0.0.
```