### PR TITLE
Minor fixes around `SecretKey`

### DIFF
--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -85,6 +85,23 @@ public struct KeyPair
         KeyPair kp = KeyPair.fromSeed(Seed.fromString(seedStr));
     }
 
+    /***************************************************************************
+
+        Signs a message with this keypair's private key
+
+        Params:
+          msg = The message to sign
+
+        Returns:
+          The signature of `msg` using `this`
+
+    ***************************************************************************/
+
+    public Signature sign (scope const(ubyte)[] msg) const nothrow @nogc
+    {
+        return this.secret.sign(msg);
+    }
+
     /// Generate a new, random, keypair
     public static KeyPair random () @nogc
     {

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -788,7 +788,7 @@ public class NetworkManager
             }
         };
 
-        payload.signPayload(this.validator_config.key_pair.secret);
+        payload.signPayload(this.validator_config.key_pair);
 
         try
         {

--- a/source/agora/registry/API.d
+++ b/source/agora/registry/API.d
@@ -43,13 +43,13 @@ public struct RegistryPayload
     public Signature signature;
 
     ///
-    public void signPayload (const ref SecretKey secret_key) nothrow
+    public void signPayload (in SecretKey secret_key) nothrow
     {
         this.signature = secret_key.sign(hashFull(this.data)[]);
     }
 
     ///
-    public bool verifySignature (const ref PublicKey public_key) const nothrow @nogc @safe
+    public bool verifySignature (in PublicKey public_key) const nothrow @nogc @safe
     {
         return public_key.verify(this.signature, hashFull(this.data)[]);
     }

--- a/source/agora/registry/API.d
+++ b/source/agora/registry/API.d
@@ -43,13 +43,13 @@ public struct RegistryPayload
     public Signature signature;
 
     ///
-    public void signPayload(const ref SecretKey secret_key) nothrow
+    public void signPayload (const ref SecretKey secret_key) nothrow
     {
-        signature = secret_key.sign(hashFull(data)[]);
+        this.signature = secret_key.sign(hashFull(this.data)[]);
     }
 
     ///
-    public bool verifySignature(const ref PublicKey public_key) const nothrow @nogc @safe
+    public bool verifySignature (const ref PublicKey public_key) const nothrow @nogc @safe
     {
         return public_key.verify(this.signature, hashFull(this.data)[]);
     }

--- a/source/agora/registry/API.d
+++ b/source/agora/registry/API.d
@@ -43,9 +43,9 @@ public struct RegistryPayload
     public Signature signature;
 
     ///
-    public void signPayload (in SecretKey secret_key) nothrow
+    public void signPayload (in KeyPair kp) nothrow
     {
-        this.signature = secret_key.sign(hashFull(this.data)[]);
+        this.signature = kp.sign(hashFull(this.data)[]);
     }
 
     ///


### PR DESCRIPTION
As mentioned in #1702 we should remove `SecretKey`. Those commits aim in that direction, by clearing up the field around it (removing one of the only direct usage), along with some little style fixes found along the way.