### PR TITLE
Flash tests: wait for channel gossiping

### DIFF
--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -588,7 +588,7 @@ unittest
     charlie.waitChannelOpen(bob_charlie_chan_id);
     /+++++++++++++++++++++++++++++++++++++++++++++/
 
-    /+ CHARLIE BOB => ALICE CHANNEL +/
+    /+ OPEN CHARLIE => ALICE CHANNEL +/
     /+++++++++++++++++++++++++++++++++++++++++++++/
     // the utxo the funding tx will spend (only relevant to the funder)
     const charlie_utxo = UTXO.getHash(hashFull(txs[2]), 0);


### PR DESCRIPTION
I'm pretty sure this is the root cause of https://github.com/bpfkorea/agora/issues/1772.

Obviously retries should be put in place as well. But for now this should fix the tests.