### PR TITLE
Determine preimages from previous cycles

### DIFF
--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -612,10 +612,9 @@ public class ValidatorSet
         {
             auto results = this.db.execute(
                 "SELECT preimage, enrolled_height, distance " ~
-                "FROM validator_set WHERE key = ? AND enrolled_height <= ? " ~
-                "AND enrolled_height + distance >= ? AND active = ?",
-                enroll_key, height.value, height.value,
-                EnrollmentStatus.Active);
+                "FROM validator_set WHERE key = ? " ~
+                "AND enrolled_height + distance >= ? ORDER BY enrolled_height + distance",
+                enroll_key, height.value);
 
             if (!results.empty && results.oneValue!(byte[]).length != 0)
             {
@@ -625,7 +624,8 @@ public class ValidatorSet
                 ushort distance = row.peek!ushort(2);
 
                 auto pi = PreImageInfo(enroll_key, preimage, distance);
-                return pi.adjust(enrolled_height + distance - height);
+                auto times = enrolled_height + distance - height;
+                return (times > pi.distance) ? PreImageInfo.init : pi.adjust(times);
             }
         }
         catch (Exception ex)

--- a/source/agora/test/ValidatorCount.d
+++ b/source/agora/test/ValidatorCount.d
@@ -44,6 +44,7 @@ unittest
     auto gen_key_pair = WK.Keys.Genesis;
     // Get the genesis block, make sure it's the only block externalized
     auto blocks = node_1.getBlocksFrom(0, 2);
+    assert(blocks.length == 1, "Should only have Genesis Block at this time");
 
     Transaction[] txs;
 
@@ -75,6 +76,6 @@ unittest
     Thread.sleep(2.seconds);  // wait for propagation
 
     // New block was not created because all validators would expire
-    network.assertSameBlocks(iota(network.nodes.length),
-        Height(GenesisValidatorCycle - 1));
+    assert(node_1.getBlockHeight() == GenesisValidatorCycle - 1,
+        "Block should not have been externalized as there will be no active validators for next block");
 }


### PR DESCRIPTION
This enables the calculation of older preimages that are from earlier
enrollment heights than the current.