### PR TITLE
Add a warning message when slashing a validator

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -545,6 +545,8 @@ public class Ledger
             block.header.missing_validators);
         foreach (utxo; validators_utxos)
         {
+            log.warn("Slashing validator UTXO {} at height {}",
+                     utxo, block.header.height);
             this.enroll_man.unenrollValidator(utxo);
         }
     }


### PR DESCRIPTION
Slashing a validator is an important enough event that it definitely needs to be logged.
Since the 'Info' level is already overcrowded, and slashing has incidence on the consensus,
add it at the warning level.