### PR TITLE
NetworkManager: Authenticate Validator node identity

### DIFF
--- a/source/agora/api/Validator.d
+++ b/source/agora/api/Validator.d
@@ -104,7 +104,7 @@ public interface API : agora.api.FullNode.API
 
     ***************************************************************************/
 
-    public Identity getPublicKey (PublicKey key);
+    public Identity getPublicKey (PublicKey key = PublicKey.init);
 
     /***************************************************************************
 

--- a/source/agora/api/Validator.d
+++ b/source/agora/api/Validator.d
@@ -46,6 +46,7 @@ import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.ValidatorBlockSig;
 import agora.crypto.Hash;
 import agora.crypto.Key;
+import agora.crypto.Schnorr;
 import agora.flash.api.FlashAPI;
 static import agora.api.FullNode;
 
@@ -62,6 +63,16 @@ public import agora.api.FullNode;
 @serializationPolicy!(Base64ArrayPolicy)
 public interface FlashValidatorAPI : API, ExtendedFlashAPI
 {
+}
+
+/// Identity of a Validator node
+public struct Identity
+{
+    /// Public Key of the node
+    PublicKey key;
+
+    /// MAC
+    ubyte[] mac;
 }
 
 /*******************************************************************************
@@ -82,15 +93,18 @@ public interface API : agora.api.FullNode.API
 
     /***************************************************************************
 
+        Params:
+            key = key of the peer
+
         Returns:
-            The public key of this node
+            The public key of this node and a secret to prove identity
 
         API:
             GET /public_key
 
     ***************************************************************************/
 
-    public PublicKey getPublicKey ();
+    public Identity getPublicKey (PublicKey key);
 
     /***************************************************************************
 

--- a/source/agora/flash/OnionPacket.d
+++ b/source/agora/flash/OnionPacket.d
@@ -447,8 +447,8 @@ unittest
 
 *******************************************************************************/
 
-private Point generateSharedSecret (bool is_sender, Scalar our_secret,
-    Point their_pubkey)
+public Point generateSharedSecret (bool is_sender, Scalar our_secret,
+    Point their_pubkey) @trusted nothrow
 {
     auto shared_key = our_secret * their_pubkey;
 

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -223,17 +223,21 @@ public class NetworkClient
 
     /***************************************************************************
 
+        Params:
+            key = key of the peer
+
         Returns:
-            the node's public key.
+            The public key of this node and a secret to prove identity
 
         Throws:
             `Exception` if the request failed.
 
     ***************************************************************************/
 
-    public PublicKey getPublicKey () @trusted
+    public Identity getPublicKey (PublicKey key = PublicKey.init) @trusted
     {
-        return this.attemptRequest!(API.getPublicKey, Throw.Yes)(this.api);
+        return this.attemptRequest!(API.getPublicKey, Throw.Yes)(this.api,
+            key);
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -256,11 +256,25 @@ public class Validator : FullNode, API
     }
 
     /// GET /public_key
-    public override PublicKey getPublicKey () pure nothrow @safe
+    public override Identity getPublicKey (PublicKey key) nothrow @safe
     {
+        import agora.flash.OnionPacket : generateSharedSecret;
+        import libsodium.crypto_auth;
         endpoint_request_stats.increaseMetricBy!"agora_endpoint_calls_total"(
             1, "public_key", "http");
-        return this.config.validator.key_pair.address;
+
+        Identity id = Identity(this.config.validator.key_pair.address);
+        if (key == PublicKey.init)
+            return id;
+
+        Hash shared_sec = generateSharedSecret(false,
+            this.config.validator.key_pair.secret, key).hashFull();
+        static assert(shared_sec.sizeof >= crypto_auth_KEYBYTES);
+
+        id.mac.length = crypto_auth_BYTES;
+        () @trusted { crypto_auth (id.mac.ptr, id.key[].ptr,
+            id.key[].length, shared_sec[].ptr); } ();
+        return id;
     }
 
     /***************************************************************************
@@ -574,7 +588,7 @@ public class Validator : FullNode, API
 
     private Hash getFrozenUTXO () @safe
     {
-        const pub_key = this.getPublicKey();
+        const pub_key = this.config.validator.key_pair.address;
         foreach (key, utxo; this.utxo_set.getUTXOs(pub_key))
         {
             if (utxo.type == TxType.Freeze &&

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -256,7 +256,7 @@ public class Validator : FullNode, API
     }
 
     /// GET /public_key
-    public override Identity getPublicKey (PublicKey key) nothrow @safe
+    public override Identity getPublicKey (PublicKey key = PublicKey.init) nothrow @safe
     {
         import agora.flash.OnionPacket : generateSharedSecret;
         import libsodium.crypto_auth;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -550,6 +550,11 @@ public struct NodePair
     /// used in the Nomination protocol.
     private shared(TimePoint)* cur_time;
 
+    ///
+    public TestAPI api;
+
+    alias api this;
+
     /// Get the current clock time
     @property TimePoint time () @trusted @nogc nothrow
     {
@@ -853,7 +858,7 @@ public class TestAPIManager
         foreach (ref interf; conf.interfaces)
         {
             this.reg.register(interf.address, api.listener());
-            this.nodes ~= NodePair(interf.address, api, time);
+            this.nodes ~= NodePair(interf.address, api, time, api);
         }
         return api;
     }
@@ -1719,7 +1724,7 @@ public class TestFullNode : FullNode, TestAPI
     }
 
     /// FullNode does not implement this
-    public override Identity getPublicKey (PublicKey) @safe
+    public override Identity getPublicKey (PublicKey key = PublicKey.init) @safe
     {
         // NetworkManager assumes that if key == PublicKey.init,
         // we are *not* a Validator node, treated as a FullNode instead.
@@ -1777,7 +1782,7 @@ public class TestValidatorNode : Validator, TestAPI
     public override Enrollment createEnrollmentData ()
     {
         Hash[] utxo_hashes;
-        auto pubkey = this.getPublicKey(PublicKey.init).key;
+        auto pubkey = this.getPublicKey().key;
         auto utxos = this.utxo_set.getUTXOs(pubkey);
         assert(utxos.length > 0, format!"No utxo for public key %s"(pubkey));
         foreach (key, utxo; utxos)

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -40,7 +40,7 @@ void manyValidators (size_t validators)
     // generate 18 blocks, 2 short of the enrollments expiring.
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    const keys = network.nodes.map!(node => node.client.getPublicKey(PublicKey.init).key)
+    const keys = network.nodes.map!(node => node.getPublicKey().key)
         .dropExactly(GenesisValidators).takeExactly(conf.outsider_validators)
         .array;
 

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -26,6 +26,7 @@ void manyValidators (size_t validators)
     import std.format;
     import std.range;
     import core.time : seconds;
+    import agora.crypto.Key;
 
     TestConf conf = { outsider_validators : validators - GenesisValidators,
         txs_to_nominate : 0 };
@@ -39,7 +40,7 @@ void manyValidators (size_t validators)
     // generate 18 blocks, 2 short of the enrollments expiring.
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    const keys = network.nodes.map!(node => node.client.getPublicKey())
+    const keys = network.nodes.map!(node => node.client.getPublicKey(PublicKey.init).key)
         .dropExactly(GenesisValidators).takeExactly(conf.outsider_validators)
         .array;
 

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -16,6 +16,10 @@ module agora.test.NetworkDiscovery;
 version (unittest):
 
 import agora.test.Base;
+import agora.api.Validator;
+import agora.common.Config;
+import agora.crypto.Schnorr;
+import agora.crypto.Key;
 
 ///
 unittest
@@ -82,4 +86,64 @@ unittest
         assert(addresses.sort.uniq.count >= GenesisValidators - 1,  // >= since it may connect to itself (#772)
                format("Node %s has %d peers: %s", key, addresses.length, addresses));
     }
+}
+
+///
+unittest
+{
+    import core.thread;
+    import core.atomic;
+
+    __gshared shared(int) call_count = 0;
+    __gshared NodePair impersonator_node;
+
+    static class ImpersonatorValidator : TestValidatorNode
+    {
+        mixin ForwardCtor!();
+
+        /// GET /public_key
+        protected override Identity getPublicKey (PublicKey key) nothrow @trusted
+        {
+            atomicOp!"+="(call_count, 1);
+            return Identity(this.config.validator.key_pair.address);
+        }
+    }
+
+    static class ImpersonatorManager : TestAPIManager
+    {
+        mixin ForwardCtor!();
+
+        public override void createNewNode (Config conf, string file = __FILE__,
+            int line = __LINE__)
+        {
+            if (impersonator_node == NodePair.init && conf.validator.enabled)
+            {
+                this.addNewNode!ImpersonatorValidator(conf, file, line);
+                impersonator_node = this.nodes[$ - 1];
+            }
+            else
+                super.createNewNode(conf, file, line);
+        }
+    }
+
+    TestConf conf;
+    auto network = makeTestNetwork!ImpersonatorManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+
+    int count = 0;
+    while (atomicLoad(call_count) < GenesisValidators - 1)
+    {
+        if (count++ > 30) // 3 secs
+            break;
+        Thread.sleep(100.msecs);
+    }
+
+    assert(atomicLoad(call_count) >= GenesisValidators - 1);
+
+    // All nodes should've banned impersonator_node
+    foreach (node; network.nodes)
+        if (node != impersonator_node)
+            assert(node.client.isBanned(impersonator_node.address));
 }

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -102,7 +102,8 @@ unittest
         mixin ForwardCtor!();
 
         /// GET /public_key
-        protected override Identity getPublicKey (PublicKey key) nothrow @trusted
+        protected override Identity getPublicKey (PublicKey key = PublicKey.init) 
+            nothrow @trusted
         {
             atomicOp!"+="(call_count, 1);
             return Identity(this.config.validator.key_pair.address);

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -47,14 +47,14 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.clients;
+    auto nodes = network.nodes;
 
     auto validators = GenesisValidators + conf.outsider_validators;
 
     // generate 18 blocks, 1 short of the enrollments expiring.
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    const keys = nodes.map!(node => node.getPublicKey(PublicKey.init).key)
+    const keys = nodes.map!(node => node.getPublicKey().key)
         .dropExactly(GenesisValidators)
         .takeExactly(conf.outsider_validators)
         .array;
@@ -83,7 +83,7 @@ unittest
         Height(GenesisValidatorCycle));
 
     // these are no longer enrolled
-    nodes[0 .. GenesisValidators].each!(node => node.sleep(10.minutes, true));
+    nodes[0 .. GenesisValidators].each!(node => node.client.sleep(10.minutes, true));
 
     // verify that consensus can still be reached by the leftover validators
     network.generateBlocks(iota(GenesisValidators, nodes.length),
@@ -91,7 +91,7 @@ unittest
 
     // force wake up
     nodes.takeExactly(GenesisValidators).each!(node =>
-        node.sleep(0.seconds, false));
+        node.client.sleep(0.seconds, false));
 
     // all nodes should have same block height now
     network.expectHeightAndPreImg(iota(nodes.length), Height(GenesisValidatorCycle + 1),

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -23,6 +23,7 @@ import agora.consensus.data.Params;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
+import agora.crypto.Key;
 import agora.node.FullNode;
 import agora.test.Base;
 
@@ -53,7 +54,7 @@ unittest
     // generate 18 blocks, 1 short of the enrollments expiring.
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    const keys = nodes.map!(node => node.getPublicKey())
+    const keys = nodes.map!(node => node.getPublicKey(PublicKey.init).key)
         .dropExactly(GenesisValidators)
         .takeExactly(conf.outsider_validators)
         .array;

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -137,7 +137,7 @@ unittest
                     idx, node.getQuorumConfig(), quorums_1[idx])));
     }
 
-    const keys = network.nodes.map!(node => node.client.getPublicKey(PublicKey.init).key)
+    const keys = network.nodes.map!(node => node.getPublicKey().key)
         .dropExactly(GenesisValidators).takeExactly(conf.outsider_validators)
         .array;
 

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -23,6 +23,7 @@ import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
 import agora.consensus.data.genesis.Test;
+import agora.crypto.Key;
 import agora.node.FullNode;
 import agora.utils.Log;
 import agora.test.Base;
@@ -136,7 +137,7 @@ unittest
                     idx, node.getQuorumConfig(), quorums_1[idx])));
     }
 
-    const keys = network.nodes.map!(node => node.client.getPublicKey())
+    const keys = network.nodes.map!(node => node.client.getPublicKey(PublicKey.init).key)
         .dropExactly(GenesisValidators).takeExactly(conf.outsider_validators)
         .array;
 

--- a/source/agora/test/QuorumShuffle.d
+++ b/source/agora/test/QuorumShuffle.d
@@ -44,7 +44,7 @@ unittest
 
     auto nodes = network.clients;
 
-    const keys = network.nodes.map!(node => node.client.getPublicKey(PublicKey.init).key).array;
+    const keys = network.nodes.map!(node => node.getPublicKey().key).array;
 
     QuorumConfig[] checkQuorum (Height height) {
         if (height > 0) // if not Genesis block

--- a/source/agora/test/QuorumShuffle.d
+++ b/source/agora/test/QuorumShuffle.d
@@ -18,6 +18,7 @@ version (unittest):
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
+import agora.crypto.Key;
 import agora.test.Base;
 import agora.utils.Log;
 import agora.utils.PrettyPrinter;
@@ -43,7 +44,7 @@ unittest
 
     auto nodes = network.clients;
 
-    const keys = network.nodes.map!(node => node.client.getPublicKey()).array;
+    const keys = network.nodes.map!(node => node.client.getPublicKey(PublicKey.init).key).array;
 
     QuorumConfig[] checkQuorum (Height height) {
         if (height > 0) // if not Genesis block

--- a/source/agora/test/RestoreSlashingInfo.d
+++ b/source/agora/test/RestoreSlashingInfo.d
@@ -41,14 +41,14 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.clients;
-    auto set_a = network.clients[0 .. GenesisValidators];
-    auto set_b = network.clients[GenesisValidators .. $];
+    auto nodes = network.nodes;
+    auto set_a = network.nodes[0 .. GenesisValidators];
+    auto set_b = network.nodes[GenesisValidators .. $];
 
     // generate 18 blocks, 2 short of the enrollments expiring.
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    const keys = network.nodes.map!(node => node.client.getPublicKey(PublicKey.init).key)
+    const keys = network.nodes.map!(node => node.getPublicKey().key)
         .dropExactly(GenesisValidators).takeExactly(conf.outsider_validators)
         .array;
 
@@ -84,6 +84,6 @@ unittest
 
     // Now restarting the validators in the set B, all the data of those
     // validators has been wiped out.
-    set_b.each!(node => network.restart(node));
+    set_b.each!(node => network.restart(node.client));
     network.expectHeight(Height(GenesisValidatorCycle + 1));
 }

--- a/source/agora/test/RestoreSlashingInfo.d
+++ b/source/agora/test/RestoreSlashingInfo.d
@@ -19,6 +19,7 @@ version (unittest):
 import agora.api.FullNode;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
+import agora.crypto.Key;
 import agora.test.Base;
 
 /// Situation: There are six validators enrolled in Genesis block. Right before
@@ -47,7 +48,7 @@ unittest
     // generate 18 blocks, 2 short of the enrollments expiring.
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    const keys = network.nodes.map!(node => node.client.getPublicKey())
+    const keys = network.nodes.map!(node => node.client.getPublicKey(PublicKey.init).key)
         .dropExactly(GenesisValidators).takeExactly(conf.outsider_validators)
         .array;
 

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -118,9 +118,9 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.clients;
+    auto nodes = network.nodes;
     auto spendable = network.blocks[$ - 1].spendable().array;
-    auto bad_address = nodes[5].getPublicKey(PublicKey.init).key;
+    auto bad_address = nodes[5].getPublicKey().key;
 
     // discarded UTXOs (just to trigger block creation)
     auto txs = spendable[0 .. 8].map!(txb => txb.sign()).array;

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -25,6 +25,7 @@ import agora.consensus.data.Transaction;
 import agora.consensus.EnrollmentManager;
 import agora.consensus.state.UTXOSet;
 import agora.crypto.Schnorr;
+import agora.crypto.Key;
 import agora.utils.Test;
 import agora.test.Base;
 
@@ -119,7 +120,7 @@ unittest
 
     auto nodes = network.clients;
     auto spendable = network.blocks[$ - 1].spendable().array;
-    auto bad_address = nodes[5].getPublicKey();
+    auto bad_address = nodes[5].getPublicKey(PublicKey.init).key;
 
     // discarded UTXOs (just to trigger block creation)
     auto txs = spendable[0 .. 8].map!(txb => txb.sign()).array;

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -19,6 +19,7 @@ version (unittest):
 import agora.api.FullNode;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
+import agora.crypto.Key;
 import agora.test.Base;
 
 /// Situation: One set of Validators(set A) which enrolled in the Genesis
@@ -50,7 +51,7 @@ version(none) unittest
     // generate 18 blocks, 2 short of the enrollments expiring.
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    const keys = network.nodes.map!(node => node.client.getPublicKey())
+    const keys = network.nodes.map!(node => node.client.getPublicKey(PublicKey.init).key)
         .dropExactly(GenesisValidators).takeExactly(conf.outsider_validators)
         .array;
 
@@ -149,7 +150,7 @@ unittest
     // Wait for node_1 to wake up
     node_1.ctrl.withTimeout(10.seconds,
         (scope TestAPI api) {
-            api.getPublicKey();
+            api.getPublicKey(PublicKey.init);
         }
     );
 

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -51,7 +51,7 @@ version(none) unittest
     // generate 18 blocks, 2 short of the enrollments expiring.
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    const keys = network.nodes.map!(node => node.client.getPublicKey(PublicKey.init).key)
+    const keys = network.nodes.map!(node => node.getPublicKey().key)
         .dropExactly(GenesisValidators).takeExactly(conf.outsider_validators)
         .array;
 
@@ -150,7 +150,7 @@ unittest
     // Wait for node_1 to wake up
     node_1.ctrl.withTimeout(10.seconds,
         (scope TestAPI api) {
-            api.getPublicKey(PublicKey.init);
+            api.getPublicKey();
         }
     );
 


### PR DESCRIPTION
Nodes could impersonate another Validator since there was
no authentication at NetworkManager.