### PR TITLE
Slashing test: Replace shared UTXO with an API function

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1408,6 +1408,27 @@ public interface TestAPI : ValidatorAPI
     ***************************************************************************/
 
     public bool hasAcceptedTxHash (Hash tx_hash);
+
+    /***************************************************************************
+
+        Provides access to the state of the UTXO set
+
+    ***************************************************************************/
+
+    public UTXOPair[] getUTXOs (PublicKey owner);
+
+    /// Ditto
+    public UTXO getUTXO (Hash hash);
+}
+
+/// Return type for `TestAPI.getUTXOs`
+public struct UTXOPair
+{
+    ///
+    public Hash hash;
+
+    ///
+    public UTXO utxo;
 }
 
 /// Contains routines which are implemented by both TestFullNode and
@@ -1543,6 +1564,22 @@ private mixin template TestNodeMixin ()
     public bool hasAcceptedTxHash (Hash tx_hash)
     {
         return !!(tx_hash in this.accepted_txs);
+    }
+
+    ///
+    public override UTXOPair[] getUTXOs (PublicKey owner)
+    {
+        return this.utxo_set.getUTXOs(owner).byKeyValue
+            .map!((pair) => UTXOPair(pair.key, pair.value)).array;
+    }
+
+    ///
+    public override UTXO getUTXO (Hash hash)
+    {
+        UTXO result;
+        if (!this.utxo_set.peekUTXO(hash, result))
+            throw new Exception(format("UTXO not found: %s", hash));
+        return result;
     }
 }
 

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -124,9 +124,6 @@ unittest
     // discarded UTXOs (just to trigger block creation)
     auto txs = spendable[0 .. 8].map!(txb => txb.sign()).array;
 
-    // wait for the preimage to be missed
-    Thread.sleep(5.seconds);
-
     // block 1
     txs.each!(tx => nodes[0].putTransaction(tx));
     network.expectHeight(Height(1));


### PR DESCRIPTION
```
This will make it accessible to other tests, and should not be subject
to race condition as LocalRest handles synchronization.
```

Also, I'm not quite sure what the `Thread.sleep(5.seconds)` is supposed to achieve (it says we wait to miss a pre-image, but that should not have any effect on the nodes...).