### PR TITLE
Tasks: Separate Vibe.d implementation from the interface

### DIFF
--- a/source/agora/cli/client/GenTxProcess.d
+++ b/source/agora/cli/client/GenTxProcess.d
@@ -19,7 +19,7 @@ import agora.api.FullNode;
 import agora.client.Result;
 import agora.common.Amount;
 import agora.common.crypto.Key;
-import agora.common.Task;
+import agora.common.VibeTask;
 import agora.common.Types;
 import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
@@ -147,7 +147,7 @@ public int genTxProcess (string[] args, ref string[] outputs,
     // connect to the node
     string ip_address = format("http://%s:%s", op.host, op.port);
     auto node = api_maker(ip_address);
-    auto taskman = new TaskManager;
+    auto taskman = new VibeTaskManager;
     auto last_block = node.getBlocksFrom(node.getBlockHeight(), 1)[0];
     auto txs = last_block.spendable().take(op.count)
                          .map!(txb => txb.split(

--- a/source/agora/common/VibeTask.d
+++ b/source/agora/common/VibeTask.d
@@ -1,0 +1,76 @@
+/*******************************************************************************
+
+    Contains a task manager backed by vibe.d's event loop.
+
+    Copyright:
+        Copyright (c) 2019-2021 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.common.VibeTask;
+
+public import agora.common.Task;
+
+static import vibe.core.core;
+
+import std.stdio;
+import core.time;
+
+/// Exposes primitives to run tasks through Vibe.d
+public final class VibeTaskManager : ITaskManager
+{
+    ///
+    public override void runTask (void delegate() dg) nothrow
+    {
+        this.tasks_started++;
+        vibe.core.core.runTask(dg);
+    }
+
+    ///
+    public override void wait (Duration dur) nothrow
+    {
+        try
+            vibe.core.core.sleep(dur);
+        catch (Exception exc)
+        {
+            this.log.fatal("Call to wait({}) failed: {}", dur, exc);
+            // TODO: Replace with a busy loop in non-debug mode ?
+            assert(0);
+        }
+    }
+
+    ///
+    public override ITimer setTimer (Duration timeout, void delegate() dg,
+        Periodic periodic = Periodic.No) nothrow
+    {
+        this.tasks_started++;
+        assert(dg !is null, "Cannot call this delegate if null");
+        return new VibedTimer(vibe.core.core.setTimer(timeout, dg, periodic));
+    }
+}
+
+/*******************************************************************************
+
+    Vibe.d timer
+
+*******************************************************************************/
+
+private final class VibedTimer : ITimer
+{
+    private vibe.core.core.Timer timer;
+
+    public this (vibe.core.core.Timer timer) @safe nothrow
+    {
+        this.timer = timer;
+    }
+
+    /// Ditto
+    public override void stop () @safe nothrow
+    {
+        this.timer.stop();
+    }
+}

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -91,7 +91,7 @@ public extern (C++) class Nominator : SCPDriver
     public PublicKey node_public_key;
 
     /// Task manager
-    private TaskManager taskman;
+    private ITaskManager taskman;
 
     /// Ledger instance
     protected ValidatingLedger ledger;
@@ -154,7 +154,7 @@ extern(D):
 
     public this (immutable(ConsensusParams) params, KeyPair key_pair,
         Clock clock, NetworkManager network, ValidatingLedger ledger,
-        EnrollmentManager enroll_man, TaskManager taskman, string data_dir)
+        EnrollmentManager enroll_man, ITaskManager taskman, string data_dir)
     {
         this.params = params;
         this.clock = clock;

--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -68,7 +68,7 @@ public class Channel
     private Engine engine;
 
     /// Task manager to spawn fibers with
-    public TaskManager taskman;
+    public ITaskManager taskman;
 
     /// The peer of the other end of the channel
     public FlashAPI peer;
@@ -227,7 +227,7 @@ public class Channel
 
     public this (in ChannelConfig conf, in Pair kp, PrivateNonce priv_nonce,
         PublicNonce peer_nonce, FlashAPI peer, Engine engine,
-        TaskManager taskman, void delegate (Transaction) txPublisher,
+        ITaskManager taskman, void delegate (Transaction) txPublisher,
         PaymentRouter paymentRouter,
         void delegate (ChannelConfig conf) onChannelOpen,
         void delegate (Hash, Hash, ErrorCode) onPaymentComplete,

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -73,7 +73,7 @@ public abstract class ThinFlashNode : FlashNode
     ***************************************************************************/
 
     public this (const Pair kp, Hash genesis_hash, Engine engine,
-        TaskManager taskman, string agora_address)
+        ITaskManager taskman, string agora_address)
     {
         Duration timeout;  // infinite timeout (todo: fixup)
         this.agora_node = this.getAgoraClient(agora_address, timeout);
@@ -197,7 +197,7 @@ public class AgoraFlashNode : FlashNode
     ***************************************************************************/
 
     public this (const Pair kp, Hash genesis_hash, Engine engine,
-        TaskManager taskman, FullNodeAPI agora_node,
+        ITaskManager taskman, FullNodeAPI agora_node,
         FlashAPI delegate (in Point, Duration) flashClientGetter)
     {
         this.agora_node = agora_node;
@@ -275,7 +275,7 @@ public abstract class FlashNode : ControlFlashAPI
     protected Engine engine;
 
     /// for scheduling
-    protected TaskManager taskman;
+    protected ITaskManager taskman;
 
     /// Channels which are pending and not accepted yet.
     /// Once the channel handshake is complete and only after the funding
@@ -333,7 +333,7 @@ public abstract class FlashNode : ControlFlashAPI
     ***************************************************************************/
 
     public this (const Pair kp, Hash genesis_hash, Engine engine,
-        TaskManager taskman)
+        ITaskManager taskman)
     {
         this.genesis_hash = genesis_hash;
         this.engine = engine;

--- a/source/agora/flash/UpdateSigner.d
+++ b/source/agora/flash/UpdateSigner.d
@@ -58,7 +58,7 @@ public class UpdateSigner
     private Engine engine;
 
     /// Task manager
-    private TaskManager taskman;
+    private ITaskManager taskman;
 
     /// Sequence ID we're trying to sign for
     /// Todo: we should also have some kind of incremental ID to be able to
@@ -134,7 +134,7 @@ public class UpdateSigner
     ***************************************************************************/
 
     public this (in ChannelConfig conf, in Pair kp, FlashAPI peer,
-        Point peer_pk, Engine engine, TaskManager taskman)
+        Point peer_pk, Engine engine, ITaskManager taskman)
     {
         this.conf = conf;
         this.kp = kp;

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -121,7 +121,7 @@ public class NetworkClient
     private const size_t max_retries;
 
     /// Task manager
-    private TaskManager taskman;
+    private ITaskManager taskman;
 
     /// Ban manager
     private BanManager banman;
@@ -152,7 +152,7 @@ public class NetworkClient
 
     ***************************************************************************/
 
-    public this (TaskManager taskman, BanManager banman, Address address,
+    public this (ITaskManager taskman, BanManager banman, Address address,
         API api, Duration retry, size_t max_retries)
     {
         this.taskman = taskman;

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -335,7 +335,7 @@ public class NetworkManager
     protected const ConsensusConfig consensus_config = ConsensusConfig.init;
 
     /// Task manager
-    private TaskManager taskman;
+    private ITaskManager taskman;
 
     /// Never-ending address discovery task
     protected AddressDiscoveryTask discovery_task;
@@ -382,7 +382,7 @@ public class NetworkManager
     private enum MaxConnectionTasks = 10;
 
     /// Ctor
-    public this (in Config config, Metadata metadata, TaskManager taskman, Clock clock)
+    public this (in Config config, Metadata metadata, ITaskManager taskman, Clock clock)
     {
         this.taskman = taskman;
         this.node_config = config.node;
@@ -1135,7 +1135,7 @@ public class NetworkManager
 
     ***************************************************************************/
 
-    public NetworkClient getNetworkClient (TaskManager taskman,
+    public NetworkClient getNetworkClient (ITaskManager taskman,
         BanManager banman, Address address, API api, Duration retry,
         size_t max_retries)
     {

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -34,7 +34,7 @@ import agora.common.Metadata;
 import agora.common.crypto.Key;
 import agora.serialization.Serializer;
 import agora.common.Set;
-import agora.common.Task;
+import agora.common.VibeTask;
 import agora.common.Types;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Params;
@@ -104,7 +104,7 @@ public class FullNode : API
     protected immutable(ConsensusParams) params;
 
     /// Task manager
-    protected TaskManager taskman;
+    protected ITaskManager taskman;
 
     /// Clock instance
     protected Clock clock;
@@ -514,7 +514,7 @@ public class FullNode : API
     ***************************************************************************/
 
     protected NetworkManager getNetworkManager (Metadata metadata,
-        TaskManager taskman, Clock clock)
+        ITaskManager taskman, Clock clock)
     {
         return new NetworkManager(this.config, metadata, taskman, clock);
     }
@@ -531,9 +531,9 @@ public class FullNode : API
 
     ***************************************************************************/
 
-    protected TaskManager getTaskManager ()
+    protected ITaskManager getTaskManager ()
     {
-        return new TaskManager();
+        return new VibeTaskManager();
     }
 
     /***************************************************************************
@@ -549,7 +549,7 @@ public class FullNode : API
 
     ***************************************************************************/
 
-    protected Clock getClock (TaskManager taskman)
+    protected Clock getClock (ITaskManager taskman)
     {
         // non-synchronizing clock (for now)
         return new Clock(

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -394,7 +394,7 @@ public class Validator : FullNode, API
     ***************************************************************************/
 
     protected Nominator getNominator (Clock clock, NetworkManager network,
-        ValidatingLedger ledger, EnrollmentManager enroll_man, TaskManager taskman)
+        ValidatingLedger ledger, EnrollmentManager enroll_man, ITaskManager taskman)
     {
         return new Nominator(
             this.params, this.config.validator.key_pair, clock, network, ledger,
@@ -415,7 +415,7 @@ public class Validator : FullNode, API
 
     ***************************************************************************/
 
-    protected override Clock getClock (TaskManager taskman)
+    protected override Clock getClock (ITaskManager taskman)
     {
         return new Clock((out long time_offset)
             {

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -334,7 +334,7 @@ public alias RemoteAPI (APIType) = geod24.LocalRest.RemoteAPI!(APIType, Serializ
 
 *******************************************************************************/
 
-public class LocalRestTaskManager : TaskManager
+public class LocalRestTaskManager : ITaskManager
 {
     static import geod24.LocalRest;
 
@@ -1223,7 +1223,7 @@ public class TestNetworkManager : NetworkManager
 
     ///
     protected final override TestNetworkClient getNetworkClient (
-        TaskManager taskman, BanManager banman, Address address,
+        ITaskManager taskman, BanManager banman, Address address,
         ValidatorAPI api, Duration retry, size_t max_retries)
     {
         return new TestNetworkClient(taskman, banman, address, api, retry,
@@ -1450,14 +1450,14 @@ private mixin template TestNodeMixin ()
     }
 
     /// Return a LocalRest-backed task manager
-    protected override TaskManager getTaskManager ()
+    protected override ITaskManager getTaskManager ()
     {
         return new LocalRestTaskManager();
     }
 
     /// Return an instance of the custom TestNetworkManager
     protected override NetworkManager getNetworkManager (
-        Metadata metadata, TaskManager taskman, Clock clock)
+        Metadata metadata, ITaskManager taskman, Clock clock)
     {
         assert(taskman !is null);
         return new TestNetworkManager(
@@ -1503,7 +1503,7 @@ public class TestClock : Clock
     private shared(TimePoint)* cur_time;
 
     ///
-    public this (TaskManager taskman, GetNetTimeOffset getNetTimeOffset,
+    public this (ITaskManager taskman, GetNetTimeOffset getNetTimeOffset,
         shared(TimePoint)* cur_time)
     {
         super(getNetTimeOffset,
@@ -1548,7 +1548,7 @@ public class TestFullNode : FullNode, TestAPI
     }
 
     /// Provides a unittest-adjusted clock source for the node
-    protected override TestClock getClock (TaskManager taskman)
+    protected override TestClock getClock (ITaskManager taskman)
     {
         return new TestClock(this.taskman,
             (out long time_offset) { return true; }, this.cur_time);
@@ -1659,7 +1659,7 @@ public class TestValidatorNode : Validator, TestAPI
     }
 
     /// Provides a unittest-adjusted clock source for the node
-    protected override TestClock getClock (TaskManager taskman)
+    protected override TestClock getClock (ITaskManager taskman)
     {
         return new TestClock(this.taskman,
             (out long time_offset)


### PR DESCRIPTION
Ideally, we should be able to completely ignore Vibe.d when
building the test target, provided all usages of Vibe.d have
been properly abstracted.
This is currently not possible for a number of reasons,
including the fact that the API and the implementations depend on Vibe.d.
Separating the `TaskManager` gives us one less reason.