### PR TITLE
PublicKey.verify: Accept any kind of message

### DIFF
--- a/source/agora/crypto/Key.d
+++ b/source/agora/crypto/Key.d
@@ -239,7 +239,7 @@ public struct PublicKey
 
     ***************************************************************************/
 
-    public bool verify (Signature signature, scope const(ubyte)[] msg)
+    public bool verify (T) (Signature signature, in T msg)
         const nothrow @nogc @trusted
     {
         return agora.crypto.Schnorr.verify(this.data, signature, msg);


### PR DESCRIPTION
Since we are just forwarding, we should not needlessly restrict the interface.