### PR TITLE
Don't wait for parallel/heavy tests if failed early

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -304,10 +304,10 @@ private UnitTestResult customModuleUnitTester ()
     {
         runInParallel(parallel_tests);
         runInParallel(heavy_tests);
-    }
 
-    //waiting for all parallel tasks to finish
-    iota(parallel_tests.length + heavy_tests.length).each!(x => finished_tasks_num.wait());
+        //waiting for all parallel tasks to finish
+        iota(parallel_tests.length + heavy_tests.length).each!(x => finished_tasks_num.wait());
+    }
 
     UnitTestResult result = { executed : executed, passed : passed };
     if (filtered > 0)


### PR DESCRIPTION
I think this explains those 60 minute run times..

For example this code blocks:

```D
import core.sync.semaphore;
import std.stdio;

void main ()
{
    auto finished_tasks_num = new Semaphore(0);
    finished_tasks_num.wait();  // blocked
    writeln("Done");
}
```