### PR TITLE
Set Genesis timestamp to April Fools Day 2021

### DIFF
--- a/source/agora/consensus/data/Params.d
+++ b/source/agora/consensus/data/Params.d
@@ -112,7 +112,7 @@ public immutable class ConsensusParams
 /// Ditto
 public struct ConsensusConfig
 {
-    public ulong genesis_timestamp = 1609459200; // 2021-01-01:00:00:00 GMT
+    public ulong genesis_timestamp = 1617235200; // 2021-04-01:00:00:00 GMT
 
     /// The cycle length for a validator
     public uint validator_cycle = 1008;


### PR DESCRIPTION
This is not a joke but just testing to see if system test passes more
often with a more recent Genesis start time. It was previously Jan 1st
2021