### PR TITLE
Revert BanManager minimum failed request from 100 to 1000

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -36,7 +36,7 @@ public class BanManager
     public struct Config
     {
         /// max failed requests until an address is banned
-        public size_t max_failed_requests = 100;
+        public size_t max_failed_requests = 1000;
 
         /// How long does a ban lasts, in seconds (default: 1 day)
         public Duration ban_duration = 1.days;


### PR DESCRIPTION
This seems to make the integration test fails more often.