### PR TITLE
Minor: Improve error message for self-slashing ConsensusData

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -809,7 +809,8 @@ extern(D):
 
             if (this.ledger.checkSelfSlashing(data))
             {
-                log.error("validateValue(): Slasing itself");
+                log.warn("validateValue(): Marking {} for data slashing us as invalid",
+                         nomination ? "nomination" : "vote");
                 return ValidationLevel.kInvalidValue;
             }
 


### PR DESCRIPTION
Since there was a typo in the message ('Slasing'),
might as well reword the log message to be less scary,
and decrease it to 'warn' as it *could* be triggered under normal circumstances,
but still should be checked by the node operator.