### PR TITLE
Issue1658 prevent nodes signing multiple blocks at the same height

### DIFF
--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -73,10 +73,18 @@ public struct Height
         return Height(this.value++);
     }
 
-    /// Allow to offset an height by a fixed number
+    /// Allow to offset height by an addition of a fixed number
     public Height opBinary (string op : "+") (ulong offset) const
     {
         return Height(this.value + offset);
+    }
+
+    /// Allow to offset height by a subtraction of a fixed number
+    public Height opBinary (string op : "-") (ulong offset) const
+    {
+        import std.conv : to;
+        assert(this.value - offset >= 0, "Attempt to subtract" ~ offset.to!string ~ " from height " ~ this.value.to!string);
+        return Height(this.value - offset);
     }
 
     /// Allow to offset an height by a fixed number

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -805,6 +805,53 @@ public class EnrollmentManager
 
     /***************************************************************************
 
+        Get the pre-image hash for this validator
+
+        Params:
+            enroll_key = UTXO enrollemnt key
+            height = the block height of pre-image to be returned
+
+        Returns:
+            The preimage hash if found otherwise Hash.init
+
+    ***************************************************************************/
+
+    public Hash getPreimage (in Height height) @safe nothrow
+    {
+        return this.cycle[height];
+    }
+
+    /// Ditto
+    public Hash getPreimage (in PublicKey public_key, in Height height) @safe nothrow
+    {
+        return this.getPreimage(getEnrollmentForKey(public_key), height);
+    }
+
+    /// Ditto
+    public Hash getPreimage (in Hash enroll_key, in Height height) @safe nothrow
+    {
+        return this.validator_set.getPreimageAt(enroll_key, height).hash;
+    }
+
+    /***************************************************************************
+
+        Get the UTXO key enrollemnt for a validator
+
+        Params:
+            public_key = the public key of the validator
+
+        Returns:
+            UTXO enrollemnt key
+
+    ***************************************************************************/
+
+    public Hash getEnrollmentForKey (in PublicKey public_key) @safe nothrow
+    {
+        return this.validator_set.getEnrollmentForKey(public_key);
+    }
+
+    /***************************************************************************
+
         Get the public key of node that is used for a enrollment
 
         Returns:

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -539,7 +539,7 @@ version (unittest)
     public Block makeNewTestBlock (Transactions)(const ref Block prev_block,
         Transactions txs, Hash random_seed = Hash.init,
         Enrollment[] enrollments = null, uint[] missing_validators = null,
-        KeyPair[] keys = genesis_validator_keys,
+        KeyPair[] key_pairs = genesis_validator_keys,
         ulong delegate (PublicKey) cycleForValidator = (PublicKey k) => defaultCycleZero(k),
         ulong time_offset = 0) @safe nothrow
     {
@@ -553,7 +553,7 @@ version (unittest)
         auto block = makeNewBlock(prev_block, txs,
                 time_offset ? time_offset : prev_block.header.time_offset + 1,
                 random_seed, enrollments, missing_validators);
-        return multiSigTestBlock(block, cycleForValidator, keys);
+        return multiSigTestBlock(block, cycleForValidator, key_pairs);
     }
 }
 

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -153,7 +153,8 @@ public class Ledger
         EnrollmentManager enroll_man, TransactionPool pool,
         FeeManager fee_man, Clock clock,
         Duration block_time_offset_tolerance = 60.seconds,
-        void delegate (in Block, bool) @safe onAcceptedBlock = null)
+        void delegate (in Block, bool) @safe onAcceptedBlock = null,
+        string file = __FILE__, size_t line = __LINE__)
     {
         this.log = Logger(__MODULE__);
         this.params = params;
@@ -191,10 +192,10 @@ public class Ledger
                 Block block = this.storage.readBlock(Height(height));
 
                 // Make sure our data on disk is valid
-                if (auto fail_reason = this.validateBlock(block))
+                if (auto fail_reason = this.validateBlock(block, file, line))
                     throw new Exception(
-                        "A block loaded from disk is invalid: " ~
-                        fail_reason);
+                        format!"[%s:%s]: A block loaded from disk is invalid: %s"
+                        (file, line, fail_reason));
 
                 this.addValidatedBlock(block);
             }
@@ -1001,10 +1002,11 @@ public class ValidatingLedger : Ledger
         EnrollmentManager enroll_man, TransactionPool pool,
         FeeManager fee_man, Clock clock,
         Duration block_timestamp_tolerance,
-        void delegate (in Block, bool) @safe onAcceptedBlock)
+        void delegate (in Block, bool) @safe onAcceptedBlock,
+        string file = __FILE__, size_t line = __LINE__)
     {
         super(params, engine, utxo_set, storage, enroll_man, pool, fee_man,
-            clock, block_timestamp_tolerance, onAcceptedBlock);
+            clock, block_timestamp_tolerance, onAcceptedBlock, file, line);
     }
 
     /***************************************************************************

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -303,9 +303,6 @@ public class Ledger
         Params:
             header = block header to be updated
 
-        Returns:
-            true if the block was updated
-
     ***************************************************************************/
 
     public void updateBlockMultiSig (in BlockHeader header) @safe

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1109,34 +1109,35 @@ public class TestAPIManager
 
         Params:
             client_idxs = client indices for the nodes to be checked
-            height = expected block height of the nodes
+            to_height = expected block height of the nodes
+            from_height = start of range for comparing the blocks
 
     ***************************************************************************/
 
-    void assertSameBlocks (Height height,
+    void assertSameBlocks (Height to_height, Height from_height = Height(0),
         string file = __FILE__, int line = __LINE__)
     {
-        assertSameBlocks(iota(GenesisValidators), height, file, line);
+        assertSameBlocks(iota(GenesisValidators), to_height, from_height, file, line);
     }
 
     /// Ditto
-    void assertSameBlocks (Idxs)(Idxs client_idxs, Height height,
-        string file = __FILE__, int line = __LINE__)
+    void assertSameBlocks (Idxs)(Idxs client_idxs, Height to_height,
+        Height from_height = Height(0), string file = __FILE__, int line = __LINE__)
     {
         static assert (isInputRange!Idxs);
 
         client_idxs.each!(idx =>
-            retryFor(Height(this.clients[idx].getBlockHeight()) == height,
+            retryFor(Height(this.clients[idx].getBlockHeight()) == to_height,
                 5.seconds,
                 format!"[%s:%s] Expected height %s for client #%s not %s"
-                    (file, line, height, idx,
+                    (file, line, to_height, idx,
                         this.clients[idx].getBlockHeight())));
 
         retryFor(client_idxs.map!(idx =>
             this.clients[idx].getAllBlocks()).uniq().count() == 1,
             5.seconds,
-            format!"[%s:%s] Clients %s blocks are not all the same: %s"
-                (file, line, client_idxs, client_idxs.fold!((s, i) =>
+            format!"[%s:%s] Clients %s blocks are not all the same from block %s to %s: %s"
+                (file, line, client_idxs, from_height, to_height, client_idxs.fold!((s, i) =>
                     s ~ format!"\n\n========== Client #%s ==========%s"
                         (i, prettify(this.clients[i].getAllBlocks())))("")));
     }

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -68,19 +68,20 @@ private extern(C++) class BadBlockSigningNominator : TestNominator
     {
         import agora.crypto.Hash;
 
+        const Hash preimage = "preimage".hashFull();
         // challenge = Hash(block) to Scalar
         const Scalar challenge = hashFull(block);
         final switch (reason)
         {
             case ByzantineReason.BadCommitmentR:
                 const Scalar rc = Scalar.random(); // This is normally the enrollment commitment
-                const Scalar r = rc + challenge;
+                const Scalar r = rc + Scalar(preimage);
                 const Point R = r.toPoint();
                 return sign(this.kp.secret, R, r, challenge);
             case ByzantineReason.BadSignature:
                 const Scalar rc = Scalar(hashMulti(WK.Keys.NODE2.secret,
                     "consensus.signature.noise", 0));
-                const Scalar r = rc + challenge;
+                const Scalar r = rc + Scalar(preimage);
                 const Point R = r.toPoint();
                 // Sign with random in place of validator secret key
                 const wrong_scalar_v = Scalar.random();

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -112,7 +112,8 @@ unittest
             super(args);
             this.ledger = new PickyLedger(params, this.engine, this.utxo_set, this.storage,
                 this.enroll_man, this.pool, this.fee_man, this.clock,
-                this.config.node.block_time_offset_tolerance, &this.onAcceptedBlock);
+                this.config.node.block_time_offset_tolerance, &this.onAcceptedBlock,
+                __FILE__, __LINE__);
         }
 
         public override void putTransaction (Transaction tx) @safe

--- a/source/agora/test/Simple.d
+++ b/source/agora/test/Simple.d
@@ -46,8 +46,33 @@ unittest
     network.expectHeight(Height(1));
     network.assertSameBlocks(iota(network.nodes.length), Height(1));
 
-    // Now create blocks until after the end of the first validator cycle
-    auto target_height = Height(GenesisValidatorCycle + 2);
+    // Now create blocks until one block before the end of the first validator cycle
+    auto target_height = Height(GenesisValidatorCycle - 1);
     network.generateBlocks(target_height);
     network.assertSameBlocks(target_height);
+
+    // Now create last block of the first validator cycle
+    target_height++;
+    network.generateBlocks(target_height);
+    network.assertSameBlocks(target_height, target_height - 1);
+
+    // Now create first 2 blocks of the next validator cycle
+    target_height += 2;
+    network.generateBlocks(target_height);
+    network.assertSameBlocks(target_height, target_height - 2);
+
+    // Now create last block of the second validator cycle
+    target_height += 17;
+    network.generateBlocks(target_height);
+    network.assertSameBlocks(target_height, target_height - 17);
+
+    // Now create last block of the second validator cycle
+    target_height++;
+    network.generateBlocks(target_height);
+    network.assertSameBlocks(target_height, target_height - 1);
+
+    // Now create first 2 blocks of the third validator cycle
+    target_height += 2;
+    network.generateBlocks(target_height);
+    network.assertSameBlocks(target_height, target_height - 2);
 }


### PR DESCRIPTION
This creates noise `r` for block signing for each node by adding `rc` to `preimage` reduced to Scalar.