### PR TITLE
Set timer for `checkNominate` after nominating

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -56,7 +56,7 @@ import geod24.bitblob;
 import core.stdc.stdint;
 import core.stdc.stdlib : abort;
 
-import std.algorithm : each, max, map;
+import std.algorithm;
 import std.conv;
 import std.format;
 import std.path : buildPath;
@@ -1008,6 +1008,7 @@ extern(D):
     {
         try
         {
+            ConsensusData[] values;
             foreach (ref const(Value) candidate; candidates)
             {
                 auto data = deserializeFull!ConsensusData(candidate[]);
@@ -1016,12 +1017,14 @@ extern(D):
                     assert(0, format!"combineCandidates: Invalid consensus data: %s"(
                         msg));
 
-                log.info("combineCandidates: {}", slot_idx);
                 log.trace("Combined consensus data: {}", data.prettify);
-                // todo: currently we just pick the first of the candidate values,
-                // but we should ideally pick tx's out of the combined set
-                return duplicate_value(&candidate);
+                values ~= data;
             }
+            // Nomination MUST be deterministic so we take the highest time offset for now
+            auto combined = values.sort!("a.time_offset > b.time_offset").front();
+            log.info("combineCandidates: took last of {} candiates: {}", values.length, combined.prettify);
+            const Value val = combined.serializeFull().toVec();
+            return duplicate_value(&val);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
With a periodic timer if the nominate takes more than a second then the
timer fires before the previous nominate completes. This then creates a
situation where multiple nominations are in progress but the system can
not keep up.