### PR TITLE
Setup interface: Require user to provide bind address

### DIFF
--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -49,8 +49,8 @@ public struct CommandLine
     /// Path to the config file
     public string config_path = "config.yaml";
 
-    /// Whether or not we want to initialize this node
-    public bool initialize = false;
+    /// If non-`null`, what address to bind the setup interface to
+    public string initialize;
 
     /// check state of config file and exit early
     public bool config_check;
@@ -260,7 +260,7 @@ public GetoptResult parseCommandLine (ref CommandLine cmdline, string[] args)
     return getopt(
         args,
         "initialize",
-            "The node will offer a web-based configuration interface at 127.0.0.1:2827",
+            "The address at which to offer a web-based configuration interface",
             &cmdline.initialize,
 
         "config|c",

--- a/source/agora/node/admin/Setup.d
+++ b/source/agora/node/admin/Setup.d
@@ -28,6 +28,7 @@ import vibe.data.json;
 import vibe.http.fileserver;
 import vibe.http.router;
 import vibe.http.server;
+import vibe.inet.url;
 import vibe.stream.operations;
 
 import std.format;
@@ -71,10 +72,10 @@ public class SetupInterface
     }
 
     /// Start listening for requests
-    public void start ()
+    public void start (URL url)
     {
-        auto settings = new HTTPServerSettings("127.0.0.1");
-        settings.port = 2827;
+        auto settings = new HTTPServerSettings(url.host);
+        settings.port = url.port;
         auto router = new URLRouter;
         router.post("/check", &this.handleCheck);
         router.match(HTTPMethod.OPTIONS, "*", &this.handleAllOptions);


### PR DESCRIPTION
This slightly degrades UX, but the admin interface is not something
that will be used often. It also allows to support any use case,
such as starting it wrong within the container.