### PR TITLE
CI: Add retry hack to version_build

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -11,8 +11,8 @@
     "stringImportPaths" : [ "build" ],
     "excludedSourceFiles": [ "source/scpp/*.d", "source/scpd/quorum/QuorumIntersectionTests.d" ],
     "preGenerateCommands": [
-        "$DUB source/agora/cli/version/main.d",
-        "$DUB source/scpp/build.d || sleep 5s || $DUB source/scpp/build.d"
+        "$DUB source/agora/cli/version/main.d || (sleep 5s && $DUB source/agora/cli/version/main.d)",
+        "$DUB source/scpp/build.d || (sleep 5s && $DUB source/scpp/build.d)"
     ],
     "sourceFiles-posix": [
         "source/scpp/build/BallotProtocol.o",


### PR DESCRIPTION
```
We get an odd 'no such file or directly' error on the CI sometimes,
which seems to come from a race condition in dub.
The retry hack used for the C++ build script was broken because it
used `sleep || ...`, which should have been `sleep && ...` (sleep doesn't fail).
So fix it, and apply the same hack to `version_dub`.
```