### PR TITLE
Check test GenesisBlock keys and wait for pre-images in many tests which often fail.

### DIFF
--- a/source/agora/consensus/data/genesis/Coinnet.d
+++ b/source/agora/consensus/data/genesis/Coinnet.d
@@ -65,37 +65,37 @@ unittest
 /// The enrollments that are part of the genesis block
 private immutable Enrollment[] Enrollments =
     [
-        // GCN3CTOPFFBHZKXUVBZHZN6UFFYFFAZCPJK36U2ZY3L53AL7APM36GYO
+        // boa1xzdmznw099p8e2h54pe8ed7599c99qez0f2m756ecmtamqtlq0vm73jg5mj
         Enrollment(
             Hash(`0x03b2c926071d92528f7401afb2144c1f9bfc4dbd60d116076f7dbbb4779556b628689e0c6bb8f12212a27b6ca93f8dfe8c6e951ef367302ee22dd0cb1e8b83ce`),
             Hash(`0x2e6c60eb300e240a25dcc0cef5a7d0488294b103c569754061547cfbf1455bfde84a3b445eb76c6dfe49282a404d34f02cf89b6a5076930ecea93fbfde54df96`),
             1008,
             Signature.fromString(`0xf45c14a6f9220b53128f1f08aa666ddefd125ccf2512015937a2b97248f25ce90ee306cc3ee1a422155b8ae29c92113ba66a533530558be867f86a82d5f71e7a`)),
-        // GCN2C4X4ZAUTENP3VYVA3225CUNEAHDKFXDETNRBXZCXUPIJUY64UANT
+        // boa1xzd6zuhueq5nyd0m4c4qm66az5dyq8r29hrynd3phezh50gf5c7u54eqtdh
         Enrollment(
             Hash(`0x6e05cf3391eceafec28bb35beaf30d17bc2e5df1a13c9326c9ea565a304e8cf5439e6f972b3e7ac82a3ac19e17586898d9c9d84327d437af6e838636f2ee4e78`),
             Hash(`0x07decf74191a485b86533f7bcaf34456288c27a9ea589d32b1407c5bcfc0fdeb312ec86f021597611aad7f988b99279d10cfb7d536b516b2f7f8d5bac7b36971`),
             1008,
             Signature.fromString(`0x6633727a9a0b55b2dafbdd951682b089b2b45b9644d09522370c6f1c4e2c9b2f03e1d337008a2870cb8a1bf63542539f3610af2aef502f4596b15ad20624ff47`)),
-        // GCN6C3W6DT4TP2BQBFNPDPBP7SK32CJC2ROUUBI4C7Z36TWMK6VZ3CT4
+        // boa1xzd7zmk7rnun06psp9d0r0p0lj2m6zfz63w55pguzlem7nkv274e6hn2hg3
         Enrollment(
             Hash(`0x9544c71cece09f1a585f730c0df3d0ee8ad5cbbfa0bdc9d9d294f92e2972b746f97c3b97611f693491b7dc1ddccee0081b4663876cd02e494edc5409f40818ac`),
             Hash(`0x7709cc2b7b1b6228fa0554417bfc33341f9e6a160b20da255b24b8d2bc199a277eecb2e717652acce1dd9c45a2f32789f5a9d548c5209e4e7eb84df191c77647`),
             1008,
             Signature.fromString(`0xbcab099143e5161f6a7861601a7dd3f834d6a6ff9dab1e48ac05d02c8c993c0e0e4db77439a1a08dc1c56abce1b71e4c9e6a0a20091c5168d5ebd2bfa293189c`)),
-        // GCN4CT336WB6IIKP5CDHWFYFBCNO5BG2Y4777F2QHNA5XUWSUYSQS7IP
+        // boa1xzduznmm7kp7gg20azr8k9c9pzdwapx6culll96s8dqah5kj5cjsj0le8rk
         Enrollment(
             Hash(`0x980a42069faaa81a090c5e0ba8d9264f126c569542ac83da159a06078e432f23a2a9bcd366f8b850fbb464cc1e2b636b0fae4ec71484ef1102c543e24c88fc77`),
             Hash(`0x4aae1b6921cd6ba2ea3389008ce329436f7ed455fbd731b7084183d8dcb584334ddbc2edc9e2f781bf3a5613a24cf816493e7610812587b2040909ed41ef1af1`),
             1008,
             Signature.fromString(`0x907ef65138cae7cad57d9c6804700188f66f69cfb7c4b283e4cf380a8067a23f0443dd1c84906959c97797944c7802cc3670e14d32266c617698fd71200dcce9`)),
-        // GCN7C7UCTTQQ3RN7Q7AID5ED7VJDN3XPQ6NEAOIMWNA5AWJUFFV5PRBN
+        // boa1xzdlzl5znnssm3dlslqgrayrl4frdmh0s7dyqwgvkdqaqkf5994aw53cn58
         Enrollment(
             Hash(`0xe7596f3e910432fdeb5c9168cde5f1ba3a0ff5ca8cd8a5e89eab39775d89b2ab106887615aecdb9f6ccc9691ef7bc893f08d28e053ba8de26cbf61d88a26112e`),
             Hash(`0x437706c76be50fda4dc65e3d914f0fb6f550a685e4701b124f15338f969ef1909f6ad9475e89417324a612f248a893c9cb309bf33c7d9629fae69ec09624e51a`),
             1008,
             Signature.fromString(`0xcc1d153578be5cd72e52d51a5b71f4802d574da2be4f015764aae44f39180f9a0372280688caa4a929e4c71174a7153162d834289ba52db88e830ebf1f15eabf`)),
-        // GCN5CVXGRUW3B6CJNHUVEJFHXG2WQNMRBQR2RN4TMJ727RF3VM2RA6LF
+        // boa1xzdaz4hx35kmp7zfd854yf98hx6ksdv3ps363dunvfl6l39m4v63qmyccsm
         Enrollment(
             Hash(`0xee93cf1aeed5015e453897263560fed541492963b82d73261750a92fcb120823b9af7f95ea5f85b19a03c48e7cb23035f36637487f457060fabee1720d030771`),
             Hash(`0x07d842b1d0ae9ccc697418c1aab67c2de12466bcf38c580365470360a3cfd770c6929c509b5ed6d5b8431246cc47775e122a7252723c8d726a2e0dff01e174fa`),

--- a/source/agora/consensus/data/genesis/Test.d
+++ b/source/agora/consensus/data/genesis/Test.d
@@ -174,11 +174,12 @@ unittest
     testSymmetry(GenesisBlock);
 }
 
+// These are the genesis validators ordered to match Genesis enrollments
 public immutable KeyPair[] genesis_validator_keys = [
     WK.Keys.NODE2,
-    WK.Keys.NODE3,
-    WK.Keys.NODE4,
     WK.Keys.NODE5,
+    WK.Keys.NODE4,
+    WK.Keys.NODE7,
     WK.Keys.NODE6,
-    WK.Keys.NODE7
+    WK.Keys.NODE3,
 ];

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -742,9 +742,12 @@ public class TestAPIManager
         static assert (isInputRange!Idxs);
 
         clients_idxs.each!(idx =>
-            enrolls.each!(enroll =>
-                retryFor(this.clients[idx].getPreimage(enroll.utxo_key)
-                    .distance >= distance, timeout)));
+            enrolls.enumerate.each!((idx_enroll, enroll) {
+                if (clients_idxs.canFind(idx_enroll))
+                    retryFor(this.clients[idx].getPreimage(enroll.utxo_key).distance >= distance,
+                        timeout, format!"Client #%s has no preimage for client #%s at distance %s"
+                            (idx, idx_enroll, distance));
+            }));
     }
 
     /***************************************************************************

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -213,7 +213,7 @@ unittest
     assert(node_1.getQuorumConfig().threshold == 6); // We should need all 6 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 }
 
 /// Block should be added if we have 5 of 6 valid signatures (1 not signing the envelope)
@@ -231,7 +231,7 @@ unittest
     assert(node_1.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 }
 
 /// Block should be added if we have 5 of 6 valid signatures (1 signs envelope with invalid signature)
@@ -249,7 +249,7 @@ unittest
     assert(node_1.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 }
 
 
@@ -280,6 +280,7 @@ unittest
     assert(node_1.getQuorumConfig().threshold == 4); // We should need 4 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
+    network.waitForPreimages(network.blocks[0].header.enrollments, 6);
     network.setTimeFor(Height(1));  // trigger consensus
     waitForCount(1, &network.envelope_type_counts.externalize_count, "externalize");
     Thread.sleep(1.seconds);
@@ -301,6 +302,7 @@ unittest
     assert(node_1.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
+    network.waitForPreimages(network.blocks[0].header.enrollments, 6);
     network.setTimeFor(Height(1));  // trigger consensus
     Thread.sleep(2.seconds);
     assert(atomicLoad(network.envelope_type_counts.confirm_count) == 0,

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -167,7 +167,7 @@ unittest
         .takeExactly(8)
         .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
     new_txs.each!(tx => nodes[0].putTransaction(tx));
-    network.expectHeight(Height(20), 5.seconds);
+    network.expectHeightAndPreImg(Height(20), network.blocks[0].header);
     auto b20 = nodes[0].getBlocksFrom(20, 2)[0];
     assert(b20.header.enrollments.length == 5);
 
@@ -182,8 +182,7 @@ unittest
         .takeExactly(8)
         .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
     new_txs.each!(tx => nodes[0].putTransaction(tx));
-    network.waitForPreimages(b20.header.enrollments, 1, 2.seconds);
-    network.expectHeight(Height(21), 5.seconds);
+    network.expectHeightAndPreImg(Height(21), b20.header);
     auto b21 = nodes[0].getBlocksFrom(21, 2)[0];
     assert(b21.header.enrollments.length == 1);
     assert(b21.header.enrollments[0] == new_enroll);

--- a/source/agora/test/GenesisBlock.d
+++ b/source/agora/test/GenesisBlock.d
@@ -38,5 +38,5 @@ unittest
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 }

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -47,7 +47,7 @@ unittest
     ));
     // When a block is created, the transaction is deleted from the transaction pool.
     node_1.putTransaction(txs[$-1]);
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     nodes.each!(node =>
         txs.each!(tx =>

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -150,7 +150,7 @@ unittest
     assert(last_node.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => last_node.putTransaction(tx));
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
     assertValidatorsBitmask(last_node.getAllBlocks()[1]);
 }
 
@@ -169,7 +169,7 @@ unittest
     assert(last_node.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => last_node.putTransaction(tx));
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
     assertValidatorsBitmask(last_node.getAllBlocks()[1]);
 }
 

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -104,11 +104,11 @@ unittest
 
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
     txs.each!(tx => node_1.putTransaction(tx));
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
     txs.each!(tx => node_1.putTransaction(tx));
-    network.expectHeight(Height(2));
+    network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
 }
 
 /// Merkle Proof
@@ -147,7 +147,7 @@ unittest
     const Hash expected_root = hashMulti(habcd, hefgh);
 
     // wait for transaction propagation
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     Hash[] merkle_path;
     foreach (node; nodes)
@@ -189,14 +189,11 @@ unittest
     auto txs = network.blocks[0].spendable.map!(txb => txb.sign()).array();
     txs.each!(tx => node_1.putTransaction(tx));
 
-    // wait for preimages to be revealed before making blocks
-    network.waitForPreimages(network.blocks[0].header.enrollments, 6);
-
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
     txs.each!(tx => node_1.putTransaction(tx));
-    network.expectHeight(Height(2));
+    network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
 
@@ -229,7 +226,7 @@ unittest
     network.expectHeight(Height(2));  // no new block yet (1 rejected tx)
 
     node_1.putTransaction(backup_tx);
-    network.expectHeight(Height(3));  // new block finally created
+    network.expectHeightAndPreImg(Height(3), network.blocks[0].header);  // new block finally created
 }
 
 // Ensure that when creating a frozen UTXO, the refund is not frozen too
@@ -258,7 +255,7 @@ unittest
     network.clients[0].putTransaction(tx);
 
     // Wait for the block to be created
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
     const b1 = network.clients[0].getBlock(1);
     assert(b1.txs.length == 1);
 
@@ -267,6 +264,6 @@ unittest
     assert(tx2.outputs.length == 1);
 
     network.clients[0].putTransaction(tx2);
-    network.expectHeight(Height(2));
+    network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
     assert(network.clients[0].getBlock(2).txs.length == 1);
 }

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -113,7 +113,7 @@ unittest
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
     txs.each!(tx => validator.putTransaction(tx));
 
-    network.expectHeight(Height(1), conf.timeout + 5.seconds);
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header, conf.timeout + 5.seconds);
     assert(CustomNominator.round_number >= 2,
         format("The validator's round number is %s. Expected: above %s",
             CustomNominator.round_number, 2));

--- a/source/agora/test/NameRegistry.d
+++ b/source/agora/test/NameRegistry.d
@@ -33,5 +33,5 @@ unittest
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 }

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -179,8 +179,8 @@ unittest
         // 1
         QuorumConfig(6, [
             WK.Keys.NODE3.address,
-            WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
+            WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
@@ -201,8 +201,8 @@ unittest
         // 3
         QuorumConfig(6, [
             WK.Keys.NODE3.address,
+            WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
-            WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
@@ -292,12 +292,12 @@ unittest
         // 1
         QuorumConfig(6, [
             WK.Keys.NODE3.address,
-            WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
             WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
+            WK.Keys.NODE4.address,
         ]),
 
         // 2
@@ -314,12 +314,12 @@ unittest
         // 3
         QuorumConfig(6, [
             WK.Keys.NODE3.address,
+            WK.Keys.NODE2.address,
             WK.Keys.NODE6.address,
             WK.Keys.NODE5.address,
             WK.Keys.NODE7.address,
             WK.Keys.C.address,
             WK.Keys.A.address,
-            WK.Keys.NODE4.address,
         ]),
 
         // 4

--- a/source/agora/test/Restart.d
+++ b/source/agora/test/Restart.d
@@ -132,12 +132,12 @@ unittest
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => node_1.putTransaction(tx));
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     // Now shut down & restart one node
     auto restartMe = nodes[$-1];
     scope(failure) restartMe.printLog();
     network.restart(restartMe);
     network.waitForDiscovery();
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 }

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -146,12 +146,12 @@ unittest
     auto re_validator = network.clients[0];
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => re_validator.putTransaction(tx));
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     Checked = true;
     // Now shut down & restart one node
     network.restart(re_validator);
     network.waitForDiscovery();
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
     assert(!Checked);
 }

--- a/source/agora/test/Script.d
+++ b/source/agora/test/Script.d
@@ -62,7 +62,7 @@ unittest
         .joiner().map!(txb => txb.sign());
 
     lock_txs.each!(tx => node_1.putTransaction(tx));
-    network.expectHeight(Height(6));
+    network.expectHeightAndPreImg(Height(6), network.blocks[0].header);
 
     Unlock keyUnlocker (in Transaction tx, in OutputRef out_ref) @safe nothrow
     {
@@ -86,7 +86,7 @@ unittest
     unlock_height_2.each!(tx => node_1.putTransaction(tx));
     // unlock height 3 accepted
     unlock_height_3.each!(tx => node_1.putTransaction(tx));
-    network.expectHeight(Height(7));
+    network.expectHeightAndPreImg(Height(7), network.blocks[0].header);
 
     const block_7 = node_1.getBlocksFrom(7, 1)[0];
     unlock_height_3.sort();

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -127,7 +127,8 @@ unittest
 
     // block 1
     txs.each!(tx => nodes[0].putTransaction(tx));
-    network.expectHeight(Height(1));
+    // Node index is 5 for bad node so we do not expect pre-image from it
+    network.expectHeightAndPreImg(iota(0, 5), Height(1), network.blocks[0].header);
 
     auto utxos = nodes[0].getUTXOs(bad_address);
     assert(utxos.length == 1);
@@ -209,7 +210,7 @@ unittest
     atomicStore(network.reveal_preimage, true);
 
     // block 2 created with no slashed validator
-    network.expectHeight(Height(2));
+    network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
     auto block2 = nodes[0].getBlocksFrom(2, 1)[0];
     assert(block2.header.missing_validators.length == 0);
 }

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -131,7 +131,7 @@ unittest
     // Create a block from the Genesis block
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
     txs.each!(tx => node_1.putTransaction(tx));
-    network.expectHeight(Height(1));
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     // node_1 restarts and becomes unresponsive
     network.restart(node_1);
@@ -140,11 +140,12 @@ unittest
     // Make 2 blocks
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
     txs.each!(tx => node_2.putTransaction(tx));
-    network.expectHeight(iota(1,nodes.length), Height(2));
+    network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(2), network.blocks[0].header);
+    network.expectHeight(iota(1, nodes.length), Height(2));
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
     txs.each!(tx => node_2.putTransaction(tx));
-    network.expectHeight(iota(1,nodes.length), Height(3));
+    network.expectHeightAndPreImg(iota(1,nodes.length), Height(3), network.blocks[0].header);
 
     // Wait for node_1 to wake up
     node_1.ctrl.withTimeout(10.seconds,
@@ -153,7 +154,7 @@ unittest
         }
     );
 
-    network.expectHeight(Height(3));
+    network.expectHeightAndPreImg(Height(3), network.blocks[0].header);
 
     // The node_2 restart and is disabled to respond, which means that
     // the node_2 will be slashed soon.
@@ -166,5 +167,5 @@ unittest
 
     // The new block has been inserted to the ledger with the approval
     // of the node_1, although node_2 was shutdown.
-    network.expectHeight(Height(4));
+    network.expectHeightAndPreImg(Height(4), network.blocks[0].header);
 }

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -271,8 +271,8 @@ unittest
     // Wake one up right before cycle ends
     sleep_node_2.ctrl.sleep(0.seconds);
     // Let it catch up
-    network.expectHeight(iota(GenesisValidators - 1),
-        Height(GenesisValidatorCycle - 1));
+    network.expectHeightAndPreImg(iota(0, GenesisValidators - 1),
+        Height(GenesisValidatorCycle - 1), network.blocks[0].header);
 
     network.generateBlocks(iota(GenesisValidators - 1),
         Height(GenesisValidatorCycle));
@@ -282,8 +282,8 @@ unittest
 
     // This nodes will wake up to an expired cycle, it should immediately enroll
     sleep_node_1.ctrl.sleep(0.seconds);
-    // Let it catch up
-    network.expectHeight(Height(GenesisValidatorCycle));
+    // Let the last node catch up
+    network.expectHeight([ GenesisValidators - 1 ], Height(GenesisValidatorCycle));
 
     network.generateBlocks(iota(GenesisValidators),
         Height(GenesisValidatorCycle + 1));


### PR DESCRIPTION
When we use the genesis enrolled node keys in unit tests we want the
index of the node key to match the index of the matching enrollment.
In some tests we need to know which indexes to wait for blocks or
preimages. Having the genesis_validator_keys indexes matching the
enrollments in the test GenesisBlock helps.