### PR TITLE
Block retrieval fixup

### DIFF
--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -393,14 +393,12 @@ public class NetworkClient
 
             If the request failed, returns an empty array
 
-        Throws:
-            Exception if the request failed.
-
     ***************************************************************************/
 
     public const(Block)[] getBlocksFrom (ulong height, uint max_blocks)
+        nothrow
     {
-        return this.attemptRequest!(API.getBlocksFrom, Throw.Yes)(this.api,
+        return this.attemptRequest!(API.getBlocksFrom, Throw.No)(this.api,
             height, max_blocks);
     }
 

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -875,7 +875,7 @@ public class NetworkManager
 
         node_pairs.sort!((a, b) => a.height > b.height);
 
-        LNextNode: foreach (pair; node_pairs) try
+        LNextNode: foreach (pair; node_pairs)
         {
             if (height > pair.height)
                 continue;  // this node does not have newer blocks than us
@@ -904,18 +904,22 @@ public class NetworkManager
                 log.info("Received blocks [{}..{}]",
                     blocks[0].header.height, blocks[$ - 1].header.height);
 
-                // one or more blocks were rejected, stop retrieval from node
-                if (!onReceivedBlocks(blocks, preimages))
-                    continue LNextNode;
+                try
+                {
+                    // one or more blocks were rejected, stop retrieval from node
+                    if (!onReceivedBlocks(blocks, preimages))
+                        continue LNextNode;
+                }
+                catch (Exception ex)
+                {
+                    // @BUG: Ledger routines should be marked nothrow,
+                    // or else storage issues should be handled differently.
+                    log.error("Error in onReceivedBlocks(): {}", ex);
+                }
 
                 height += blocks.length;
             }
             while (height < pair.height);
-        }
-        catch (Exception ex)
-        {
-            log.error("Couldn't retrieve blocks: {}. Will try again later..",
-                ex.msg);
         }
     }
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -341,7 +341,7 @@ public class FullNode : API
 
                 this.network.getBlocksFrom(
                     Height(this.ledger.getBlockHeight() + 1),
-                    &addBlocks);
+                    &this.addBlocks);
                 this.network.getUnknownTXs(this.ledger);
                 this.network.getMissingBlockSigs(this.ledger);
             }
@@ -360,21 +360,23 @@ public class FullNode : API
             preimages = the preimages needed to check the validity of the blocks
 
         Returns:
-            true if the blocks and preimages was added
+            the last read block height, or 0 if none were accepted
 
     ***************************************************************************/
 
-    public bool addBlocks (const(Block)[] blocks, const(PreImageInfo)[] preimages)
+    public Height addBlocks (const(Block)[] blocks, const(PreImageInfo)[] preimages)
         @safe
     {
+        Height last_height;
         foreach (block; blocks)
         {
             if(!this.ledger.enrollment_manager.addPreimages(preimages))
-                return false;
+                return last_height;
             if (!this.ledger.acceptBlock(block))
-                return false;
+                return last_height;
+            last_height = block.header.height;
         }
-        return true;
+        return last_height;
     }
 
     /***************************************************************************

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -370,8 +370,12 @@ public class FullNode : API
         Height last_height;
         foreach (block; blocks)
         {
-            if(!this.ledger.enrollment_manager.addPreimages(preimages))
-                return last_height;
+            // ignore return value:
+            // there's at least two cases where preimages will be rejected:
+            // A) We already have a duplicate preimage
+            // B) The preimage is for a newer enrollment which is in one of the
+            //    `blocks` which we haven't read from yet
+            this.ledger.enrollment_manager.addPreimages(preimages);
             if (!this.ledger.acceptBlock(block))
                 return last_height;
             last_height = block.header.height;


### PR DESCRIPTION
This is just an optimization bugfix, but actually it uncovered a whole host of issues. The biggest one is that there are numerous methods in the Ledger which return status codes (`bool` return), but which also **throw**.

That means these exceptions can be accidentally caught and swallowed. I attempted marking some nothrow, but there's a very large chain of calls that needs to be marked nothrow to make this work. So we'll have to do this in another PR.

The commit messages explain in more detail.