### PR TITLE
Fixes Issue1658: Sign blocks using pre-image for noise

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -705,6 +705,23 @@ public class EnrollmentManager
 
     /***************************************************************************
 
+        Get the pre-image hash for this validator
+
+        Params:
+            height = the block height of pre-image to be returned
+
+        Returns:
+            The preimage hash if found otherwise Hash.init
+
+    ***************************************************************************/
+
+    public Hash getOurPreimage (in Height height) @safe nothrow
+    {
+        return this.cycle[height];
+    }
+
+    /***************************************************************************
+
         Get the public key of node that is used for a enrollment
 
         Returns:

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -360,7 +360,37 @@ public class ValidatorSet
 
     /***************************************************************************
 
-        Gets the number of active validators at the block height.
+        Get the utxo_key used for enrollment for the given public key
+
+        Params:
+            height = block height to fetch utxo_key
+            public_key = public key of the validator
+
+        Returns:
+            Return UTXO key as Hash
+
+    ***************************************************************************/
+
+    public Hash getEnrollmentForKey (in Height height, in PublicKey public_key) @trusted nothrow
+    {
+        try
+        {
+            auto results = this.db.execute("SELECT key FROM validator " ~
+                "WHERE public_key = ? AND enrolled_height >= ? AND enrolled_height < ? ",
+                public_key, this.minEnrollmentHeight(height), height);
+            if (!results.empty && results.oneValue!(byte[]).length != 0)
+                return Hash(results.front.peek!(char[])(0));
+        }
+        catch (Exception ex)
+        {
+            log.error("ManagedDatabase operation error: {}", ex.msg);
+        }
+        return Hash.init;
+    }
+
+    /***************************************************************************
+
+        Gets the number of active validators at a given block height.
 
         This function finds validators that should be active at a given height,
         provided they do not get slashed. Active validators are those
@@ -560,6 +590,10 @@ public class ValidatorSet
                 assert(preimage_height >= height); // The query should ensure this
                 return pi.adjust(preimage_height - height);
             }
+            else
+            {
+                log.trace("No preimage found for utxo {} at height {}", enroll_key, height.value);
+            }
         }
         catch (Exception ex)
         {
@@ -601,8 +635,8 @@ public class ValidatorSet
 
         if (auto reason = isInvalidReason(preimage, prev_preimage))
         {
-            log.info("Invalid pre-image data: {}. Pre-image: {}",
-                reason, preimage);
+            log.info("Invalid pre-image data: {}. Pre-image: {}, previous: {}",
+                reason, preimage, prev_preimage);
             return false;
         }
 

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -29,6 +29,7 @@ import agora.crypto.Key;
 import agora.crypto.Schnorr;
 import agora.script.Engine;
 import agora.script.Lock;
+import agora.utils.PrettyPrinter;
 import VEn = agora.consensus.validation.Enrollment;
 import VTx = agora.consensus.validation.Transaction;
 import agora.utils.Log;
@@ -650,7 +651,7 @@ version (unittest)
         if (!success)
         {
             try {
-                writeln(mustBeValid ? "Invalid block: " : "Valid block: ", block);
+                writeln(mustBeValid ? "Invalid block: " : "Valid block: ", block.prettify);
                 writefln("prev: %s (%s), enrolled: %s, " ~
                          "cycle: %s, prev_time_offset: %s, curr_time_offset: %s, tolerance: %s",
                          prev_height, prev_hash, enrolled_validators,

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -882,7 +882,7 @@ public class Ledger
         Hash[] valid_keys;
         foreach (idx, key; keys)
         {
-            if (missing_validators.find(idx).empty())
+            if (!missing_validators.canFind(idx))
                 valid_keys ~= key;
         }
 

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -68,19 +68,20 @@ private extern(C++) class BadBlockSigningNominator : TestNominator
     {
         import agora.crypto.Hash;
 
+        const Hash preimage = "preimage".hashFull();
         // challenge = Hash(block) to Scalar
         const Scalar challenge = hashFull(block);
         final switch (reason)
         {
             case ByzantineReason.BadCommitmentR:
                 const Scalar rc = Scalar.random(); // This is normally the enrollment commitment
-                const Scalar r = rc + challenge;
+                const Scalar r = rc + Scalar(preimage);
                 const Point R = r.toPoint();
                 return sign(this.kp.secret, R, r, challenge);
             case ByzantineReason.BadSignature:
                 const Scalar rc = Scalar(hashMulti(WK.Keys.NODE2.secret,
                     "consensus.signature.noise", 0));
-                const Scalar r = rc + challenge;
+                const Scalar r = rc + Scalar(preimage);
                 const Point R = r.toPoint();
                 // Sign with random in place of validator secret key
                 const wrong_scalar_v = Scalar.random();


### PR DESCRIPTION
The signature noise is calculated by adding the enrollment commitment and the pre-image at the block height being signed.