### PR TITLE
Improve encapsulation of validator index maps

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -134,10 +134,28 @@ public class EnrollmentManager
 
         /// used for validating the signature
         private PublicKey[ulong][Height] index_to_key;
+
+        /***********************************************************************
+
+            Update the validator key index maps
+
+            Params:
+                height = the block height the validators will next sign
+
+        ***********************************************************************/
+
+        public void update (in Height height, in PublicKey[] keys) @safe nothrow
+        {
+            foreach (idx, key; keys)
+            {
+                this.key_to_index[height][key] = idx;
+                this.index_to_key[height][idx] = key;
+            }
+        }
     }
 
     /// Ditto
-    private ValidatorKeyMap keymap;
+    public ValidatorKeyMap keymap;
 
     /***************************************************************************
 
@@ -179,28 +197,6 @@ public class EnrollmentManager
     {
         this(new ManagedDatabase(":memory:"), new ManagedDatabase(":memory:"),
              key_pair, params);
-    }
-
-
-    /***************************************************************************
-
-        Update the validator key index maps
-
-        Params:
-            height = the block height the validators will next sign
-
-    ***************************************************************************/
-
-    public void updateValidatorIndexMaps (in Height height) @safe
-    {
-        auto keys = this.getActiveValidatorPublicKeys(height);
-
-        log.trace("Update validator lookup maps at height {}: {}", height, keys);
-        foreach (idx, key; keys)
-        {
-            this.keymap.key_to_index[height][key] = idx;
-            this.keymap.index_to_key[height][idx] = key;
-        }
     }
 
     /***************************************************************************

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -247,27 +247,6 @@ public class EnrollmentManager
 
     /***************************************************************************
 
-        Params:
-            height = the height at which to look up the mapping for
-            index = the index for which to find the associated Key
-
-        Returns:
-            the key belonging to this index,
-            or `PublicKey.init` if none was found
-
-    ***************************************************************************/
-
-    public PublicKey getValidatorAtIndex (in Height height, in ulong index)
-        const @safe nothrow
-    {
-        if (height !in this.keymap.index_to_key || index !in this.keymap.index_to_key[height])
-            return PublicKey.init;
-        else
-            return this.keymap.index_to_key[height][index];
-    }
-
-    /***************************************************************************
-
         Add a enrollment data to the enrollment pool
 
         Params:

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -1904,7 +1904,6 @@ unittest
     // create the last block of the cycle to make the `Enrollment`s enrolled
     new_txs = genGeneralBlock(new_txs);
     assert(ledger.getBlockHeight() == Height(20));
-    ledger.enroll_man.updateValidatorIndexMaps(Height(21));
     auto b20 = ledger.getBlocksFrom(Height(20))[0];
     assert(b20.header.enrollments.length == 4);
 

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -557,7 +557,11 @@ public class Ledger
                 assert(0);
             }
         }
-        this.enroll_man.updateValidatorIndexMaps(block.header.height + 1);
+
+        const Height next = block.header.height + 1;
+        auto keys = this.enroll_man.getActiveValidatorPublicKeys(next);
+        this.log.trace("Update validator lookup maps at height {}: {}", next, keys);
+        this.enroll_man.keymap.update(next, keys);
         this.updateSlashedValidatorSet(block);
     }
 


### PR DESCRIPTION
This is by no means perfect but it's enough of a step up that it deserves its own PR IMO.

Here's the first commit message which explains the reasoning behind the change:
```
Those maps are slightly redundant (especially when it comes to the most recent height),
and problematic as they are currently stored in the EnrollmentManager.
Since they are validator-related, it would seem more appropriate to have them in
either the Ledger or the ValidatorSet. For such a transition to be easy,
it would be better if all methods related to it were properly encapsulated,
which this commit starts doing.
Further commits will move elements of the function inside the new structure.
This wasn't done in one go as this refactor also provides opportunity to
remove other usages, and to improve error handling (e.g. some parts depend
on the logger inside EnrollmentManager, which conflicts with our goal).
```