### PR TITLE
Restore Node logging capacity in unittests

### DIFF
--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -137,6 +137,19 @@ public alias LogLevel = Ocean.Level;
 /// Ditto
 public alias Log = Ocean.Log;
 
+version (unittest)
+{
+    // As we spawn one node per thread (except for the main thread),
+    // we need to configure each thread's logger, a task normally
+    // handled by `agora.node.main` / `agora.node.Runner`.
+    static this ()
+    {
+        auto appender = CircularAppender!()();
+        appender.layout(new AgoraLayout());
+        Log.root.add(appender);
+    }
+}
+
 /// Define options to configure a Logger
 /// Loosely inspired from `ocean.utils.log.Config`
 public struct LoggerConfig


### PR DESCRIPTION
PR1983, while making logger configurable, inadvertently removed code that
allowed logs to be saved and later accessed while running network tests.
This means that nowadays, when a test fails, we don't have any insight into what happened.