### PR TITLE
Flash: Store a KeyPair instead of a Pair

### DIFF
--- a/source/agora/node/FlashFullNode.d
+++ b/source/agora/node/FlashFullNode.d
@@ -237,9 +237,8 @@ public class FlashFullNode : FullNode, FlashFullNodeAPI
         assert(this.config.flash.enabled);
         assert(!this.config.validator.enabled);
 
-        immutable kp = Pair(this.config.flash.key_pair.secret,
-            this.config.flash.key_pair.secret.toPoint);
-        this.flash = new AgoraFlashNode(kp, hashFull(this.params.Genesis),
+        this.flash = new AgoraFlashNode(this.config.flash.key_pair,
+            hashFull(this.params.Genesis),
             this.engine, this.taskman, this, &this.getFlashClient);
     }
 

--- a/source/agora/node/FlashValidator.d
+++ b/source/agora/node/FlashValidator.d
@@ -89,9 +89,8 @@ public class FlashValidator : Validator, FlashValidatorAPI
         assert(this.config.flash.enabled);
         assert(this.config.validator.enabled);
 
-        immutable kp = Pair(this.config.validator.key_pair.secret,
-            this.config.validator.key_pair.secret.toPoint);
-        this.flash = new AgoraFlashNode(kp, hashFull(this.params.Genesis),
+        this.flash = new AgoraFlashNode(this.config.validator.key_pair,
+            hashFull(this.params.Genesis),
             this.engine, this.taskman, this, &this.getFlashClient);
     }
 


### PR DESCRIPTION
We're moving away from `Pair`, and using `KeyPair` everywhere now,
since it contains the component of a `Pair` itself.
To keep the diff reviewable, this only affect places where `Pair`
was used. A later change will use `PublicKey` instead of `Point`.