### PR TITLE
Refactor BanManager.Config

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -15,6 +15,7 @@
 module agora.common.BanManager;
 
 import agora.serialization.Serializer;
+import agora.common.Config : BanConfig;
 import agora.common.Types;
 import agora.network.Clock;
 import agora.utils.InetUtils;
@@ -34,16 +35,6 @@ mixin AddLogger!();
 /// ditto
 public class BanManager
 {
-    /// Ban configuration
-    public struct Config
-    {
-        /// max failed requests until an address is banned
-        public size_t max_failed_requests = 1000;
-
-        /// How long does a ban lasts, in seconds (default: 1 day)
-        public Duration ban_duration = 1.days;
-    }
-
     ///
     private struct Status
     {
@@ -95,7 +86,7 @@ public class BanManager
     }
 
     /// configuration
-    private const Config config;
+    private const BanConfig config;
 
     /// per-address status
     private BannedList ips;
@@ -117,7 +108,7 @@ public class BanManager
 
     ***************************************************************************/
 
-    public this (Config config, Clock clock, cstring data_dir) @safe nothrow pure
+    public this (BanConfig config, Clock clock, cstring data_dir) @safe nothrow pure
     {
         this.config = config;
         this.clock = clock;
@@ -330,7 +321,7 @@ unittest
     class UnitBanMan : BanManager
     {
         TimePoint time;
-        this () { super(Config(10, 1.days), null, null); }
+        this () { super(BanConfig(10, 1.days), null, null); }
         protected override TimePoint getCurTime () const { return this.time; }
         public override void dump () { }
         public override void load () { }

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -85,7 +85,7 @@ public struct Config
         "Type must be shareable accross threads");
 
     /// Ban manager config
-    public BanManager.Config banman;
+    public BanConfig banman;
 
     /// The node config
     public NodeConfig node;
@@ -213,6 +213,16 @@ public struct ValidatorConfig
 
     /// How often should the periodic preimage reveal timer trigger (in seconds)
     public Duration preimage_reveal_interval = 10.seconds;
+}
+
+/// Ban configuration
+public struct BanConfig
+{
+    /// max failed requests until an address is banned
+    public size_t max_failed_requests = 1000;
+
+    /// How long does a ban lasts, in seconds (default: 1 day)
+    public Duration ban_duration = 1.days;
 }
 
 /// Admin API config
@@ -654,9 +664,9 @@ validator:
 }
 
 /// Parse the banman config section
-private BanManager.Config parseBanManagerConfig (Node* node, in CommandLine cmdln)
+private BanConfig parseBanManagerConfig (Node* node, in CommandLine cmdln)
 {
-    BanManager.Config conf;
+    BanConfig conf;
     conf.max_failed_requests = get!(size_t, "banman", "max_failed_requests")(cmdln, node);
     conf.ban_duration = get!(Duration, "banman", "ban_duration",
                              str => str.to!ulong.seconds)(cmdln, node);

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -762,7 +762,7 @@ public class NetworkManager
 
     ***************************************************************************/
 
-    protected BanManager getBanManager (in BanManager.Config banman_conf,
+    protected BanManager getBanManager (in BanConfig banman_conf,
         Clock clock, cstring data_dir)
     {
         return new BanManager(banman_conf, clock, data_dir);

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1236,7 +1236,7 @@ public class TestNetworkManager : NetworkManager
 
     ***************************************************************************/
 
-    protected override TestBanManager getBanManager (in BanManager.Config conf,
+    protected override TestBanManager getBanManager (in BanConfig conf,
         Clock clock, cstring data_dir)
     {
         return new TestBanManager(conf, clock, data_dir);
@@ -1857,7 +1857,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
         return conf;
     }
 
-    BanManager.Config ban_conf =
+    BanConfig ban_conf =
     {
         max_failed_requests : test_conf.max_failed_requests,
         ban_duration: test_conf.ban_duration,

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1751,6 +1751,9 @@ public struct TestConf
     /// max failed requests before a node is banned
     size_t max_failed_requests = 100;
 
+    /// the default duration of a ban
+    Duration ban_duration = 300.seconds;
+
     /// max listener nodes. If set to 0, set to this.nodes - 1
     size_t max_listeners;
 
@@ -1857,7 +1860,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
     BanManager.Config ban_conf =
     {
         max_failed_requests : test_conf.max_failed_requests,
-        ban_duration: 300.seconds,
+        ban_duration: test_conf.ban_duration,
     };
 
     immutable(Address[]) makeNetworkConfig (size_t idx, Address[] addresses)


### PR DESCRIPTION
We moved `BanManager.Config` to `Config` as `BanConfig` because it's more convenient to manage configuration in one place. 

Part of #1657 