### PR TITLE
Directly add our own enrollments to the pool when re-enrolling

### DIFF
--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -115,7 +115,7 @@ public class EnrollmentPool
             () @trusted {
                 this.db.execute("REPLACE INTO enrollment_pool " ~
                     "(key, val, avail_height) VALUES (?, ?, ?)",
-                    enroll.utxo_key.toString(), buffer, avail_height.value);
+                    enroll.utxo_key, buffer, avail_height.value);
             }();
         }
         catch (Exception ex)

--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -67,19 +67,20 @@ public class EnrollmentPool
 
     /***************************************************************************
 
-        Add a enrollment data to the enrollment pool
+        Add a enrollment data to the enrollment pool after validating it
 
         Params:
             enroll = the enrollment data to add
             avail_height = height at which the enrollment is available
             finder = the delegate to find UTXOs with
+            findEnrollment = A delegate to find previous enrollments
 
         Returns:
             true if the enrollment data has been added to the enrollment pool
 
     ***************************************************************************/
 
-    public bool add (const ref Enrollment enroll, Height avail_height,
+    public bool add (in Enrollment enroll, in Height avail_height,
         scope UTXOFinder finder, scope EnrollmentFinder findEnrollment) @safe nothrow
     {
         // check validity of the enrollment data
@@ -98,6 +99,25 @@ public class EnrollmentPool
             return false;
         }
 
+        return this.addValidated(enroll, avail_height);
+    }
+
+    /***************************************************************************
+
+        Directly add an enrollment to the pool, without validation
+
+        Params:
+            enroll = the enrollment data to add
+            avail_height = height at which the enrollment is available
+
+        Returns:
+            true if the enrollment data has been added to the enrollment pool
+
+    ***************************************************************************/
+
+    public bool addValidated (in Enrollment enroll, in Height avail_height)
+        @safe nothrow
+    {
         static ubyte[] buffer;
         try
         {


### PR DESCRIPTION
```
Previously, we would not save our own enrollment to the pool when re-enrolling,
instead relying on the gossipping done by other nodes.
To make this more straightforward, we also split the 'EnrollmentPool.add' method
between add (with validation) and 'addValidated', in a manner similar to the Ledger.
```

Testing locally with the single-node network.