### PR TITLE
Remove `createEnrollmentData` endpoint

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -106,7 +106,7 @@ public class EnrollmentManager
     public ValidatorSet validator_set;  // FIXME: Made public to ease transition to raise this to ledger
 
     /// Enrollment pool managing enrollments waiting to be a validator
-    private EnrollmentPool enroll_pool;
+    public EnrollmentPool enroll_pool;
 
     /// Ditto
     private PreImageCycle cycle;

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -78,8 +78,7 @@ unittest
     auto first_node = network.clients[0];
 
     // Request enrollment at the height of 15
-    auto enroll = first_node.createEnrollmentData();
-    first_node.enrollValidator(enroll);
+    auto enroll = first_node.setRecurringEnrollment(true);
 
     // Make 5 blocks in order to finish the validator cycle
     network.generateBlocks(Height(GenesisValidatorCycle));


### PR DESCRIPTION
The function, `createEnrollmentData` does not match with the way a node tries to enroll. So we remove the function and use `checkAndEnroll` instead.

Fixes #1659 