### PR TITLE
Logs: Remove noisy log about a valid signature

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -491,13 +491,6 @@ extern(D):
                 challenge.toString(PrintMode.Clear));
             return;
         }
-        else
-        {
-            log.trace("VALID Envelope signature {} \nfor public key {} \n" ~
-                "envelope {}\nchallenge {}",
-                envelope.signature, public_key, scpPrettify(&envelope),
-                challenge.toString(PrintMode.Clear));
-        }
         // we check confirmed statements before validating with
         // 'scp.receiveEnvelope()'
         // There are two reasons why:


### PR DESCRIPTION
This log doesn't add any information to the developer anymore,
as the envelope is already logged in trace mode,
and the developer would expect that the signature is valid.
If that is not the case, the INVALID message will still trigger.