### PR TITLE
Reduce duplication and reduce special cases in Ledger test

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -1078,7 +1078,8 @@ public class ValidatingLedger : Ledger
         assert(data.tx_set.length - pre_cb_len <= 1);
     }
 
-    version (unittest)
+    version (unittest):
+
     private bool externalize (ConsensusData data,
         string file = __FILE__, size_t line = __LINE__)
         @trusted
@@ -1112,6 +1113,20 @@ public class ValidatingLedger : Ledger
             data.time_offset);
         return this.acceptBlock(block, file, line);
     }
+
+    /// simulate block creation as if a nomination and externalize round completed
+    private void forceCreateBlock (ulong max_txs = Block.TxsInTestBlock,
+        string file = __FILE__, size_t line = __LINE__)
+    {
+        ConsensusData data;
+        this.prepareNominatingSet(data, max_txs);
+        assert(data.tx_set.length >= max_txs);
+        if (!this.externalize(data, file, line))
+        {
+            assert(0, format!"Failure in unit test. Block %s should have been externalized!"(
+                       this.getBlockHeight() + 1));
+        }
+    }
 }
 
 /// Note: these unittests historically assume a block always contains
@@ -1119,19 +1134,6 @@ public class ValidatingLedger : Ledger
 version (unittest)
 {
     import core.stdc.time : time;
-
-    /// simulate block creation as if a nomination and externalize round completed
-    private void forceCreateBlock (ValidatingLedger ledger, ulong max_txs = Block.TxsInTestBlock,
-        string file = __FILE__, size_t line = __LINE__)
-    {
-        ConsensusData data;
-        ledger.prepareNominatingSet(data, max_txs);
-        assert(data.tx_set.length >= max_txs);
-        if (!ledger.externalize(data, file, line))
-        {
-            assert(0, format!"Failure in unit test. Block %s should have been externalized!"(ledger.getBlockHeight() + 1));
-        }
-    }
 
     /// A `Ledger` with sensible defaults for `unittest` blocks
     private final class TestLedger : ValidatingLedger


### PR DESCRIPTION
The Ledger tests suffer from many issues, which originate from the organic growth of its tests.
As rules were added, not all tests were properly adapted, leading to some place using invalid blocks in tests.
This does some preliminary work by reducing the number of functions used to generate blocks, and instead of generating blocks ad-hoc, make it go through the ledger as it is the class with all the contextual information.