### PR TITLE
Tests: Use improved addNewNode instead of repeating its code

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -758,13 +758,35 @@ public class TestAPIManager
             this.addNewNode!TestFullNode(conf, file, line);
     }
 
-    /// Convenience templated function to be called from overriding classes
-    public TestAPI addNewNode (NodeType : TestAPI) (
-        Config conf, string file = __FILE__, int line = __LINE__)
+    /***************************************************************************
+
+        Convenience templated function to be called from overriding classes
+
+        Params:
+          conf = The configuration for this node (usually forwarded from
+                 within `createNewNode`)
+          eArgs = The arguments `NodeType` has which are after `TestFullNode`'s
+                  (or `TestValidatorNode`'s) constructor arguments.
+          file = File this function is called for, forwarded to localrest for
+                 better debugging output.
+          line = Line this function is called for, forwarded to localrest for
+                 better debugging output.
+
+        Note:
+          The "extra arguments" parameter, `eArgs`, makes a few assumptions
+          which might not hold in the future, most importantly:
+          - `TestFullNode` and `TestValidatorNode` have the same ctor args;
+          - Arguments for `NodeType` are in the same order as its parent;
+
+    ***************************************************************************/
+
+    public TestAPI addNewNode (NodeType : TestAPI) (Config conf,
+        Parameters!(NodeType.__ctor)[Parameters!(TestValidatorNode.__ctor).length .. $] eArgs,
+        string file = __FILE__, int line = __LINE__)
     {
         auto time = new shared(TimePoint)(this.initial_time);
         auto api = RemoteAPI!TestAPI.spawn!NodeType(conf, &this.reg, &this.nreg,
-            this.blocks, this.test_conf, time,
+            this.blocks, this.test_conf, time, eArgs,
             conf.node.timeout, file, line);
 
         this.reg.register(conf.node.address, api.listener());

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -182,9 +182,7 @@ private class ByzantineManager (bool addSpyValidator = false,
     {
         if (this.nodes.length < byzantine_not_signing_count + byzantine_bad_signing_count)
         {
-            auto time = new shared(TimePoint)(this.initial_time);
             assert(conf.validator.enabled);
-            RemoteAPI!TestAPI node;
             if (this.nodes.length < byzantine_not_signing_count)
                 this.addNewNode!(ByzantineNode!(ByzantineReason.NotSigningEnvelope))
                     (conf, file, line);
@@ -195,15 +193,7 @@ private class ByzantineManager (bool addSpyValidator = false,
         else
             // Add spying validator as last node
             if (addSpyValidator && this.nodes.length == GenesisValidators - 1)
-            {
-                auto time = new shared(TimePoint)(this.initial_time);
-                assert(conf.validator.enabled);
-                auto node = RemoteAPI!TestAPI.spawn!SpyingValidator(
-                    conf, &this.reg, &this.nreg, this.blocks, this.test_conf,
-                    time, &this.envelope_type_counts);
-                this.reg.register(conf.node.address, node.ctrl.listener());
-                this.nodes ~= NodePair(conf.node.address, node, time);
-            }
+                this.addNewNode!SpyingValidator(conf, &this.envelope_type_counts, file, line);
             else
                 super.createNewNode(conf, file, line);
     }

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -70,14 +70,7 @@ private class SameKeyNodeAPIManager : TestAPIManager
     public override void createNewNode (Config conf, string file, int line)
     {
         if (this.nodes.length == 0)
-        {
-            auto time = new shared(TimePoint)(this.initial_time);
-            auto api = RemoteAPI!TestAPI.spawn!SameKeyValidator(
-                conf, &this.reg, &this.nreg, this.blocks, this.test_conf,
-                time, conf.node.timeout);
-            this.reg.register(conf.node.address, api.ctrl.listener());
-            this.nodes ~= NodePair(conf.node.address, api, time);
-        }
+            this.addNewNode!SameKeyValidator(conf, file, line);
         else
             super.createNewNode(conf, file, line);
     }

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -299,14 +299,7 @@ unittest
         public override void createNewNode (Config conf, string file, int line)
         {
             if (this.nodes.length == 0)
-            {
-                auto time = new shared(TimePoint)(this.initial_time);
-                auto api = RemoteAPI!TestAPI.spawn!MisbehavingValidator(
-                    conf, &this.reg, &this.nreg, this.blocks, this.test_conf,
-                    time, &this.runCount, conf.node.timeout);
-                this.reg.register(conf.node.address, api.ctrl.listener());
-                this.nodes ~= NodePair(conf.node.address, api, time);
-            }
+                this.addNewNode!MisbehavingValidator(conf, &this.runCount, file, line);
             else
                 super.createNewNode(conf, file, line);
         }

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -132,14 +132,7 @@ unittest
         public override void createNewNode (Config conf, string file, int line)
         {
             if (this.nodes.length == 5)
-            {
-                auto time = new shared(TimePoint)(this.initial_time);
-                auto api = RemoteAPI!TestAPI.spawn!NoPreImageVN(
-                    conf, &this.reg, &this.nreg, this.blocks, this.test_conf,
-                    time, conf.node.timeout);
-                this.reg.register(conf.node.address, api.ctrl.listener());
-                this.nodes ~= NodePair(conf.node.address, api, time);
-            }
+                this.addNewNode!NoPreImageVN(conf, file, line);
             else
                 super.createNewNode(conf, file, line);
         }
@@ -182,23 +175,9 @@ unittest
         public override void createNewNode (Config conf, string file, int line)
         {
             if (this.nodes.length == 0)
-            {
-                auto time = new shared(TimePoint)(this.initial_time);
-                auto api = RemoteAPI!TestAPI.spawn!NoPreImageVN(
-                    conf, &this.reg, &this.nreg, this.blocks, this.test_conf,
-                    time, conf.node.timeout);
-                this.reg.register(conf.node.address, api.ctrl.listener());
-                this.nodes ~= NodePair(conf.node.address, api, time);
-            }
+                this.addNewNode!NoPreImageVN(conf, file, line);
             else if (this.nodes.length == 5)
-            {
-                auto time = new shared(TimePoint)(this.initial_time);
-                auto api = RemoteAPI!TestAPI.spawn!BadNominatingVN(
-                    conf, &this.reg, &this.nreg, this.blocks, this.test_conf,
-                    time, conf.node.timeout);
-                this.reg.register(conf.node.address, api.ctrl.listener());
-                this.nodes ~= NodePair(conf.node.address, api, time);
-            }
+                this.addNewNode!BadNominatingVN(conf, file, line);
             else
                 super.createNewNode(conf, file, line);
         }

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -88,14 +88,7 @@ unittest
         public override void createNewNode (Config conf, string file, int line)
         {
             if (this.nodes.length == 0)
-            {
-                auto time = new shared(TimePoint)(this.initial_time);
-                auto api = RemoteAPI!TestAPI.spawn!CustomValidator(
-                    conf, &this.reg, &this.nreg, this.blocks, this.test_conf,
-                    time, conf.node.timeout);
-                this.reg.register(conf.node.address, api.ctrl.listener());
-                this.nodes ~= NodePair(conf.node.address, api, time);
-            }
+                this.addNewNode!CustomValidator(conf, file, line);
             else
                 super.createNewNode(conf, file, line);
         }

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -119,34 +119,19 @@ unittest
         /// see base class
         public override void createNewNode (Config conf, string file, int line)
         {
-            RemoteAPI!TestAPI api;
-            auto time = new shared(TimePoint)(this.initial_time);
-
             // the test has 8 nodes:
             // 6 validators => used for creating blocks
+            // 1 good FullNode => it accepts only the valid blockchain
             // 1 byzantine FullNode => lies about the blockchain
             //   (returns syntactically invalid data)
-            // 1 good FullNode => it accepts only the valid blockchain
-            if (conf.validator.enabled)
-            {
-                api = RemoteAPI!TestAPI.spawn!TestValidatorNode(
-                    conf, &this.reg, &this.nreg, this.blocks, this.test_conf,
-                    time, conf.node.timeout);
-            }
+            if (this.nodes.length <= 6)
+                super.createNewNode(conf, file, line);
             else
             {
-                if (this.nodes.length == 6)  // 7th good FN, 8th bad FN
-                    api = RemoteAPI!TestAPI.spawn!TestFullNode(conf,
-                        &this.reg, &this.nreg, this.blocks, this.test_conf,
-                        time, conf.node.timeout);
-                else
-                    api = RemoteAPI!TestAPI.spawn!BadNode(conf,
-                        &this.reg, &this.nreg, this.blocks, this.test_conf,
-                        time, conf.node.timeout);
+                assert(this.nodes.length == 7);
+                assert(conf.validator.enabled == false);
+                this.addNewNode!BadNode(conf, file, line);
             }
-
-            this.reg.register(conf.node.address, api.ctrl.listener());
-            this.nodes ~= NodePair(conf.node.address, api, time);
         }
     }
 

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -130,12 +130,8 @@ unittest
         {
             if (this.nodes.length == 0)
             {
-                auto time = new shared(TimePoint)(this.initial_time);
-                auto api = RemoteAPI!TestAPI.spawn!ReValidator(
-                    conf, &this.reg, &this.nreg, this.blocks, this.test_conf, time);
-                this.reg.register(conf.node.address, api.ctrl.listener());
-                this.nodes ~= NodePair(conf.node.address, api, time);
                 assert(conf.validator.enabled);
+                this.addNewNode!ReValidator(conf, file, line);
             }
             else
                 super.createNewNode(conf, file, line);

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -95,7 +95,6 @@ private class NoPreImageVN : TestValidatorNode
 ///     validators with the 10K of the fund going to the `CommonsBudget` address.
 unittest
 {
-    import agora.script.Lock;
     static class BadAPIManager : TestAPIManager
     {
         public static shared bool reveal_preimage = false;
@@ -106,14 +105,7 @@ unittest
         public override void createNewNode (Config conf, string file, int line)
         {
             if (this.nodes.length == 5)
-            {
-                auto time = new shared(TimePoint)(this.initial_time);
-                auto api = RemoteAPI!TestAPI.spawn!NoPreImageVN(
-                    conf, &this.reg, &this.nreg, this.blocks, this.test_conf,
-                    time, &reveal_preimage, conf.node.timeout);
-                this.reg.register(conf.node.address, api.ctrl.listener());
-                this.nodes ~= NodePair(conf.node.address, api, time);
-            }
+                this.addNewNode!NoPreImageVN(conf, &reveal_preimage, file, line);
             else
                 super.createNewNode(conf, file, line);
         }
@@ -191,14 +183,7 @@ unittest
         public override void createNewNode (Config conf, string file, int line)
         {
             if (conf.validator.enabled == true)
-            {
-                auto time = new shared(TimePoint)(this.initial_time);
-                auto api = RemoteAPI!TestAPI.spawn!NoPreImageVN(
-                    conf, &this.reg, &this.nreg, this.blocks, this.test_conf,
-                    time, &this.reveal_preimage, conf.node.timeout);
-                this.reg.register(conf.node.address, api.ctrl.listener());
-                this.nodes ~= NodePair(conf.node.address, api, time);
-            }
+                this.addNewNode!NoPreImageVN(conf, &this.reveal_preimage, file, line);
             else
                 super.createNewNode(conf, file, line);
         }


### PR DESCRIPTION
This makes the code more DRY and generic.
We probably should factor the pattern of having only one node
injected in the network as well, but we'll leave that for another commit.