### PR TITLE
Reduce the amount of module-level logger instances

### DIFF
--- a/source/agora/cli/client/GenTxProcess.d
+++ b/source/agora/cli/client/GenTxProcess.d
@@ -24,7 +24,6 @@ import agora.consensus.data.Block;
 import agora.consensus.data.Transaction;
 import agora.consensus.data.genesis.Test;
 import agora.crypto.Hash;
-import agora.utils.Log;
 import agora.utils.PrettyPrinter;
 import agora.utils.Test;
 
@@ -38,8 +37,6 @@ import std.stdio;
 import core.time;
 
 import vibe.core.core;
-
-mixin AddLogger!();
 
 /// Option required to generate and send transactions
 private struct GenTxOption
@@ -130,7 +127,7 @@ public int genTxProcess (string[] args, ref string[] outputs,
     }
     catch (Exception ex)
     {
-        log.info("Exception while generating transactions");
+        writeln("Exception while generating transactions: ", ex);
         printGenTxHelp(outputs);
         return CLIENT_EXCEPTION;
     }

--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -29,8 +29,6 @@ import core.stdc.stdlib;
 import core.stdc.time;
 import core.time;
 
-mixin AddLogger!();
-
 /// ditto
 public class BanManager
 {
@@ -94,6 +92,9 @@ public class BanManager
         }
     }
 
+    /// Logger instance
+    protected Logger log;
+
     /// configuration
     private const Config config;
 
@@ -106,6 +107,9 @@ public class BanManager
     /// Clock instance
     private Clock clock;
 
+    /// Avoid using the caller's module as our logger name
+    private static immutable string ThisModule = __MODULE__;
+
     /***************************************************************************
 
         Ctor.
@@ -114,12 +118,15 @@ public class BanManager
             config = the configuration
             clock = clock instance
             data_dir = path to the data directory
+            logger = Logger to use. Workaround for attributes' purpose.
 
     ***************************************************************************/
 
-    public this (Config config, Clock clock, cstring data_dir) @safe nothrow pure
+    public this (Config config, Clock clock, cstring data_dir,
+                 Logger logger = Logger(ThisModule)) @safe nothrow pure
     {
         this.config = config;
+        this.log = logger;
         this.clock = clock;
         this.banfile_path = buildPath(data_dir, "banned.dat");
     }

--- a/source/agora/common/ManagedDatabase.d
+++ b/source/agora/common/ManagedDatabase.d
@@ -16,16 +16,13 @@
 
 module agora.common.ManagedDatabase;
 
-import agora.utils.Log;
-
 import d2sqlite3.database;
 import d2sqlite3.sqlite3;
 
 import std.conv : emplace;
 
-import core.stdc.stdlib : abort, free, malloc;
-
-mixin AddLogger!();
+import core.stdc.stdio : printf;
+import core.stdc.stdlib : free, malloc;
 
 /// Ditto
 public class ManagedDatabase
@@ -44,7 +41,8 @@ public class ManagedDatabase
             }
             catch (Exception ex)
             {
-                log.error("Error closing database handles: {}", ex.message);
+                printf("Error closing database handles: %.*s\n",
+                       cast(int) ex.message.length, ex.message.ptr);
             }
             finally
             {
@@ -120,9 +118,7 @@ public class ManagedDatabase
             {
                 // in most cases this would only trigger if there was a
                 // code-flow error
-                try log.fatal("SQLite BEGIN statement failed: {}", exc.message);
-                catch (Exception e) { /* Nothing more we can do at this point */ }
-                abort();
+                assert(0, "SQLite BEGIN statement failed: " ~ exc.message);
             }
         }
     }
@@ -140,9 +136,7 @@ public class ManagedDatabase
             {
                 // in most cases this would only trigger if there was a
                 // code-flow error
-                try log.fatal("SQLite COMMIT statement failed: {}", exc.message);
-                catch (Exception e) { /* Nothing more we can do at this point */ }
-                abort();
+                assert(0, "SQLite COMMIT statement failed: " ~ exc.message);
             }
         }
     }
@@ -160,9 +154,7 @@ public class ManagedDatabase
             {
                 // in most cases this would only trigger if there was a
                 // code-flow error
-                try log.fatal("SQLite ROLLBACK statement failed: {}", exc.message);
-                catch (Exception e) { /* Nothing more we can do at this point */ }
-                abort();
+                assert(0, "SQLite ROLLBACK statement failed: " ~ exc.message);
             }
         }
     }

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -75,8 +75,6 @@ import std.file;
 import std.path;
 import std.string;
 
-mixin AddLogger!();
-
 /*******************************************************************************
 
     Handle enrollment data and manage the validators set
@@ -85,6 +83,9 @@ mixin AddLogger!();
 
 public class EnrollmentManager
 {
+    /// Logger instance
+    private Logger log;
+
     /// SQLite db instance
     private ManagedDatabase db;
 
@@ -148,6 +149,7 @@ public class EnrollmentManager
     public this (string db_path, KeyPair key_pair,
         immutable(ConsensusParams) params)
     {
+        this.log = Logger(__MODULE__);
         assert(params !is null);
         this.params = params;
         this.key_pair = key_pair;
@@ -222,7 +224,7 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public ulong getIndexOfValidator (in Height height, in Point K) const nothrow @safe
+    public ulong getIndexOfValidator (in Height height, in Point K) nothrow @safe
     {
         if (height !in this.key_to_index)
         {

--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -36,11 +36,12 @@ import d2sqlite3.library;
 import d2sqlite3.results;
 import d2sqlite3.sqlite3;
 
-mixin AddLogger!();
-
 /// Ditto
 public class EnrollmentPool
 {
+    /// Logger instance
+    protected Logger log;
+
     /// SQLite DB instance
     private ManagedDatabase db;
 
@@ -56,6 +57,7 @@ public class EnrollmentPool
     public this (ManagedDatabase db)
     {
         this.db = db;
+        this.log = Logger(__MODULE__);
 
         // create the table for enrollment pool if it doesn't exist yet
         this.db.execute("CREATE TABLE IF NOT EXISTS enrollment_pool " ~

--- a/source/agora/consensus/SCPEnvelopeStore.d
+++ b/source/agora/consensus/SCPEnvelopeStore.d
@@ -28,12 +28,13 @@ import scpd.types.Stellar_SCP;
 import std.file : exists;
 import std.range;
 
-mixin AddLogger!();
-
 
 /// Ditto
 public class SCPEnvelopeStore
 {
+    /// Logger instance
+    protected Logger log;
+
     /// SQLite db instance
     private ManagedDatabase db;
 
@@ -49,6 +50,7 @@ public class SCPEnvelopeStore
 
     public this (in string db_path)
     {
+        this.log = Logger(__MODULE__);
         const db_exists = db_path.exists;
         if (db_exists)
             log.info("Loading database from: {}", db_path);

--- a/source/agora/consensus/SlashPolicy.d
+++ b/source/agora/consensus/SlashPolicy.d
@@ -43,8 +43,6 @@ import std.algorithm;
 import std.conv;
 import std.range;
 
-mixin AddLogger!();
-
 /*******************************************************************************
 
     Manage the policy for slashing
@@ -98,10 +96,7 @@ public class SlashPolicy
 
         Hash[] keys;
         if (!this.enroll_man.getEnrolledUTXOs(keys) || keys.length == 0)
-        {
-            log.fatal("Could not retrieve enrollments / no enrollments found");
-            assert(0);
-        }
+            assert(0, "Could not retrieve enrollments / no enrollments found");
 
         foreach (idx, utxo_key; keys)
         {
@@ -131,10 +126,7 @@ public class SlashPolicy
 
         Hash[] keys;
         if (!this.enroll_man.getEnrolledUTXOs(keys))
-        {
-            log.fatal("Could not retrieve enrollments");
-            assert(0);
-        }
+            assert(0, "Could not retrieve enrollments");
 
         foreach (idx; missing_validators)
         {
@@ -160,10 +152,7 @@ public class SlashPolicy
     {
         Hash[] keys;
         if (!this.enroll_man.getEnrolledUTXOs(keys) || keys.length == 0)
-        {
-            log.fatal("Could not retrieve enrollments / no enrollments found");
-            assert(0);
-        }
+            assert(0, "Could not retrieve enrollments / no enrollments found");
 
         Hash[] valid_keys;
         foreach (key; keys)
@@ -201,10 +190,7 @@ public class SlashPolicy
     {
         Hash[] keys;
         if (!this.enroll_man.getEnrolledUTXOs(keys) || keys.length == 0)
-        {
-            log.fatal("Could not retrieve enrollments / no enrollments found");
-            assert(0);
-        }
+            assert(0, "Could not retrieve enrollments / no enrollments found");
 
         Hash[] valid_keys;
         foreach (idx, key; keys)
@@ -265,17 +251,11 @@ public class SlashPolicy
     {
         Hash[] keys;
         if (!this.enroll_man.getEnrolledUTXOs(keys) || keys.length == 0)
-        {
-            log.fatal("Could not retrieve enrollments / no enrollments found");
-            assert(0);
-        }
+            assert(0, "Could not retrieve enrollments / no enrollments found");
 
         auto enroll_index = this.enroll_man.getIndexOfEnrollment();
         if (enroll_index != ulong.max && !missing_validators.find(enroll_index).empty)
-        {
-            log.fatal("The node is slashing itself.");
-            assert(0);
-        }
+            assert(0, "The node is slashing itself.");
 
         uint[] local_missing_validators;
         foreach (idx, key; keys)

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -62,8 +62,6 @@ import std.format;
 import std.path : buildPath;
 import core.time : msecs, seconds;
 
-mixin AddLogger!();
-
 // TODO: The block should probably have a size limit rather than a maximum
 //  number of transactions.
 //  But for now set a maximum number of transactions to a thousand
@@ -72,6 +70,9 @@ enum MaxTransactionsPerBlock = 1000;
 /// Ditto
 public extern (C++) class Nominator : SCPDriver
 {
+    /// Logger instance
+    private Logger log;
+
     /// Consensus parameters
     protected immutable(ConsensusParams) params;
 
@@ -153,6 +154,7 @@ extern(D):
         Clock clock, NetworkManager network, ValidatingLedger ledger,
         EnrollmentManager enroll_man, ITaskManager taskman, string data_dir)
     {
+        this.log = Logger(__MODULE__);
         this.params = params;
         this.clock = clock;
         this.network = network;
@@ -925,7 +927,7 @@ extern(D):
     }
 
     /// If more than half have signed create a combined Schnorr multisig and return the updated block
-    private Block updateMultiSignature (const ref Block block) const
+    private Block updateMultiSignature (const ref Block block)
     {
         auto all_validators = this.enroll_man.getCountOfValidators(block.header.height);
 

--- a/source/agora/consensus/state/UTXOCache.d
+++ b/source/agora/consensus/state/UTXOCache.d
@@ -21,11 +21,8 @@ public import agora.consensus.data.UTXO;
 import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.serialization.Serializer;
-import agora.utils.Log;
 
 import std.file;
-
-mixin AddLogger!();
 
 /// Delegate to find an unspent UTXO
 public alias UTXOFinder = bool delegate (in Hash utxo, out UTXO) nothrow @safe;
@@ -152,17 +149,13 @@ abstract class UTXOCache
     public bool findUTXO (in Hash utxo, out UTXO value) nothrow @safe
     {
         if (utxo in this.used_utxos)
-        {
-            log.trace("findUTXO: utxo_hash {} found in used_utxos: {}", utxo, used_utxos);
             return false;  // double-spend
-        }
 
         if (this.peekUTXO(utxo, value))
         {
             this.used_utxos.put(utxo);
             return true;
         }
-        log.trace("findUTXO: utxo_hash {} not found", utxo);
         return false;
     }
 

--- a/source/agora/consensus/state/UTXODB.d
+++ b/source/agora/consensus/state/UTXODB.d
@@ -21,11 +21,8 @@ public import agora.consensus.state.UTXOCache;
 import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.serialization.Serializer;
-import agora.utils.Log;
 
 import std.file;
-
-mixin AddLogger!();
 
 ///
 package class UTXODB
@@ -44,17 +41,10 @@ package class UTXODB
 
     public this (string utxo_db_path)
     {
-        const db_exists = utxo_db_path.exists;
-        if (db_exists)
-            log.info("Loading UTXO database from: {}", utxo_db_path);
-
         // todo: can fail. we would have to recover by either:
         // A) reconstructing it from our blockchain storage
         // B) requesting the UTXO set from our peers
         this.db = new ManagedDatabase(utxo_db_path);
-
-        if (db_exists)
-            log.info("Loaded database from: {}", utxo_db_path);
 
         // create the table if it doesn't exist yet
         this.db.execute("CREATE TABLE IF NOT EXISTS utxo_map " ~

--- a/source/agora/consensus/state/UTXOSet.d
+++ b/source/agora/consensus/state/UTXOSet.d
@@ -22,11 +22,8 @@ import agora.consensus.state.UTXODB;
 import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.serialization.Serializer;
-import agora.utils.Log;
 
 import std.file;
-
-mixin AddLogger!();
 
 ///
 public class UTXOSet : UTXOCache

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -37,8 +37,6 @@ import d2sqlite3.sqlite3;
 
 import std.typecons : Tuple;
 
-mixin AddLogger!();
-
 public enum EnrollmentStatus : int
 {
     Expired = 0,
@@ -74,6 +72,9 @@ public alias ExpiringValidator = Tuple!(Height, "enrolled_height",
 /// Ditto
 public class ValidatorSet
 {
+    /// Logger instance
+    protected Logger log;
+
     /// SQLite db instance
     private ManagedDatabase db;
 
@@ -94,6 +95,7 @@ public class ValidatorSet
     {
         this.db = db;
         this.params = params;
+        this.log = Logger(__MODULE__);
 
         // create the table for validator set if it doesn't exist yet
         this.db.execute("CREATE TABLE IF NOT EXISTS validator_set " ~

--- a/source/agora/network/Clock.d
+++ b/source/agora/network/Clock.d
@@ -54,8 +54,6 @@ import agora.utils.Log;
 import core.stdc.time;
 import core.time;
 
-mixin AddLogger!();
-
 /// Delegate used to calculate the time offset to apply in `networkTime`
 public alias GetNetTimeOffset = bool delegate (out long) @safe nothrow;
 

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -61,8 +61,6 @@ import std.range : walkLength;
 import core.stdc.time;
 import core.time;
 
-mixin AddLogger!();
-
 /// Ditto
 public class NetworkManager
 {
@@ -325,6 +323,9 @@ public class NetworkManager
         }
     }
 
+    /// Logger instance
+    protected Logger log;
+
     /// Config instance
     public const NodeConfig node_config = NodeConfig.init;
 
@@ -384,6 +385,7 @@ public class NetworkManager
     /// Ctor
     public this (in Config config, Metadata metadata, ITaskManager taskman, Clock clock)
     {
+        this.log = Logger(__MODULE__);
         this.taskman = taskman;
         this.node_config = config.node;
         this.validator_config = config.validator;
@@ -410,7 +412,7 @@ public class NetworkManager
 
             // add the DNS seeds
             if (config.dns_seeds.length > 0)
-                this.addAddresses(resolveDNSSeeds(config.dns_seeds));
+                this.addAddresses(resolveDNSSeeds(config.dns_seeds, this.log));
         }
     }
 
@@ -1253,7 +1255,7 @@ public class NetworkManager
 
 *******************************************************************************/
 
-private Set!Address resolveDNSSeeds (in string[] dns_seeds)
+private Set!Address resolveDNSSeeds (in string[] dns_seeds, ref Logger log)
 {
     import std.conv;
     import std.string;

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -37,8 +37,6 @@ import std.path;
 import std.stdio;
 
 
-mixin AddLogger!();
-
 /*******************************************************************************
 
     Define the storage for blocks
@@ -195,6 +193,9 @@ private size_t findBlockPosition (IndexHeight self, Height height) @safe nothrow
 
 public class BlockStorage : IBlockStorage
 {
+    /// Logger instance
+    protected Logger log;
+
     /// Instance of memory mapped file
     private MmFile file;
 
@@ -222,12 +223,18 @@ public class BlockStorage : IBlockStorage
     /// Pre-allocated constant file path
     private immutable string index_path;
 
+    /// Avoid using the calling module's name for our logger
+    private static immutable string ThisModule = __MODULE__;
+
     /***************************************************************************
 
         Construct an instance of a `BlockStorage`
 
         Params:
             path = Path to the directory where the block files are stored
+            logger = Logger to use.
+                     This is used to keep the ctor `@safe pure nothrow`,
+                     despite the `Logger` constructor not being any of this.
 
         Note:
             The object is not usable after construction.
@@ -236,8 +243,10 @@ public class BlockStorage : IBlockStorage
 
     ***************************************************************************/
 
-    public this (string path) nothrow @safe pure
+    public this (string path, Logger logger = Logger(ThisModule))
+        nothrow @safe pure
     {
+        this.log = logger;
         this.root_path = path;
         this.file_index = ulong.max;
         this.length = ulong.max;

--- a/source/agora/node/FlashFullNode.d
+++ b/source/agora/node/FlashFullNode.d
@@ -74,8 +74,6 @@ import std.range;
 
 import core.time;
 
-mixin AddLogger!();
-
 /// Common routines implemented by both FlashFullNode / FlashValidator.
 /// Cannot use multiple inheritance in D.
 public mixin template FlashNodeCommon ()
@@ -218,6 +216,9 @@ public mixin template FlashNodeCommon ()
 ///
 public class FlashFullNode : FullNode, FlashFullNodeAPI
 {
+    /// Logger instance
+    private Logger log;
+
     /// Flash node
     protected AgoraFlashNode flash;
 

--- a/source/agora/node/FlashValidator.d
+++ b/source/agora/node/FlashValidator.d
@@ -67,8 +67,6 @@ import core.stdc.stdlib : abort;
 import core.stdc.time;
 import core.time;
 
-mixin AddLogger!();
-
 ///
 public class FlashValidator : Validator, FlashValidatorAPI
 {

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -74,8 +74,6 @@ import std.range;
 
 import core.time;
 
-mixin AddLogger!();
-
 /// Maximum number of blocks that will be sent in a call to getBlocksFrom()
 private enum uint MaxBatchBlocksSent = 20;
 
@@ -94,6 +92,9 @@ private enum uint MaxBatchTranscationsSent = 100;
 
 public class FullNode : API
 {
+    /// Loggger instance
+    protected Logger log;
+
     /// Metadata instance
     protected Metadata metadata;
 
@@ -169,6 +170,7 @@ public class FullNode : API
         import COINNET = agora.consensus.data.genesis.Coinnet;
 
         this.config = config;
+        this.log = this.makeLogger();
 
         auto commons_budget = config.node.testing ?
             TESTNET.CommonsBudgetAddress : COINNET.CommonsBudgetAddress;
@@ -494,6 +496,12 @@ public class FullNode : API
     protected StatsServer getStatsServer ()
     {
         return new StatsServer(this.config.node.stats_listening_port);
+    }
+
+    /// Returns: The Logger to use for this class
+    protected Logger makeLogger ()
+    {
+        return Logger(__MODULE__);
     }
 
     /***************************************************************************

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -843,7 +843,7 @@ public class Ledger
 
     ***************************************************************************/
 
-    public void accumulateFees (in Block block) nothrow @safe
+    public void accumulateFees (in Block block) @safe
     {
         if (block.header.height == Height(0))
         {

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -61,8 +61,6 @@ import std.range;
 
 import core.time : Duration, seconds;
 
-mixin AddLogger!();
-
 version (unittest)
 {
     //import agora.consensus.data.genesis.Test;
@@ -73,6 +71,10 @@ version (unittest)
 public class Ledger
 {
     import agora.crypto.ECC : Point;
+
+    /// Logger instance
+    protected Logger log;
+
     /// Script execution engine
     private Engine engine;
 
@@ -153,6 +155,7 @@ public class Ledger
         Duration block_time_offset_tolerance = 60.seconds,
         void delegate (in Block, bool) @safe onAcceptedBlock = null)
     {
+        this.log = Logger(__MODULE__);
         this.params = params;
         this.engine = engine;
         this.utxo_set = utxo_set;

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -37,8 +37,6 @@ import std.typecons : Tuple, tuple;
 
 import core.time;
 
-mixin AddLogger!();
-
 ///
 public alias NodeListenerTuple = Tuple!(FullNode, "node", HTTPListener, "http_listener");
 
@@ -59,6 +57,7 @@ public NodeListenerTuple runNode (Config config)
 {
     setVibeLogLevel(config.logging.level);
     Log.root.level(config.logging.level, true);
+    auto log = Logger(__MODULE__);
     log.trace("Config is: {}", config);
 
     auto settings = new HTTPServerSettings(config.node.address);

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -49,8 +49,6 @@ import std.algorithm : each;
 import core.stdc.stdlib : abort;
 import core.time;
 
-mixin AddLogger!();
-
 /*******************************************************************************
 
     Implementation of the Validator node
@@ -372,6 +370,12 @@ public class Validator : FullNode, API
     {
         endpoint_request_stats.increaseMetricBy!"agora_endpoint_calls_total"(1, "receive_block_signature", "http");
         this.nominator.receiveBlockSignature(block_sig);
+    }
+
+    /// Returns: The Logger to use for this class
+    protected override Logger makeLogger ()
+    {
+        return Logger(this.config.validator.key_pair.address.toString());
     }
 
     /***************************************************************************

--- a/source/agora/node/admin/AdminInterface.d
+++ b/source/agora/node/admin/AdminInterface.d
@@ -32,8 +32,6 @@ import std.format;
 import std.meta;
 import std.traits;
 
-mixin AddLogger!();
-
 /*******************************************************************************
 
     Class for Admin interface
@@ -53,6 +51,9 @@ mixin AddLogger!();
 
 public class AdminInterface
 {
+    /// Logger instance
+    protected Logger log;
+
     /// HTTP listener
     private HTTPListener listener;
 
@@ -78,6 +79,7 @@ public class AdminInterface
 
     public this (const Config config, const KeyPair key_pair, Clock clock)
     {
+        this.log = Logger(__MODULE__);
         this.config = config;
         this.key_pair = key_pair;
         this.clock = clock;

--- a/source/agora/node/admin/QRCodeInterface.d
+++ b/source/agora/node/admin/QRCodeInterface.d
@@ -20,7 +20,6 @@ import agora.consensus.data.PreImageInfo;
 import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.crypto.Schnorr: Signature;
-import agora.utils.Log;
 import agora.network.Clock;
 
 import barcode;
@@ -33,8 +32,6 @@ import std.datetime.timezone : UTC;
 import std.format;
 
 import core.time : days;
-
-mixin AddLogger!();
 
 /*******************************************************************************
 

--- a/source/agora/node/admin/Setup.d
+++ b/source/agora/node/admin/Setup.d
@@ -35,8 +35,6 @@ import std.format;
 import std.meta;
 import std.traits;
 
-mixin AddLogger!();
-
 /*******************************************************************************
 
     Class dedicated to the setup part of the administrative interface
@@ -55,6 +53,8 @@ mixin AddLogger!();
 
 public class SetupInterface
 {
+    /// Logger instance
+    protected Logger log;
     /// Path at with to write the config file
     private string path;
     /// HTTP listener, to stop listening once we wrote the config file
@@ -69,6 +69,7 @@ public class SetupInterface
     do
     {
         this.path = config_path;
+        this.log = Logger(__MODULE__);
     }
 
     /// Start listening for requests

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -28,7 +28,6 @@ import agora.node.admin.Setup;
 import agora.node.FullNode;
 import agora.node.Validator;
 import agora.node.Runner;
-import agora.utils.Log;
 import agora.utils.Workarounds;
 
 import vibe.core.core;
@@ -39,8 +38,6 @@ import std.getopt;
 import std.path : absolutePath;
 import std.stdio;
 import std.typecons : Nullable;
-
-mixin AddLogger!();
 
 /// Application entry point
 private int main (string[] args)

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -422,8 +422,8 @@ private final class LocalRestTimer : ITimer
 /// A ban manager not loading and dumping
 public class TestBanManager : BanManager
 {
-    /// Ctor
-    public this (Parameters!(BanManager.__ctor) args)
+    /// Ctor (exclude the 'Logger' default argument)
+    public this (Parameters!(BanManager.__ctor)[0 .. 3] args)
     {
         super(args);
     }


### PR DESCRIPTION
This does some much-needed cleanup in the logger instances, and I hope that it will reduce the memory usage on the servers, as it seems a good chunk of the leaks come from the memory allocated by the Loggers. Normally having an allocation in module ctor wouldn't be an issue, but Vibe.d spawns and kills threads often, or so it seems.