### PR TITLE
Use the proper offset in EnrollMan's tests

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -1241,7 +1241,7 @@ unittest
     foreach (idx, kp; pairs[0 .. 3])
     {
         auto enroll = EnrollmentManager.makeEnrollment(
-            utxo_hashes[idx], kp, params.ValidatorCycle, cast(uint) idx);
+            utxo_hashes[idx], kp, params.ValidatorCycle, 0);
 
         assert(man.addEnrollment(enroll, kp.address, Height(1), &utxo_set.peekUTXO));
         assert(man.enroll_pool.count() == idx + 1);
@@ -1457,7 +1457,7 @@ unittest
     foreach (idx, kp; pairs[0 .. 3])
     {
         enrollments ~= EnrollmentManager.makeEnrollment(
-            utxo_hashes[idx], kp, params.ValidatorCycle, cast(uint)  idx);
+            utxo_hashes[idx], kp, params.ValidatorCycle, 0);
     }
 
     Height block_height = Height(2);


### PR DESCRIPTION
The test was using the index as the offset, which is a bit odd,
as the offset should be the number of previous Enrollments.
Just use 0 here to make it more predictable.