### PR TITLE
Modified style guide: func type ctr preceds attr

### DIFF
--- a/doc/Style.md
+++ b/doc/Style.md
@@ -99,7 +99,10 @@ Functions have a space between their name and their opening parenthesis
 E.g. a function is: `void foobar ()`, not `void foobar()`.
 With parameters: `void foobar (int p1, void* p2)`.
 Templated functions are written as `void foobar (T) (T arg)`.
-This makes functions easy to `grep` for.
+This makes functions easy to `grep` for. Type constructors like `const`, `immutable`,
+`inout`, `shared` must appear before other attributes like `pure` or `@nogc`, so
+`void foobar () const @nogc pure` is correct, while `void foobar () pure const @nogc`
+ is not.
 
 ### Attributes (@trusted, @safe, @nogc, pure, etc)
 


### PR DESCRIPTION
Function's type constructors like 'const' should preced regular
attributes like pure

https://github.com/bosagora/agora/pull/1768#discussion_r599294338