### PR TITLE
Remove duplicated 'sign' method from SecretKey

### DIFF
--- a/source/agora/cli/client/SendTxProcess.d
+++ b/source/agora/cli/client/SendTxProcess.d
@@ -280,7 +280,7 @@ unittest
     };
     Hash send_txhash = hashFull(tx);
     auto key_pair = KeyPair.fromSeed(Seed.fromString(key));
-    tx.inputs[0].unlock = genKeyUnlock(key_pair.secret.sign(send_txhash[]));
+    tx.inputs[0].unlock = genKeyUnlock(key_pair.sign(send_txhash[]));
 
     foreach (ref line; outputs)
         writeln(line);

--- a/source/agora/common/crypto/Key.d
+++ b/source/agora/common/crypto/Key.d
@@ -99,7 +99,8 @@ public struct KeyPair
 
     public Signature sign (scope const(ubyte)[] msg) const nothrow @nogc
     {
-        return this.secret.sign(msg);
+        return agora.crypto.Schnorr.sign(
+            Pair(this.secret.data, this.address.data), msg);
     }
 
     /// Generate a new, random, keypair
@@ -352,23 +353,6 @@ public struct SecretKey
         import ocean.text.convert.Formatter : ocean_format = format;
         assert(phobos_format("%s", sk) == "**SECRET**");
         assert(ocean_format("{}", sk) == "**SECRET**");
-    }
-
-    /***************************************************************************
-
-        Signs a message with this private key
-
-        Params:
-          msg = The message to sign
-
-        Returns:
-          The signature of `msg` using `this`
-
-    ***************************************************************************/
-
-    public Signature sign (scope const(ubyte)[] msg) const nothrow @nogc
-    {
-        return agora.crypto.Schnorr.sign(Pair.fromScalar(this.data), msg);
     }
 }
 

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -634,7 +634,7 @@ unittest
         tx = Transaction(TxType.Payment, [Input(last_hash, 0)],[Output(Amount(100_000), key_pairs[idx+1].address)]);
         last_hash = hashFull(tx);
         tx.inputs[0].unlock = genKeyUnlock(
-            key_pairs[idx].secret.sign(last_hash[]));
+            key_pairs[idx].sign(last_hash[]));
         txs ~= tx;
     }
 

--- a/source/agora/node/admin/QRCodeInterface.d
+++ b/source/agora/node/admin/QRCodeInterface.d
@@ -108,7 +108,7 @@ public class QRCodeInterface
         );
 
         login_info.voter_card.signature =
-            this.key_pair.secret.sign(hashFull(login_info.voter_card)[]);
+            this.key_pair.sign(hashFull(login_info.voter_card)[]);
 
         res.headers["Content-Type"] = "image/svg+xml";
         res.headers["Vary"] = "Accept-Encoding";

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -91,7 +91,7 @@ unittest
                 last_block = block;
             }
 
-            auto signTx (Transaction tx) @trusted { return prev_key.secret.sign(hashFull(tx)[]); }
+            auto signTx (Transaction tx) @trusted { return prev_key.sign(hashFull(tx)[]); }
 
             foreach (block1; blocks)
             {


### PR DESCRIPTION
Since KeyPair is aimed at being the replacement for Pair,
we should only expose the 'sign' primitive here.
This way, we prevent re-generating the public key every time
we sign.