### PR TITLE
Enrollment: Rename `random_seed` to `commitment`

### DIFF
--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -309,25 +309,25 @@ public class EnrollmentPool
 
 version (unittest)
 private Enrollment createEnrollment(in Hash utxo_key,
-    const ref KeyPair key_pair, ref Scalar random_seed_src,
+    const ref KeyPair key_pair, ref Scalar commitment_src,
     uint validator_cycle)
 {
     import std.algorithm;
 
     Pair pair = Pair.fromScalar(key_pair.secret);
 
-    Hash random_seed;
+    Hash commitment;
     Hash[] preimages;
     auto enroll = Enrollment();
     auto signature_noise = Pair.random();
 
     enroll.utxo_key = utxo_key;
     enroll.cycle_length = validator_cycle;
-    preimages ~= hashFull(random_seed_src);
+    preimages ~= hashFull(commitment_src);
     foreach (i; 0 ..  enroll.cycle_length-1)
         preimages ~= hashFull(preimages[i]);
     reverse(preimages);
-    enroll.random_seed = preimages[0];
+    enroll.commitment = preimages[0];
     enroll.enroll_sig = sign(pair, signature_noise, enroll);
     return enroll;
 }

--- a/source/agora/consensus/PreImage.d
+++ b/source/agora/consensus/PreImage.d
@@ -411,7 +411,7 @@ public struct PreImageCycleImpl
           secret = The secret key of the node, used as part of the hash
                    to generate the cycle seeds
           consume = If true, calculate the cycle index. Otherwise, just
-                   get the random seed which is the first pre-image
+                   get the commitment which is the first pre-image
 
         Returns:
           The hash of the current enrollment round

--- a/source/agora/consensus/SlashPolicy.d
+++ b/source/agora/consensus/SlashPolicy.d
@@ -364,7 +364,7 @@ unittest
         caches[0][$ - 2],
         1
     );
-    assert(hashFull(preimage_1.hash) == enrollments[0].random_seed);
+    assert(hashFull(preimage_1.hash) == enrollments[0].commitment);
     enroll_man.addPreimage(preimage_1);
     auto gotten_image = enroll_man.getValidatorPreimage(enrollments[0].utxo_key);
     assert(preimage_1 == gotten_image);
@@ -375,7 +375,7 @@ unittest
         caches[1][$ - 2],
         1
     );
-    assert(hashFull(preimage_2.hash) == enrollments[1].random_seed);
+    assert(hashFull(preimage_2.hash) == enrollments[1].commitment);
     enroll_man.addPreimage(preimage_2);
     gotten_image = enroll_man.getValidatorPreimage(enrollments[1].utxo_key);
     assert(preimage_2 == gotten_image);

--- a/source/agora/consensus/data/Enrollment.d
+++ b/source/agora/consensus/data/Enrollment.d
@@ -39,8 +39,8 @@ public struct Enrollment
     /// K: UTXO hash, A hash of a frozen UTXO
     public Hash utxo_key;
 
-    /// X: random seed, The nth image of random value
-    public Hash random_seed;
+    /// X: commitment, The nth image of random value
+    public Hash commitment;
 
     /// n: cycle length, the number of rounds a validator will participate in
     /// (currently fixed to (freezing period / 2)
@@ -64,7 +64,7 @@ public struct Enrollment
     public void computeHash (scope HashDg dg) const nothrow @safe @nogc
     {
         hashPart(this.utxo_key, dg);
-        hashPart(this.random_seed, dg);
+        hashPart(this.commitment, dg);
         hashPart(this.cycle_length, dg);
     }
 }
@@ -95,7 +95,7 @@ unittest
                               "5ea9638d7bff58d2c0cc2467c18e38b36367be78");
     Enrollment record = {
         utxo_key: key,
-        random_seed: seed,
+        commitment: seed,
         cycle_length: 42,
         enroll_sig: sig,
     };

--- a/source/agora/consensus/data/genesis/package.d
+++ b/source/agora/consensus/data/genesis/package.d
@@ -100,7 +100,7 @@ version (unittest) public void checkGenesisEnrollments (
                 .fold!((s, e) =>
                     format!"%s\n%s"
                     (s, format!"    // %s\n    Enrollment(\n        Hash(`%s`),\n        Hash(`%s`),\n        %s,\n        Signature.fromString(`%s`)),"
-                        (e.key, e.enrol.utxo_key, e.enrol.random_seed, e.enrol.cycle_length, e.enrol.enroll_sig.toString())))
+                        (e.key, e.enrol.utxo_key, e.enrol.commitment, e.enrol.cycle_length, e.enrol.enroll_sig.toString())))
                     ("\n    enrollments: [")));
 }
 

--- a/source/agora/consensus/protocol/Data.d
+++ b/source/agora/consensus/protocol/Data.d
@@ -57,7 +57,7 @@ unittest
                               "5ea9638d7bff58d2c0cc2467c18e38b36367be78");
     const Enrollment record = {
         utxo_key: key,
-        random_seed: seed,
+        commitment: seed,
         cycle_length: 1008,
         enroll_sig: sig,
     };

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -147,7 +147,7 @@ public class ValidatorSet
                     enroll.utxo_key,
                     pubkey,
                     enroll.cycle_length, height.value, ZeroDistance,
-                    enroll.random_seed,
+                    enroll.commitment,
                     enroll.enroll_sig.R,
                     EnrollmentStatus.Active);
             }();
@@ -824,7 +824,7 @@ public class ValidatorSet
 
 version (unittest)
 private Enrollment createEnrollment(in Hash utxo_key,
-    const KeyPair key_pair, ref Scalar random_seed_src,
+    const KeyPair key_pair, ref Scalar commitment_src,
     uint validator_cycle)
 {
     import std.algorithm;
@@ -834,11 +834,11 @@ private Enrollment createEnrollment(in Hash utxo_key,
     auto enroll = Enrollment();
     auto signature_noise = Pair.random();
     auto cache = PreImageCache(validator_cycle, 1);
-    cache.reset(hashFull(random_seed_src));
+    cache.reset(hashFull(commitment_src));
 
     enroll.utxo_key = utxo_key;
     enroll.cycle_length = validator_cycle;
-    enroll.random_seed = cache[$ - 1];
+    enroll.commitment = cache[$ - 1];
     enroll.enroll_sig = sign(pair.v, pair.V, signature_noise.V,
         signature_noise.v, enroll);
     return enroll;
@@ -931,7 +931,7 @@ unittest
 
     // test for adding and getting preimage
     assert(set.getPreimage(utxos[0])
-        == PreImageInfo(enroll.utxo_key, enroll.random_seed, 0));
+        == PreImageInfo(enroll.utxo_key, enroll.commitment, 0));
     auto preimage = PreImageInfo(utxos[0], cache[$ - 11], 10);
     assert(set.addPreimage(preimage));
     assert(set.getPreimage(utxos[0]) == preimage);
@@ -940,7 +940,7 @@ unittest
     assert(set.getPreimageAt(utxos[0], Height(12))  // N/A: not revealed yet!
         == PreImageInfo.init);
     assert(set.getPreimageAt(utxos[0], Height(1))
-        == PreImageInfo(enroll.utxo_key, enroll.random_seed, 0));
+        == PreImageInfo(enroll.utxo_key, enroll.commitment, 0));
     assert(set.getPreimageAt(utxos[0], Height(11)) == preimage);
     assert(set.getPreimageAt(utxos[0], Height(10)) ==
         PreImageInfo(preimage.utxo, hashFull(preimage.hash),

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -650,7 +650,7 @@ public EnrollmentFinder getGenesisEnrollmentFinder () nothrow @trusted
             state.status = EnrollmentStatus.Active;
             state.enrolled_height = Height(0);
             state.cycle_length = enrolls[0].cycle_length;
-            state.preimage.hash = enrolls[0].random_seed;
+            state.preimage.hash = enrolls[0].commitment;
             state.preimage.distance = 0;
         }
 
@@ -933,7 +933,7 @@ unittest
     auto utxo_hash1 = UTXO.getHash(hashFull(txs_2[0]), 0);
     Enrollment enroll1;
     enroll1.utxo_key = utxo_hash1;
-    enroll1.random_seed = hashFull(Scalar.random());
+    enroll1.commitment = hashFull(Scalar.random());
     enroll1.cycle_length = 1008;
     enroll1.enroll_sig = sign(node_key_pair.v, node_key_pair.V, signature_noise.V,
         signature_noise.v, enroll1);
@@ -941,7 +941,7 @@ unittest
     auto utxo_hash2 = UTXO.getHash(hashFull(txs_2[1]), 0);
     Enrollment enroll2;
     enroll2.utxo_key = utxo_hash2;
-    enroll2.random_seed = hashFull(Scalar.random());
+    enroll2.commitment = hashFull(Scalar.random());
     enroll2.cycle_length = 1008;
     enroll2.enroll_sig = sign(node_key_pair.v, node_key_pair.V, signature_noise.V,
         signature_noise.v, enroll2);
@@ -1082,7 +1082,7 @@ unittest
         auto utxo_hash1 = UTXO.getHash(hashFull(txs_2[1]), 0);
         Enrollment enroll1;
         enroll1.utxo_key = utxo_hash1;
-        enroll1.random_seed = hashFull(Scalar.random());
+        enroll1.commitment = hashFull(Scalar.random());
         enroll1.cycle_length = 1008;
         enroll1.enroll_sig = sign(node_key_pair.v, node_key_pair.V, signature_noise.V,
             signature_noise.v, enroll1);

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -90,7 +90,7 @@ public string isInvalidReason (in Enrollment enrollment,
         // Create a dummy copy
         PreImageInfo temp = enroll_state.preimage;
         // And patch its distance and hash
-        temp.hash = enrollment.random_seed;
+        temp.hash = enrollment.commitment;
         auto dist = height - (enroll_state.enrolled_height + enroll_state.preimage.distance);
         assert(dist < ushort.max);
         temp.distance = cast(ushort) dist;
@@ -164,7 +164,7 @@ unittest
 
     Enrollment enroll1;
     enroll1.utxo_key = utxo_hash1;
-    enroll1.random_seed = hashFull(Scalar.random());
+    enroll1.commitment = hashFull(Scalar.random());
     enroll1.cycle_length = 1008;
     enroll1.enroll_sig = sign(node_key_pair_1, signature_noise, enroll1);
 
@@ -172,7 +172,7 @@ unittest
 
     Enrollment enroll2;
     enroll2.utxo_key = utxo_hash2;
-    enroll2.random_seed = hashFull(Scalar.random());
+    enroll2.commitment = hashFull(Scalar.random());
     enroll2.cycle_length = 1008;
     enroll2.enroll_sig = sign(node_key_pair_2, signature_noise, enroll2);
 
@@ -180,7 +180,7 @@ unittest
 
     Enrollment enroll3;
     enroll3.utxo_key = utxo_hash3;
-    enroll3.random_seed = hashFull(Scalar.random());
+    enroll3.commitment = hashFull(Scalar.random());
     enroll3.cycle_length = 1008;
     enroll3.enroll_sig = sign(node_key_pair_3, signature_noise, enroll3);
 
@@ -189,7 +189,7 @@ unittest
 
     Enrollment enroll4;
     enroll4.utxo_key = utxo_hash4;
-    enroll4.random_seed = hashFull(Scalar.random());
+    enroll4.commitment = hashFull(Scalar.random());
     enroll4.cycle_length = 1008;
     enroll4.enroll_sig = sign(node_key_pair_invalid, signature_noise, enroll4);
 
@@ -231,7 +231,7 @@ unittest
     auto cycle = PreImageCycle(key_pairs[0].secret, params.ValidatorCycle);
 
     enroll1.utxo_key = utxo_hash1;
-    enroll1.random_seed = cycle[Height(0)];
+    enroll1.commitment = cycle[Height(0)];
     enroll1.cycle_length = params.ValidatorCycle;
     enroll1.enroll_sig = sign(node_key_pair_1, signature_noise, enroll1);
 
@@ -244,7 +244,7 @@ unittest
     // First 2 iterations should fail because commitment is wrong
     foreach (offset; [-1, +1, 0])
     {
-        enroll1.random_seed = cycle[Height(params.ValidatorCycle + offset)];
+        enroll1.commitment = cycle[Height(params.ValidatorCycle + offset)];
         enroll1.enroll_sig = sign(node_key_pair_1, signature_noise, enroll1);
         assert((offset == 0) == (validator_set.add(Height(params.ValidatorCycle),
                             utxoPeek, enroll1, key_pairs[0].address) is null));

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -148,7 +148,7 @@ unittest
     const b20 = nodes[0].getBlocksFrom(20, 2)[0];
     network.expectHeightAndPreImg(iota(1), Height(21), b20.header);
 
-    PreImageInfo org_preimage = PreImageInfo(enroll.utxo_key, enroll.random_seed, 0);
+    PreImageInfo org_preimage = PreImageInfo(enroll.utxo_key, enroll.commitment, 0);
 
     // Wait for the revelation of new pre-image to complete
     PreImageInfo preimage_2;
@@ -209,10 +209,10 @@ unittest
 
     const known_preimage = network.clients.front().getPreimage(enroll.utxo_key);
     assert(known_preimage.distance == 0);
-    assert(known_preimage.hash == enroll.random_seed);
+    assert(known_preimage.hash == enroll.commitment);
     // Send the same pre-image as received
     network.clients().front().receivePreimage(
-        PreImageInfo(enroll.utxo_key, enroll.random_seed, 0));
+        PreImageInfo(enroll.utxo_key, enroll.commitment, 0));
 
     // Just to be sure, in case this unittest runs last
     Thread.sleep(50.msecs);
@@ -358,7 +358,7 @@ unittest
     const e0 = b0.header.enrollments[0];
 
     // Wait for the revelation of new pre-image to complete
-    const org_preimage = PreImageInfo(e0.utxo_key, e0.random_seed, 0);
+    const org_preimage = PreImageInfo(e0.utxo_key, e0.commitment, 0);
     PreImageInfo preimage_2;
     retryFor(org_preimage != (preimage_2 = nodes[0].getPreimage(e0.utxo_key)),
         15.seconds);

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -73,7 +73,7 @@ unittest
     assert(blocks[blocks.length - 1].header.enrollments.length == blocks[0].header.enrollments.length);
 }
 
-// Recurring enrollment with wrong `random_seed`
+// Recurring enrollment with wrong `commitment`
 // When nodes reach the end of their validation cycle, they will try to
 // re-enroll with the same commitment in the GenesisBlock (ie. Height(0))
 // They should not be able to enroll and no new block should be created.

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -529,7 +529,7 @@ private struct EnrollmentFmt
         {
             formattedWrite(sink, "{ utxo: %s, seed: %s, cycles: %s, sig: %s }",
                 HashFmt(this.enroll.utxo_key),
-                HashFmt(this.enroll.random_seed),
+                HashFmt(this.enroll.commitment),
                 this.enroll.cycle_length,
                 HashFmt(this.enroll.enroll_sig.toBlob()));
         }
@@ -556,7 +556,7 @@ unittest
     Enrollment enrollment =
     {
         utxo_key: key,
-        random_seed: seed,
+        commitment: seed,
         cycle_length: 1008,
         enroll_sig: sig,
     };
@@ -611,7 +611,7 @@ unittest
     const Enrollment record =
     {
         utxo_key: key,
-        random_seed: seed,
+        commitment: seed,
         cycle_length: 1008,
         enroll_sig: sig,
     };

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -430,7 +430,7 @@ unittest
     const Enrollment record =
     {
         utxo_key: key,
-        random_seed: seed,
+        commitment: seed,
         cycle_length: 1008,
         enroll_sig: sig,
     };


### PR DESCRIPTION
We currently have a few concepts of "random seed"s.

- `Enrollment.random_seed`, first preimage revealed
- `rand_seed` in `EnrollmentManager` and `SlashPolicy`, a preimage for a certain block height (`getRandomSeed()`)
- `Block.random_seed`
- `rand_seed` in Quorum

The first has been renamed to to reduce ambiguity.