### PR TITLE
Remove serialize hook on PublicKey

### DIFF
--- a/source/agora/crypto/Key.d
+++ b/source/agora/crypto/Key.d
@@ -206,20 +206,6 @@ public struct PublicKey
             "GDD5RFGBIUAFCOXQA246BOUPHCK7ZL2NSHDU7DVAPNPTJJKVPJMNLQFF"));
     }
 
-    /***************************************************************************
-
-        Key Serialization
-
-        Params:
-            dg = Serialize function
-
-    ***************************************************************************/
-
-    public void serialize (scope SerializeDg dg) const @safe
-    {
-        dg(this.data[]);
-    }
-
     ///
     unittest
     {


### PR DESCRIPTION
Since PublicKey has a known size, we can always serialize it
as a static array instead of a dynamic one.