### PR TITLE
KeyPair: Remove Seed type, always use SecretKey

### DIFF
--- a/source/agora/cli/client/SendTxProcess.d
+++ b/source/agora/cli/client/SendTxProcess.d
@@ -182,7 +182,7 @@ public int sendTxProcess (string[] args, ref string[] outputs,
         return CLIENT_INVALID_ARGUMENTS;
 
     // create the transaction
-    auto key_pair = KeyPair.fromSeed(Seed.fromString(op.key));
+    auto key_pair = KeyPair.fromSeed(SecretKey.fromString(op.key));
 
     Transaction tx =
     {
@@ -277,7 +277,7 @@ unittest
         [Output(Amount(amount), PublicKey.fromString(address))]
     };
     Hash send_txhash = hashFull(tx);
-    auto key_pair = KeyPair.fromSeed(Seed.fromString(key));
+    auto key_pair = KeyPair.fromSeed(SecretKey.fromString(key));
     tx.inputs[0].unlock = genKeyUnlock(key_pair.sign(send_txhash[]));
 
     foreach (ref line; outputs)

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -578,7 +578,7 @@ private ValidatorConfig parseValidatorConfig (Node* node, in CommandLine cmdln)
     ValidatorConfig result = {
         enabled: true,
         key_pair:
-            KeyPair.fromSeed(Seed.fromString(get!(string, "validator", "seed")(cmdln, node))),
+            KeyPair.fromSeed(SecretKey.fromString(get!(string, "validator", "seed")(cmdln, node))),
         registry_address: registry_address,
         addresses_to_register : assumeUnique(parseSequence("addresses_to_register", cmdln, *node, true)),
         recurring_enrollment : recurring_enrollment,
@@ -597,7 +597,7 @@ private FlashConfig parseFlashConfig (Node* node, in CommandLine cmdln,
 
     immutable KeyPair kp = validator_config.enabled
         ? validator_config.key_pair
-        : KeyPair.fromSeed(Seed.fromString(get!(string, "flash", "seed")(
+        : KeyPair.fromSeed(SecretKey.fromString(get!(string, "flash", "seed")(
             cmdln, node)));
 
     const bool testing = opt!(bool, "flash", "testing")(cmdln, node);
@@ -633,7 +633,7 @@ validator:
         assert(config.enabled);
         assert(config.preimage_reveal_interval == 99.seconds);
         assert(config.key_pair == KeyPair.fromSeed(
-            Seed.fromString("SCT4KKJNYLTQO4TVDPVJQZEONTVVW66YLRWAINWI3FZDY7U4JS4JJEI4")));
+            SecretKey.fromString("SCT4KKJNYLTQO4TVDPVJQZEONTVVW66YLRWAINWI3FZDY7U4JS4JJEI4")));
         assert(!config.recurring_enrollment);
     }
     {

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1390,7 +1390,7 @@ private struct SCPEnvelopeHash
     () @trusted
     {
         auto seed = "SAI4SRN2U6UQ32FXNYZSXA5OIO6BYTJMBFHJKX774IGS2RHQ7DOEW5SJ";
-        auto pair = KeyPair.fromSeed(Seed.fromString(seed));
+        auto pair = KeyPair.fromSeed(SecretKey.fromString(seed));
         auto msg = getStHash().hashFull();
         env.signature = Signature("0x000000000000000000016f605ea9638d7bff58d2c0c" ~
                               "c2467c18e38b36367be78000000000000000000016f60" ~

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -443,7 +443,7 @@ unittest
     ballot.counter = 42;
     ballot.value = cd.serializeFull[].toVec();
 
-    auto pair = KeyPair.fromSeed(Seed.fromString("SCFPAX2KQEMBHCG6SJ77YTHVOYKUVHEFDROVFCKTZUG7Z6Q5IKSNG6NQ"));
+    auto pair = KeyPair.fromSeed(SecretKey.fromString("SCFPAX2KQEMBHCG6SJ77YTHVOYKUVHEFDROVFCKTZUG7Z6Q5IKSNG6NQ"));
 
     auto qc = QuorumConfig(2,
         [PublicKey.fromString("GBFDLGQQDDE2CAYVELVPXUXR572ZT5EOTMGJQBPTIHSLPEOEZYQQCEWN"),


### PR DESCRIPTION
```
Part of 1773, this removes a structure which is now almost unused.
The only important piece of functionality was the ability to pretty-print
the seed string, as well as parse it, and has been moved to SecretKey.
```

@linked0 : That should also make it easier for you to implement Bech32.