### PR TITLE
Using UTXOCache instead of UTXOSet in Ledger ctr

### DIFF
--- a/source/agora/consensus/state/UTXOCache.d
+++ b/source/agora/consensus/state/UTXOCache.d
@@ -99,6 +99,29 @@ abstract class UTXOCache
 
     /***************************************************************************
 
+        Returns:
+            the number of elements in the UTXO set
+
+    ***************************************************************************/
+
+    public abstract size_t length () @safe;
+
+    /***************************************************************************
+
+        Get UTXOs from the UTXO set
+
+        Params:
+            pubkey = the key by which to search UTXOs in UTXOSet
+
+        Returns:
+            the associative array for UTXOs
+
+    ***************************************************************************/
+
+    public abstract UTXO[Hash] getUTXOs (in PublicKey pubkey) nothrow @safe;
+
+    /***************************************************************************
+
         Get an UTXO from the UTXO set.
 
         Params:
@@ -256,5 +279,38 @@ public class TestUTXOSet : UTXOCache
     protected override void add (in Hash utxo, UTXO value) @safe
     {
         this.storage[utxo] = value;
+    }
+
+    /***************************************************************************
+
+        Returns:
+            the number of elements in the UTXO set
+
+    ***************************************************************************/
+
+    public override size_t length () @safe
+    {
+        return this.storage.length;
+    }
+
+    /***************************************************************************
+
+        Get UTXOs from the UTXO set
+
+        Params:
+            pubkey = the key by which to search UTXOs in UTXOSet
+
+        Returns:
+            the associative array for UTXOs
+
+    ***************************************************************************/
+
+    public override UTXO[Hash] getUTXOs (in PublicKey pubkey) nothrow @safe
+    {
+        UTXO[Hash] utxos;
+        foreach (const ref key_val; storage.byKeyValue)
+            if (key_val.value.output.lock.bytes[] == pubkey[])
+                utxos[key_val.key] = key_val.value;
+        return utxos;
     }
 }

--- a/source/agora/consensus/state/UTXODB.d
+++ b/source/agora/consensus/state/UTXODB.d
@@ -102,7 +102,7 @@ package class UTXODB
 
     ***************************************************************************/
 
-    public UTXO[Hash] getUTXOs (const ref PublicKey pubkey) nothrow @trusted
+    public UTXO[Hash] getUTXOs (in PublicKey pubkey) nothrow @trusted
     {
         scope (failure) assert(0);
 

--- a/source/agora/consensus/state/UTXOSet.d
+++ b/source/agora/consensus/state/UTXOSet.d
@@ -53,7 +53,7 @@ public class UTXOSet : UTXOCache
 
     ***************************************************************************/
 
-    public size_t length () @safe
+    public override size_t length () @safe
     {
         return this.utxo_db.length();
     }
@@ -70,7 +70,7 @@ public class UTXOSet : UTXOCache
 
     ***************************************************************************/
 
-    public UTXO[Hash] getUTXOs (const ref PublicKey pubkey) nothrow @safe
+    public override UTXO[Hash] getUTXOs (in PublicKey pubkey) nothrow @safe
     {
         return this.utxo_db.getUTXOs(pubkey);
     }

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -90,7 +90,7 @@ public class Ledger
     private Block last_block;
 
     /// UTXO set
-    private UTXOSet utxo_set;
+    private UTXOCache utxo_set;
 
     // Clock instance
     private Clock clock;
@@ -154,7 +154,7 @@ public class Ledger
     ***************************************************************************/
 
     public this (immutable(ConsensusParams) params,
-        Engine engine, UTXOSet utxo_set, IBlockStorage storage,
+        Engine engine, UTXOCache utxo_set, IBlockStorage storage,
         EnrollmentManager enroll_man, TransactionPool pool,
         FeeManager fee_man, Clock clock,
         Duration block_time_offset_tolerance = 60.seconds,


### PR DESCRIPTION
This PR is just to be able to unblock #1917, it only fixes the Ledger constructor. 

There are a lot of naming problems, some methods use ...utxoset... while some other use ...utxocache...  I didn't attempt to fix those in this PR.

fixes: #1943 