### PR TITLE
Fetch available preimages during periodic catchup

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -891,7 +891,7 @@ public class NetworkManager
             log.info("Retrieving preimages from the height of {} from {}..",
                 start_height, pair.client.address);
 
-            auto preimages = pair.client.getPreimages(start_height, height);
+            auto preimages = pair.client.getPreimages(start_height, start_height + MaxBlocks);
 
             log.info("Received {} preimages", preimages.length);
 


### PR DESCRIPTION
The preimages were being fetched for each height. As they are often
revealed for future blocks we should fetch all the available preimages
from the other nodes.