### PR TITLE
Allow Agora to listen to multiple interfaces

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -21,10 +21,6 @@ node:
   min_listeners: 2
   # Maximum number of non-validating nodes to connect to
   max_listeners: 10
-  # Address to which we bind
-  address: 0.0.0.0 # Any node can bind - default value
-  # Port on which we bind
-  port:    2826    # 0xB0A, default value
   # Number of milliseconds to wait between retrying requests
   retry_delay: 3000
   # Maximum number of retries to issue before a request is considered failed
@@ -43,6 +39,16 @@ node:
   # The duration between requests for retrieving the latest blocks
   # from all other nodes
   block_catchup_interval_secs: 20
+
+# Each entry in this array is an interface Agora will listen to, allowing to
+# expose the same node on more than one network interface or with different
+# API, such as having one interface using HTTP+JSON and the other TCP+binary.
+interfaces:
+  - type: http
+    # Address to which we bind
+    address: 0.0.0.0 # Any node can bind - default value
+    # Port on which we bind
+    port:    2826    # 0xB0A, default value
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -7,8 +7,6 @@ node:
 
   min_listeners: 3
   max_listeners: 10
-  address: 0.0.0.0
-  port:    1826
   retry_delay: 3000
   max_retries: 50
   timeout: 5000
@@ -16,6 +14,14 @@ node:
   data_dir: .cache
   block_interval_sec: 5
   block_catchup_interval_secs: 5
+
+interfaces:
+  - type: http
+    address: 0.0.0.0
+    port:    1826
+  - type: http
+    address: 0.0.0.0
+    port:    1735
 
 consensus:
   validator_cycle: 20
@@ -44,11 +50,11 @@ validator:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-2:2826
-  - http://node-3:3826
-  - http://node-4:4826
-  - http://node-5:5826
-  - http://node-6:6826
+  - http://node-2:2735
+  - http://node-3:3735
+  - http://node-4:4735
+  - http://node-5:5735
+  - http://node-6:6735
 
 ################################################################################
 ##                               Logging options                              ##

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -6,8 +6,6 @@ node:
   testing: true
   min_listeners: 6
   max_listeners: 10
-  address: 0.0.0.0
-  port:    2826
   retry_delay: 3000
   max_retries: 50
   timeout: 5000
@@ -15,6 +13,14 @@ node:
   data_dir: .cache
   block_interval_sec: 5
   block_catchup_interval_secs: 5
+
+interfaces:
+  - type: http
+    address: 0.0.0.0
+    port:    2826
+  - type: http
+    address: 0.0.0.0
+    port:    2735
 
 consensus:
   validator_cycle: 20
@@ -49,12 +55,12 @@ validator:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-0:1826
-  - http://node-3:3826
-  - http://node-4:4826
-  - http://node-5:5826
-  - http://node-6:6826
-  - http://node-7:7826
+  - http://node-0:1735
+  - http://node-3:3735
+  - http://node-4:4735
+  - http://node-5:5735
+  - http://node-6:6735
+  - http://node-7:7735
 
 ################################################################################
 ##                               Logging options                              ##

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -6,8 +6,6 @@ node:
   testing: true
   min_listeners: 6
   max_listeners: 10
-  address: 0.0.0.0
-  port:    3826
   retry_delay: 3000
   max_retries: 50
   timeout: 5000
@@ -15,6 +13,14 @@ node:
   data_dir: .cache
   block_interval_sec: 5
   block_catchup_interval_secs: 5
+
+interfaces:
+  - type: http
+    address: 0.0.0.0
+    port:    3826
+  - type: http
+    address: 0.0.0.0
+    port:    3735
 
 consensus:
   validator_cycle: 20
@@ -49,12 +55,12 @@ validator:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-0:1826
-  - http://node-2:2826
-  - http://node-4:4826
-  - http://node-5:5826
-  - http://node-6:6826
-  - http://node-7:7826
+  - http://node-0:1735
+  - http://node-2:2735
+  - http://node-4:4735
+  - http://node-5:5735
+  - http://node-6:6735
+  - http://node-7:7735
 
 ################################################################################
 ##                               Logging options                              ##

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -6,8 +6,6 @@ node:
   testing: true
   min_listeners: 6
   max_listeners: 10
-  address: 0.0.0.0
-  port:    4826
   retry_delay: 3000
   max_retries: 50
   timeout: 5000
@@ -15,6 +13,14 @@ node:
   data_dir: .cache
   block_interval_sec: 5
   block_catchup_interval_secs: 5
+
+interfaces:
+  - type: http
+    address: 0.0.0.0
+    port:    4826
+  - type: http
+    address: 0.0.0.0
+    port:    4735
 
 consensus:
   validator_cycle: 20
@@ -49,12 +55,12 @@ validator:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-0:1826
-  - http://node-2:2826
-  - http://node-3:3826
-  - http://node-5:5826
-  - http://node-6:6826
-  - http://node-7:7826
+  - http://node-0:1735
+  - http://node-2:2735
+  - http://node-3:3735
+  - http://node-5:5735
+  - http://node-6:6735
+  - http://node-7:7735
 
 ################################################################################
 ##                               Logging options                              ##

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -6,8 +6,6 @@ node:
   testing: true
   min_listeners: 6
   max_listeners: 10
-  address: 0.0.0.0
-  port:    5826
   retry_delay: 3000
   max_retries: 50
   timeout: 5000
@@ -15,6 +13,14 @@ node:
   data_dir: .cache
   block_interval_sec: 5
   block_catchup_interval_secs: 5
+
+interfaces:
+  - type: http
+    address: 0.0.0.0
+    port:    5826
+  - type: http
+    address: 0.0.0.0
+    port:    5735
 
 consensus:
   validator_cycle: 20
@@ -49,12 +55,12 @@ validator:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-0:1826
-  - http://node-2:2826
-  - http://node-3:3826
-  - http://node-4:4826
-  - http://node-6:6826
-  - http://node-7:7826
+  - http://node-0:1735
+  - http://node-2:2735
+  - http://node-3:3735
+  - http://node-4:4735
+  - http://node-6:6735
+  - http://node-7:7735
 
 ################################################################################
 ##                               Logging options                              ##

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -6,8 +6,6 @@ node:
   testing: true
   min_listeners: 6
   max_listeners: 10
-  address: 0.0.0.0
-  port:    6826
   retry_delay: 3000
   max_retries: 50
   timeout: 5000
@@ -15,6 +13,14 @@ node:
   data_dir: .cache
   block_interval_sec: 5
   block_catchup_interval_secs: 5
+
+interfaces:
+  - type: http
+    address: 0.0.0.0
+    port:    6826
+  - type: http
+    address: 0.0.0.0
+    port:    6735
 
 consensus:
   validator_cycle: 20
@@ -49,12 +55,12 @@ validator:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-0:1826
-  - http://node-2:2826
-  - http://node-3:3826
-  - http://node-4:4826
-  - http://node-5:5826
-  - http://node-7:7826
+  - http://node-0:1735
+  - http://node-2:2735
+  - http://node-3:3735
+  - http://node-4:4735
+  - http://node-5:5735
+  - http://node-7:7735
 
 ################################################################################
 ##                               Logging options                              ##

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -6,8 +6,6 @@ node:
   testing: true
   min_listeners: 6
   max_listeners: 10
-  address: 0.0.0.0
-  port:    7826
   retry_delay: 3000
   max_retries: 50
   timeout: 5000
@@ -15,6 +13,14 @@ node:
   data_dir: .cache
   block_interval_sec: 5
   block_catchup_interval_secs: 5
+
+interfaces:
+  - type: http
+    address: 0.0.0.0
+    port:    7826
+  - type: http
+    address: 0.0.0.0
+    port:    7735
 
 consensus:
   validator_cycle: 20
@@ -49,12 +55,12 @@ validator:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - http://node-0:1826
-  - http://node-2:2826
-  - http://node-3:3826
-  - http://node-4:4826
-  - http://node-5:5826
-  - http://node-6:6826
+  - http://node-0:1735
+  - http://node-2:2735
+  - http://node-3:3735
+  - http://node-4:4735
+  - http://node-5:5735
+  - http://node-6:6735
 
 ################################################################################
 ##                               Logging options                              ##


### PR DESCRIPTION
Contains a bunch of refactoring, but the end goal is to make Agora able to listen either on HTTP or RPC.
Part of #203 .