### PR TITLE
Fix shutdown by using our own signal handler

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -162,7 +162,7 @@ public class BanManager
 
     ***************************************************************************/
 
-    public void dump ()
+    public void dump () @safe
     {
         auto ban_file = File(this.banfile_path, "wb");
         serializePart(this.ips, (in bytes) @trusted => ban_file.rawWrite(bytes));

--- a/source/agora/common/Metadata.d
+++ b/source/agora/common/Metadata.d
@@ -39,7 +39,7 @@ public abstract class Metadata
     public abstract void load ();
 
     /// Dump the metadata
-    public abstract void dump ();
+    public abstract void dump () @safe;
 }
 
 /// Metadata stored in memory (for unittests)
@@ -49,7 +49,7 @@ public class MemMetadata : Metadata
     public override void load () {}
 
     ///
-    public override void dump () {}
+    public override void dump () @safe {}
 }
 
 /// Metadata stored on disk (for persistence)
@@ -94,7 +94,7 @@ public class DiskMetadata : Metadata
     }
 
     /// Dump metadata to disk
-    public override void dump ()
+    public override void dump () @safe
     {
         auto bytes = serializeFull(this.peers);
         std.file.write(this.file_path, bytes);

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -220,9 +220,31 @@ public abstract class FlashNode : FlashControlAPI
         this.gossip_timer.stop();
         this.open_chan_timer.stop();
 
-        this.dump();
-        foreach (chan; channels.byValue)
-            chan.dump();
+        try this.dump();
+        catch (Exception exc)
+        {
+            () @trusted {
+                printf("Error happened while dumping this node's state: %.*s\n",
+                       cast(int) exc.msg.length, exc.msg.ptr);
+
+                scope (failure) assert(0);
+                writeln("========================================");
+                writeln("Full stack trace: ", exc);
+            }();
+        }
+
+        foreach (pair; this.channels.byKeyValue)
+        {
+            try pair.value.dump();
+            catch (Exception exc)
+            {
+                scope (failure) assert(0);
+                () @trusted {
+                    writefln("Error happened while dumping a channel's (%s) state: %s",
+                             pair.key, exc);
+                }();
+            }
+        }
     }
 
     /***************************************************************************

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -215,7 +215,7 @@ public abstract class FlashNode : FlashControlAPI
 
     ***************************************************************************/
 
-    public void shutdown ()
+    public void shutdown () @safe
     {
         this.gossip_timer.stop();
         this.open_chan_timer.stop();

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -168,7 +168,7 @@ public class NetworkClient
     }
 
     /// Shut down the gossiping timer
-    public void shutdown ()
+    public void shutdown () @safe
     {
         this.gossip_timer.stop();
     }

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -1050,7 +1050,7 @@ public class NetworkManager
     }
 
     /// Shut down timers & dump the metadata
-    public void shutdown ()
+    public void shutdown () @safe
     {
         foreach (peer; this.peers)
             peer.client.shutdown();

--- a/source/agora/node/FlashFullNode.d
+++ b/source/agora/node/FlashFullNode.d
@@ -336,7 +336,7 @@ public class FlashFullNode : FullNode, FlashFullNodeAPI
         }
     }
 
-    public override void shutdown ()
+    public override void shutdown () @safe
     {
         this.flash.shutdown();
         this.periodic_timer.stop();

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -424,7 +424,7 @@ public class FullNode : API
 
     ***************************************************************************/
 
-    public void shutdown ()
+    public void shutdown () @safe
     {
         log.info("Shutting down..");
         foreach (timer; this.timers)

--- a/source/agora/stats/Server.d
+++ b/source/agora/stats/Server.d
@@ -43,7 +43,7 @@ public class StatsServer
     }
 
     ///
-    public void shutdown ()
+    public void shutdown () @safe
     {
         this.http_listener.stopListening();
     }


### PR DESCRIPTION
```
Currently, we sometimes fail to shutdown because the Vibe.d
signal handler does not call our shutdown procedure.
This should fix that and remove any issues we saw with shutting down the node.
Note that this doesn't handle broken pipe (as Vibe.d does), as there currently
doesn't seem to be a need for it.
```