### PR TITLE
CombineCandidates take the latest time offset

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -360,7 +360,9 @@ extern(D):
             return;
         }
 
-        if (cur_time < this.getExpectedBlockTime())
+        const block_time_offset_tolerance_secs = this.ledger.block_time_offset_tolerance.total!"seconds";
+        const expectedBlockTimeThisNode = this.getExpectedBlockTime();
+        if (!(cur_time + block_time_offset_tolerance_secs > this.getExpectedBlockTime()))
             return;  // too early to nominate
 
         ConsensusData data;

--- a/source/agora/test/TimeBlockInterval.d
+++ b/source/agora/test/TimeBlockInterval.d
@@ -23,13 +23,14 @@ import agora.test.Base;
 ///
 unittest
 {
-    TestConf conf = { txs_to_nominate : 2, block_interval_sec : 10 };
+    TestConf conf = { txs_to_nominate : 2, block_interval_sec : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
+    assert(conf.block_interval_sec > 60); // Must be more than offset tolerance
     auto nodes = network.clients;
     auto node_1 = nodes[0];
 


### PR DESCRIPTION
If there are multiple candidates then for SCP to help converge on a
deterministic nominate statement then we take the latest time offset.
To prevent many different time offsets being nominated we also use the
expected time offset for the consensus data nomination.
Also when checking if it is time to nominate then take into account the
time offset tolerance. 