### PR TITLE
Remove duplicate check for self slashing

### DIFF
--- a/source/agora/consensus/SlashPolicy.d
+++ b/source/agora/consensus/SlashPolicy.d
@@ -251,10 +251,6 @@ public class SlashPolicy
         if (!this.enroll_man.getEnrolledUTXOs(keys) || keys.length == 0)
             assert(0, "Could not retrieve enrollments / no enrollments found");
 
-        auto enroll_index = this.enroll_man.getIndexOfEnrollment();
-        if (enroll_index != ulong.max && !missing_validators.find(enroll_index).empty)
-            assert(0, "The node is slashing itself.");
-
         uint[] local_missing_validators;
         foreach (idx, key; keys)
         {


### PR DESCRIPTION
I think after a recent refactor the check was accidentally duplicated.
The check is performed in `checkSelfSlashing` function.