### PR TITLE
Flash tests: Increase default timeout to 10s

### DIFF
--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -371,7 +371,7 @@ public class FlashNodeFactory (FlashListenerType = FlashListener)
         RemoteAPI!TestFlashAPI api = RemoteAPI!TestFlashAPI.spawn!FlashNodeImpl(
             conf, this.agora_registry, agora_address, storage,
             &this.flash_registry, &this.listener_registry,
-            5.seconds);  // timeout from main thread
+            10.seconds);  // timeout from main thread
 
         this.addresses ~= pair.V;
         this.nodes ~= api;


### PR DESCRIPTION
This matches the non-flash tests and should hopefully resolve some of the timeouts at L724 in Flash.d