### PR TITLE
BlockStorage: use serializer for Signature in updateBlockSig

### DIFF
--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -474,10 +474,7 @@ public class BlockStorage : IBlockStorage
         this.is_saving = true;
         scope(exit) this.is_saving = false;
 
-        if (!this.write(data_position + SignatureOffset, sig.toBlob()[]))
-            assert(0);
-
-        size_t block_size = ValidatorsOffset;
+        size_t block_size = SignatureOffset;
         scope SerializeDg dg = (in ubyte[] data) @safe
         {
             // write to memory
@@ -486,6 +483,7 @@ public class BlockStorage : IBlockStorage
 
             block_size += data.length;
         };
+        serializePart(sig, dg);
         serializePart(validators, dg);
         this.writeChecksum();
     }

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -568,7 +568,7 @@ public class BlockStorage : IBlockStorage
 
     private size_t readSizeT (size_t pos) @trusted
     {
-        ubyte[] data = this.read(pos, pos+size_t.sizeof);
+        ubyte[] data = this.read(pos, size_t.sizeof);
         return *cast(size_t*)(data.ptr);
     }
 


### PR DESCRIPTION
Blocks are deserialized as a whole. Instead of toBlob(), updated signatures
should use serializer too.

Fixes #1848