### PR TITLE
Add `{EM,ValidatorSet}.countActive` to respect the given height

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -994,11 +994,22 @@ public class EnrollmentManager
             `height`.
             Returns 0 in case of error.
 
-    ***************************************************************************/
+     ***************************************************************************/
 
     public ulong getValidatorCount (in Height height) @safe nothrow
     {
-        return this.validator_set.getValidatorCount(height);
+        return this.validator_set.countActive(height + 1);
+    }
+
+    /***************************************************************************
+
+        See `ValidatorSet.countActive`
+
+    ***************************************************************************/
+
+    public ulong countActive (in Height height) @safe nothrow
+    {
+        return this.validator_set.countActive(height);
     }
 
     /***************************************************************************

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -556,23 +556,6 @@ public class EnrollmentManager
 
     /***************************************************************************
 
-        Get the number of active validators.
-
-        Client code can use this between clearExpiredValidators() calls to
-        determine if the number of validators has changed, and act accordingly.
-
-        Returns:
-            the number of active validators
-
-    ***************************************************************************/
-
-    public size_t validatorCount (in Height height) @safe
-    {
-        return this.validator_set.getValidatorCount(height);
-    }
-
-    /***************************************************************************
-
         Check if an enrollment is a valid candidate for the proposed height
 
         This method is very similar to `addEnrollment`. This one deals with
@@ -1197,7 +1180,7 @@ unittest
     man.getEnrollments(enrolls, Height(9), &utxo_set.peekUTXO);
     assert(enrolls.length == 1);
     // One Enrollment was moved to validator set
-    assert(man.validatorCount(Height(9)) == 1);
+    assert(man.getValidatorCount(Height(9)) == 1);
     assert(man.enroll_pool.count() == 1);
 
     man.enroll_pool.remove(utxo_hashes[0]);
@@ -1236,7 +1219,7 @@ unittest
     assert(man.addValidator(ordered_enrollments[1], WK.Keys[1].address, Height(11),
             &utxo_set.peekUTXO, utxos) is null);
     man.clearExpiredValidators(Height(11));
-    assert(man.validatorCount(Height(11)) == 2);
+    assert(man.getValidatorCount(Height(11)) == 2);
     assert(man.getEnrolledUTXOs(keys));
     assert(keys.length == 2);
 
@@ -1246,7 +1229,7 @@ unittest
     assert(man.addValidator(ordered_enrollments[2], WK.Keys[2].address, Height(1019),
             &utxo_set.peekUTXO, utxos) is null);
     man.clearExpiredValidators(Height(1019));
-    assert(man.validatorCount(Height(1019)) == 1);
+    assert(man.getValidatorCount(Height(1019)) == 1);
     assert(man.getEnrolledUTXOs(keys));
     assert(keys.length == 1);
     assert(keys[0] == ordered_enrollments[2].utxo_key);

--- a/source/agora/consensus/SlashPolicy.d
+++ b/source/agora/consensus/SlashPolicy.d
@@ -332,7 +332,7 @@ unittest
     foreach (idx, enroll; enrollments)
         assert(enroll_man.addValidator(enroll, pairs[idx].address, Height(1),
             &utxo_set.peekUTXO, self_utxos) is null);
-    assert(enroll_man.validatorCount(Height(1)) == 8);
+    assert(enroll_man.getValidatorCount(Height(1)) == 8);
 
     // create slashing manager
     scope slash_man = new SlashPolicy(enroll_man, params);

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -239,7 +239,7 @@ unittest
                                                 key_pairs[0].address) is null);
 
     validator_set.clearExpiredValidators(Height(params.ValidatorCycle));
-    assert(validator_set.getValidatorCount(Height(params.ValidatorCycle)) == 0);
+    assert(validator_set.countActive(Height(params.ValidatorCycle)) == 0);
 
     // First 2 iterations should fail because commitment is wrong
     foreach (offset; [-1, +1, 0])
@@ -249,7 +249,7 @@ unittest
         assert((offset == 0) == (validator_set.add(Height(params.ValidatorCycle),
                             utxoPeek, enroll1, key_pairs[0].address) is null));
     }
-    assert(validator_set.getValidatorCount(Height(params.ValidatorCycle)) == 1);
+    assert(validator_set.countActive(Height(params.ValidatorCycle)) == 1);
 
     Enrollment invalid;
     assert(isInvalidReason(invalid,

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -198,7 +198,7 @@ public class Ledger
                 this.replayStoredBlock(this.storage.readBlock(Height(height)));
             }
         }
-        else if (this.enroll_man.getValidatorCount(this.last_block.header.height) == 0)
+        else if (this.enroll_man.countActive(this.last_block.header.height) == 0)
         {
             // +1 because the genesis block counts as one
             const ulong block_count = this.last_block.header.height + 1;
@@ -272,12 +272,12 @@ public class Ledger
             return false;
         }
 
-        const old_count = this.enroll_man.getValidatorCount(block.header.height);
+        const old_count = this.enroll_man.countActive(this.getBlockHeight());
 
         this.storage.saveBlock(block);
         this.addValidatedBlock(block);
 
-        const new_count = this.enroll_man.getValidatorCount(block.header.height);
+        const new_count = this.enroll_man.countActive(block.header.height);
         // there was a change in the active validator set
         const bool validators_changed = block.header.enrollments.length > 0
             || new_count != old_count;

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -198,7 +198,7 @@ public class Ledger
                 this.replayStoredBlock(this.storage.readBlock(Height(height)));
             }
         }
-        else if (this.enroll_man.validatorCount(this.last_block.header.height) == 0)
+        else if (this.enroll_man.getValidatorCount(this.last_block.header.height) == 0)
         {
             // +1 because the genesis block counts as one
             const ulong block_count = this.last_block.header.height + 1;
@@ -272,12 +272,12 @@ public class Ledger
             return false;
         }
 
-        const old_count = this.enroll_man.validatorCount(block.header.height);
+        const old_count = this.enroll_man.getValidatorCount(block.header.height);
 
         this.storage.saveBlock(block);
         this.addValidatedBlock(block);
 
-        const new_count = this.enroll_man.validatorCount(block.header.height);
+        const new_count = this.enroll_man.getValidatorCount(block.header.height);
         // there was a change in the active validator set
         const bool validators_changed = block.header.enrollments.length > 0
             || new_count != old_count;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1524,7 +1524,7 @@ private mixin template TestNodeMixin ()
     /// Get the active validator count for the current block height
     public override ulong getValidatorCount (in Height height)
     {
-        return this.enroll_man.validatorCount(height);
+        return this.enroll_man.getValidatorCount(height);
     }
 
     /// Localrest: the address (key) is provided directly to the network manager


### PR DESCRIPTION
```
The behavior of `getValidatorCount` could be surprising to the reader:
it was getting the number of potential validators at the height after the provided one.
The documentation and the parameter name didn't advertise this fact properly,
and while most usages were correct, there are a few red flags.

Since it is widely used with both "current block" and "next block" semantics,
the first step is to allow one to use both separately,
by making `ValidatorSet` return the correct value,
and later on remove `EnrollmentManager.getValidatorCount`.
```