### PR TITLE
Minor improvements to SQL usability

### DIFF
--- a/doc/Database.md
+++ b/doc/Database.md
@@ -11,11 +11,11 @@ For more informations, see [this description](https://github.com/bosagora/agora/
 
 Our oldest table, only contain binary serialized data, should be changed to a readable format.
 
-| Field name  | SQL Type | D type    | Attributes  | Comment                                                |
-|-------------|----------|-----------|-------------|--------------------------------------------------------|
-| key         | TEXT     | string    | PRIMARY KEY | The key is the UTXO hash                               |
-| val         | BLOB     | UTXO      | NOT NULL    | Binary serialized UTXO, should be converted to text    |
-| pubkey_hash | TEXT     | PublicKey | NOT NULL    | It's not actually a hash but the key                   |
+| Field name | SQL Type | D type    | Attributes  | Comment                                                |
+|------------|----------|-----------|-------------|--------------------------------------------------------|
+| key        | TEXT     | string    | PRIMARY KEY | The key is the UTXO hash                               |
+| val        | BLOB     | UTXO      | NOT NULL    | Binary serialized UTXO, should be converted to text    |
+| pubkey     | TEXT     | PublicKey | NOT NULL    | The public key owning this UTXO                        |
 
 
 ### `validator` table

--- a/doc/Database.md
+++ b/doc/Database.md
@@ -7,7 +7,7 @@ For more informations, see [this description](https://github.com/bosagora/agora/
 
 ## State DB
 
-### `utxo_map` table
+### `utxo` table
 
 Our oldest table, only contain binary serialized data, should be changed to a readable format.
 
@@ -18,9 +18,9 @@ Our oldest table, only contain binary serialized data, should be changed to a re
 | pubkey_hash | TEXT     | PublicKey | NOT NULL    | It's not actually a hash but the key                   |
 
 
-### `validator_set` table
+### `validator` table
 
-Should be cleaned up and make readable. Once `utxo_map` is usable, both can be used in combination.
+Should be cleaned up and make readable. Once `utxo` is usable, both can be used in combination.
 
 | Field name      | SQL Type | D type           | Attributes                  | Comment                                            |
 |-----------------|----------|------------------|-----------------------------|----------------------------------------------------|
@@ -35,7 +35,7 @@ Should be cleaned up and make readable. Once `utxo_map` is usable, both can be u
 
 ### `node_enroll_data` table
 
-This table should be removed in favor of querying `validator_set` directly.
+This table should be removed in favor of querying `validator` directly.
 
 | Field name | SQL Type | D type | Attributes  | Comment                                                           |
 |------------|----------|--------|-------------|-------------------------------------------------------------------|

--- a/doc/Database.md
+++ b/doc/Database.md
@@ -13,9 +13,9 @@ Our oldest table, only contain binary serialized data, should be changed to a re
 
 | Field name  | SQL Type | D type    | Attributes  | Comment                                                |
 |-------------|----------|-----------|-------------|--------------------------------------------------------|
-| key         | BLOB     | string    | PRIMARY KEY | The key is the UTXO hash, should be `TEXT`             |
+| key         | TEXT     | string    | PRIMARY KEY | The key is the UTXO hash                               |
 | val         | BLOB     | UTXO      | NOT NULL    | Binary serialized UTXO, should be converted to text    |
-| pubkey_hash | BLOB     | PublicKey | NOT NULL    | It's not actually a hash but the key, should be `TEXT` |
+| pubkey_hash | TEXT     | PublicKey | NOT NULL    | It's not actually a hash but the key                   |
 
 
 ### `validator_set` table

--- a/source/agora/consensus/state/UTXODB.d
+++ b/source/agora/consensus/state/UTXODB.d
@@ -44,7 +44,7 @@ package class UTXODB
         this.db = db;
         // create the table if it doesn't exist yet
         this.db.execute("CREATE TABLE IF NOT EXISTS utxo " ~
-            "(key TEXT PRIMARY KEY, val BLOB NOT NULL, pubkey_hash TEXT NOT NULL)");
+            "(key TEXT PRIMARY KEY, val BLOB NOT NULL, pubkey TEXT NOT NULL)");
     }
 
     /***************************************************************************
@@ -106,7 +106,7 @@ package class UTXODB
         scope (failure) assert(0);
 
         UTXO[Hash] utxos;
-        auto results = db.execute("SELECT key, val FROM utxo WHERE pubkey_hash = ?",
+        auto results = db.execute("SELECT key, val FROM utxo WHERE pubkey = ?",
             pubkey);
 
         foreach (row; results)
@@ -136,7 +136,7 @@ package class UTXODB
 
         scope (failure) assert(0);
         () @trusted {
-            db.execute("INSERT INTO utxo (key, val, pubkey_hash) VALUES (?, ?, ?)",
+            db.execute("INSERT INTO utxo (key, val, pubkey) VALUES (?, ?, ?)",
                 key, buffer, value.output.address); }();
     }
 

--- a/source/agora/consensus/state/UTXODB.d
+++ b/source/agora/consensus/state/UTXODB.d
@@ -43,7 +43,7 @@ package class UTXODB
     {
         this.db = db;
         // create the table if it doesn't exist yet
-        this.db.execute("CREATE TABLE IF NOT EXISTS utxo_map " ~
+        this.db.execute("CREATE TABLE IF NOT EXISTS utxo " ~
             "(key TEXT PRIMARY KEY, val BLOB NOT NULL, pubkey_hash TEXT NOT NULL)");
     }
 
@@ -57,7 +57,7 @@ package class UTXODB
     public size_t length () @safe
     {
         return () @trusted {
-            return this.db.execute("SELECT count(*) FROM utxo_map")
+            return this.db.execute("SELECT count(*) FROM utxo")
                 .oneValue!size_t;
         }();
     }
@@ -78,7 +78,7 @@ package class UTXODB
     public bool find (in Hash key, out UTXO value) nothrow @trusted
     {
         scope (failure) assert(0);
-        auto results = db.execute("SELECT val FROM utxo_map WHERE key = ?", key);
+        auto results = db.execute("SELECT val FROM utxo WHERE key = ?", key);
 
         foreach (row; results)
         {
@@ -106,7 +106,7 @@ package class UTXODB
         scope (failure) assert(0);
 
         UTXO[Hash] utxos;
-        auto results = db.execute("SELECT key, val FROM utxo_map WHERE pubkey_hash = ?",
+        auto results = db.execute("SELECT key, val FROM utxo WHERE pubkey_hash = ?",
             pubkey);
 
         foreach (row; results)
@@ -136,7 +136,7 @@ package class UTXODB
 
         scope (failure) assert(0);
         () @trusted {
-            db.execute("INSERT INTO utxo_map (key, val, pubkey_hash) VALUES (?, ?, ?)",
+            db.execute("INSERT INTO utxo (key, val, pubkey_hash) VALUES (?, ?, ?)",
                 key, buffer, value.output.address); }();
     }
 
@@ -153,6 +153,6 @@ package class UTXODB
     {
         scope (failure) assert(0);
         () @trusted {
-            db.execute("DELETE FROM utxo_map WHERE key = ?", key); }();
+            db.execute("DELETE FROM utxo WHERE key = ?", key); }();
     }
 }


### PR DESCRIPTION
Shortening names so join and manual queries are easier, and using TEXT so that the DB is (a bit) more readable.
Also having the `pubkey_hash` field as TEXT will allow to join `utxo` with `validator`.