### PR TITLE
Human-readable part for test network

### DIFF
--- a/source/agora/crypto/Key.d
+++ b/source/agora/crypto/Key.d
@@ -113,7 +113,7 @@ unittest
 
 private immutable int VersionWidth = 1;
 private immutable int ChecksumWidth = 2;
-private immutable char[3] HumanReadablePart = "boa";
+shared public char[3] HumanReadablePart = "boa";
 
 /// Represent a public key / address
 public struct PublicKey
@@ -139,7 +139,7 @@ public struct PublicKey
         ubyte[VersionWidth + PublicKey.sizeof] bin;
         bin[0] = VersionByte.AccountID;
         bin[VersionWidth .. $] = this.data[];
-        return encodeBech32(HumanReadablePart, bin, Encoding.Bech32m).
+        return encodeBech32(cast(char[])HumanReadablePart, bin, Encoding.Bech32m).
             assumeUnique;
     }
 
@@ -149,7 +149,7 @@ public struct PublicKey
         ubyte[VersionWidth + PublicKey.sizeof] bin;
         bin[0] = VersionByte.AccountID;
         bin[VersionWidth .. $] = this.data[];
-        string encoded = encodeBech32(HumanReadablePart, bin,
+        string encoded = encodeBech32(cast(char[])HumanReadablePart, bin,
             Encoding.Bech32m).assumeUnique;
         sink(encoded);
     }
@@ -157,6 +157,7 @@ public struct PublicKey
     ///
     unittest
     {
+        HumanReadablePart = "boa";
         immutable address = `boa1xrra39xpg5q9zwhsq6u7pw508z2let6dj8r5lr4q0d0nff240fvd27yme3h`;
         PublicKey pubkey = PublicKey.fromString(address);
 
@@ -183,7 +184,7 @@ public struct PublicKey
     public static PublicKey fromString (scope const(char)[] str) @trusted
     {
         auto dec = decodeBech32(str);
-        enforce(dec.hrp == HumanReadablePart);
+        enforce(dec.hrp == cast(char[])HumanReadablePart);
         enforce(dec.data.length == VersionWidth + PublicKey.sizeof);
         enforce(dec.data[0] == VersionByte.AccountID);
         return PublicKey(typeof(this.data)(dec.data[VersionWidth .. $]));

--- a/source/agora/flash/Types.d
+++ b/source/agora/flash/Types.d
@@ -297,7 +297,7 @@ unittest
     static immutable string s = "0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ec";
     assert(flashPrettify(Scalar.fromString(s).toPoint()) == "0xe66666",
         flashPrettify(Scalar.fromString(s).toPoint()));
-    assert(flashPrettify(PublicKey(Scalar.fromString(s).toPoint())) == "boa1xpvx",
+    assert(flashPrettify(PublicKey(Scalar.fromString(s).toPoint())) == "bot1xpvx",
         flashPrettify(PublicKey(Scalar.fromString(s).toPoint())));
 }
 

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -24,6 +24,7 @@ else:
 
 import agora.common.Config;
 import agora.common.FileBasedLock;
+import agora.crypto.Key;
 import agora.node.admin.Setup;
 import agora.node.FullNode;
 import agora.node.Validator;
@@ -145,6 +146,11 @@ private int main (string[] args)
             writefln("Config file '%s' successfully parsed.", cmdln.config_path);
         return 0;
     }
+
+    // Set the human-readable part for addresses
+    if (config.get().node.testing)
+        HumanReadablePart = "bot";
+
 
     if (config.get().admin.enabled && !config.get().validator.enabled)
     {

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2006,6 +2006,9 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
     import std.digest;
     import std.range;
 
+    // Set the human-readable part for addresses
+    HumanReadablePart = "bot";
+
     // We know we're in the main thread
     // Vibe.d messes with the scheduler - reset it
     static import std.concurrency;

--- a/tests/system/source/main.d
+++ b/tests/system/source/main.d
@@ -19,6 +19,7 @@ import agora.consensus.data.genesis;
 import TestGenesis = agora.consensus.data.genesis.Test;
 import agora.consensus.data.genesis.Test;
 import agora.consensus.data.Transaction;
+import agora.crypto.Key;
 import agora.common.Set;
 import agora.crypto.Hash;
 import agora.utils.PrettyPrinter;
@@ -48,6 +49,9 @@ int main (string[] args)
     }
     /// Address array of nodes
     const addresses = args[1..$];
+
+    // Set the human-readable part for addresses
+    HumanReadablePart = "bot";
 
     API[] clients;
     foreach (const ref addr; addresses)


### PR DESCRIPTION
This sets the prefix, or `bot` in the human-readable part of `bech32` addresses in the test network.

Fixes #1354 