### PR TITLE
CI: Upgrade to LDC v1.26.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,14 +26,14 @@ jobs:
         ## See https://github.com/ldc-developers/ldc/issues/3702
         # os: [ ubuntu-18.04, macOS-10.15, windows-2019 ]
         os: [ ubuntu-18.04, macOS-10.15]
-        dc: [ ldc-master, ldc-1.25.0 ]
+        dc: [ ldc-master, ldc-1.26.0 ]
         # Define job-specific parameters
         include:
           # By default, don't generate artifacts nor run vtable checks for push
           - { artifacts: false, run_vtable_checks: false }
           # Only generate when the latest ldc is used
           # IMPORTANT: Update this when the compiler support is changed!
-          - { dc: ldc-1.25.0, artifacts: true, run_vtable_checks: true }
+          - { dc: ldc-1.26.0, artifacts: true, run_vtable_checks: true }
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,11 @@ jobs:
       # of the nigthly is broken
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, macOS-10.15, windows-2019 ]
+        ## TODO: Re-enable once memory usage while reducing Agora is reduced
+        ## Currently it takes 7GB+ which OOM on the CI.
+        ## See https://github.com/ldc-developers/ldc/issues/3702
+        # os: [ ubuntu-18.04, macOS-10.15, windows-2019 ]
+        os: [ ubuntu-18.04, macOS-10.15]
         dc: [ ldc-master, ldc-1.25.0 ]
         # Define job-specific parameters
         include:
@@ -30,9 +34,6 @@ jobs:
           # Only generate when the latest ldc is used
           # IMPORTANT: Update this when the compiler support is changed!
           - { dc: ldc-1.25.0, artifacts: true, run_vtable_checks: true }
-        exclude:
-          # Disabled due to https://github.com/ldc-developers/ldc/issues/3702
-          - { dc: ldc-master, os: windows-2019 }
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ and add it to your `.bashrc`, `.zshrc`, etc...
 
 ```console
 # Install the LDC compiler (you might want to use a newer version)
-curl https://dlang.org/install.sh | bash -s ldc-1.25.0
+curl https://dlang.org/install.sh | bash -s ldc-1.26.0
 # Add LDC to the $PATH
-source ~/dlang/ldc-1.25.0/activate
+source ~/dlang/ldc-1.26.0/activate
 # Clone this repository
 git clone https://github.com/bosagora/agora.git
 # Use the git root as working directory


### PR DESCRIPTION
Requires https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/20950 to be complete.