### PR TITLE
Make pretty printer more generic

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -534,7 +534,7 @@ extern(D):
             if (auto fail_reason = this.ledger.getValidTXSet(con_data, received_tx_set))
             {
                 log.info("Missing TXs while checking envelope signature : {}",
-                    prettify(envelope));
+                    scpPrettify(&envelope));
                 return; // We dont have all the TXs for this block. Try to catchup
             }
             const Block proposed_block = makeNewBlock(last_block,
@@ -712,7 +712,7 @@ extern(D):
         if (auto fail_reason = this.ledger.getValidTXSet(con_data, signed_tx_set))
         {
             log.info("Missing TXs while signing confirm ballot {}",
-                prettify(envelope));
+                scpPrettify(&envelope));
             return;
         }
 


### PR DESCRIPTION
Should probably leave your suggestions on what is the best formatting layout.

Also note that calling `prettify` on a struct which embeds unions will fail because `toString` has been marked as `@safe` here. I think this is actually a good thing because it prevents us from printing out all of the union values at once (only one of the unions would ever be valid).

Fixes #1903