### PR TITLE
Renamed different overloads of expectBlock

### DIFF
--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -74,7 +74,7 @@ unittest
 
     genBlockTransactions(1).each!(tx => nodes[0].putTransaction(tx));
     // wait until the transactions were gossiped
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 
 
     // full node will be banned if it cannot communicate
@@ -91,7 +91,7 @@ unittest
         auto new_tx = genBlockTransactions(1);
         left_txs ~= new_tx;
         new_tx.each!(tx => nodes[0].putTransaction(tx));
-        network.expectBlock(iota(0, 4), Height(1 + block_idx + 1));
+        network.expectHeight(iota(0, 4), Height(1 + block_idx + 1));
         retryFor(nodes[full_node_idx].getBlockHeight() == 1, 1.seconds,
             format!"Expected Full node height of exactly 1 not %s"(nodes[full_node_idx].getBlockHeight()));
     }
@@ -113,5 +113,5 @@ unittest
     auto new_tx = genBlockTransactions(1);
     left_txs ~= new_tx;
     new_tx.each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(6));
+    network.expectHeight(Height(6));
 }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -600,15 +600,15 @@ public class TestAPIManager
 
     ***************************************************************************/
 
-    public void expectBlock (Height height, Duration timeout = 10.seconds,
+    public void expectHeight (Height height, Duration timeout = 10.seconds,
         string file = __FILE__, int line = __LINE__)
     {
-        this.expectBlock(iota(this.clients.length), height, timeout,
+        this.expectHeight(iota(this.clients.length), height, timeout,
             file, line);
     }
 
     /// Ditto
-    public void expectBlock (Idxs)(Idxs clients_idxs, Height height,
+    public void expectHeight (Idxs)(Idxs clients_idxs, Height height,
         Duration timeout = 10.seconds,
         string file = __FILE__, int line = __LINE__)
     {
@@ -638,16 +638,16 @@ public class TestAPIManager
 
     ***************************************************************************/
 
-    public void expectBlock (Height height, const(BlockHeader) enroll_header,
+    public void expectHeightAndPreImg (Height height, const(BlockHeader) enroll_header,
         Duration timeout = 10.seconds,
         string file = __FILE__, int line = __LINE__)
     {
-        this.expectBlock(iota(GenesisValidators), height, enroll_header,
+        this.expectHeightAndPreImg(iota(GenesisValidators), height, enroll_header,
             timeout, file, line);
     }
 
     /// Ditto
-    public void expectBlock (Idxs)(Idxs clients_idxs, Height height,
+    public void expectHeightAndPreImg (Idxs)(Idxs clients_idxs, Height height,
         const(BlockHeader) enroll_header, Duration timeout = 10.seconds,
         string file = __FILE__, int line = __LINE__)
     {
@@ -657,7 +657,7 @@ public class TestAPIManager
         auto distance = cast(ushort)(height - enroll_header.height - 1);
         waitForPreimages(clients_idxs, enroll_header.enrollments,
             distance, timeout);
-        this.expectBlock(clients_idxs, height, timeout, file, line);
+        this.expectHeight(clients_idxs, height, timeout, file, line);
     }
 
     /***************************************************************************
@@ -1049,7 +1049,7 @@ public class TestAPIManager
                 (file, line, enrolled_height));
         // Check block is at target height for the participating clients
         const enroll_block = first_client.getBlock(enrolled_height);
-        expectBlock(client_idxs, target_height,
+        expectHeightAndPreImg(client_idxs, target_height,
             enroll_block.header, 10.seconds, file, line);
     }
 

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -213,7 +213,7 @@ unittest
     assert(node_1.getQuorumConfig().threshold == 6); // We should need all 6 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 }
 
 /// Block should be added if we have 5 of 6 valid signatures (1 not signing the envelope)
@@ -231,7 +231,7 @@ unittest
     assert(node_1.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 }
 
 /// Block should be added if we have 5 of 6 valid signatures (1 signs envelope with invalid signature)
@@ -249,7 +249,7 @@ unittest
     assert(node_1.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 }
 
 

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -99,7 +99,7 @@ unittest
     // generate 16 blocks
     network.generateBlocks(Height(16));
     assert(network.blocks[0].header.enrollments.length >= 1);
-    network.expectBlock(Height(16), network.blocks[0].header, 5.seconds);
+    network.expectHeightAndPreImg(Height(16), network.blocks[0].header, 5.seconds);
 
     // Discarded UTXOs (just to trigger block creation)
     auto spendable = network.blocks[$ - 1].spendable().array;
@@ -115,7 +115,7 @@ unittest
 
     // Block 17
     txs.each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(17), network.blocks[0].header, 10.seconds);
+    network.expectHeightAndPreImg(Height(17), network.blocks[0].header, 10.seconds);
 
     // Freeze builders
     auto freezable = txs[$ - 4]
@@ -133,7 +133,7 @@ unittest
 
     // Block 18
     freeze_txs.each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(18), network.blocks[0].header, 5.seconds);
+    network.expectHeightAndPreImg(Height(18), network.blocks[0].header, 5.seconds);
 
     // Block 19
     auto new_txs = txs[$ - 3]
@@ -141,7 +141,7 @@ unittest
         .takeExactly(8)
         .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
     new_txs.each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(19), network.blocks[0].header, 5.seconds);
+    network.expectHeightAndPreImg(Height(19), network.blocks[0].header, 5.seconds);
 
     // Now we re-enroll the first validator with a new UTXO but it will fail
     // because an enrollment with same public key of the first validator is
@@ -167,7 +167,7 @@ unittest
         .takeExactly(8)
         .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
     new_txs.each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(20), 5.seconds);
+    network.expectHeight(Height(20), 5.seconds);
     auto b20 = nodes[0].getBlocksFrom(20, 2)[0];
     assert(b20.header.enrollments.length == 5);
 
@@ -183,7 +183,7 @@ unittest
         .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
     new_txs.each!(tx => nodes[0].putTransaction(tx));
     network.waitForPreimages(b20.header.enrollments, 1, 2.seconds);
-    network.expectBlock(Height(21), 5.seconds);
+    network.expectHeight(Height(21), 5.seconds);
     auto b21 = nodes[0].getBlocksFrom(21, 2)[0];
     assert(b21.header.enrollments.length == 1);
     assert(b21.header.enrollments[0] == new_enroll);

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -121,7 +121,7 @@ unittest
                 .map!(ptx => TxBuilder(ptx).refund(WK.Keys[count].address).sign())
                 .array();
         txs.each!(tx => nodes[1].putTransaction(tx));
-        network.expectBlock(Height(count + 1), b0.header);
+        network.expectHeightAndPreImg(Height(count + 1), b0.header);
     }
 
     // Now create an Enrollment for nodes[0], create block #20, and restart nodes[0]
@@ -131,14 +131,14 @@ unittest
         .map!(ptx => TxBuilder(ptx).refund(WK.Keys[20].address).sign())
         .array();
     txs.each!(tx => nodes[1].putTransaction(tx));
-    network.expectBlock(iota(1), Height(GenesisValidatorCycle),
+    network.expectHeightAndPreImg(iota(1), Height(GenesisValidatorCycle),
         b0.header);
     retryFor(nodes[0].getBlocksFrom(20, 1)[0].header.enrollments.length == 1,
         2.seconds);
 
     network.restart(nodes[0]);
     network.waitForDiscovery();
-    network.expectBlock(iota(1), Height(20));
+    network.expectHeight(iota(1), Height(20));
 
     // Now make a new block and make sure only nodes[0] signs it
     txs = txs
@@ -146,7 +146,7 @@ unittest
         .array();
     txs.each!(tx => nodes[1].putTransaction(tx));
     const b20 = nodes[0].getBlocksFrom(20, 2)[0];
-    network.expectBlock(iota(1), Height(21), b20.header);
+    network.expectHeightAndPreImg(iota(1), Height(21), b20.header);
 
     PreImageInfo org_preimage = PreImageInfo(enroll.utxo_key, enroll.random_seed, 0);
 

--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -48,7 +48,7 @@ unittest
         // send it to one node
         txs.each!(tx => node_1.putTransaction(tx));
 
-        network.expectBlock(new_block_height, blocks[0].header);
+        network.expectHeightAndPreImg(new_block_height, blocks[0].header);
 
         // add next block
         blocks ~= node_1.getBlocksFrom(new_block_height, 1);
@@ -191,7 +191,7 @@ unittest
         // send it to one node
         txs.each!(tx => valid_node.putTransaction(tx));
 
-        network.expectBlock(iota(1, GenesisValidators),
+        network.expectHeightAndPreImg(iota(1, GenesisValidators),
             new_block_height, blocks[0].header);
 
         // add next block
@@ -250,9 +250,9 @@ unittest
         .deduct(Amount.UnitPerCoin).sign()).array();
     // Send a single TX with fees to a node
     node_1.putTransaction(txs[0]);
-    network.expectBlock(Height(1), blocks[0].header);
+    network.expectHeightAndPreImg(Height(1), blocks[0].header);
 
     // The fees from the last block should not trigger a new block creation
     Thread.sleep(1.seconds);
-    network.expectBlock(Height(1), blocks[0].header);
+    network.expectHeightAndPreImg(Height(1), blocks[0].header);
 }

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -327,7 +327,7 @@ unittest
     foreach (idx, tx; txs)
     {
         node_1.putTransaction(tx);
-        network.expectBlock(Height(idx + 1), network.blocks[0].header);
+        network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
     auto factory = new FlashNodeFactory(network.getRegistry());
@@ -353,7 +353,7 @@ unittest
         utxo, Amount(10_000), Settle_1_Blocks, bob_pair.V);
 
     // await funding transaction
-    network.expectBlock(Height(9), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(9), network.blocks[0].header);
     const block_9 = node_1.getBlocksFrom(9, 1)[$ - 1];
     assert(block_9.txs.any!(tx => tx.hashFull() == chan_id));
 
@@ -387,16 +387,16 @@ unittest
 
     // alice is acting bad
     log.info("Alice unilaterally closing the channel..");
-    network.expectBlock(Height(10), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(10), network.blocks[0].header);
     auto tx_10 = node_1.getBlocksFrom(10, 1)[0].txs[0];
     assert(tx_10 == update_tx);
 
     // at this point bob will automatically publish the latest update tx
-    network.expectBlock(Height(11), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(11), network.blocks[0].header);
 
     // and then a settlement will be published (but only after time lock expires)
     auto settle_tx = bob.getLastSettleTx(chan_id);
-    network.expectBlock(Height(12), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(12), network.blocks[0].header);
     auto tx_12 = node_1.getBlocksFrom(12, 1)[0].txs[0];
     //assert(tx_12 == settle_tx);
 }
@@ -424,7 +424,7 @@ unittest
     foreach (idx, tx; txs)
     {
         node_1.putTransaction(tx);
-        network.expectBlock(Height(idx + 1), network.blocks[0].header);
+        network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
     auto factory = new FlashNodeFactory(network.getRegistry());
@@ -459,7 +459,7 @@ unittest
     log.info("Alice bob channel ID: {}", alice_bob_chan_id);
 
     // await alice & bob channel funding transaction
-    network.expectBlock(Height(9), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(9), network.blocks[0].header);
     const block_9 = node_1.getBlocksFrom(9, 1)[$ - 1];
     assert(block_9.txs.any!(tx => tx.hashFull() == alice_bob_chan_id));
 
@@ -477,7 +477,7 @@ unittest
     log.info("Bob Charlie channel ID: {}", bob_charlie_chan_id);
 
     // await bob & bob channel funding transaction
-    network.expectBlock(Height(10), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(10), network.blocks[0].header);
     const block_10 = node_1.getBlocksFrom(10, 1)[$ - 1];
     assert(block_10.txs.any!(tx => tx.hashFull() == bob_charlie_chan_id));
 
@@ -507,14 +507,14 @@ unittest
     //
     log.info("Beginning bob => charlie collaborative close..");
     bob.beginCollaborativeClose(bob_charlie_chan_id);
-    network.expectBlock(Height(11), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(11), network.blocks[0].header);
     auto block11 = node_1.getBlocksFrom(11, 1)[0];
     log.info("bob closing tx: {}", bob.getClosingTx(bob_charlie_chan_id));
     assert(block11.txs[0] == bob.getClosingTx(bob_charlie_chan_id));
 
     log.info("Beginning alice => bob collaborative close..");
     alice.beginCollaborativeClose(alice_bob_chan_id);
-    network.expectBlock(Height(12), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(12), network.blocks[0].header);
     auto block12 = node_1.getBlocksFrom(12, 1)[0];
     log.info("alice closing tx: {}", alice.getClosingTx(alice_bob_chan_id));
     assert(block12.txs[0] == alice.getClosingTx(alice_bob_chan_id));
@@ -542,7 +542,7 @@ unittest
     foreach (idx, tx; txs)
     {
         node_1.putTransaction(tx);
-        network.expectBlock(Height(idx + 1), network.blocks[0].header);
+        network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
     auto factory = new FlashNodeFactory(network.getRegistry());
@@ -577,7 +577,7 @@ unittest
     log.info("Alice bob channel ID: {}", alice_bob_chan_id);
 
     // await alice & bob channel funding transaction
-    network.expectBlock(Height(9), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(9), network.blocks[0].header);
     const block_9 = node_1.getBlocksFrom(9, 1)[$ - 1];
     assert(block_9.txs.any!(tx => tx.hashFull() == alice_bob_chan_id));
 
@@ -595,7 +595,7 @@ unittest
     log.info("Bob Charlie channel ID: {}", bob_charlie_chan_id);
 
     // await bob & bob channel funding transaction
-    network.expectBlock(Height(10), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(10), network.blocks[0].header);
     const block_10 = node_1.getBlocksFrom(10, 1)[$ - 1];
     assert(block_10.txs.any!(tx => tx.hashFull() == bob_charlie_chan_id));
 
@@ -613,7 +613,7 @@ unittest
     log.info("Charlie Alice channel ID: {}", charlie_alice_chan_id);
 
     // await bob & bob channel funding transaction
-    network.expectBlock(Height(11), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(11), network.blocks[0].header);
     const block_11 = node_1.getBlocksFrom(11, 1)[$ - 1];
     assert(block_11.txs.any!(tx => tx.hashFull() == charlie_alice_chan_id));
 
@@ -674,7 +674,7 @@ unittest
     foreach (idx, tx; txs)
     {
         node_1.putTransaction(tx);
-        network.expectBlock(Height(idx + 1), network.blocks[0].header);
+        network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
     auto factory = new FlashNodeFactory(network.getRegistry());
@@ -709,7 +709,7 @@ unittest
     log.info("Alice bob channel ID: {}", alice_bob_chan_id);
 
     // await alice & bob channel funding transaction
-    network.expectBlock(Height(9), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(9), network.blocks[0].header);
     const block_9 = node_1.getBlocksFrom(9, 1)[$ - 1];
     assert(block_9.txs.any!(tx => tx.hashFull() == alice_bob_chan_id));
 
@@ -727,7 +727,7 @@ unittest
     log.info("Bob Charlie channel ID: {}", bob_charlie_chan_id);
 
     // await bob & bob channel funding transaction
-    network.expectBlock(Height(10), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(10), network.blocks[0].header);
     const block_10 = node_1.getBlocksFrom(10, 1)[$ - 1];
     assert(block_10.txs.any!(tx => tx.hashFull() == bob_charlie_chan_id));
 
@@ -747,7 +747,7 @@ unittest
     log.info("Bob Charlie channel ID: {}", bob_charlie_chan_id_2);
 
     // await bob & bob channel funding transaction
-    network.expectBlock(Height(11), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(11), network.blocks[0].header);
     const block_11 = node_1.getBlocksFrom(11, 1)[$ - 1];
     assert(block_11.txs.any!(tx => tx.hashFull() == bob_charlie_chan_id_2));
 
@@ -772,7 +772,7 @@ unittest
     charlie.waitForUpdateIndex(bob_charlie_chan_id_2, 2);
 
     bob.beginCollaborativeClose(bob_charlie_chan_id_2);
-    network.expectBlock(Height(12), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(12), network.blocks[0].header);
     auto block12 = node_1.getBlocksFrom(12, 1)[0];
     assert(block12.txs[0] == bob.getClosingTx(bob_charlie_chan_id_2));
     assert(block12.txs[0].outputs.length == 2);
@@ -780,7 +780,7 @@ unittest
     assert(block12.txs[0].outputs[1].value == Amount(2000));
 
     alice.beginCollaborativeClose(alice_bob_chan_id);
-    network.expectBlock(Height(13), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(13), network.blocks[0].header);
     auto block13 = node_1.getBlocksFrom(13, 1)[0];
     assert(block13.txs[0] == alice.getClosingTx(alice_bob_chan_id));
     assert(block13.txs[0].outputs.length == 2);
@@ -788,7 +788,7 @@ unittest
     assert(block13.txs[0].outputs[1].value == Amount(2010));
 
     bob.beginCollaborativeClose(bob_charlie_chan_id);
-    network.expectBlock(Height(14), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(14), network.blocks[0].header);
     auto block14 = node_1.getBlocksFrom(14, 1)[0];
     assert(block14.txs[0] == bob.getClosingTx(bob_charlie_chan_id));
     assert(block14.txs[0].outputs.length == 1); // No updates
@@ -829,7 +829,7 @@ unittest
     foreach (idx, tx; txs)
     {
         node_1.putTransaction(tx);
-        network.expectBlock(Height(idx + 1), network.blocks[0].header);
+        network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
     auto factory = new FlashNodeFactory(network.getRegistry());
@@ -856,7 +856,7 @@ unittest
     log.info("Alice bob channel ID: {}", alice_bob_chan_id);
 
     // await alice & bob channel funding transaction
-    network.expectBlock(Height(9), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(9), network.blocks[0].header);
     const block_9 = node_1.getBlocksFrom(9, 1)[$ - 1];
     assert(block_9.txs.any!(tx => tx.hashFull() == alice_bob_chan_id));
 
@@ -873,7 +873,7 @@ unittest
     Thread.sleep(1.seconds);
 
     bob.beginCollaborativeClose(alice_bob_chan_id);
-    network.expectBlock(Height(10), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(10), network.blocks[0].header);
     auto block10 = node_1.getBlocksFrom(10, 1)[0];
     assert(block10.txs[0] == bob.getClosingTx(alice_bob_chan_id));
     assert(block10.txs[0].outputs.length == 1); // No updates

--- a/source/agora/test/GenesisBlock.d
+++ b/source/agora/test/GenesisBlock.d
@@ -38,5 +38,5 @@ unittest
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 }

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -47,7 +47,7 @@ unittest
     ));
     // When a block is created, the transaction is deleted from the transaction pool.
     node_1.putTransaction(txs[$-1]);
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 
     nodes.each!(node =>
         txs.each!(tx =>

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -150,7 +150,7 @@ unittest
     assert(last_node.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => last_node.putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
     assertValidatorsBitmask(last_node.getAllBlocks()[1]);
 }
 
@@ -169,7 +169,7 @@ unittest
     assert(last_node.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => last_node.putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
     assertValidatorsBitmask(last_node.getAllBlocks()[1]);
 }
 

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -58,7 +58,7 @@ unittest
 
         // send it to one node
         txs.each!(tx => node_1.putTransaction(tx));
-        network.expectBlock(Height(block_idx + 1), blocks[0].header);
+        network.expectHeightAndPreImg(Height(block_idx + 1), blocks[0].header);
 
         blocks ~= node_1.getBlocksFrom(block_idx + 1, 1);
         block_txes ~= txs.sort.array;
@@ -104,11 +104,11 @@ unittest
 
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
     txs.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
     txs.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(2));
+    network.expectHeight(Height(2));
 }
 
 /// Merkle Proof
@@ -147,7 +147,7 @@ unittest
     const Hash expected_root = hashMulti(habcd, hefgh);
 
     // wait for transaction propagation
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 
     Hash[] merkle_path;
     foreach (node; nodes)
@@ -192,11 +192,11 @@ unittest
     // wait for preimages to be revealed before making blocks
     network.waitForPreimages(network.blocks[0].header.enrollments, 6);
 
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
     txs.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(2));
+    network.expectHeight(Height(2));
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
 
@@ -226,10 +226,10 @@ unittest
     txs.each!(tx => node_1.putTransaction(tx));
 
     Thread.sleep(2.seconds);  // wait for propagation
-    network.expectBlock(Height(2));  // no new block yet (1 rejected tx)
+    network.expectHeight(Height(2));  // no new block yet (1 rejected tx)
 
     node_1.putTransaction(backup_tx);
-    network.expectBlock(Height(3));  // new block finally created
+    network.expectHeight(Height(3));  // new block finally created
 }
 
 // Ensure that when creating a frozen UTXO, the refund is not frozen too
@@ -258,7 +258,7 @@ unittest
     network.clients[0].putTransaction(tx);
 
     // Wait for the block to be created
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
     const b1 = network.clients[0].getBlock(1);
     assert(b1.txs.length == 1);
 
@@ -267,6 +267,6 @@ unittest
     assert(tx2.outputs.length == 1);
 
     network.clients[0].putTransaction(tx2);
-    network.expectBlock(Height(2));
+    network.expectHeight(Height(2));
     assert(network.clients[0].getBlock(2).txs.length == 1);
 }

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -86,7 +86,7 @@ unittest
     txs.enumerate.each!((idx, tx) => network.clients[idx % network.clients.length]
         .putTransaction(tx));
 
-    network.expectBlock(Height(1), blocks[0].header);
+    network.expectHeightAndPreImg(Height(1), blocks[0].header);
 }
 
 // A node never receives the TXs that was externalized. It should be able to
@@ -163,5 +163,5 @@ unittest
     Thread.sleep(1.seconds);
     txs.each!(tx => assert(!picky_node.hasTransactionHash(tx.hashFull())));
 
-    network.expectBlock(Height(1), blocks[0].header);
+    network.expectHeightAndPreImg(Height(1), blocks[0].header);
 }

--- a/source/agora/test/LockHeight.d
+++ b/source/agora/test/LockHeight.d
@@ -35,7 +35,7 @@ unittest
     // height 1
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
     txs.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     const Height UnlockHeight_2 = Height(2);
     auto unlock_2_txs = txs.map!(tx => TxBuilder(tx).sign(TxType.Payment,
@@ -54,7 +54,7 @@ unittest
     // should be accepted
     unlock_2_txs.each!(tx => node_1.putTransaction(tx));
 
-    network.expectBlock(Height(2), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
 
     auto blocks = node_1.getBlocksFrom(2, 1);
     assert(blocks.length == 1);

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -55,7 +55,7 @@ void manyValidators (size_t validators)
     network.generateBlocks(Height(GenesisValidatorCycle - 1));
 
     // make sure outsiders are up to date
-    network.expectBlock(iota(GenesisValidators, validators),
+    network.expectHeight(iota(GenesisValidators, validators),
         Height(GenesisValidatorCycle - 1));
 
     // Now we enroll new validators and re-enroll the original validators
@@ -66,7 +66,7 @@ void manyValidators (size_t validators)
         Height(GenesisValidatorCycle));
 
     // make sure outsiders are up to date
-    network.expectBlock(iota(GenesisValidators, validators),
+    network.expectHeight(iota(GenesisValidators, validators),
         Height(GenesisValidatorCycle));
 
     // check all validators are enrolled

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -156,7 +156,7 @@ unittest
 
     // block 1
     txs.each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 }
 
 /// Situation: There is a validator does not reveal a pre-image for next
@@ -201,5 +201,5 @@ unittest
 
     // try to make block 1
     txs.each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 }

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -113,7 +113,7 @@ unittest
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
     txs.each!(tx => validator.putTransaction(tx));
 
-    network.expectBlock(Height(1), conf.timeout + 5.seconds);
+    network.expectHeight(Height(1), conf.timeout + 5.seconds);
     assert(CustomNominator.round_number >= 2,
         format("The validator's round number is %s. Expected: above %s",
             CustomNominator.round_number, 2));

--- a/source/agora/test/NameRegistry.d
+++ b/source/agora/test/NameRegistry.d
@@ -33,5 +33,5 @@ unittest
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 }

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -50,7 +50,7 @@ unittest
     // clear filter after 100 msecs, the above requests will eventually be gossiped
     Thread.sleep(100.msecs);
     nodes[1 .. $].each!(node => node.clearFilter());
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 }
 
 /// test request timeouts
@@ -80,5 +80,5 @@ unittest
     // node 1 will keep trying to send transactions up to
     // max_retries * (retry_delay + timeout) seconds (see Base.d),
     const delay = conf.max_retries * (conf.retry_delay + conf.timeout);
-    network.expectBlock(Height(1), delay);
+    network.expectHeight(Height(1), delay);
 }

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -52,7 +52,7 @@ unittest
     nodes.take(GenesisValidators / 2).each!(node => node.clearFilter());
 
     const b0 = nodes[0].getBlocksFrom(0, 2)[0];
-    network.expectBlock(Height(1), b0.header);
+    network.expectHeightAndPreImg(Height(1), b0.header);
 }
 
 /// test behavior when a node sends bad block data
@@ -160,13 +160,13 @@ unittest
     // create genesis block
     last_txs = genesisSpendable().map!(txb => txb.sign()).array();
     last_txs.each!(tx => node_validators[0].putTransaction(tx));
-    network.expectBlock(iota(GenesisValidators), Height(1));
+    network.expectHeight(iota(GenesisValidators), Height(1));
 
     // create 1 additional block and enough `tx`es
     auto txs = last_txs.map!(tx => TxBuilder(tx).sign()).array();
     // send it to one node
     txs.each!(tx => node_validators[0].putTransaction(tx));
-    network.expectBlock(iota(GenesisValidators), Height(2));
+    network.expectHeight(iota(GenesisValidators), Height(2));
     last_txs = txs;
 
     // the validator node has 2 blocks, but bad node pretends to have 3

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -67,7 +67,7 @@ unittest
     network.generateBlocks(Height(GenesisValidatorCycle - 1));
 
     // make sure outsiders are up to date
-    network.expectBlock(iota(GenesisValidators, validators),
+    network.expectHeight(iota(GenesisValidators, validators),
         Height(GenesisValidatorCycle - 1));
 
     // re-enroll Genesis validators and enroll outsider validators
@@ -78,7 +78,7 @@ unittest
         Height(GenesisValidatorCycle));
 
     // make sure outsiders are up to date
-    network.expectBlock(iota(GenesisValidators, validators),
+    network.expectHeight(iota(GenesisValidators, validators),
         Height(GenesisValidatorCycle));
 
     // these are no longer enrolled
@@ -93,6 +93,6 @@ unittest
         node.sleep(0.seconds, false));
 
     // all nodes should have same block height now
-    network.expectBlock(iota(nodes.length), Height(GenesisValidatorCycle + 1),
+    network.expectHeightAndPreImg(iota(nodes.length), Height(GenesisValidatorCycle + 1),
         nodes[0].getAllBlocks()[GenesisValidatorCycle].header);
 }

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -149,7 +149,7 @@ unittest
     network.generateBlocks(Height(GenesisValidatorCycle - 1));
 
     // make sure outsiders are up to date
-    network.expectBlock(iota(GenesisValidators, validators),
+    network.expectHeight(iota(GenesisValidators, validators),
         Height(GenesisValidatorCycle - 1));
 
     // Now we enroll new validators and re-enroll the original validators
@@ -160,7 +160,7 @@ unittest
         Height(GenesisValidatorCycle));
 
     // make sure outsiders are up to date
-    network.expectBlock(iota(GenesisValidators, validators),
+    network.expectHeight(iota(GenesisValidators, validators),
         Height(GenesisValidatorCycle));
 
     enum quorums_2 = [

--- a/source/agora/test/Restart.d
+++ b/source/agora/test/Restart.d
@@ -38,13 +38,13 @@ unittest
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 
     // Now shut down & restart one node
     auto restartMe = nodes[$-1];
     network.restart(restartMe);
     network.waitForDiscovery();
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 }
 
 /// Node which has a persistent Ledger (restart always clear the local state)
@@ -132,12 +132,12 @@ unittest
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 
     // Now shut down & restart one node
     auto restartMe = nodes[$-1];
     scope(failure) restartMe.printLog();
     network.restart(restartMe);
     network.waitForDiscovery();
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 }

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -146,12 +146,12 @@ unittest
     auto re_validator = network.clients[0];
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => re_validator.putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 
     Checked = true;
     // Now shut down & restart one node
     network.restart(re_validator);
     network.waitForDiscovery();
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
     assert(!Checked);
 }

--- a/source/agora/test/RestoreSlashingInfo.d
+++ b/source/agora/test/RestoreSlashingInfo.d
@@ -84,5 +84,5 @@ unittest
     // Now restarting the validators in the set B, all the data of those
     // validators has been wiped out.
     set_b.each!(node => network.restart(node));
-    network.expectBlock(Height(GenesisValidatorCycle + 1));
+    network.expectHeight(Height(GenesisValidatorCycle + 1));
 }

--- a/source/agora/test/Script.d
+++ b/source/agora/test/Script.d
@@ -62,7 +62,7 @@ unittest
         .joiner().map!(txb => txb.sign());
 
     lock_txs.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(6));
+    network.expectHeight(Height(6));
 
     Unlock keyUnlocker (in Transaction tx, in OutputRef out_ref) @safe nothrow
     {
@@ -86,7 +86,7 @@ unittest
     unlock_height_2.each!(tx => node_1.putTransaction(tx));
     // unlock height 3 accepted
     unlock_height_3.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(7));
+    network.expectHeight(Height(7));
 
     const block_7 = node_1.getBlocksFrom(7, 1)[0];
     unlock_height_3.sort();
@@ -121,7 +121,7 @@ unittest
 
     // height 1, many Outputs
     txs.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     auto split_up = txs
         .map!(tx => iota(tx.outputs.length)
@@ -133,21 +133,21 @@ unittest
     auto txs_2 = split_up[2].map!(txb => txb.sign()).array;
 
     txs_0.each!(tx => node_1.putTransaction(tx));      // accepted
-    network.expectBlock(Height(2), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
     auto blocks = node_1.getBlocksFrom(2, 1);
     assert(blocks.length == 1);
     sort(txs_0);
     assert(blocks[0].txs == txs_0);
 
     txs_1.each!(tx => node_1.putTransaction(tx));      // accepted
-    network.expectBlock(Height(3), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(3), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(3, 1);
     assert(blocks.length == 1);
     sort(txs_1);
     assert(blocks[0].txs == txs_1);
 
     txs_2.each!(tx => node_1.putTransaction(tx));      // accepted
-    network.expectBlock(Height(4), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(4), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(4, 1);
     assert(blocks.length == 1);
     sort(txs_2);
@@ -175,7 +175,7 @@ unittest
 
     age_2_txs.each!(tx => node_1.putTransaction(tx));
     age_3_txs.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(5), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(5), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(5, 1);
     assert(blocks.length == 1);
     sort(age_3_txs);
@@ -217,7 +217,7 @@ unittest
 
     // height 1, many Outputs
     txs.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     auto split_up = txs
         .map!(tx => iota(tx.outputs.length)
@@ -226,7 +226,7 @@ unittest
     auto txs_0 = split_up[0].map!(txb => txb.sign()).array;
 
     txs_0.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(2), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
     auto blocks = node_1.getBlocksFrom(2, 1);
     assert(blocks.length == 1);
     sort(txs_0);
@@ -256,7 +256,7 @@ unittest
 
     true_a_txs.each!(tx => node_1.putTransaction(tx));
     true_b_txs.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(3), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(3), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(3, 1);
     assert(blocks.length == 1);
     sort(true_a_txs);
@@ -286,7 +286,7 @@ unittest
 
     false_a_txs.each!(tx => node_1.putTransaction(tx));
     false_b_txs.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(4), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(4), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(4, 1);
     assert(blocks.length == 1);
     sort(false_b_txs);

--- a/source/agora/test/Simple.d
+++ b/source/agora/test/Simple.d
@@ -43,7 +43,7 @@ unittest
     // First create a block with single transaction
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
     network.assertSameBlocks(iota(network.nodes.length), Height(1));
 
     // Now create blocks until after the end of the first validator cycle

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -133,7 +133,7 @@ unittest
 
     // block 1
     txs.each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 
     auto frozen_hash = utxo_set.getUTXOs(bad_address).keys[0];
     auto frozen_utxo = utxo_set.getUTXOs(bad_address).values[0];
@@ -144,7 +144,7 @@ unittest
     // block 2
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
     txs.each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(2));
+    network.expectHeight(Height(2));
     auto block2 = nodes[0].getBlocksFrom(2, 1)[0];
     assert(block2.header.missing_validators.length == 1);
     assert(nodes[0].getValidatorCount() == 5,
@@ -202,19 +202,19 @@ unittest
 
     // block 1
     txs.each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 
     // block 2 must not be created because all the validators do not
     // reveal any pre-images after their enrollments.
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
     txs.each!(tx => nodes[0].putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 
     // all the validators start revealing pre-images
     atomicStore(network.reveal_preimage, true);
 
     // block 2 created with no slashed validator
-    network.expectBlock(Height(2));
+    network.expectHeight(Height(2));
     auto block2 = nodes[0].getBlocksFrom(2, 1)[0];
     assert(block2.header.missing_validators.length == 0);
 }

--- a/source/agora/test/UnlockAge.d
+++ b/source/agora/test/UnlockAge.d
@@ -38,7 +38,7 @@ unittest
 
     // height 1, many Outputs
     txs.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     auto split_up = txs
         .map!(tx => iota(tx.outputs.length)
@@ -55,7 +55,7 @@ unittest
 
     age_3_txs.each!(tx => node_1.putTransaction(tx));  // rejected, wrong age
     txs_0.each!(tx => node_1.putTransaction(tx));      // accepted
-    network.expectBlock(Height(2), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
     auto blocks = node_1.getBlocksFrom(2, 1);
     assert(blocks.length == 1);
     sort(txs_0);
@@ -63,7 +63,7 @@ unittest
 
     age_3_txs.each!(tx => node_1.putTransaction(tx));  // rejected again
     txs_1.each!(tx => node_1.putTransaction(tx));      // accepted
-    network.expectBlock(Height(3), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(3), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(3, 1);
     assert(blocks.length == 1);
     sort(txs_1);
@@ -71,14 +71,14 @@ unittest
 
     age_3_txs.each!(tx => node_1.putTransaction(tx));  // rejected again
     txs_2.each!(tx => node_1.putTransaction(tx));      // accepted
-    network.expectBlock(Height(4), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(4), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(4, 1);
     assert(blocks.length == 1);
     sort(txs_2);
     assert(blocks[0].txs == txs_2);
 
     age_3_txs.each!(tx => node_1.putTransaction(tx));  // finally accepted
-    network.expectBlock(Height(5), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(5), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(5, 1);
     assert(blocks.length == 1);
     sort(age_3_txs);

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -84,7 +84,7 @@ unittest
     // Now restarting the validators in the set B, all the data of those
     // validators has been wiped out.
     set_b.each!(node => network.restart(node));
-    network.expectBlock(Height(GenesisValidatorCycle));
+    network.expectHeight(Height(GenesisValidatorCycle));
 
     // Sanity check
     nodes.enumerate.each!((idx, node) =>
@@ -136,7 +136,7 @@ unittest
     // Create a block from the Genesis block
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
     txs.each!(tx => node_1.putTransaction(tx));
-    network.expectBlock(Height(1));
+    network.expectHeight(Height(1));
 
     // node_1 restarts and becomes unresponsive
     network.restart(node_1);
@@ -145,11 +145,11 @@ unittest
     // Make 2 blocks
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
     txs.each!(tx => node_2.putTransaction(tx));
-    network.expectBlock(iota(1,nodes.length), Height(2));
+    network.expectHeight(iota(1,nodes.length), Height(2));
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
     txs.each!(tx => node_2.putTransaction(tx));
-    network.expectBlock(iota(1,nodes.length), Height(3));
+    network.expectHeight(iota(1,nodes.length), Height(3));
 
     // Wait for node_1 to wake up
     node_1.ctrl.withTimeout(10.seconds,
@@ -158,7 +158,7 @@ unittest
         }
     );
 
-    network.expectBlock(Height(3));
+    network.expectHeight(Height(3));
 
     // The node_2 restart and is disabled to respond, which means that
     // the node_2 will be slashed soon.
@@ -171,5 +171,5 @@ unittest
 
     // The new block has been inserted to the ledger with the approval
     // of the node_1, although node_2 was shutdown.
-    network.expectBlock(Height(4));
+    network.expectHeight(Height(4));
 }

--- a/source/agora/test/ValidatorCount.d
+++ b/source/agora/test/ValidatorCount.d
@@ -55,7 +55,7 @@ unittest
 
         // send it to one node
         txs.each!(tx => node_1.putTransaction(tx));
-        network.expectBlock(Height(block_idx), blocks[0].header);
+        network.expectHeightAndPreImg(Height(block_idx), blocks[0].header);
 
         // add next block
          blocks ~= node_1.getBlocksFrom(block_idx, 1);

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -54,7 +54,7 @@ unittest
         // send it to one node
         txs.each!(tx => node_1.putTransaction(tx));
 
-        network.expectBlock(new_block_height, blocks[0].header);
+        network.expectHeightAndPreImg(new_block_height, blocks[0].header);
 
         // add next block
         blocks ~= node_1.getBlocksFrom(new_block_height, 1);
@@ -146,7 +146,7 @@ unittest
         // send it to one node
         txs.each!(tx => node_1.putTransaction(tx));
 
-        network.expectBlock(new_block_height, blocks[0].header);
+        network.expectHeightAndPreImg(new_block_height, blocks[0].header);
 
         // add next block
         blocks ~= node_1.getBlocksFrom(new_block_height, 1);
@@ -271,7 +271,7 @@ unittest
     // Wake one up right before cycle ends
     sleep_node_2.ctrl.sleep(0.seconds);
     // Let it catch up
-    network.expectBlock(iota(GenesisValidators - 1),
+    network.expectHeight(iota(GenesisValidators - 1),
         Height(GenesisValidatorCycle - 1));
 
     network.generateBlocks(iota(GenesisValidators - 1),
@@ -283,7 +283,7 @@ unittest
     // This nodes will wake up to an expired cycle, it should immediately enroll
     sleep_node_1.ctrl.sleep(0.seconds);
     // Let it catch up
-    network.expectBlock(Height(GenesisValidatorCycle));
+    network.expectHeight(Height(GenesisValidatorCycle));
 
     network.generateBlocks(iota(GenesisValidators),
         Height(GenesisValidatorCycle + 1));

--- a/source/agora/test/VariableBlockSize.d
+++ b/source/agora/test/VariableBlockSize.d
@@ -43,7 +43,7 @@ unittest
     foreach (block_idx, block_txs; txs.chunks(txs_to_nominate).enumerate)
     {
         block_txs.each!(tx => network.clients[0].putTransaction(tx));
-        network.expectBlock(Height(block_idx + 1), network.blocks[0].header,
+        network.expectHeightAndPreImg(Height(block_idx + 1), network.blocks[0].header,
             5.seconds);
     }
 


### PR DESCRIPTION
Some overloads of expectBlock check for preimage and some don't. This
different behavior should be obvious from the function name.

fixes: #1779