### PR TITLE
CI: Install libsodium directly on OSX

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,8 +57,7 @@ jobs:
     - name: '[OSX] Install dependencies & setup environment'
       if: runner.os == 'macOS'
       run: |
-        brew install coreutils pkg-config
-        ./ci/ci_osx_setup.sh
+        brew install coreutils libsodium pkg-config
         echo "LIBRARY_PATH=${LD_LIBRARY_PATH-}:/usr/local/lib/" >> $GITHUB_ENV
         echo "PKG_CONFIG_PATH=/usr/local/opt/sqlite/lib/pkgconfig:/usr/local/opt/openssl@1.1/lib/pkgconfig/" >> $GITHUB_ENV
 

--- a/ci/ci_osx_setup.sh
+++ b/ci/ci_osx_setup.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -xeu
-set -o pipefail
-
-mkdir -p $HOME/Dependencies/
-wget -P $HOME/Dependencies/ https://homebrew.bintray.com/bottles/libsodium-1.0.18.high_sierra.bottle.tar.gz
-tar -C /usr/local/Cellar/ -xf $HOME/Dependencies/libsodium-1.0.18.high_sierra.bottle.tar.gz
-brew link libsodium


### PR DESCRIPTION
When the CI was put in place, running brew update was extremely slow (3+ minutes).
At the time, it was dominating the CI time. The solution we used was to directly
download the bottle from bintray and install / link it, and it worked well.
However, Bintray has shut down on May 1st and this script is now broken.
As Homebrew has migrated to use Github packages directly, and there has been a few
releases of homebrew since then, brew upgrade is long longer necessary,
and the download is likely to be much faster.