### PR TITLE
Set same value to `max_retries` except `TestConf`

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -24,7 +24,7 @@ node:
   # Number of milliseconds to wait between retrying requests
   retry_delay: 3000
   # Maximum number of retries to issue before a request is considered failed
-  max_retries: 10
+  max_retries: 50
   # Timeout for each request in milliseconds
   timeout: 5000
   # Path to the data directory (if the path doesn't exist it will be created)

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -189,7 +189,7 @@ public struct NodeConfig
     public Duration retry_delay = 3.seconds;
 
     /// Maximum number of retries to issue before a request is considered failed
-    public size_t max_retries = 10;
+    public size_t max_retries = 50;
 
     /// Timeout for each request
     public Duration timeout = 5000.msecs;


### PR DESCRIPTION
Set the same value to all the `max_retries` variables except `TestConf`.
It's just for consistency because there's no reason why they are different values.

Fixes #1657 