### PR TITLE
Nominator: Use a KeyPair instead of crypto's Pair

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -85,7 +85,7 @@ public extern (C++) class Nominator : SCPDriver
     private NetworkManager network;
 
     /// Key pair of this node
-    public KeyPair kp;
+    protected KeyPair kp;
 
     /// Task manager
     private ITaskManager taskman;

--- a/source/agora/crypto/Key.d
+++ b/source/agora/crypto/Key.d
@@ -97,7 +97,7 @@ public struct KeyPair
 
     ***************************************************************************/
 
-    public Signature sign (scope const(ubyte)[] msg) const nothrow @nogc
+    public Signature sign (T) (in T msg) const nothrow @nogc
     {
         return agora.crypto.Schnorr.sign(
             Pair(this.secret.data, this.address.data), msg);

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -306,13 +306,13 @@ public class Validator : FullNode, API
         // Make sure the indexes are up to date
         this.nominator.enroll_man.updateValidatorIndexMaps(block.header.height);
         auto node_validator_index = this.nominator.enroll_man
-            .getIndexOfValidator(block.header.height, this.nominator.schnorr_pair.V);
+            .getIndexOfValidator(block.header.height, this.nominator.kp.address);
 
         // It can be a block before this validator was enrolled
         if (node_validator_index == ulong.max)
         {
             log.trace("This validator {} was not active at height {}",
-                this.nominator.node_public_key, block.header.height);
+                this.nominator.kp.address, block.header.height);
             return this.ledger.acceptBlock(block);
         }
         assert(node_validator_index < validators, format!"The validator index %s is invalid"(node_validator_index));
@@ -321,13 +321,13 @@ public class Validator : FullNode, API
             log.trace("This node's signature is already in the block signature");
             // Gossip this signature as it may have been only shared via ballot signing
             this.network.gossipBlockSignature(ValidatorBlockSig(block.header.height,
-                this.nominator.node_public_key, sig.s));
+                this.nominator.kp.address, sig.s));
         }
         else
         {
             signed_validators[node_validator_index] = true;
             this.network.gossipBlockSignature(ValidatorBlockSig(block.header.height,
-                this.nominator.node_public_key, sig.s));
+                this.nominator.kp.address, sig.s));
             log.trace("Periodic Catchup: ADD to block signature R: {} and s: {}",
                 sig.R, sig.s.toString(PrintMode.Clear));
             const signed_block = block.updateSignature(

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -306,13 +306,13 @@ public class Validator : FullNode, API
         // Make sure the indexes are up to date
         this.nominator.enroll_man.updateValidatorIndexMaps(block.header.height);
         auto node_validator_index = this.nominator.enroll_man
-            .getIndexOfValidator(block.header.height, this.nominator.kp.address);
+            .getIndexOfValidator(block.header.height, this.config.validator.key_pair.address);
 
         // It can be a block before this validator was enrolled
         if (node_validator_index == ulong.max)
         {
             log.trace("This validator {} was not active at height {}",
-                this.nominator.kp.address, block.header.height);
+                this.config.validator.key_pair.address, block.header.height);
             return this.ledger.acceptBlock(block);
         }
         assert(node_validator_index < validators, format!"The validator index %s is invalid"(node_validator_index));
@@ -321,13 +321,13 @@ public class Validator : FullNode, API
             log.trace("This node's signature is already in the block signature");
             // Gossip this signature as it may have been only shared via ballot signing
             this.network.gossipBlockSignature(ValidatorBlockSig(block.header.height,
-                this.nominator.kp.address, sig.s));
+                this.config.validator.key_pair.address, sig.s));
         }
         else
         {
             signed_validators[node_validator_index] = true;
             this.network.gossipBlockSignature(ValidatorBlockSig(block.header.height,
-                this.nominator.kp.address, sig.s));
+                this.config.validator.key_pair.address, sig.s));
             log.trace("Periodic Catchup: ADD to block signature R: {} and s: {}",
                 sig.R, sig.s.toString(PrintMode.Clear));
             const signed_block = block.updateSignature(

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -79,7 +79,7 @@ private extern(C++) class ByzantineNominator : TestNominator
         final switch (reason)
         {
             case ByzantineReason.BadSigningEnvelope:
-                envelope.signature = sign(this.schnorr_pair,
+                envelope.signature = this.kp.sign(
                     Hash.fromString(
                         "0x412ce227771d98240ffb0015ae49349670eded40267865c18f655db662d4e698f" ~
                         "7caa4fcffdc5c068a07532637cf5042ae39b7af418847385480e620e1395986"));

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -76,7 +76,7 @@ private extern(C++) class BadBlockSigningNominator : TestNominator
                 const Scalar rc = Scalar.random(); // This is normally the enrollment commitment
                 const Scalar r = rc + challenge;
                 const Point R = r.toPoint();
-                return Sig(R, multiSigSign(r, this.schnorr_pair.v, challenge));
+                return Sig(R, multiSigSign(r, this.kp.secret, challenge));
             case ByzantineReason.BadSignature:
                 const Scalar rc = Scalar(hashMulti(WK.Keys.NODE2.secret,
                     "consensus.signature.noise", 0));


### PR DESCRIPTION
```
The former is intended to be used in Agora, and is a wrapper around the former.
This also removes the duplication between the pair and node_public_key.
```

The middle commit was the main intent. In the process, I realized that `sign` should take more than just an array of bytes (which will unblock #1765) and that the keypair was used from `node.Validator` (??), so both issues were fixed.