### PR TITLE
NameRegistry: Use alpine:edge to build image

### DIFF
--- a/Dockerfile.NameRegistry
+++ b/Dockerfile.NameRegistry
@@ -8,7 +8,7 @@ RUN dub --version
 RUN AGORA_VERSION=${AGORA_VERSION} dub build --skip-registry=all --compiler=ldc2 --config name-registry
 
 # Runner
-FROM alpine:3.12.0
+FROM alpine:edge
 RUN apk --no-cache add ldc-runtime llvm-libunwind libgcc libsodium libstdc++ sqlite-libs
 COPY --from=RegistryBuilder /root/agora/build/name-registry /usr/local/bin/name-registry
 WORKDIR /name-registry/


### PR DESCRIPTION
We get a long log of symbol-related errors. This is preventing the `name-registry` from starting.
```
Mar 12 00:04:34 eu-001.bosagora.io docker[221700]: Error relocating /usr/local/bin/name-registry: _D4core9exception16OutOfMemoryError6__vtblZ: symbol not found
Mar 12 00:04:34 eu-001.bosagora.io docker[221700]: Error relocating /usr/local/bin/name-registry: _D4core9exception16OutOfMemoryError7__ClassZ: symbol not found
Mar 12 00:04:35 eu-001.bosagora.io systemd[1]: name-registry.service: Main process exited, code=exited, status=127/n/a
Mar 12 00:04:35 eu-001.bosagora.io systemd[1]: name-registry.service: Failed with result 'exit-code'.
```
I am assuming it's due to the outdated compiler.