### PR TITLE
Replace block_height with height

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -129,7 +129,7 @@ public interface API
 
         Get the array of blocks starting from the provided block height.
 
-        The block at `block_height` is included in the array.
+        The block at `height` is included in the array.
         Note that a node is free to return less blocks than asked for.
         However it must never return more blocks than asked for.
 
@@ -137,16 +137,16 @@ public interface API
             GET /blocks_from
 
         Params:
-            block_height = the starting block height to begin retrieval from
+            height = the starting block height to begin retrieval from
             max_blocks   = the maximum blocks to return at once
 
         Returns:
-            the array of blocks starting from block_height,
+            the array of blocks starting from height,
             up to `max_blocks`
 
     ***************************************************************************/
 
-    public const(Block)[] getBlocksFrom (ulong block_height, uint max_blocks);
+    public const(Block)[] getBlocksFrom (ulong height, uint max_blocks);
 
     /***************************************************************************
 
@@ -174,7 +174,7 @@ public interface API
             GET /merkle_path
 
         Params:
-            block_height = Height of the block that contains the transaction hash
+            height = Height of the block that contains the transaction hash
             hash         = transaction hash
 
         Returns:
@@ -182,7 +182,7 @@ public interface API
 
     ***************************************************************************/
 
-    public Hash[] getMerklePath (ulong block_height, Hash hash);
+    public Hash[] getMerklePath (ulong height, Hash hash);
 
     /***************************************************************************
 

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -506,7 +506,7 @@ unittest
     scope payload_checker = new FeeManager();
     scope checker = &payload_checker.check;
 
-    Height block_height;
+    Height height;
 
     Transaction secondTx;
     Transaction thirdTx;
@@ -522,7 +522,7 @@ unittest
     // Expected height : 0
     // Expected Status : melted
     {
-        block_height = 0;
+        height = 0;
         Transaction previousTx =
             { outputs: [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ] };
 
@@ -532,7 +532,7 @@ unittest
         {
             const Hash utxo_hash = hashMulti(previousHash, idx);
             const UTXO utxo_value = {
-                unlock_height: block_height+1,
+                unlock_height: height+1,
                 type: TxType.Payment,
                 output: output
             };
@@ -546,7 +546,7 @@ unittest
     // Expected height : 1
     // Expected Status : frozen
     {
-        block_height = 1;
+        height = 1;
         secondTx = Transaction(
             TxType.Freeze,
             [Input(previousHash, 0)],
@@ -555,7 +555,7 @@ unittest
         secondTx.inputs[0].unlock = signUnlock(key_pairs[0], secondTx);
 
         // Second Transaction is VALID.
-        assert(secondTx.isValid(engine, storage.getUTXOFinder(), block_height, checker));
+        assert(secondTx.isValid(engine, storage.getUTXOFinder(), height, checker));
 
         // Save to UTXOSet
         secondHash = hashFull(secondTx);
@@ -563,7 +563,7 @@ unittest
         {
             const Hash utxo_hash = hashMulti(secondHash, idx);
             const UTXO utxo_value = {
-                unlock_height: block_height+1,
+                unlock_height: height+1,
                 type: TxType.Freeze,
                 output: output
             };
@@ -577,7 +577,7 @@ unittest
     // Expected height : 2
     // Expected Status : melting
     {
-        block_height = 2;
+        height = 2;
         thirdTx = Transaction(
             TxType.Payment,
             [Input(secondHash, 0)],
@@ -586,7 +586,7 @@ unittest
         thirdTx.inputs[0].unlock = signUnlock(key_pairs[1], thirdTx);
 
         // Third Transaction is VALID.
-        assert(thirdTx.isValid(engine, storage.getUTXOFinder(), block_height, checker));
+        assert(thirdTx.isValid(engine, storage.getUTXOFinder(), height, checker));
 
         // Save to UTXOSet
         thirdHash = hashFull(thirdTx);
@@ -594,7 +594,7 @@ unittest
         {
             const Hash utxo_hash = hashMulti(thirdHash, idx);
             const UTXO utxo_value = {
-                unlock_height: block_height+2016,
+                unlock_height: height+2016,
                 type: TxType.Payment,
                 output: output
             };
@@ -608,7 +608,7 @@ unittest
     // Expected height : 2+2015
     // Expected Status : melting
     {
-        block_height = 2+2015;  //  this is melting, not melted
+        height = 2+2015;  //  this is melting, not melted
         fourthTx = Transaction(
             TxType.Payment,
             [Input(thirdHash, 0)],
@@ -617,7 +617,7 @@ unittest
         fourthTx.inputs[0].unlock = signUnlock(key_pairs[2], fourthTx);
 
         // Third Transaction is INVALID.
-        assert(!fourthTx.isValid(engine, storage.getUTXOFinder(), block_height, checker));
+        assert(!fourthTx.isValid(engine, storage.getUTXOFinder(), height, checker));
     }
 
     // Creates the fifth payment transaction
@@ -626,7 +626,7 @@ unittest
     // Expected height : 2+2016
     // Expected Status : melted
     {
-        block_height = 2+2016;  //  this is melted
+        height = 2+2016;  //  this is melted
         fifthTx = Transaction(
             TxType.Payment,
             [Input(thirdHash, 0)],
@@ -635,7 +635,7 @@ unittest
         fifthTx.inputs[0].unlock = signUnlock(key_pairs[2], fourthTx);
 
         // Third Transaction is VALID.
-        assert(fifthTx.isValid(engine, storage.getUTXOFinder(), block_height, checker));
+        assert(fifthTx.isValid(engine, storage.getUTXOFinder(), height, checker));
 
         // Save to UTXOSet
         fifthHash = hashFull(fifthTx);
@@ -643,7 +643,7 @@ unittest
         {
             const Hash utxo_hash = hashMulti(fifthHash, idx);
             const UTXO utxo_value = {
-                unlock_height: block_height+1,
+                unlock_height: height+1,
                 type: TxType.Payment,
                 output: output
             };

--- a/source/agora/flash/API.d
+++ b/source/agora/flash/API.d
@@ -175,7 +175,7 @@ public interface FlashAPI
             secrets = the secrets the proposer wishes to disclose
             rev_htlcs = the htlcs the proposer wishes to drop
             peer_nonce = the nonce the calling peer will use
-            block_height = the block height of the calling node. This is needed
+            height = the block height of the calling node. This is needed
                 in order to properly resolve any pending HTLCs in the channel.
                 For example, timed-out HTLCs should be replaced with a payout
                 back to the funder. If the called node's local block height
@@ -191,7 +191,7 @@ public interface FlashAPI
     public Result!PublicNonce proposeUpdate (/* in */ Hash chan_id,
         /* in */ uint seq_id, /* in */ Hash[] secrets,
         /* in */ Hash[] rev_htlcs, /* in */ PublicNonce peer_nonce,
-        /* in */ Height block_height);
+        /* in */ Height height);
 
     /***************************************************************************
 

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -381,14 +381,14 @@ public class NetworkClient
     /***************************************************************************
 
         Get the array of blocks starting from the provided block height.
-        The block at block_height is included in the array.
+        The block at height is included in the array.
 
         Params:
-            block_height = the starting block height to begin retrieval from
+            height = the starting block height to begin retrieval from
             max_blocks   = the maximum blocks to return at once
 
         Returns:
-            the array of blocks starting from block_height,
+            the array of blocks starting from height,
             up to `max_blocks`.
 
             If the request failed, returns an empty array
@@ -398,10 +398,10 @@ public class NetworkClient
 
     ***************************************************************************/
 
-    public const(Block)[] getBlocksFrom (ulong block_height, uint max_blocks)
+    public const(Block)[] getBlocksFrom (ulong height, uint max_blocks)
     {
         return this.attemptRequest!(API.getBlocksFrom, Throw.Yes)(this.api,
-            block_height, max_blocks);
+            height, max_blocks);
     }
 
     /***************************************************************************

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -834,14 +834,14 @@ public class NetworkManager
 
     /***************************************************************************
 
-        Retrieve blocks starting from block_height up to the highest block
+        Retrieve blocks starting from height up to the highest block
         that's available from the connected nodes.
 
         As requests may fail, this function should be called with a timer
         to ensure consistency of the node's ledger with other nodes.
 
         Params:
-            block_height = the starting block height to begin retrieval from
+            height = the starting block height to begin retrieval from
             onReceivedBlocks = delegate to call with the received blocks
                                if it returns false, further processing of blocks
                                from the same node is rejected due to invalid
@@ -849,7 +849,7 @@ public class NetworkManager
 
     ***************************************************************************/
 
-    public void getBlocksFrom (Height block_height,
+    public void getBlocksFrom (Height height,
         scope bool delegate(const(Block)[],
         const(PreImageInfo)[]) @safe onReceivedBlocks) nothrow
     {
@@ -877,27 +877,27 @@ public class NetworkManager
 
         LNextNode: foreach (pair; node_pairs) try
         {
-            if (block_height > pair.height)
+            if (height > pair.height)
                 continue;  // this node does not have newer blocks than us
 
             log.info("Retrieving blocks [{}..{}] from {}..",
-                block_height, pair.height, pair.client.address);
+                height, pair.height, pair.client.address);
             const MaxBlocks = 1024;
 
             do
             {
                 auto start_height =
-                    block_height < this.consensus_config.validator_cycle ?
-                        0 : block_height - this.consensus_config.validator_cycle;
+                    height < this.consensus_config.validator_cycle ?
+                        0 : height - this.consensus_config.validator_cycle;
 
                 log.info("Retrieving preimages from the height of {} from {}..",
                     start_height, pair.client.address);
 
-                auto preimages = pair.client.getPreimages(start_height, block_height);
+                auto preimages = pair.client.getPreimages(start_height, height);
 
                 log.info("Received {} preimages", preimages.length);
 
-                auto blocks = pair.client.getBlocksFrom(block_height, MaxBlocks);
+                auto blocks = pair.client.getBlocksFrom(height, MaxBlocks);
                 if (blocks.length == 0)
                     continue LNextNode;
 
@@ -908,9 +908,9 @@ public class NetworkManager
                 if (!onReceivedBlocks(blocks, preimages))
                     continue LNextNode;
 
-                block_height += blocks.length;
+                height += blocks.length;
             }
-            while (block_height < pair.height);
+            while (height < pair.height);
         }
         catch (Exception ex)
         {
@@ -921,7 +921,7 @@ public class NetworkManager
 
     /***************************************************************************
 
-        Retrieve blocks starting from block_height up to the highest block
+        Retrieve blocks starting from height up to the highest block
         that's available from the connected nodes.
 
     ***************************************************************************/

--- a/source/agora/node/FlashFullNode.d
+++ b/source/agora/node/FlashFullNode.d
@@ -179,10 +179,10 @@ public mixin template FlashNodeCommon ()
     public override Result!PublicNonce proposeUpdate (/* in */ Hash chan_id,
         /* in */ uint seq_id, /* in */ Hash[] secrets,
         /* in */ Hash[] rev_htlcs, /* in */ PublicNonce peer_nonce,
-        /* in */ Height block_height) @trusted
+        /* in */ Height height) @trusted
     {
         return this.flash.proposeUpdate(chan_id, seq_id, secrets, rev_htlcs,
-            peer_nonce, block_height);
+            peer_nonce, height);
     }
 
     ///

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -734,12 +734,12 @@ public class FullNode : API
     }
 
     /// GET: /blocks_from
-    public override const(Block)[] getBlocksFrom (ulong block_height,
+    public override const(Block)[] getBlocksFrom (ulong height,
         uint max_blocks)  @safe
     {
         this.endpoint_request_stats
             .increaseMetricBy!"agora_endpoint_calls_total"(1, "blocks_from", "http");
-        return this.ledger.getBlocksFrom(Height(block_height))
+        return this.ledger.getBlocksFrom(Height(height))
             .take(min(max_blocks, MaxBatchBlocksSent)).array;
     }
 
@@ -752,16 +752,16 @@ public class FullNode : API
     }
 
     /// GET: /merkle_path
-    public override Hash[] getMerklePath (ulong block_height, Hash hash) @safe
+    public override Hash[] getMerklePath (ulong height, Hash hash) @safe
     {
         this.endpoint_request_stats.increaseMetricBy!"agora_endpoint_calls_total"(1, "merkle_path", "http");
 
-        const Height height = Height(block_height);
+        const Height stored_height = Height(height);
 
-        if (this.ledger.getBlockHeight() < height)
+        if (this.ledger.getBlockHeight() < stored_height)
             return null;
 
-        Block block = this.storage.readBlock(height);
+        Block block = this.storage.readBlock(stored_height);
         size_t index = block.findHashIndex(hash);
         if (index >= block.txs.length)
             return null;

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -536,11 +536,11 @@ public class Validator : FullNode, API
         enrolled. Enroll when necessary.
 
         Params:
-            block_height = Current block height
+            height = Current block height
 
     ***************************************************************************/
 
-    protected void checkAndEnroll (Height block_height) @safe
+    protected void checkAndEnroll (Height height) @safe
     {
         Hash enroll_key = this.enroll_man.getEnrolledUTXO(
             this.utxo_set.getUTXOFinder());
@@ -553,12 +553,12 @@ public class Validator : FullNode, API
 
         // This validators enrollment will expire next cycle or not enrolled at all
         if (enrolled == ulong.max ||
-            block_height + 1 >= enrolled + this.params.ValidatorCycle)
+            height + 1 >= enrolled + this.params.ValidatorCycle)
         {
             log.trace("Sending Enrollment at height {} for {} cycles with {}",
-                block_height, this.params.ValidatorCycle, enroll_key);
+                height, this.params.ValidatorCycle, enroll_key);
             this.network.peers.each!(p => p.client.sendEnrollment(
-                this.enroll_man.createEnrollment(enroll_key, block_height + 1)));
+                this.enroll_man.createEnrollment(enroll_key, height + 1)));
         }
     }
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -983,19 +983,19 @@ public class TestAPIManager
             externalized during the Network Unit tests
 
         Params:
-            block_height = the desired block height
+            height = the desired block height
             client_idxs = client indices for the participating validators
 
     ***************************************************************************/
 
-    public void generateBlocks (Height block_height,
+    public void generateBlocks (Height height,
         string file = __FILE__, int line = __LINE__)
     {
-        generateBlocks(iota(GenesisValidators), block_height, file, line);
+        generateBlocks(iota(GenesisValidators), height, file, line);
     }
 
     /// Ditto
-    public void generateBlocks (Idxs)(Idxs client_idxs, Height block_height,
+    public void generateBlocks (Idxs)(Idxs client_idxs, Height height,
         string file = __FILE__, int line = __LINE__)
     {
         static assert (isInputRange!Idxs);
@@ -1005,7 +1005,7 @@ public class TestAPIManager
         const last_block = client.getBlock(client.getBlockHeight());
 
         // Call addBlock for each block to be externalised for these clients
-        iota(block_height - last_block.header.height)
+        iota(height - last_block.header.height)
             .each!(_ => this.addBlock(client_idxs, file, line));
     }
 

--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -39,19 +39,19 @@ unittest
 
     Transaction[] txs;
 
-    void createAndExpectNewBlock (Height new_block_height)
+    void createAndExpectNewBlock (Height new_height)
     {
         // create enough tx's for a single block
-        txs = blocks[new_block_height - 1].spendable().map!(txb => txb
+        txs = blocks[new_height - 1].spendable().map!(txb => txb
             .deduct(Amount.UnitPerCoin).sign()).array();
 
         // send it to one node
         txs.each!(tx => node_1.putTransaction(tx));
 
-        network.expectHeightAndPreImg(new_block_height, blocks[0].header);
+        network.expectHeightAndPreImg(new_height, blocks[0].header);
 
         // add next block
-        blocks ~= node_1.getBlocksFrom(new_block_height, 1);
+        blocks ~= node_1.getBlocksFrom(new_height, 1);
 
         auto cb_txs = blocks[$-1].txs.filter!(tx => tx.type == TxType.Coinbase)
             .array;
@@ -182,20 +182,20 @@ unittest
 
     Transaction[] txs;
 
-    void createAndExpectNewBlock (Height new_block_height)
+    void createAndExpectNewBlock (Height new_height)
     {
         // create enough tx's for a single block
-        txs = blocks[new_block_height - 1].spendable().map!(txb => txb
+        txs = blocks[new_height - 1].spendable().map!(txb => txb
             .deduct(Amount.UnitPerCoin).sign()).array();
 
         // send it to one node
         txs.each!(tx => valid_node.putTransaction(tx));
 
         network.expectHeightAndPreImg(iota(1, GenesisValidators),
-            new_block_height, blocks[0].header);
+            new_height, blocks[0].header);
 
         // add next block
-        blocks ~= valid_node.getBlocksFrom(new_block_height, 1);
+        blocks ~= valid_node.getBlocksFrom(new_height, 1);
 
         auto cb_txs = blocks[$-1].txs.filter!(tx => tx.type == TxType.Coinbase)
             .array;

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -64,7 +64,7 @@ unittest
         mixin ForwardCtor!();
 
         /// return phony blocks
-        public override const(Block)[] getBlocksFrom (ulong block_height,
+        public override const(Block)[] getBlocksFrom (ulong height,
             uint max_blocks)
         {
             Block[] blocks;

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -46,18 +46,18 @@ unittest
 
     Transaction[] txs;
 
-    void createAndExpectNewBlock (Height new_block_height)
+    void createAndExpectNewBlock (Height new_height)
     {
         // create enough tx's for a single block
-        txs = blocks[new_block_height - 1].spendable().map!(txb => txb.sign()).array();
+        txs = blocks[new_height - 1].spendable().map!(txb => txb.sign()).array();
 
         // send it to one node
         txs.each!(tx => node_1.putTransaction(tx));
 
-        network.expectHeightAndPreImg(new_block_height, blocks[0].header);
+        network.expectHeightAndPreImg(new_height, blocks[0].header);
 
         // add next block
-        blocks ~= node_1.getBlocksFrom(new_block_height, 1);
+        blocks ~= node_1.getBlocksFrom(new_height, 1);
     }
 
     // create GenesisValidatorCycle - 1 blocks
@@ -137,19 +137,19 @@ unittest
 
     Transaction[] txs;
 
-    void createAndExpectNewBlock (Height new_block_height)
+    void createAndExpectNewBlock (Height new_height)
     {
         // create enough tx's for a single block
-        txs = blocks[new_block_height - 1].spendable().map!(txb => txb.sign())
+        txs = blocks[new_height - 1].spendable().map!(txb => txb.sign())
             .array();
 
         // send it to one node
         txs.each!(tx => node_1.putTransaction(tx));
 
-        network.expectHeightAndPreImg(new_block_height, blocks[0].header);
+        network.expectHeightAndPreImg(new_height, blocks[0].header);
 
         // add next block
-        blocks ~= node_1.getBlocksFrom(new_block_height, 1);
+        blocks ~= node_1.getBlocksFrom(new_height, 1);
     }
 
     // create GenesisValidatorCycle - 1 blocks


### PR DESCRIPTION
As this is block chain software when we have variable named height it is
almost always the block height. If not then it can be named differently.
This helps keep the code a bit cleaner and means less typing.