### PR TITLE
PreImageInfo: Rename 'enroll_key' to 'utxo' and other simplifications

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -665,26 +665,6 @@ public class EnrollmentManager
 
     /***************************************************************************
 
-        Check if a pre-image exists
-
-        Params:
-            utxo = The UTXO for the enrollment in which the pre-image is
-                contained.
-            distance = The distance of the preimage
-
-        Returns:
-            true if the pre-image exists
-
-    ***************************************************************************/
-
-    public bool hasPreimage (in Hash utxo, in ushort distance) @safe
-        nothrow
-    {
-        return this.validator_set.hasPreimage(utxo, distance);
-    }
-
-    /***************************************************************************
-
         Generate the random seed reduced from the preimages for the provided
         block height.
 

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -650,7 +650,7 @@ public class EnrollmentManager
         if (next_dist >= this.params.ValidatorCycle)
             return false;
 
-        preimage.enroll_key = this.enroll_key;
+        preimage.utxo = this.enroll_key;
         preimage.distance = cast(ushort)next_dist;
         const enrolled = this.validator_set.getEnrolledHeight(this.enroll_key);
         preimage.hash = this.cycle[enrolled + next_dist];
@@ -662,7 +662,7 @@ public class EnrollmentManager
         Check if a pre-image exists
 
         Params:
-            enroll_key = The key for the enrollment in which the pre-image is
+            utxo = The UTXO for the enrollment in which the pre-image is
                 contained.
             distance = The distance of the preimage
 
@@ -671,10 +671,10 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public bool hasPreimage (in Hash enroll_key, in ushort distance) @safe
+    public bool hasPreimage (in Hash utxo, in ushort distance) @safe
         nothrow
     {
-        return this.validator_set.hasPreimage(enroll_key, distance);
+        return this.validator_set.hasPreimage(utxo, distance);
     }
 
     /***************************************************************************
@@ -722,8 +722,7 @@ public class EnrollmentManager
         Get validator's pre-image from the validator set.
 
         Params:
-            enroll_key = The key for the enrollment in which the pre-image is
-                contained.
+            utxo = The frozen UTXO used for enrollment.
 
         Returns:
             the PreImageInfo of the enrolled key if it exists,
@@ -731,10 +730,10 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public PreImageInfo getValidatorPreimage (in Hash enroll_key)
-        @trusted nothrow
+    public PreImageInfo getValidatorPreimage (in Hash utxo)
+        @safe nothrow
     {
-        return this.validator_set.getPreimage(enroll_key);
+        return this.validator_set.getPreimage(utxo);
     }
 
     /***************************************************************************
@@ -791,7 +790,7 @@ public class EnrollmentManager
         foreach (image; preimages)
         {
             auto stored_image =
-                this.validator_set.getPreimage(image.enroll_key);
+                this.validator_set.getPreimage(image.utxo);
             if (stored_image == PreImageInfo.init ||
                 stored_image.distance >= image.distance)
                 continue;
@@ -951,7 +950,7 @@ public class EnrollmentManager
         try
         {
             auto results = this.db.execute("SELECT val FROM node_enroll_data " ~
-                "WHERE key = ?", "enroll_key");
+                "WHERE key = ?", "utxo");
 
             if (!results.empty)
                 return Hash(results.oneValue!(string));
@@ -966,26 +965,26 @@ public class EnrollmentManager
 
     /***************************************************************************
 
-        Set the key for the enrollment for this node
+        Set the UTXO for the enrollment for this node
 
-        If saving an enrollment key fails, this displays a log messages and just
+        If saving to the database fails, this displays a log messages and just
         returns. The `enroll_key` stores the value anyway and it can be restored
         from the catch-up process later. If the database or serialization
         operation fails, it means that node is not in normal situation overall.
 
         Params:
-            enroll_key = the key for the enrollment
+            utxo = the key for the enrollment
 
     ***************************************************************************/
 
-    private void setEnrollmentKey (in Hash enroll_key) @trusted nothrow
+    private void setEnrollmentKey (in Hash utxo) @trusted nothrow
     {
-        this.enroll_key = enroll_key;
+        this.enroll_key = utxo;
 
         try
         {
             this.db.execute("REPLACE into node_enroll_data " ~
-                "(key, val) VALUES (?, ?)", "enroll_key", enroll_key);
+                "(key, val) VALUES (?, ?)", "utxo", enroll_key);
         }
         catch (Exception ex)
         {
@@ -1625,7 +1624,7 @@ unittest
         auto cache = PreImageCache(PreImageCycle.NumberOfCycles, params.ValidatorCycle);
         cache.reset(hashMulti(kp.secret, "consensus.preimages", 0));
 
-        PreImageInfo preimage = { enroll_key : utxos[idx],
+        PreImageInfo preimage = { utxo : utxos[idx],
             distance : cast(ushort)params.ValidatorCycle,
             hash : cache[$ - params.ValidatorCycle - 1] };
 

--- a/source/agora/consensus/SlashPolicy.d
+++ b/source/agora/consensus/SlashPolicy.d
@@ -225,10 +225,7 @@ public class SlashPolicy
         auto preimage = this.enroll_man.getValidatorPreimage(utxo_key);
         auto enrolled = this.enroll_man.getEnrolledHeight(preimage.utxo);
         assert(height >= enrolled);
-        if (preimage.distance >= cast(ushort)(height - enrolled))
-            return true;
-        else
-            return false;
+        return preimage.distance >= cast(ushort)(height - enrolled);
     }
 
     /***************************************************************************

--- a/source/agora/consensus/SlashPolicy.d
+++ b/source/agora/consensus/SlashPolicy.d
@@ -223,7 +223,7 @@ public class SlashPolicy
             return true;
 
         auto preimage = this.enroll_man.getValidatorPreimage(utxo_key);
-        auto enrolled = this.enroll_man.getEnrolledHeight(preimage.enroll_key);
+        auto enrolled = this.enroll_man.getEnrolledHeight(preimage.utxo);
         assert(height >= enrolled);
         if (preimage.distance >= cast(ushort)(height - enrolled))
             return true;

--- a/source/agora/consensus/data/PreImageInfo.d
+++ b/source/agora/consensus/data/PreImageInfo.d
@@ -25,7 +25,7 @@ import agora.common.Types;
 public struct PreImageInfo
 {
     /// The key for the enrollment, used to look the commitment up
-    public Hash enroll_key;
+    public Hash utxo;
 
     /// The value of the pre-image at the distance from the commitment
     public Hash hash;
@@ -40,14 +40,14 @@ unittest
 
     testSymmetry!PreImageInfo();
 
-    Hash key = Hash("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f" ~
-                    "1b60a8ce26f000000000019d6689c085ae165831e934ff763ae46a2" ~
-                    "a6c172b3f1b60a8ce26f");
+    Hash utxo = Hash("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f" ~
+                     "1b60a8ce26f000000000019d6689c085ae165831e934ff763ae46a2" ~
+                     "a6c172b3f1b60a8ce26f");
     Hash hash = Hash("0X4A5E1E4BAAB89F3A32518A88C31BC87F618F76673E2CC77AB212" ~
                      "7B7AFDEDA33B4A5E1E4BAAB89F3A32518A88C31BC87F618F76673E" ~
                      "2CC77AB2127B7AFDEDA33B");
     PreImageInfo img = {
-        enroll_key: key,
+        utxo: utxo,
         hash: hash,
         distance: 42,
     };

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -696,7 +696,7 @@ public class ValidatorSet
     {
         import agora.consensus.validation.PreImage : isInvalidReason;
 
-        const prev_preimage = this.getPreimage(preimage.enroll_key);
+        const prev_preimage = this.getPreimage(preimage.utxo);
 
         if (prev_preimage == PreImageInfo.init)
         {
@@ -723,7 +723,7 @@ public class ValidatorSet
             () @trusted {
                 this.db.execute("UPDATE validator_set SET preimage = ?, " ~
                     "distance = ? WHERE key = ? AND active = ?",
-                    preimage.hash, preimage.distance, preimage.enroll_key,
+                    preimage.hash, preimage.distance, preimage.utxo,
                     EnrollmentStatus.Active);
             }();
         }
@@ -988,7 +988,7 @@ unittest
         == PreImageInfo(enroll.utxo_key, enroll.random_seed, 0));
     assert(set.getPreimageAt(utxos[0], Height(11)) == preimage);
     assert(set.getPreimageAt(utxos[0], Height(10)) ==
-        PreImageInfo(preimage.enroll_key, hashFull(preimage.hash),
+        PreImageInfo(preimage.utxo, hashFull(preimage.hash),
             cast(ushort)(preimage.distance - 1)));
 
     // test for clear up expired validators

--- a/source/agora/consensus/validation/PreImage.d
+++ b/source/agora/consensus/validation/PreImage.d
@@ -50,8 +50,8 @@ version (unittest)
 public string isInvalidReason (in PreImageInfo new_image,
     in PreImageInfo prev_image, uint validator_cycle) nothrow @safe
 {
-    if (new_image.enroll_key != prev_image.enroll_key)
-        return "The pre-image's enrollment key differs from its descendant";
+    if (new_image.utxo != prev_image.utxo)
+        return "The pre-image's UTXO differs from its descendant";
 
     if (new_image.distance <= prev_image.distance)
         return "The height of new pre-image is not greater than that of the previous one";
@@ -92,7 +92,7 @@ unittest
     PreImageInfo new_image = PreImageInfo(hashFull("abc"), preimages[100], 101);
     assert(new_image.isValid(prev_image, params.ValidatorCycle));
 
-    // invalid pre-image with wrong enrollment key
+    // invalid pre-image with wrong UTXO
     new_image = PreImageInfo(hashFull("xyz"), preimages[100], 101);
     assert(!new_image.isValid(prev_image, params.ValidatorCycle));
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -825,7 +825,7 @@ public class FullNode : API
                 catch (Exception e)
                 {
                     log.error("Error sending preImage (enroll_key: {}) to {} :{}",
-                        pre_image.enroll_key, address, e);
+                        pre_image.utxo, address, e);
                 }
             });
         }


### PR DESCRIPTION
The first commit renames 'enroll_key' to UTXO and is up for discussion.
Personally I find it more descriptive and less confusing.
The other commits are simplification of existing code (or removal) and should be fairly straightforward.