### PR TITLE
Unit test refactor to remove `getTestRandomSeed`

### DIFF
--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -543,9 +543,6 @@ version (unittest)
         ulong delegate (PublicKey) cycleForValidator = (PublicKey k) => defaultCycleZero(k),
         ulong time_offset = 0) @safe nothrow
     {
-        if (random_seed == Hash.init)
-            random_seed = getTestRandomSeed();
-
         // the time_offset passed to makeNewBlock should really be
         // prev_block.header.time_offset + ConsensusParams.BlockInterval instead of
         // prev_block.header.time_offset + 1

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -1307,13 +1307,13 @@ version (unittest)
         public override Hash getExternalizedRandomSeed (in Height height,
             in uint[] missing_validators) @safe nothrow
         {
-            return getTestRandomSeed();
+            return Hash.init; // Make it clear we are not checking in these tests
         }
 
         ///
         public override Hash getRandomSeed () nothrow @safe
         {
-            return getTestRandomSeed();
+            return Hash.init; // Make it clear we are not checking in these tests
         }
     }
 }
@@ -1588,13 +1588,13 @@ unittest
         public override Hash getExternalizedRandomSeed (in Height height,
             in uint[] missing_validators) @safe nothrow
         {
-            return getTestRandomSeed();
+            return Hash.init; // Make it clear we are not checking in these tests
         }
 
         ///
         public override Hash getRandomSeed () nothrow @safe
         {
-            return getTestRandomSeed();
+            return Hash.init; // Make it clear we are not checking in these tests
         }
     }
 
@@ -2044,6 +2044,6 @@ unittest
     assert(!ledger.externalize(data));
 
     auto last_block = ledger.getLastBlock();
-    const block = makeNewBlock(last_block, cb_tx_set, data.time_offset, getTestRandomSeed());
+    const block = makeNewBlock(last_block, cb_tx_set, data.time_offset, Hash.init);
     assert(ledger.validateBlock(block) == "Block: Must contain other transactions than Coinbase");
 }

--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -286,12 +286,6 @@ public auto genesisSpendable () @safe pure nothrow
     return GenesisBlock.spendable;
 }
 
-/// Get random seed for making new block
-public Hash getTestRandomSeed () @safe nothrow
-{
-    return hashFull(Hash.init);
-}
-
 /*******************************************************************************
 
     A little utility to ensure a function is only called once


### PR DESCRIPTION
The getTestRandomSeed function was hashing `Hash.init` to use in unit
tests to avoid the assertion in `block.isInvalidReason`. This leads to
test code which is harder to reason about. As a first step and to make
it clearer what is being tested this removes the `getTestRandomSeed`.
The assertion in the `block.isInvalidReason` is not included if running
`version (unittest)` mode. This is still not ideal but I think is a step
in the right direction.