### PR TITLE
Remove register[As]Listener

### DIFF
--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -262,53 +262,6 @@ public class NetworkClient
 
     /***************************************************************************
 
-        Register the node's address to listen for gossiping messages.
-
-        This method is to call the API endpoint, or 'register_listener` which
-        is not declared as one of the `FullNode` API in `FullNode.d` because
-        we must use the `HTTPServerRequest` object to retrieve the address of
-        a client. The `register_address` REST path is registered in the `runNode`
-        function of `Runner.d`.
-
-        Throws:
-            `Exception` if the request failed.
-
-    ***************************************************************************/
-
-    public void registerListener ()
-    {
-        foreach (idx; 0 .. this.max_retries)
-        {
-            try
-            {
-                int statusCode;
-                requestHTTP(format("%s/register_listener", this.address),
-                    (scope req) {
-                        req.method = HTTPMethod.POST;
-                    },
-                    (scope res) {
-                        statusCode = res.statusCode;
-                        if (res.statusCode != 200)
-                            this.log.info("Response of {}/register_listener : {}",
-                                this.address, res);
-
-                    }
-                );
-                if (statusCode == 200)
-                    return;
-           }
-           catch (Exception ex)
-           {
-               this.log.format(LogLevel.Trace, "Request '{}' to {} failed: {}",
-                   "registerListener", this.address, ex.message);
-               if (idx + 1 < this.max_retries) // wait after each failure except last
-                   this.taskman.wait(this.retry_delay);
-           }
-       }
-    }
-
-    /***************************************************************************
-
         Get the network info of the node, stored in the
         `node_info` parameter if the request succeeded.
 

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -460,14 +460,6 @@ public class NetworkManager
         this.discovery_task.add(node.client);
         this.metadata.peers.put(node.client.address);
         this.connection_tasks.remove(node.client.address);
-
-        this.registerAsListener(node.client);
-    }
-
-    /// Overridable for LocalRest which uses public keys
-    protected void registerAsListener (NetworkClient client)
-    {
-        client.registerListener();
     }
 
     /***************************************************************************
@@ -707,25 +699,6 @@ public class NetworkManager
                 this.connection_tasks[address].start();
             }
         }
-    }
-
-    /***************************************************************************
-
-        Register the given address as a listener for gossip / consensus messages.
-
-        This adds the given address to the connecting queue, but does not
-        immediately connect to it. Addresses are currently handled in the
-        start() loop, which will exit as soon as 'min_listeners' are reached.
-
-        Params:
-            address = the address of node to register
-
-    ***************************************************************************/
-
-    public void registerListener (Address address)
-    {
-        if (this.shouldEstablishConnection(address))
-            this.addAddress(address);
     }
 
     /***************************************************************************

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -812,22 +812,6 @@ public class FullNode : API
     * the business code.                                                       *
     ***************************************************************************/
 
-    /***************************************************************************
-
-        Register the given address as a listener for gossip / consensus messages.
-
-        This register the given address into the `NetworkManager`.
-
-        Params:
-            address = the address of node to register
-
-    ***************************************************************************/
-
-    public void registerListener (Address address) @trusted
-    {
-        this.network.registerListener(address);
-    }
-
     /// GET: /node_info
     public override NodeInfo getNodeInfo () pure nothrow @safe
     {

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -111,21 +111,6 @@ public Listeners runNode (Config config)
         return result.node.getBanManager().isBanned(address.toAddressString());
     };
 
-    // Register a path for `register_listener` adding client's address.
-    router.route("/register_listener")
-        .post((scope HTTPServerRequest req, scope HTTPServerResponse res)
-        {
-            string addr = format("http://%s:%d",
-                req.clientAddress.toAddressString(), req.clientAddress.port());
-
-            // TODO: disabled as this code is wrong. The client port here is not
-            // the listening port of the node which tried to establish a connection.
-            version (none)
-                result.node.registerListener(addr);
-            res.statusCode = 200;
-            res.writeVoidBody();
-        });
-
     setTimer(0.seconds, &result.node.start, Periodic.No);  // asynchronous
 
     if (result.admin !is null)

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1186,38 +1186,6 @@ public class TestAPIManager
 
 /*******************************************************************************
 
-    Adds additional networking capabilities for use in unittests
-
-*******************************************************************************/
-
-public class TestNetworkClient : NetworkClient
-{
-    /// See NetworkClient ctor
-    public this (Parameters!(NetworkClient.__ctor) args)
-    {
-        super(args);
-    }
-
-    /***************************************************************************
-
-        Register the node's address to listen for gossiping messages.
-
-        address = the adddress of the node
-
-        Throws:
-            `Exception` if the request failed.
-
-    ***************************************************************************/
-
-    public void registerListenerAddress (Address address)
-    {
-        return this.attemptRequest!(TestAPI.registerListenerAddress, Throw.Yes)(
-            cast(TestAPI)this.api, address);
-    }
-}
-
-/*******************************************************************************
-
     Base class for `NetworkManager` used in unittests.
     This class is instantiated once per unittested node.
 
@@ -1276,15 +1244,6 @@ public class TestNetworkManager : NetworkManager
                "' without first creating it");
     }
 
-    ///
-    protected final override TestNetworkClient getNetworkClient (
-        ITaskManager taskman, BanManager banman, Address address,
-        ValidatorAPI api, Duration retry, size_t max_retries)
-    {
-        return new TestNetworkClient(taskman, banman, address, api, retry,
-            max_retries);
-    }
-
     /***************************************************************************
 
         Params:
@@ -1322,12 +1281,6 @@ public class TestNetworkManager : NetworkManager
         (Address address)
     {
         assert(0, "Not supported");
-    }
-
-    /// Overridable for LocalRest which uses public keys
-    protected final override void registerAsListener (NetworkClient client)
-    {
-        (cast(TestNetworkClient)client).registerListenerAddress(this.address);
     }
 }
 
@@ -1414,23 +1367,6 @@ public interface TestAPI : ValidatorAPI
 
     /// Get the active validator count for the current block height
     public ulong countActive (in Height height);
-
-    /***************************************************************************
-
-        Register the given address to listen for gossiping messages.
-
-        This method is the API endpoint for LocalRest, which is corresponding to
-        the `register_address` REST interface.
-
-        Params:
-            address = the address of node to register
-
-        Throws:
-            `Exception` if the request failed.
-
-    ***************************************************************************/
-
-    public void registerListenerAddress (Address address);
 
     /// Get the list of expected quorum configs
     public QuorumConfig[] getExpectedQuorums (in PublicKey[], Height);
@@ -1591,12 +1527,6 @@ private mixin template TestNodeMixin ()
     public override ulong countActive (in Height height)
     {
         return this.enroll_man.validator_set.countActive(height);
-    }
-
-    /// Localrest: the address (key) is provided directly to the network manager
-    public override void registerListenerAddress (Address address)
-    {
-        this.network.registerListener(address);
     }
 
     /// Manually initiate a clock synchronization event

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -65,9 +65,6 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    import core.thread;
-    Thread.sleep(2.seconds);  // registerListener() can take a while..
-
     auto nodes = network.clients;
     auto node_1 = nodes[0];
 


### PR DESCRIPTION
This was only used in unittest and not in the actual, deployed node.
Now that we have the registry, it should not be necessary.