### PR TITLE
Replace distance with height for pre images

### DIFF
--- a/doc/Database.md
+++ b/doc/Database.md
@@ -24,16 +24,16 @@ Our oldest table, only contain binary serialized data, should be changed to a re
 
 Should be cleaned up and make readable. Once `utxo` is usable, both can be used in combination.
 
-| Field name      | SQL Type | D type           | Attributes                  | Comment                                            |
-|-----------------|----------|------------------|-----------------------------|----------------------------------------------------|
-| key             | TEXT     | Hash             | PRIMARY KEY (with `active`) | The `utxo` field in the `Enrollment`               |
-| public_key      | TEXT     | PublicKey        |                             | Should be replaced with a join using the UTXO hash |
-| cycle_length    | INTEGER  | ulong            |                             | Should be removed.                                 |
-| enrolled_height | INTEGER  | Height           |                             |                                                    |
-| distance        | INTEGER  | ushort           |                             |                                                    |
-| preimage        | TEXT     | Hash             |                             |                                                    |
-| nonce           | TEXT     | Point            |                             | The `R` used to sign the `Enrollment`              |
-| active          | INTEGER  | EnrollmentStatus | PRIMARY KEY (with `key`)    | An enum (boolean). Should be removed.              |
+| Field name      | SQL Type | D type           | Attributes                           | Comment                                            |
+|-----------------|----------|------------------|--------------------------------------|----------------------------------------------------|
+| key             | TEXT     | Hash             | PRIMARY KEY (with `enrolled_height`) | The `utxo` field in the `Enrollment`               |
+| public_key      | TEXT     | PublicKey        |                                      | Should be replaced with a join using the UTXO hash |
+| cycle_length    | INTEGER  | ulong            |                                      | Should be removed.                                 |
+| enrolled_height | INTEGER  | Height           | PRIMARY KEY (with `key`)             |                                                    |
+| height          | INTEGER  | ulong            |                                      |                                                    |
+| preimage        | TEXT     | Hash             |                                      |                                                    |
+| nonce           | TEXT     | Point            |                                      | The `R` used to sign the `Enrollment`              |
+| slashed_height  | INTEGER  | Height           |                                      | Height at which a validator is slashed or null     |
 
 ### `node_enroll_data` table
 

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -780,20 +780,7 @@ public class EnrollmentManager
 
     public ulong getIndexOfEnrollment () @safe nothrow
     {
-        if (this.enroll_key == Hash.init)
-            return ulong.max;
-
-        Hash[] utxo_keys;
-        if (!this.validator_set.getEnrolledUTXOs(utxo_keys))
-            assert(0);
-
-        foreach (idx, key; utxo_keys)
-            if (key == this.enroll_key)
-                return idx;
-
-        log.fatal("Index of the node's enrollment not found. Enrollment: {}",
-            this.enroll_key);
-        assert(0);
+        return this.getIndexOfValidator(height, this.key_pair.address);
     }
 
     /// Returns: true if this validator is currently enrolled

--- a/source/agora/consensus/data/PreImageInfo.d
+++ b/source/agora/consensus/data/PreImageInfo.d
@@ -28,22 +28,22 @@ public struct PreImageInfo
     /// The key for the enrollment, used to look the commitment up
     public Hash utxo;
 
-    /// The value of the pre-image at the distance from the commitment
+    /// The value of the pre-image at the height from Genesis
     public Hash hash;
 
-    /// The distance between this pre-image and the initial commitment
-    public ushort distance;
+    /// The Height of the block that this pre-image is for
+    public Height height;
 
     /***************************************************************************
 
-        Reduce the distance and adjust `hash` accordingly
+        Reduce the height and adjust `hash` accordingly
 
-        This method hashes `this.hash` `value` times, and offset `this.distance`
+        This method hashes `this.hash` `value` times, and offset `this.height`
         by the same amount.
 
         Params:
           value = The amount to offset the pre-image by.
-                  Must be lesser or equal to `this.distance`.
+                  Must be lesser or equal to `this.height`.
 
         Returns:
           A reference to itself for easy chaining.
@@ -52,11 +52,11 @@ public struct PreImageInfo
 
     public ref PreImageInfo adjust (size_t value) return @safe nothrow @nogc
     {
-        assert(this.distance >= value);
+        assert(this.height >= value);
         while (value > 0)
         {
             this.hash = this.hash.hashFull();
-            this.distance -= 1;
+            this.height -= 1;
             --value;
         }
         return this;
@@ -78,7 +78,7 @@ unittest
     PreImageInfo img = {
         utxo: utxo,
         hash: hash,
-        distance: 42,
+        height: Height(42),
     };
     testSymmetry(img);
 }

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -528,7 +528,7 @@ extern(D):
             }
 
             Hash random_seed = this.ledger.getExternalizedRandomSeed(
-                last_block.header.height, con_data.missing_validators);
+                last_block.header.height + 1, con_data.missing_validators);
 
             Transaction[] received_tx_set;
             if (auto fail_reason = this.ledger.getValidTXSet(con_data, received_tx_set))
@@ -706,7 +706,7 @@ extern(D):
         }();
 
         const Hash random_seed = this.ledger.getExternalizedRandomSeed(
-                last_block.header.height, con_data.missing_validators);
+                last_block.header.height + 1, con_data.missing_validators);
 
         Transaction[] signed_tx_set;
         if (auto fail_reason = this.ledger.getValidTXSet(con_data, signed_tx_set))
@@ -804,7 +804,7 @@ extern(D):
             return ValidationLevel.kInvalidValue;
         }
 
-        if (this.ledger.checkSelfSlashing(data))
+        if (this.ledger.checkSelfSlashing(Height(slot_idx), data))
         {
             log.warn("validateValue(): Marking {} for data slashing us as invalid",
                      nomination ? "nomination" : "vote");
@@ -859,7 +859,7 @@ extern(D):
 
         log.info("Externalized consensus data set at {}: {}", height, prettify(data));
         Hash random_seed = this.ledger.getExternalizedRandomSeed(
-            last_block.header.height, data.missing_validators);
+            last_block.header.height + 1, data.missing_validators);
         Transaction[] externalized_tx_set;
         if (auto fail_reason = this.ledger.getValidTXSet(data,
             externalized_tx_set))

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -22,8 +22,7 @@ import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
 import agora.consensus.Fee;
 import agora.consensus.state.UTXOCache;
-import agora.consensus.state.ValidatorSet : EnrollmentFinder, EnrollmentState,
-                                            EnrollmentStatus;
+import agora.consensus.state.ValidatorSet : EnrollmentFinder, EnrollmentState;
 import agora.crypto.ECC;
 import agora.crypto.Hash;
 import agora.crypto.Key;
@@ -648,11 +647,10 @@ public EnrollmentFinder getGenesisEnrollmentFinder () nothrow @trusted
 
         if (!enrolls.empty)
         {
-            state.status = EnrollmentStatus.Active;
             state.enrolled_height = Height(0);
             state.cycle_length = enrolls[0].cycle_length;
             state.preimage.hash = enrolls[0].commitment;
-            state.preimage.distance = 0;
+            state.preimage.height = 0;
         }
 
         return enrolls.length != 0;

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -67,7 +67,7 @@ import vibe.data.json;
 import vibe.web.rest;
 
 import std.algorithm;
-import std.conv : to;
+import std.conv : to, text;
 import std.exception;
 import std.file;
 import std.format;
@@ -784,7 +784,7 @@ public class FullNode : API
         this.utxo_set.peekUTXO(enroll.utxo_key, utxo);
         const utxo_address = utxo.output.address;
         if (this.enroll_man.addEnrollment(enroll, utxo_address,
-            this.ledger.getBlockHeight(), this.utxo_set.getUTXOFinder()))
+            this.ledger.getBlockHeight() + 1, this.utxo_set.getUTXOFinder()))
         {
             log.info("Accepted enrollment: {}", prettify(enroll));
             this.network.peers.each!(p => p.client.sendEnrollment(enroll));

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -914,31 +914,6 @@ public class Ledger
 
     /***************************************************************************
 
-        Generate the random seed reduced from the preimages for the provided
-        block height.
-
-        Params:
-            height = the desired block height to look up the images for
-
-        Returns:
-            the random seed
-
-    ***************************************************************************/
-
-    public Hash getValidatorRandomSeed (in Height height) nothrow
-    {
-        Hash[] keys;
-        if (!this.enroll_man.getEnrolledUTXOs(keys) || keys.length == 0)
-        {
-            log.fatal("Could not retrieve enrollments / no enrollments found");
-            assert(0);
-        }
-
-        return this.enroll_man.getRandomSeed(keys, height);
-    }
-
-    /***************************************************************************
-
         Get the random seed reduced from the preimages of validators
         except the provided 'missing_validators'.
 

--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -112,7 +112,7 @@ unittest
     nodes[0 .. GenesisValidators].each!(node => node.clearFilter());
 
     // Before setting the network time and adding transactions we need to ensure pre-images have been sent
-    network.waitForPreimages(network.blocks[0].header.enrollments, 6);
+    network.waitForPreimages(network.blocks[0].header.enrollments, Height(6));
     network.setTimeFor(Height(6));  // full node should be unbanned now
 
     auto new_tx = genBlockTransactions(1);

--- a/source/agora/test/BlockTimeConsensus.d
+++ b/source/agora/test/BlockTimeConsensus.d
@@ -49,8 +49,7 @@ unittest
 
     void checkHeight(Height height)
     {
-        network.waitForPreimages(b0.header.enrollments,
-            cast(ushort) (height - 1));
+        network.waitForPreimages(b0.header.enrollments, height);
         network.setTimeFor(height);
         network.assertSameBlocks(height);
         auto time_offset = nodes[0].getBlocksFrom(height, 1)[0].header.time_offset;

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -280,7 +280,7 @@ unittest
     assert(node_1.getQuorumConfig().threshold == 4); // We should need 4 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.waitForPreimages(network.blocks[0].header.enrollments, 6);
+    network.waitForPreimages(network.blocks[0].header.enrollments, Height(6));
     network.setTimeFor(Height(1));  // trigger consensus
     waitForCount(1, &network.envelope_type_counts.externalize_count, "externalize");
     Thread.sleep(1.seconds);
@@ -302,7 +302,7 @@ unittest
     assert(node_1.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.waitForPreimages(network.blocks[0].header.enrollments, 6);
+    network.waitForPreimages(network.blocks[0].header.enrollments, Height(6));
     network.setTimeFor(Height(1));  // trigger consensus
     Thread.sleep(2.seconds);
     assert(atomicLoad(network.envelope_type_counts.confirm_count) == 0,

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -46,7 +46,7 @@ private class SameKeyValidator : TestValidatorNode
         // Find a UTXO which is not used for the enrollments in Genesis block
         Hash unused_utxo;
         Hash[] enroll_keys;
-        assert(this.enroll_man.getEnrolledUTXOs(enroll_keys));
+        assert(this.enroll_man.getEnrolledUTXOs(Height(1), enroll_keys));
         foreach (utxo; utxo_hashes)
         {
             if (!canFind(enroll_keys, utxo))

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -148,7 +148,7 @@ unittest
     auto node_bad = nodes[GenesisValidators + 1];  // full node, returns bad blocks in getBlocksFrom()
 
     // wait for preimages to be revealed before making blocks
-    network.waitForPreimages(network.blocks[0].header.enrollments, 6);
+    network.waitForPreimages(network.blocks[0].header.enrollments, Height(6));
 
     // enable filtering first
     node_validators.each!(node => node.filter!(API.getBlocksFrom));

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -264,12 +264,12 @@ unittest
                     idx, node.getQuorumConfig(), quorums_2[idx])));
     }
 
-    // create 19 blocks with all validators (1 short of end of 2nd cycle)
+    // create 19 more blocks with all validators (1 short of end of 2nd cycle)
     network.generateBlocks(iota(validators),
         Height((2 * GenesisValidatorCycle) - 1));
 
     // Re-enroll
-    iota(validators).each!(idx => network.enroll(idx));
+    iota(validators).each!(idx => network.enroll(iota(validators), idx));
 
     // Generate the last block of cycle with Genesis validators
     network.generateBlocks(iota(validators),

--- a/source/agora/test/RestoreSlashingInfo.d
+++ b/source/agora/test/RestoreSlashingInfo.d
@@ -65,7 +65,7 @@ unittest
 
     // wait for other nodes to get to same block height
     set_b.enumerate.each!((idx, node) =>
-        retryFor(node.getBlockHeight() == GenesisValidatorCycle - 1, 2.seconds,
+        retryFor(node.getBlockHeight() == GenesisValidatorCycle - 1, 5.seconds,
             format!"Expected block height %s but outsider %s has height %s."
                 (GenesisValidatorCycle - 1, idx, node.getBlockHeight())));
 

--- a/source/agora/test/TimeBlockInterval.d
+++ b/source/agora/test/TimeBlockInterval.d
@@ -57,8 +57,7 @@ unittest
 
     void checkHeight(Height height)
     {
-        network.waitForPreimages(b0.header.enrollments,
-            cast(ushort) (height - 1), 30.seconds);
+        network.waitForPreimages(b0.header.enrollments, height, 30.seconds);
         network.setTimeFor(height);
         network.assertSameBlocks(height);
     }

--- a/source/agora/test/TimeDrift.d
+++ b/source/agora/test/TimeDrift.d
@@ -39,7 +39,7 @@ unittest
     auto nodes = network.clients;
 
     // Make sure nodes have revealed their preimage for height 1
-    network.waitForPreimages(GenesisBlock.header.enrollments, 1);
+    network.waitForPreimages(GenesisBlock.header.enrollments, Height(1));
 
     // sanity check for the generated quorum config
     nodes.enumerate.each!((idx, node) =>
@@ -112,7 +112,7 @@ unittest
         checkNodeNetworkTime(idx, height));
 
     // Make sure nodes have revealed their preimage for height 2
-    network.waitForPreimages(GenesisBlock.header.enrollments, 2);
+    network.waitForPreimages(GenesisBlock.header.enrollments, Height(2));
 
     txs.take(2).each!(tx => nodes[0].putTransaction(tx));
     // wait for propagation


### PR DESCRIPTION
This changes the database field `distance` to `height` in the
`validator` table as it now is the block height for the `pre-image`.
This makes it much easier to work with preimages.
The `active` flag is also removed as we can deduce if an enrollment is
active from the `enrollment_height`. We keep all the previous enrollment
cycle records so that we know which validators were active during
previous cycles. This is needed for verifying signatures that we receive
after a new cycle has started.