### PR TITLE
EM: Ensure consistency between validator cycles

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -1677,9 +1677,11 @@ unittest
         });
 
     auto man = new EnrollmentManager(WK.Keys.A,
-        new immutable(ConsensusParams));
-    auto e1 = EnrollmentManager.makeEnrollment(utxos[0], WK.Keys.A, 10, 0);
-    auto e2 = EnrollmentManager.makeEnrollment(utxos[1], WK.Keys.B, 10, 0);
+        new immutable(ConsensusParams)(20));
+    auto e1 = EnrollmentManager.makeEnrollment(
+        utxos[0], WK.Keys.A, man.params.ValidatorCycle, 0);
+    auto e2 = EnrollmentManager.makeEnrollment(
+        utxos[1], WK.Keys.B, man.params.ValidatorCycle, 0);
 
     assert(man.addEnrollment(e1, WK.Keys.A.address, Height(1), &utxo_set.peekUTXO));
     assert(man.addEnrollment(e2, WK.Keys.B.address, Height(1), &utxo_set.peekUTXO));


### PR DESCRIPTION
```
We were creating an Enrollment with a ValidatorCycle of 10,
while the actual ValidatorCycle of ConsensusParams was 1008.
```

It is the only test that fails the following diff:
```diff
diff --git a/source/agora/consensus/EnrollmentManager.d b/source/agora/consensus/EnrollmentManager.d
index 4c32b4b25..4a9ab38a2 100644
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -297,6 +297,8 @@ public class EnrollmentManager
     {
         const Height enrolled = this.getEnrolledHeight(enroll.utxo_key);

+        assert(enroll.cycle_length == this.params.ValidatorCycle);
+
         // The first height at which the enrollment can be enrolled
         // is either the next block (if there is no prior enrollment)
         // or the height of the last enrollment + the validator cycle.
```