### PR TITLE
Flash: Add multi-key management support

### DIFF
--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -646,11 +646,6 @@ private FlashConfig parseFlashConfig (Node* node, in CommandLine cmdln,
     const timeout = get!(Duration, "flash", "timeout", str => str.to!ulong.msecs)
         (cmdln, node);
 
-    immutable KeyPair kp = validator_config.enabled
-        ? validator_config.key_pair
-        : KeyPair.fromSeed(SecretKey.fromString(get!(string, "flash", "seed")(
-            cmdln, node)));
-
     const bool testing = opt!(bool, "flash", "testing")(cmdln, node);
     if (testing)
         enforce(node_config.testing,
@@ -673,7 +668,6 @@ private FlashConfig parseFlashConfig (Node* node, in CommandLine cmdln,
         enabled: true,
         timeout: timeout,
         testing: testing,
-        key_pair: kp,
         listener_address: listener_address,
         min_funding: min_funding.coins,
         max_funding: max_funding.coins,

--- a/source/agora/flash/Config.d
+++ b/source/agora/flash/Config.d
@@ -34,7 +34,8 @@ public struct FlashConfig
     /// Flash name registry address
     public string registry_address;
 
-    // Network addresses that will be registered with the public key
+    // Network addresses that will be registered with the associated managed
+    // public keys
     public immutable string[] addresses_to_register;
 
     /// Timeout for requests
@@ -44,11 +45,6 @@ public struct FlashConfig
     /// and send & receive Flash transactions. If `true` then
     /// `NodeConfig.testing` must also be true or else configuration will fail.
     public bool testing = false;
-
-    /// The seed to use for the keypair of this Flash node. If this value is
-    /// empty and `enabled` is true then the same key-pair will be used as
-    /// the one set in `validator.key_pair`.
-    public immutable KeyPair key_pair;
 
     /// Address to the listener which will receive payment / update notifications
     public string listener_address;

--- a/source/agora/flash/ErrorCode.d
+++ b/source/agora/flash/ErrorCode.d
@@ -22,6 +22,9 @@ public enum ErrorCode : ushort
     /// Unknown error
     Unknown,
 
+    /// This Flash node does not manage this public key
+    KeyNotRecognized,
+
     /// Cannot find this node in the flash node registry
     AddressNotFound,
 

--- a/source/agora/flash/OnionPacket.d
+++ b/source/agora/flash/OnionPacket.d
@@ -504,8 +504,8 @@ unittest
 
 /// OnionPacket payment router
 public alias PaymentRouter =
-    void delegate (in Hash chan_id, in Hash payment_hash, in Amount amount,
-        in Height lock_height, in OnionPacket packet);
+    void delegate (in PublicKey pk, in Hash chan_id, in Hash payment_hash,
+        in Amount amount, in Height lock_height, in OnionPacket packet);
 
 /// Routing failure packet
 public struct OnionError

--- a/source/agora/flash/UpdateSigner.d
+++ b/source/agora/flash/UpdateSigner.d
@@ -329,7 +329,8 @@ public class UpdateSigner
 
             this.taskman.wait(WaitTime);
 
-            settle_res = peer.requestSettleSig(this.conf.chan_id, seq_id);
+            settle_res = peer.requestSettleSig(this.kp.address,
+                PublicKey(this.peer_pk), this.conf.chan_id, seq_id);
             if (settle_res.error)
             {
                 // todo: retry?
@@ -375,7 +376,8 @@ public class UpdateSigner
 
             this.taskman.wait(WaitTime);
 
-            update_res = peer.requestUpdateSig(this.conf.chan_id, seq_id);
+            update_res = peer.requestUpdateSig(this.kp.address,
+                PublicKey(this.peer_pk), this.conf.chan_id, seq_id);
             if (update_res.error)
             {
                 // todo: retry?
@@ -413,7 +415,8 @@ public class UpdateSigner
         // confirm to the peer we're done, and await for peer's own confirmation
         while (1)
         {
-            auto result = peer.confirmChannelUpdate(this.conf.chan_id, seq_id);
+            auto result = peer.confirmChannelUpdate(this.kp.address,
+                PublicKey(this.peer_pk), this.conf.chan_id, seq_id);
             if (result.error)
             {
                 log.info("{}: confirmChannelUpdate rejected, trying again..: {}",

--- a/source/agora/flash/api/FlashListenerAPI.d
+++ b/source/agora/flash/api/FlashListenerAPI.d
@@ -14,6 +14,7 @@
 module agora.flash.api.FlashListenerAPI;
 
 import agora.common.Types;
+import agora.crypto.Key;
 import agora.flash.Config;
 import agora.flash.ErrorCode;
 import agora.flash.Invoice;
@@ -43,7 +44,7 @@ public interface FlashListenerAPI
 
     ***************************************************************************/
 
-    public void onChannelNotify (Hash chan_id, ChannelState state,
+    public void onChannelNotify (PublicKey pk, Hash chan_id, ChannelState state,
         ErrorCode error);
 
     /***************************************************************************
@@ -63,7 +64,7 @@ public interface FlashListenerAPI
 
     ***************************************************************************/
 
-    public string onRequestedChannelOpen (ChannelConfig chan_conf);
+    public string onRequestedChannelOpen (PublicKey pk, ChannelConfig chan_conf);
 
     /***************************************************************************
 
@@ -74,7 +75,7 @@ public interface FlashListenerAPI
 
     ***************************************************************************/
 
-    public void onPaymentSuccess (Invoice invoice);
+    public void onPaymentSuccess (PublicKey pk, Invoice invoice);
 
     /***************************************************************************
 
@@ -86,5 +87,5 @@ public interface FlashListenerAPI
 
     ***************************************************************************/
 
-    public void onPaymentFailure (Invoice invoice, ErrorCode error);
+    public void onPaymentFailure (PublicKey pk, Invoice invoice, ErrorCode error);
 }


### PR DESCRIPTION
Fixes #1999

@TrustHenry @MichaelKim20 this will allow a single Flash node to manage multiple key-pairs. I will work on the rest of the issues now. 

In the current design the key-pairs are still shared with the Flash node. It might be possible in the future to change this so that the Wallet is doing signing and sharing the signature with the Flash node. I'll file a separate issue for that.