### PR TITLE
Clock sync even if not enrolled

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -421,10 +421,6 @@ public class Validator : FullNode, API
     {
         return new Clock((out long time_offset)
             {
-                // not enrolled - no need to synchronize clocks
-                if (!this.enroll_man.isEnrolled(&this.utxo_set.peekUTXO))
-                    return false;
-
                 return this.network.getNetTimeOffset(this.qc.threshold,
                     time_offset);
             },

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1673,10 +1673,6 @@ public class TestValidatorNode : Validator, TestAPI
         return new TestClock(this.taskman,
             (out long time_offset)
             {
-                // not enrolled - no need to synchronize clocks
-                if (!this.enroll_man.isEnrolled(&this.utxo_set.peekUTXO))
-                    return false;
-
                 return this.network.getNetTimeOffset(this.qc.threshold,
                     time_offset);
             },


### PR DESCRIPTION
At startup we may not yet know if we are enrolled or about to enroll so
it is better to always sync with network clock.