### PR TITLE
Unit test refactor to remove multiSigTestBlock

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -486,7 +486,7 @@ public class EnrollmentManager
 
     public Scalar getCommitmentNonceScalar (in Height height) const @safe nothrow
     {
-        ulong index = ulong((height - 1) / this.cycle.preimages.length());
+        ulong index = ulong((height - 1) / this.params.ValidatorCycle);
         return Scalar(hashMulti(this.key_pair.secret, "consensus.signature.noise", index));
     }
 

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -475,23 +475,6 @@ public class EnrollmentManager
 
     /***************************************************************************
 
-        Get the r that was used to sign the enrollment of this validator node
-
-        Params:
-            height = height of block that r will sign
-        Returns:
-            The initial `r` used when signing the Enrollment
-
-    ***************************************************************************/
-
-    public Scalar getCommitmentNonceScalar (in Height height) const @safe nothrow
-    {
-        ulong index = ulong((height - 1) / this.params.ValidatorCycle);
-        return Scalar(hashMulti(this.key_pair.secret, "consensus.signature.noise", index));
-    }
-
-    /***************************************************************************
-
         Get all the enrolled validator's UTXO keys.
 
         Params:

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -539,6 +539,7 @@ extern(D):
             }
             const Block proposed_block = makeNewBlock(last_block,
                 received_tx_set, con_data.time_offset, random_seed,
+                this.enroll_man.getCountOfValidators(last_block.header.height + 1),
                 con_data.enrolls, con_data.missing_validators);
             const block_sig = ValidatorBlockSig(Height(envelope.statement.slotIndex),
                 public_key, Scalar(envelope.statement.pledges.confirm_.value_sig));
@@ -712,6 +713,7 @@ extern(D):
 
         const proposed_block = makeNewBlock(last_block,
             signed_tx_set, con_data.time_offset, random_seed,
+            this.enroll_man.getCountOfValidators(last_block.header.height + 1),
             con_data.enrolls, con_data.missing_validators);
 
         const Signature sig = createBlockSignature(proposed_block);
@@ -853,7 +855,7 @@ extern(D):
 
         log.info("Externalized consensus data set at {}: {}", height, prettify(data));
         Hash random_seed = this.ledger.getExternalizedRandomSeed(
-            last_block.header.height + 1, data.missing_validators);
+            height, data.missing_validators);
         Transaction[] externalized_tx_set;
         if (auto fail_reason = this.ledger.getValidTXSet(data,
             externalized_tx_set))
@@ -864,6 +866,7 @@ extern(D):
         }
         const block = makeNewBlock(last_block,
             externalized_tx_set, data.time_offset, random_seed,
+            this.enroll_man.getCountOfValidators(last_block.header.height + 1),
             data.enrolls, data.missing_validators);
 
         // If we did not sign yet then add signature and gossip to other nodes

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -640,14 +640,8 @@ extern(D):
 
     public Signature createBlockSignature (in Block block) @safe nothrow
     {
-        // challenge = Hash(block) to Scalar
-        const Scalar challenge = hashFull(block);
-
-        // rc = r used in signing the commitment
-        const Scalar rc = this.enroll_man.getCommitmentNonceScalar(block.header.height);
-        const Scalar r = rc + challenge; // make it unique each challenge
-        const Point R = r.toPoint();
-        return sign(this.kp.secret, R, r, challenge);
+        return block.header.createBlockSignature(this.kp.secret,
+            ulong((block.header.height - 1) / this.params.ValidatorCycle));
     }
 
     extern (C++):

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -958,7 +958,7 @@ unittest
                               "3864fc1c8fd1469f4be80b853764da53f6a5b41661");
     uint[] missing_validators = [];
 
-    auto block3 = makeNewTestBlock(block2, txs_3, preimage_root, enrollments,
+    auto block3 = makeNewTestBlock(block2, txs_3, preimage_root, genesis_validator_keys, enrollments,
         missing_validators);
     block3.assertValid(engine, block2.header.height, hashFull(block2.header), findUTXO,
         Enrollment.MinValidatorCount, checker, findGenesisEnrollments, preimage_root);
@@ -1098,7 +1098,7 @@ unittest
                                   "3864fc1c8fd1469f4be80b853764da53f6a5b41661");
         uint[] missing_validators = [];
 
-        auto block3 = makeNewTestBlock(block2, txs_3, preimage_root, enrollments,
+        auto block3 = makeNewTestBlock(block2, txs_3, preimage_root, genesis_validator_keys, enrollments,
             missing_validators);
         assert(block3.header.enrollments.length == Enrollment.MinValidatorCount);
         block3.assertValid(engine, block2.header.height, hashFull(block2.header),

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -1171,7 +1171,7 @@ public class ValidatingLedger : Ledger
             data.missing_validators);
 
         auto next_block = Height(this.last_block.header.height + 1);
-        KeyPair[] public_keys = iota(0, this.enroll_man.getCountOfValidators(next_block))
+        auto key_pairs = iota(0, this.enroll_man.getCountOfValidators(next_block))
             .map!(idx => PublicKey(this.enroll_man.getValidatorAtIndex(next_block, idx)[]))
             .map!(K => WK.Keys[K])
             .array();
@@ -1185,13 +1185,8 @@ public class ValidatingLedger : Ledger
         }
 
         const block = makeNewTestBlock(this.last_block,
-            externalized_tx_set, random_seed, data.enrolls,
-            data.missing_validators, public_keys,
-            (PublicKey pubkey)
-            {
-                return 0;   // This is the number of re-enrollments (currently always 0 in these tests)
-            },
-            data.time_offset);
+            externalized_tx_set, random_seed, key_pairs,
+            data.enrolls, data.missing_validators, data.time_offset);
         return this.acceptBlock(block, file, line);
     }
 
@@ -2044,6 +2039,6 @@ unittest
     assert(!ledger.externalize(data));
 
     auto last_block = ledger.getLastBlock();
-    const block = makeNewBlock(last_block, cb_tx_set, data.time_offset, Hash.init);
+    const block = makeNewBlock(last_block, cb_tx_set, data.time_offset, Hash.init, genesis_validator_keys.length);
     assert(ledger.validateBlock(block) == "Block: Must contain other transactions than Coinbase");
 }

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -560,7 +560,7 @@ Outputs (1): boa1xzgenes5...gm67(61,000,000)
 
     const Block second_block = makeNewBlock(GenesisBlock,
         genesisSpendable().take(2).map!(txb => txb.sign(TxType.Payment,
-            null, Height(0), 0, &unlocker)), 0, Hash.init);
+            null, Height(0), 0, &unlocker)), 0, Hash.init, genesis_validator_keys.length);
 
     auto validators = BitField!ubyte(2);
     validators[1] = true;

--- a/tests/unit/BlockStorage.d
+++ b/tests/unit/BlockStorage.d
@@ -58,7 +58,7 @@ private void main ()
                 Output(Amount(1_000), WK.Keys[idx % 8].address)
             ]
         );
-        blocks ~= makeNewBlock(blocks[$ - 1], [tx], blocks[$ - 1].header.time_offset + 1, Hash.init);
+        blocks ~= makeNewBlock(blocks[$ - 1], [tx], blocks[$ - 1].header.time_offset + 1, Hash.init, genesis_validator_keys.length);
         block_hashes ~= hashFull(blocks[$ - 1].header);
         storage.saveBlock(blocks[$ - 1]);
     }

--- a/tests/unit/BlockStorageChecksum.d
+++ b/tests/unit/BlockStorageChecksum.d
@@ -55,7 +55,8 @@ private void writeBlocks (string path)
     foreach (block_idx; 0 .. BlockCount)
     {
         Transaction[8] txs;
-        auto block = makeNewBlock(blocks[$ - 1], txs[], blocks[$ - 1].header.time_offset + 1, Hash.init);
+        auto block = makeNewBlock(blocks[$ - 1], txs[], blocks[$ - 1].header.time_offset + 1, Hash.init,
+            genesis_validator_keys.length);
         storage.saveBlock(block);
         blocks ~= block;
     }

--- a/tests/unit/BlockStorageMultiSig.d
+++ b/tests/unit/BlockStorageMultiSig.d
@@ -58,7 +58,7 @@ private void main ()
 
     void signBlockSig1 (Height h)
     {
-        block = makeNewBlock(prev_block, txs, prev_block.header.time_offset + 1, Hash.init);
+        block = makeNewBlock(prev_block, txs, prev_block.header.time_offset + 1, Hash.init, genesis_validator_keys.length);
         block.header.signature = Signature(Scalar.random().toPoint(), Scalar.random());
         block.header.validators = BitField!ubyte(6);
         block.header.validators[1] = true;

--- a/tests/unit/BlockStorageMultiTx.d
+++ b/tests/unit/BlockStorageMultiTx.d
@@ -47,7 +47,7 @@ private void main ()
     Transaction[] txs = genesisSpendable().map!(txb => txb.refund(WK.Keys.A.address).sign()).array();
     foreach (block_idx; 0 .. BlockCount)
     {
-        auto block = makeNewBlock(blocks[$ - 1], txs, blocks[$ - 1].header.time_offset + 1, Hash.init);
+        auto block = makeNewBlock(blocks[$ - 1], txs, blocks[$ - 1].header.time_offset + 1, Hash.init, genesis_validator_keys.length);
         storage.saveBlock(block);
         blocks ~= block;
         // Prepare transactions for the next block


### PR DESCRIPTION
The `multiSigTestBlock` unit test function was used to sign a Block
in unit tests with code similar to the prodution code. For some tests it
is required to mimic the behavior of multiple nodes signing a block.
However where posible the real code should be used and only a thin layer
of test code which can access the `WK.keys` (well known keys for unit
tests) and call the real implementation.