### PR TITLE
Default quorum threshold to 4 of 6

### DIFF
--- a/source/agora/consensus/data/Params.d
+++ b/source/agora/consensus/data/Params.d
@@ -96,7 +96,7 @@ public immutable class ConsensusParams
     /// Default for unittest, uses the test genesis block
     version (unittest) public this (
         uint validator_cycle = 1008, uint max_quorum_nodes = 7,
-        uint quorum_threshold = 80)
+        uint quorum_threshold = 60)
     {
         import agora.consensus.data.genesis.Test : GenesisBlock;
         import agora.utils.WellKnownKeys;


### PR DESCRIPTION
The default is 80% which means 5 / 6 for our System tests. Not sure what value we really want here but checking if it is why we do not externalize.