### PR TITLE
Check if async nominating already

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -345,8 +345,8 @@ extern(D):
     private void checkNominate () @safe
     {
         const slot_idx = this.ledger.getBlockHeight() + 1;
-        // are we done nominating this round
-        if (this.last_confirmed_height >= slot_idx)
+        // are we done nominating this round or in async process
+        if (this.last_confirmed_height >= slot_idx || this.is_nominating)
             return;
 
         const cur_time = this.clock.networkTime();

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -263,7 +263,6 @@ extern(D):
 
     public void stopNominationRound (Height height) @safe nothrow
     {
-        this.is_nominating = false;
         () @trusted { this.scp.stopNomination(height); }();
 
         foreach (timer; this.active_timers)
@@ -373,6 +372,7 @@ extern(D):
         // note: we are not passing the previous tx set as we don't really
         // need it at this point (might later be necessary for chain upgrades)
         this.nominate(slot_idx, data);
+        this.is_nominating = false;
     }
 
     /***************************************************************************


### PR DESCRIPTION
This is related to SCP nomination where we are already in process of
nominating but the checkNominate is called by the timer. The check if we
are already in the process of a nomination was removed when a check that
we only confirm once. This adds back the check.