### PR TITLE
Flash: Make sure Payee sets enough lock_time

### DIFF
--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -1441,7 +1441,7 @@ unittest
     Amount total_amount;
     Height use_lock_height;
     Point[] shared_secrets;
-    onion = createOnionPacket(hashFull(42), Height(1000), Amount(100), path,
+    onion = createOnionPacket(hashFull(42), Amount(100), path,
         total_amount, use_lock_height, shared_secrets);
     pay_res = alice.proposePayment(chan_id, 0, hashFull(42), total_amount,
         use_lock_height, onion, PublicNonce.init, Height.init);


### PR DESCRIPTION
While building the onion, payee will try to accompany
all the htlc_delta values on route. If they don't result in
enough lock time, should be increased according to the settle_time.

We ignore settle_time configurations on the path, nodes should be expected
to set appropriate htlc_delta.