### PR TITLE
Flash tests: Kill timer on shutdown()

### DIFF
--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -78,6 +78,9 @@ public interface TestFlashAPI : ControlFlashAPI
 
     /// Print out the contents of the log
     public abstract void printLog ();
+
+    /// Shut down any timers (forwards to ThinFlashNode.shutdown)
+    public void shutdownNode ();
 }
 
 /// A thin localrest flash node which itself is not a FullNode / Validator
@@ -100,6 +103,12 @@ public class TestFlashNode : ThinFlashNode, TestFlashAPI
         const TestStackMaxItemSize = 512;
         auto engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
         super(kp, genesis_hash, engine, new LocalRestTaskManager(), agora_address);
+    }
+
+    ///
+    public override void shutdownNode ()
+    {
+        super.shutdown();  // kill timers
     }
 
     ///
@@ -274,7 +283,10 @@ public class FlashNodeFactory
             enforce(this.flash_registry.unregister(address.to!string));
 
         foreach (node; this.nodes)
+        {
+            node.shutdownNode();
             node.ctrl.shutdown();
+        }
     }
 }
 


### PR DESCRIPTION
Small fixup for a loose timer in the tests.

Actually I think we have a similar problem with other non-flash tests. If we have two nodes and call `.shutdown` on each of them this will stop the timers for each node in turn, but it can't happen at the exact same time. So the second node's timer might just happen to wake up at the same time and try to call the first node (which has now been shut down). I've seen this in tests.

I think the proper fix for all the tests is to handle connection losses gracefully.