### PR TITLE
Test: Use the proper values for FullNodes' ConsensusConfig

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1922,6 +1922,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
         {
             banman : ban_conf,
             node : makeNodeConfig(self_address),
+            consensus: makeConsensusConfig(),
             network : makeNetworkConfig(idx, addresses),
         };
 


### PR DESCRIPTION
This omission means that full nodes would not correctly
follow the chain, for example their ValidatorCycle value
was 1008 instead of 20.