### PR TITLE
Signature catchup consider slashed

### DIFF
--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -300,7 +300,7 @@ public class ValidatorSet
 
     /***************************************************************************
 
-        Get all the current validators in ascending order of public key
+        Get all the current validators in ascending order of the utxo key
 
         Params:
             pub_keys = will contain the public keys
@@ -334,7 +334,7 @@ public class ValidatorSet
 
     /***************************************************************************
 
-        Get all the current validators in ascending order with the utxo_key
+        Get all the current validators in ascending order with the utxo key
 
         Params:
             validators = will be filled with all the validators during

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -981,7 +981,7 @@ public class NetworkManager
                     headers.map!(header =>
                         tuple(header.height,
                             iota(0, enrolled_validators[header.height]).filter!(i =>
-                                header.validators[i]).count()
+                                header.validators[i] || header.missing_validators.canFind(i)).count() // Take into account the slashed validators
                         )
                     ).assocArray;
 
@@ -998,7 +998,7 @@ public class NetworkManager
                         foreach (header; peer.client.getBlockHeaders(missing_heights))
                         {
                             auto sig_signed_validators = iota(enrolled_validators[header.height]).filter!(i =>
-                                header.validators[i]).count();
+                                header.validators[i] || header.missing_validators.canFind(i)).count();
                             if (sig_signed_validators > signed_validators[header.height])
                             {
                                 try


### PR DESCRIPTION
During periodic signature catchup, a count of signatures at the previous few block heights should take into account if any validators have been slashed. Otherwise it will check each connected peer even though there are no more signatures to be fetched.