### PR TITLE
Improve utility for vanity key mining

### DIFF
--- a/source/agora/cli/vanity/dub.json
+++ b/source/agora/cli/vanity/dub.json
@@ -7,6 +7,7 @@
     "mainSourceFile": "main.d",
     "importPaths": [ "../../../" ],
     "sourceFiles": [
+        "../../common/Types.d",
         "../../crypto/Crc16.d",
         "../../crypto/Key.d"
     ],


### PR DESCRIPTION
```
- Use Pair instead of KeyPair, ensuring we get correct Scalars;
- Use an extra array of boolean to avoid piggybacking on the first byte;
- Add support for special names (nodes, genesis, commons);
```