### PR TITLE
Upgrade CI ubuntu runners to 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,8 @@ jobs:
         ## TODO: Re-enable once memory usage while reducing Agora is reduced
         ## Currently it takes 7GB+ which OOM on the CI.
         ## See https://github.com/ldc-developers/ldc/issues/3702
-        # os: [ ubuntu-18.04, macOS-10.15, windows-2019 ]
-        os: [ ubuntu-18.04, macOS-10.15]
+        # os: [ ubuntu-20.04, macOS-10.15, windows-2019 ]
+        os: [ ubuntu-20.04, macOS-10.15]
         dc: [ ldc-master, ldc-1.26.0 ]
         # Define job-specific parameters
         include:


### PR DESCRIPTION
Ubuntu 18.04 provides an older version of libsodium in it's
official repositories. We were previously using a PPA to get the
latest version but that seems to be either not present in the Github
runners or that PPA no longer provides libsodium.

Simplest way to get the most recent libsodium is to upgrade runners to
ubuntu 20.04