### PR TITLE
Fix random seed generation

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -680,7 +680,7 @@ public class EnrollmentManager
                 log.info("No preimage at height {} for validator key {}", height.value, key);
                 continue;
             }
-            rand_seed = hashMulti(rand_seed, preimage);
+            rand_seed = hashMulti(rand_seed, preimage.hash);
         }
 
         return rand_seed;
@@ -1488,15 +1488,15 @@ unittest
 
     utxos.sort();  // must be sorted by enrollment key
     assert(man.getRandomSeed(utxos, Height(1)) ==
-        Hash(`0xd24632cc1614e4890e91f98691b893e61b9e49c9ac3b69ef49b32f5e27a70daf682dda3be26fa898de4227dc4c1dcbcbd6337deba74492224a3a38a07410bac6`),
+        Hash(`0x82c3bf560f5d656162293f55b1d21d426be502bf2104fbc75611bc2ee6a275bfee35bb9d6010b5d38014420fd16e3d35c942bc452cbdb7f0f9eef73b5e5ea2fa`),
         man.getRandomSeed(utxos, Height(1)).to!string);
 
     assert(man.getRandomSeed(utxos, Height(params.ValidatorCycle / 2)) ==
-        Hash(`0xeb075dea34f1881d9f3e91aab7f6c26d40b5859c66ad4c11b9fb92a5b1aac1f85ddf570844666ffc36e349591df28f6d279926f52b213886ba30e4a7f4a99f0b`),
+        Hash(`0xff413a98b3bba2c4b831e518970f24fca92063b0c12b982337a73bb254225e43eb4a3cdf75d145bf20b6ff16e70349185c82ba2fd6c33e078c43b5c116a89ddb`),
         man.getRandomSeed(utxos, Height(params.ValidatorCycle / 2)).to!string);
 
     assert(man.getRandomSeed(utxos, Height(params.ValidatorCycle)) ==
-        Hash(`0xef0f8605d75a813cd30e69d3f4299ad342d50ac56be4f565a978ece6de16515887e5236d3176bd7a25ac58658689ce870b5017f031733a6a20d45bc525b78659`),
+        Hash(`0x272bb00e388a3dab4797e4af79ecc1a297bc39c3ab785f1473120c69c3c043f8a3dbbe0abfe6a141a6c23d1d36aff3db9321b45f1c446170a7b6b0a5bc0d6e7f`),
         man.getRandomSeed(utxos, Height(params.ValidatorCycle)).to!string);
 }
 

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -25,8 +25,9 @@ import agora.consensus.data.Transaction;
 import agora.consensus.data.genesis.Test;
 import agora.crypto.Key;
 import agora.node.FullNode;
-import agora.utils.Log;
 import agora.test.Base;
+import agora.utils.Log;
+import agora.utils.PrettyPrinter;
 
 import std.algorithm;
 import std.format;
@@ -65,8 +66,7 @@ unittest
         {
             import std.string;
             const quorum = node.getQuorumConfig();
-            writefln("L%s: Node %s: Threshold: %s Nodes: %s", line, idx,
-                quorum.threshold, quorum.nodes.map!(e => e.to!string));
+            writefln("L%s: Node %s: \n%s", line, idx, quorum.prettify);
         }
     }
 
@@ -134,7 +134,7 @@ unittest
         nodes.enumerate.each!((idx, node) =>
             retryFor(node.getQuorumConfig() == quorums_1[idx], 5.seconds,
                 format("Node %s has quorum config %s. Expected quorums_1: %s",
-                    idx, node.getQuorumConfig(), quorums_1[idx])));
+                    idx, node.getQuorumConfig().prettify, quorums_1[idx].prettify)));
     }
 
     const keys = network.nodes.map!(node => node.getPublicKey().key)

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -170,7 +170,7 @@ unittest
             WK.Keys.NODE3.address,
             WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
-            WK.Keys.NODE5.address,
+            WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
             WK.Keys.NODE4.address,
@@ -181,7 +181,7 @@ unittest
             WK.Keys.NODE3.address,
             WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
-            WK.Keys.NODE5.address,
+            WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
             WK.Keys.NODE4.address,
@@ -189,10 +189,10 @@ unittest
 
         // 2
         QuorumConfig(6, [
-            WK.Keys.NODE3.address,
             WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
             WK.Keys.NODE5.address,
+            WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
             WK.Keys.NODE4.address,
@@ -200,7 +200,7 @@ unittest
 
         // 3
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
+            WK.Keys.NODE3.address,
             WK.Keys.NODE6.address,
             WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
@@ -211,10 +211,10 @@ unittest
 
         // 4
         QuorumConfig(6, [
-            WK.Keys.NODE3.address,
             WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
             WK.Keys.NODE5.address,
+            WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
             WK.Keys.NODE4.address,
@@ -223,8 +223,8 @@ unittest
         // 5
         QuorumConfig(6, [
             WK.Keys.NODE3.address,
+            WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
-            WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
@@ -235,7 +235,7 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE3.address,
             WK.Keys.NODE2.address,
-            WK.Keys.NODE6.address,
+            WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
@@ -244,10 +244,10 @@ unittest
 
         // 7
         QuorumConfig(6, [
+            WK.Keys.NODE3.address,
             WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
             WK.Keys.NODE5.address,
-            WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
             WK.Keys.NODE4.address,
@@ -283,28 +283,28 @@ unittest
             WK.Keys.NODE3.address,
             WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
+            WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
-            WK.Keys.NODE4.address,
         ]),
 
         // 1
         QuorumConfig(6, [
             WK.Keys.NODE3.address,
+            WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
             WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
-            WK.Keys.NODE4.address,
         ]),
 
         // 2
         QuorumConfig(6, [
             WK.Keys.NODE3.address,
             WK.Keys.NODE2.address,
-            WK.Keys.NODE6.address,
+            WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
@@ -313,7 +313,7 @@ unittest
 
         // 3
         QuorumConfig(6, [
-            WK.Keys.NODE2.address,
+            WK.Keys.NODE3.address,
             WK.Keys.NODE6.address,
             WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
@@ -324,9 +324,9 @@ unittest
 
         // 4
         QuorumConfig(6, [
+            WK.Keys.NODE3.address,
             WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
-            WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
@@ -338,27 +338,27 @@ unittest
             WK.Keys.NODE3.address,
             WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
+            WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
-            WK.Keys.NODE4.address,
         ]),
 
         // 6
         QuorumConfig(6, [
             WK.Keys.NODE3.address,
             WK.Keys.NODE2.address,
+            WK.Keys.NODE6.address,
             WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
-            WK.Keys.NODE4.address,
         ]),
 
         // 7
         QuorumConfig(6, [
             WK.Keys.NODE3.address,
-            WK.Keys.NODE6.address,
+            WK.Keys.NODE2.address,
             WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
             WK.Keys.C.address,


### PR DESCRIPTION
Use the hash of the `preimage` rather than the complete struct.