### PR TITLE
 Flash: Authenticate error messages 

### DIFF
--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -884,20 +884,31 @@ public abstract class FlashNode : ControlFlashAPI
 
             auto chans = (*path).map!(hop => hop.chan_id);
             OnionError deobfuscated = err;
-            foreach (secret; shared_secrets)
+            size_t failing_hop_idx = shared_secrets.length - 1;
+            foreach (idx, secret; shared_secrets)
             {
                 if (chans.canFind(deobfuscated.chan_id))
+                {
+                    failing_hop_idx = idx;
                     break;
+                }
                 deobfuscated = deobfuscated.obfuscate(secret);
             }
+            if (!chans.canFind(deobfuscated.chan_id))
+                return;
 
-            if (chans.canFind(deobfuscated.chan_id))
-            {
-                log.info(this.conf.key_pair.address.flashPrettify, " Got error: ",
-                    deobfuscated);
-                this.payment_errors[deobfuscated.payment_hash] ~= deobfuscated;
-                this.dump();
-            }
+            // Get the PublicKey of the node we think is failing
+            const failing_node_pk = (*path)[failing_hop_idx].pub_key;
+            const failing_chan = this.known_channels[deobfuscated.chan_id];
+            // Check the failing node is a peer of the failing channel
+            if (failing_chan.funder_pk != failing_node_pk &&
+                failing_chan.peer_pk != failing_node_pk)
+                return;
+
+            log.info(this.conf.key_pair.address.flashPrettify, " Got error: ",
+                deobfuscated);
+            this.payment_errors[deobfuscated.payment_hash] ~= deobfuscated;
+            this.dump();
         }
         else
             foreach (id, channel; this.channels)

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -947,8 +947,8 @@ public abstract class FlashNode : ControlFlashAPI
         {
             foreach (id, chan; this.channels)
                 chan.learnSecrets([], [payment_hash], this.last_height);
-            this.reportPaymentError(chan_id, OnionError(Hash.init,
-                payment_hash, chan_id, error));
+            this.reportPaymentError(chan_id, OnionError(payment_hash,
+                chan_id, error));
         }
     }
 

--- a/source/agora/flash/OnionPacket.d
+++ b/source/agora/flash/OnionPacket.d
@@ -523,9 +523,6 @@ public alias PaymentRouter =
 /// Routing failure packet
 public struct OnionError
 {
-    // todo: replace with actual HMAC
-    Hash hmac;
-
     /// Failed payment hash
     Hash payment_hash;
 
@@ -571,8 +568,8 @@ public OnionError obfuscate (OnionError error, Point secret) @trusted
 
 unittest
 {
-    auto org = OnionError(hashFull(1), hashFull(2),
-        hashFull(3), ErrorCode.LockTooLarge);
+    auto org = OnionError(hashFull(2), hashFull(3),
+        ErrorCode.LockTooLarge);
     const secret = Pair.random.V;
 
     auto obfuscated = org.obfuscate(secret);


### PR DESCRIPTION
While the payee node deobfuscates the error message it can
detect which node the message originates from. Ignore the error if the
origin node of the message is not a peer of the failing channel.