### PR TITLE
Assert handler: Print stacktrace directly

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -126,6 +126,23 @@ void testAssertHandler (string file, ulong line, string msg) nothrow
             "================================ ASSERT HANDLER ===============================\n");
         output.formattedWrite!"[%s:%s] Assertion thrown during test: %s\n"
             (file, line, msg);
+
+        // Print stack trace starting from the failing line
+        scope trace = defaultTraceHandler(null);
+        bool findStart = false;
+        foreach (traceLine; trace)
+        {
+            if (!findStart)
+            {
+                if (traceLine.canFind("_d_assert"))
+                    findStart = true;
+                continue;
+            }
+            output.formattedWrite("%s\n", traceLine);
+        }
+
+        output.formattedWrite(
+            "================================ NODE LOGS ===============================\n");
         CircularAppender!()().print(output);
         stdout.flush();
     }


### PR DESCRIPTION
The logic here also means that we skip over druntime's internal frame,
having the most relevant frame at the top.