### PR TITLE
Simplify PreImageCycle to not require the secret when seeking

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -152,15 +152,7 @@ public class EnrollmentManager
         assert(params !is null);
         this.params = params;
         this.key_pair = key_pair;
-        this.cycle = PreImageCycle(
-            /* nounce: */ 0,
-            /* index:  */ 0,
-            /* seeds:  */ PreImageCache(PreImageCycle.NumberOfCycles,
-                this.params.ValidatorCycle),
-            // Since those pre-images might be accessed often,
-            // use an interval of 1 (no interval)
-            /* preimages: */ PreImageCache(this.params.ValidatorCycle, 1)
-        );
+        this.cycle = PreImageCycle(params.ValidatorCycle);
 
         this.db = new ManagedDatabase(db_path);
         this.validator_set = new ValidatorSet(this.db, params);
@@ -1263,9 +1255,7 @@ unittest
     Enrollment[] ordered_enrollments;
     foreach (idx, kp; pairs[0 .. 3])
     {
-        auto cycle = PreImageCycle(
-            0, 0, PreImageCache(PreImageCycle.NumberOfCycles, params.ValidatorCycle),
-            PreImageCache(params.ValidatorCycle, 1));
+        auto cycle = PreImageCycle(params.ValidatorCycle);
         const seed = cycle.populate(kp.secret, true);
         auto enroll = EnrollmentManager.makeEnrollment(
             kp, utxo_hashes[idx], params.ValidatorCycle,
@@ -1397,13 +1387,7 @@ unittest
 
     // Note: This was copied from `EnrollmentManager` constructor and should
     // be kept in sync with it
-    auto cycle = PreImageCycle(
-        /* nounce: */ 0,
-        /* index:  */ 0,
-        /* seeds:  */ PreImageCache(PreImageCycle.NumberOfCycles,
-            params.ValidatorCycle),
-        /* preimages: */ PreImageCache(params.ValidatorCycle, 1)
-    );
+    auto cycle = PreImageCycle(params.ValidatorCycle);
 
     auto secret = Scalar.random();
     Scalar fake_secret; // Used whenever `secret` *shouldn't* be used
@@ -1489,9 +1473,7 @@ unittest
     Enrollment[] enrollments;
     foreach (idx, kp; pairs[0 .. 3])
     {
-        auto cycle = PreImageCycle(
-            0, 0, PreImageCache(PreImageCycle.NumberOfCycles, params.ValidatorCycle),
-            PreImageCache(params.ValidatorCycle, 1));
+        auto cycle = PreImageCycle(params.ValidatorCycle);
         const seed = cycle.populate(kp.secret, true);
         auto enroll = EnrollmentManager.makeEnrollment(
             kp, utxo_hashes[idx], params.ValidatorCycle,
@@ -1656,9 +1638,7 @@ unittest
 
     foreach (idx, kp; pairs)
     {
-        auto cycle = PreImageCycle(
-            0, 0, PreImageCache(PreImageCycle.NumberOfCycles, params.ValidatorCycle),
-            PreImageCache(params.ValidatorCycle, 1));
+        auto cycle = PreImageCycle(params.ValidatorCycle);
 
         const seed = cycle.populate(kp.secret, true);
         const enroll = EnrollmentManager.makeEnrollment(

--- a/source/agora/consensus/PreImage.d
+++ b/source/agora/consensus/PreImage.d
@@ -284,13 +284,37 @@ unittest
 
 public struct PreImageCycle
 {
+    /// Make sure we get initializedby disabling the default ctor
+    @disable public this ();
+
+    /// Construct an instance with the provided cycle length
+    public this (uint cycle_length) @safe nothrow
+    {
+        this.impl = PreImageCycleImpl(
+            /* nonce: */ 0,
+            /* index: */ 0,
+            /* seeds: */ PreImageCache(PreImageCycleImpl.NumberOfCycles, cycle_length),
+            /* preimages: */ PreImageCache(cycle_length, 1),
+        );
+    }
+
+    ///
+    public alias impl this;
+
+    ///
+    public PreImageCycleImpl impl;
+}
+
+/// Ditto
+public struct PreImageCycleImpl
+{
     @safe nothrow:
 
     /// Make sure we get initialized by disabling the default ctor
     @disable public this ();
 
     /// Re-introduce the all-parameter default ctor
-    public this (typeof(PreImageCycle.tupleof) args) pure @nogc
+    public this (typeof(PreImageCycleImpl.tupleof) args) pure @nogc
     {
         this.tupleof = args;
     }
@@ -475,14 +499,14 @@ unittest
 {
     const ValidatorCycle = 2;
     auto secret = Scalar.random();
-    auto pop_cycle = PreImageCycle(
+    auto pop_cycle = PreImageCycleImpl(
             /* nonce: */ 0,
             /* index:  */ 0,
             /* seeds:  */ PreImageCache(PreImageCycle.NumberOfCycles,
                 ValidatorCycle),
             /* preimages: */ PreImageCache(ValidatorCycle, 1)
         );
-    auto seek_cycle = PreImageCycle(
+    auto seek_cycle = PreImageCycleImpl(
             /* nonce: */ 0,
             /* index:  */ 0,
             /* seeds:  */ PreImageCache(PreImageCycle.NumberOfCycles,

--- a/source/agora/consensus/SlashPolicy.d
+++ b/source/agora/consensus/SlashPolicy.d
@@ -335,7 +335,7 @@ unittest
     PreImageCache[] caches;
     foreach (idx, kp; pairs)
     {
-        auto cycle = PreImageCycle(params.ValidatorCycle);
+        auto cycle = PreImageCycle(kp.secret, params.ValidatorCycle);
         const seed = cycle.populate(kp.secret, true);
         caches ~= cycle.preimages;
         auto enroll = EnrollmentManager.makeEnrollment(

--- a/source/agora/consensus/SlashPolicy.d
+++ b/source/agora/consensus/SlashPolicy.d
@@ -335,10 +335,7 @@ unittest
     PreImageCache[] caches;
     foreach (idx, kp; pairs)
     {
-        auto cycle = PreImageCycle(
-                0, 0,
-                PreImageCache(PreImageCycle.NumberOfCycles, params.ValidatorCycle),
-                PreImageCache(params.ValidatorCycle, 1));
+        auto cycle = PreImageCycle(params.ValidatorCycle);
         const seed = cycle.populate(kp.secret, true);
         caches ~= cycle.preimages;
         auto enroll = EnrollmentManager.makeEnrollment(

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -220,15 +220,7 @@ unittest
                                         &validator_set.findRecentEnrollment));
 
     const utxoPeek = &utxo_set.peekUTXO;
-    auto cycle = PreImageCycle(
-        /* nounce: */ 0,
-        /* index:  */ 0,
-        /* seeds:  */ PreImageCache(PreImageCycle.NumberOfCycles,
-                                    params.ValidatorCycle),
-        // Since those pre-images might be accessed often,
-        // use an interval of 1 (no interval)
-        /* preimages: */ PreImageCache(params.ValidatorCycle, 1)
-    );
+    auto cycle = PreImageCycle(params.ValidatorCycle);
 
     enroll1.utxo_key = utxo_hash1;
     enroll1.random_seed = cycle.getPreImage(key_pairs[0].secret, Height(0));

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -220,10 +220,10 @@ unittest
                                         &validator_set.findRecentEnrollment));
 
     const utxoPeek = &utxo_set.peekUTXO;
-    auto cycle = PreImageCycle(params.ValidatorCycle);
+    auto cycle = PreImageCycle(key_pairs[0].secret, params.ValidatorCycle);
 
     enroll1.utxo_key = utxo_hash1;
-    enroll1.random_seed = cycle.getPreImage(key_pairs[0].secret, Height(0));
+    enroll1.random_seed = cycle[Height(0)];
     enroll1.cycle_length = params.ValidatorCycle;
     enroll1.enroll_sig = sign(node_key_pair_1, signature_noise, enroll1);
 
@@ -236,8 +236,7 @@ unittest
     // First 2 iterations should fail because commitment is wrong
     foreach (offset; [-1, +1, 0])
     {
-        enroll1.random_seed = cycle.getPreImage(key_pairs[0].secret,
-                                        Height(params.ValidatorCycle + offset));
+        enroll1.random_seed = cycle[Height(params.ValidatorCycle + offset)];
         enroll1.enroll_sig = sign(node_key_pair_1, signature_noise, enroll1);
         assert((offset == 0) == (validator_set.add(Height(params.ValidatorCycle),
                             utxoPeek, enroll1, key_pairs[0].address) is null));

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -1723,10 +1723,7 @@ unittest
     auto pairs = iota(4).map!(idx => WK.Keys[idx]).array;
     foreach (idx, kp; pairs)
     {
-        auto cycle = PreImageCycle(
-                0, 0,
-                PreImageCache(PreImageCycle.NumberOfCycles, params.ValidatorCycle),
-                PreImageCache(params.ValidatorCycle, 1));
+        auto cycle = PreImageCycle(params.ValidatorCycle);
         const seed = cycle.populate(kp.secret, true);
         caches ~= cycle.preimages;
         auto enroll = EnrollmentManager.makeEnrollment(
@@ -1826,10 +1823,7 @@ unittest
         UTXO stake;
         assert(ledger.utxo_set.peekUTXO(key, stake));
         KeyPair kp = WK.Keys[stake.output.address];
-        auto cycle = PreImageCycle(
-            0, 0,
-            PreImageCache(PreImageCycle.NumberOfCycles, params.ValidatorCycle),
-            PreImageCache(params.ValidatorCycle, 1));
+        auto cycle = PreImageCycle(params.ValidatorCycle);
         const preimage = PreImageInfo(key,
             cycle.getPreImage(kp.secret, Height(params.ValidatorCycle)),
                 cast (ushort) (params.ValidatorCycle));

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -1723,7 +1723,7 @@ unittest
     auto pairs = iota(4).map!(idx => WK.Keys[idx]).array;
     foreach (idx, kp; pairs)
     {
-        auto cycle = PreImageCycle(params.ValidatorCycle);
+        auto cycle = PreImageCycle(kp.secret, params.ValidatorCycle);
         const seed = cycle.populate(kp.secret, true);
         caches ~= cycle.preimages;
         auto enroll = EnrollmentManager.makeEnrollment(
@@ -1823,9 +1823,8 @@ unittest
         UTXO stake;
         assert(ledger.utxo_set.peekUTXO(key, stake));
         KeyPair kp = WK.Keys[stake.output.address];
-        auto cycle = PreImageCycle(params.ValidatorCycle);
-        const preimage = PreImageInfo(key,
-            cycle.getPreImage(kp.secret, Height(params.ValidatorCycle)),
+        auto cycle = PreImageCycle(kp.secret, params.ValidatorCycle);
+        const preimage = PreImageInfo(key, cycle[Height(params.ValidatorCycle)],
                 cast (ushort) (params.ValidatorCycle));
 
         ledger.enroll_man.addPreimage(preimage);


### PR DESCRIPTION
Looking at how `PreImageCycle` was used (in order to get #1662 merged), it was obvious that this has grown a bit too cumbersome. Something that stood out is that `populate` is actually not used. Prior to removing it, I simplified a bit the way we were using this struct.