### PR TITLE
Correct values in configuration on banning and retry

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -26,11 +26,11 @@ node:
   # Port on which we bind
   port:    2826    # 0xB0A, default value
   # Number of milliseconds to wait between retrying requests
-  retry_delay: 5000
+  retry_delay: 3000
   # Maximum number of retries to issue before a request is considered failed
-  max_retries: 5
+  max_retries: 10
   # Timeout for each request in milliseconds
-  timeout: 2500
+  timeout: 5000
   # Path to the data directory (if the path doesn't exist it will be created)
   data_dir: .cache
   # The local address where the stats server (currently Prometheus)
@@ -117,7 +117,7 @@ flash:
 ################################################################################
 banman:
   # max failed requests until an address is banned
-  max_failed_requests: 1000
+  max_failed_requests: 100
   # the default duration of a ban
   ban_duration: 86400
 

--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -36,7 +36,7 @@ public class BanManager
     public struct Config
     {
         /// max failed requests until an address is banned
-        public size_t max_failed_requests = 1000;
+        public size_t max_failed_requests = 100;
 
         /// How long does a ban lasts, in seconds (default: 1 day)
         public Duration ban_duration = 1.days;

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -160,10 +160,10 @@ public struct NodeConfig
     public Duration retry_delay = 3.seconds;
 
     /// Maximum number of retries to issue before a request is considered failed
-    public size_t max_retries = 5;
+    public size_t max_retries = 10;
 
     /// Timeout for each request
-    public Duration timeout = 500.msecs;
+    public Duration timeout = 5000.msecs;
 
     /// Path to the data directory to store metadata and blockchain data
     public string data_dir = "/var/lib/agora/";

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -166,7 +166,7 @@ public struct NodeConfig
     public Duration timeout = 5000.msecs;
 
     /// Path to the data directory to store metadata and blockchain data
-    public string data_dir = "/var/lib/agora/";
+    public string data_dir = ".cache";
 
     /// The duration between requests for retrieving the latest blocks
     /// from all other nodes

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1752,13 +1752,13 @@ public struct TestConf
     bool configure_network = true;
 
     /// the delay between request retries
-    Duration retry_delay = 100.msecs;
+    Duration retry_delay = 500.msecs;
 
     /// minimum clients to connect to (defaults to nodes.length - 1)
     size_t min_listeners;
 
     /// max retries before a request is considered failed
-    size_t max_retries = 20;
+    size_t max_retries = 10;
 
     /// request timeout for each node
     Duration timeout = 5.seconds;

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -20,7 +20,10 @@ import agora.test.Base;
 ///
 unittest
 {
-    TestConf conf = TestConf.init;
+    TestConf conf =
+    {
+        retry_delay : 100.msecs,
+    };
     auto network = makeTestNetwork(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -9,9 +9,9 @@ node:
   max_listeners: 10
   address: 0.0.0.0
   port:    1826
-  retry_delay: 500
-  max_retries: 20
-  timeout: 10000
+  retry_delay: 3000
+  max_retries: 10
+  timeout: 5000
   # Path to the data directory (if the path doesn't exist it will be created)
   data_dir: .cache
   block_interval_sec: 5

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -8,9 +8,9 @@ node:
   max_listeners: 10
   address: 0.0.0.0
   port:    2826
-  retry_delay: 500
-  max_retries: 20
-  timeout: 10000
+  retry_delay: 3000
+  max_retries: 10
+  timeout: 5000
   # Path to the data directory (if the path doesn't exist it will be created)
   data_dir: .cache
   block_interval_sec: 5

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -8,9 +8,9 @@ node:
   max_listeners: 10
   address: 0.0.0.0
   port:    3826
-  retry_delay: 500
-  max_retries: 20
-  timeout: 10000
+  retry_delay: 3000
+  max_retries: 10
+  timeout: 5000
   # Path to the data directory (if the path doesn't exist it will be created)
   data_dir: .cache
   block_interval_sec: 5

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -8,9 +8,9 @@ node:
   max_listeners: 10
   address: 0.0.0.0
   port:    4826
-  retry_delay: 500
-  max_retries: 20
-  timeout: 10000
+  retry_delay: 3000
+  max_retries: 10
+  timeout: 5000
   # Path to the data directory (if the path doesn't exist it will be created)
   data_dir: .cache
   block_interval_sec: 5

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -8,9 +8,9 @@ node:
   max_listeners: 10
   address: 0.0.0.0
   port:    5826
-  retry_delay: 500
-  max_retries: 20
-  timeout: 10000
+  retry_delay: 3000
+  max_retries: 10
+  timeout: 5000
   # Path to the data directory (if the path doesn't exist it will be created)
   data_dir: .cache
   block_interval_sec: 5

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -8,9 +8,9 @@ node:
   max_listeners: 10
   address: 0.0.0.0
   port:    6826
-  retry_delay: 500
-  max_retries: 20
-  timeout: 10000
+  retry_delay: 3000
+  max_retries: 10
+  timeout: 5000
   # Path to the data directory (if the path doesn't exist it will be created)
   data_dir: .cache
   block_interval_sec: 5

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -8,9 +8,9 @@ node:
   max_listeners: 10
   address: 0.0.0.0
   port:    7826
-  retry_delay: 500
-  max_retries: 20
-  timeout: 10000
+  retry_delay: 3000
+  max_retries: 10
+  timeout: 5000
   # Path to the data directory (if the path doesn't exist it will be created)
   data_dir: .cache
   block_interval_sec: 5


### PR DESCRIPTION
We should wait some time to ban any unanswering node after many retries and failed requests. We now set the waiting time to about 1 hour. Actually, the total time of multiplication of `retry_delay`, `max_retries`, `timeout`, and `max_failed_requests` in the commits could be one and a half hours.

We mostly refer to the values of `infrastructure` because it is used for the live test system. Anyway, one hour could be the best time to wait before banning a bad node.

Fixes #1657 