### PR TITLE
Flash: Add proper channel close notification & ability to unilaterally close

### DIFF
--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -1638,57 +1638,6 @@ LOuter: while (1)
 
     /***************************************************************************
 
-        Begin a unilateral closing of the channel.
-
-        The channel will attempt to co-operatively close by offering the
-        counter-party to sign a closing transaction which spends directly
-        from the funding transaction where the closing transaction is not
-        encumbered by any sequence locks.
-
-        This closing transaction will need to be externalized before the
-        channel may be considered closed.
-
-        If the counter-party is not collaborative or is non-responsive,
-        the node will wait until `cooperative_close_timeout` time has passed
-        since the last failed co-operative close request. If this timeout is
-        reached the node will forcefully publish the trigger transaction.
-
-        Once the trigger transaction is externalized the node will publish
-        the latest update transaction if any, and subsequently will publish the
-        settlement transaction. The settlement transaction may only be published
-        after `settle_time` blocks were externalized after the trigger/update
-        transaction's UTXO was included in the blockchain - this leaves enough
-        time for the counter-party to react and publish a newer update &
-        settlement transactions in case the closing party tries to cheat by
-        publishing a stale update & settlement pair of transactions.
-
-        Params:
-            seq_id = the sequence ID.
-
-        Returns:
-            the update signature,
-            or an error code with an optional error message.
-
-    ***************************************************************************/
-
-    public void beginUnilateralClose ()
-    {
-        // todo: should only be called once
-        assert(this.state == ChannelState.Open);
-        this.state = ChannelState.PendingClose;
-
-        // publish the trigger transaction
-        // note that the settlement will be published automatically after the
-        // node detects the trigger tx published to the blockchain and after
-        // its relative lock time expires.
-        const trigger_tx = this.channel_updates[0].update_tx;
-        log.info("{}: Publishing trigger tx: {}", this.kp.address.flashPrettify,
-            trigger_tx.hashFull().flashPrettify);
-        this.txPublisher(cast()trigger_tx);
-    }
-
-    /***************************************************************************
-
         Begin a collaborative close of the channel.
 
         The node will send the counter-party a `closeChannel` request,

--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -1699,11 +1699,12 @@ LOuter: while (1)
 
     ***************************************************************************/
 
-    public void beginCollaborativeClose ()
+    public Result!bool beginCollaborativeClose ()
     {
-        // todo: should only be called once
-        //assert(this.state == ChannelState.Open);
-        // todo: can already be PendingClose if it was requested by another peer
+        if (this.state != ChannelState.Open)
+            return Result!bool(ErrorCode.ChannelNotOpen,
+                "Channel is not open");
+
         this.state = ChannelState.PendingClose;
 
         const Fee = Amount(100);  // todo: coordinate based on return value
@@ -1729,6 +1730,7 @@ LOuter: while (1)
         }
 
         this.collectCloseSignatures(priv_nonce, close_res.value);
+        return Result!bool(true);
     }
 
     /***************************************************************************

--- a/source/agora/flash/ControlAPI.d
+++ b/source/agora/flash/ControlAPI.d
@@ -45,9 +45,13 @@ public interface ControlFlashAPI : FlashAPI
         Params:
             chan_id = the ID of the channel to close
 
+        Returns:
+            true if this channel ID exists and may be closed,
+            else an error
+
     ***************************************************************************/
 
-    public void beginCollaborativeClose (/* in */ Hash chan_id);
+    public Result!bool beginCollaborativeClose (/* in */ Hash chan_id);
 
     /***************************************************************************
 

--- a/source/agora/flash/ControlAPI.d
+++ b/source/agora/flash/ControlAPI.d
@@ -55,6 +55,26 @@ public interface ControlFlashAPI : FlashAPI
 
     /***************************************************************************
 
+        If the counter-party rejects a collaborative closure,
+        the wallet may initiate a unilateral closure of the channel.
+
+        This will publish the latest update transaction to the blockchain,
+        and after the time lock expires the settlement transaction will be
+        published too.
+
+        Params:
+            chan_id = the ID of the channel to close
+
+        Returns:
+            true if this channel ID exists and may be closed,
+            else an error
+
+    ***************************************************************************/
+
+    public Result!bool beginUnilateralClose (/* in */ Hash chan_id);
+
+    /***************************************************************************
+
         Schedule opening a new channel with another flash node.
         If this funding_utxo is already used, an error is returned.
         Otherwise, the Listener will receive a notification through

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -826,11 +826,12 @@ public abstract class FlashNode : ControlFlashAPI
     }
 
     ///
-    public override void beginCollaborativeClose (/* in */ Hash chan_id)
+    public override Result!bool beginCollaborativeClose (/* in */ Hash chan_id)
     {
-        auto channel = chan_id in this.channels;
-        assert(channel !is null);
-        channel.beginCollaborativeClose();
+        if (auto channel = chan_id in this.channels)
+            return channel.beginCollaborativeClose();
+
+        return Result!bool(ErrorCode.InvalidChannelID, "Channel ID not found");
     }
 
     ///

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -835,6 +835,15 @@ public abstract class FlashNode : ControlFlashAPI
     }
 
     ///
+    public override Result!bool beginUnilateralClose (/* in */ Hash chan_id)
+    {
+        if (auto channel = chan_id in this.channels)
+            return channel.beginUnilateralClose();
+
+        return Result!bool(ErrorCode.InvalidChannelID, "Channel ID not found");
+    }
+
+    ///
     public override Result!Hash openNewChannel (/* in */ Hash funding_utxo,
         /* in */ Amount capacity, /* in */ uint settle_time,
         /* in */ Point peer_pk)
@@ -915,7 +924,7 @@ public abstract class FlashNode : ControlFlashAPI
         assert(channel !is null);
 
         const state = channel.getState();
-        if (state >= ChannelState.PendingClose)
+        if (state >= ChannelState.StartedCollaborativeClose)
         {
             log.info("Error: waitChannelOpen({}) called on channel state {}",
                 chan_id.flashPrettify, state);

--- a/source/agora/flash/Types.d
+++ b/source/agora/flash/Types.d
@@ -55,10 +55,20 @@ public enum ChannelState
     /// The channel is open and ready for new balance update requests.
     Open,
 
-    /// A channel closure was requested. New balance update requests will
-    /// be rejected. For safety reasons, the channel's metadata should be kept
+    /// A channel closure was requested either by the wallet or by the
+    /// counter-party. New balance update requests will be rejected.
+    //// For safety reasons the channel's metadata should be kept
     /// around until the channel's state becomes `Closed`.
-    PendingClose,
+    StartedCollaborativeClose,
+
+    /// The counter-party rejected collaboratively closing this channel.
+    /// The wallet has the option to either unilaterally close the channel,
+    /// or to attempt a collaborative close again at a later point.
+    RejectedCollaborativeClose,
+
+    /// The channel is being unilaterally closed by publishing an
+    /// update transaction to the blockchain.
+    StartedUnilateralClose,
 
     /// The funding transaction has been spent and externalized.
     /// This marks the channel as closed.


### PR DESCRIPTION
There's still some things missing with regards to serialization. E.g. if the node crashes, restarting it won't automatically attempt channel closure.

I'll file a separate issue related to behavior on crash / reload.