### PR TITLE
Remove second validator count function

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -562,9 +562,9 @@ public class EnrollmentManager
 
     ***************************************************************************/
 
-    public size_t validatorCount () @safe
+    public size_t validatorCount (in Height height) @safe
     {
-        return this.validator_set.count();
+        return this.validator_set.getValidatorCount(height);
     }
 
     /***************************************************************************
@@ -1211,7 +1211,7 @@ unittest
     man.getEnrollments(enrolls, Height(9), &utxo_set.peekUTXO);
     assert(enrolls.length == 1);
     // One Enrollment was moved to validator set
-    assert(man.validator_set.count() == 1);
+    assert(man.validatorCount(Height(9)) == 1);
     assert(man.enroll_pool.count() == 1);
 
     man.enroll_pool.remove(utxo_hashes[0]);
@@ -1250,7 +1250,7 @@ unittest
     assert(man.addValidator(ordered_enrollments[1], WK.Keys[1].address, Height(11),
             &utxo_set.peekUTXO, utxos) is null);
     man.clearExpiredValidators(Height(11));
-    assert(man.validatorCount() == 2);
+    assert(man.validatorCount(Height(11)) == 2);
     assert(man.getEnrolledUTXOs(keys));
     assert(keys.length == 2);
 
@@ -1260,7 +1260,7 @@ unittest
     assert(man.addValidator(ordered_enrollments[2], WK.Keys[2].address, Height(1019),
             &utxo_set.peekUTXO, utxos) is null);
     man.clearExpiredValidators(Height(1019));
-    assert(man.validatorCount() == 1);
+    assert(man.validatorCount(Height(1019)) == 1);
     assert(man.getEnrolledUTXOs(keys));
     assert(keys.length == 1);
     assert(keys[0] == ordered_enrollments[2].utxo_key);

--- a/source/agora/consensus/SlashPolicy.d
+++ b/source/agora/consensus/SlashPolicy.d
@@ -332,7 +332,7 @@ unittest
     foreach (idx, enroll; enrollments)
         assert(enroll_man.addValidator(enroll, pairs[idx].address, Height(1),
             &utxo_set.peekUTXO, self_utxos) is null);
-    assert(enroll_man.validatorCount() == 8);
+    assert(enroll_man.validatorCount(Height(1)) == 8);
 
     // create slashing manager
     scope slash_man = new SlashPolicy(enroll_man, params);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -198,7 +198,7 @@ public class Ledger
                 this.replayStoredBlock(this.storage.readBlock(Height(height)));
             }
         }
-        else if (this.enroll_man.validatorCount() == 0)
+        else if (this.enroll_man.validatorCount(this.last_block.header.height) == 0)
         {
             // +1 because the genesis block counts as one
             const ulong block_count = this.last_block.header.height + 1;
@@ -272,12 +272,12 @@ public class Ledger
             return false;
         }
 
-        const old_count = this.enroll_man.validatorCount();
+        const old_count = this.enroll_man.validatorCount(block.header.height);
 
         this.storage.saveBlock(block);
         this.addValidatedBlock(block);
 
-        const new_count = this.enroll_man.validatorCount();
+        const new_count = this.enroll_man.validatorCount(block.header.height);
         // there was a change in the active validator set
         const bool validators_changed = block.header.enrollments.length > 0
             || new_count != old_count;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1359,7 +1359,7 @@ public interface TestAPI : ValidatorAPI
     public QuorumConfig getQuorumConfig ();
 
     /// Get the active validator count for the current block height
-    public ulong getValidatorCount ();
+    public ulong getValidatorCount (in Height height);
 
     /***************************************************************************
 
@@ -1481,9 +1481,9 @@ private mixin template TestNodeMixin ()
     }
 
     /// Get the active validator count for the current block height
-    public override ulong getValidatorCount ()
+    public override ulong getValidatorCount (in Height height)
     {
-        return this.enroll_man.validatorCount();
+        return this.enroll_man.validatorCount(height);
     }
 
     /// Localrest: the address (key) is provided directly to the network manager

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -71,9 +71,9 @@ void manyValidators (size_t validators)
 
     // check all validators are enrolled
     network.clients.enumerate.each!((idx, node) =>
-        retryFor(node.getValidatorCount() == validators, 5.seconds,
+        retryFor(node.getValidatorCount(Height(19)) == validators, 5.seconds,
             format("Node %s has validator count %s. Expected: %s",
-                idx, node.getValidatorCount(), validators)));
+                idx, node.getValidatorCount(Height(19)), validators)));
 
     // first validated block using all nodes
     network.generateBlocks(iota(validators), Height(GenesisValidatorCycle + 1));

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -155,8 +155,8 @@ unittest
     network.expectHeight(Height(2));
     auto block2 = nodes[0].getBlocksFrom(2, 1)[0];
     assert(block2.header.missing_validators.length == 1);
-    assert(nodes[0].getValidatorCount() == 5,
-        format!"Invalid validator count, current: %s"(nodes[0].getValidatorCount()));
+    auto cnt = nodes[0].getValidatorCount(block2.header.height);
+    assert(cnt == 5, format!"Invalid validator count, current: %s"(cnt));
 
     // check if the frozen UTXO is refunded to the owner and
     // the penalty is re-routed to the `CommonsBudget`

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -88,9 +88,9 @@ unittest
 
     // Sanity check
     nodes.enumerate.each!((idx, node) =>
-        retryFor(node.getValidatorCount == conf.outsider_validators, 3.seconds,
+        retryFor(node.getValidatorCount(Height(20)) == conf.outsider_validators, 3.seconds,
             format("Node %s has validator count %s. Expected: %s",
-                idx, node.getValidatorCount(), conf.outsider_validators)));
+                idx, node.getValidatorCount(Height(20)), conf.outsider_validators)));
 
     // Check the connection states are complete for the set B
     set_b.each!(node =>


### PR DESCRIPTION
The count function is a duplicate of getValidatorCount. It did not take
a height as a parameter but in coming changes we will require height to
be provided to enable counting the validators. So this prepares the way
for those changes.