### PR TITLE
Ledger test: Change a test to use a cycle of 20

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -1415,7 +1415,7 @@ unittest
 
     // One block before `ValidatorCycle`, validator is still active
     {
-        const ValidatorCycle = 10;
+        const ValidatorCycle = 20;
         auto params = new immutable(ConsensusParams)(ValidatorCycle);
         const blocks = genBlocksToIndex(ValidatorCycle - 1, params);
         scope ledger = new TestLedger(WK.Keys.A, blocks, params);


### PR DESCRIPTION
One of the main issue with the Ledger tests at the moment
is that it bypasses some checks, leading to tests using
invalid blocks. One of the many reasons blocks are invalid
is that there's a different cycle length being used
(ConsensusParams and Genesis are not consistent).
This will be fixed in a later PR, but this specific test
can be easily fixed now.