### PR TITLE
Make {FullNode,Validator}.config mutable

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -100,7 +100,7 @@ public class FullNode : API
     protected Logger log;
 
     /// Config instance
-    protected const Config config;
+    protected Config config;
 
     /// Parameters for consensus-critical constants
     protected immutable(ConsensusParams) params;
@@ -227,7 +227,7 @@ public class FullNode : API
 
     ***************************************************************************/
 
-    public this (const Config config)
+    public this (Config config)
     {
         this.config = config;
         this.log = this.makeLogger();

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -82,7 +82,7 @@ public class Validator : FullNode, API
     private bool started;
 
     /// Ctor
-    public this (const Config config)
+    public this (Config config)
     {
         assert(config.validator.enabled);
         super(config);

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1765,9 +1765,6 @@ public class TestValidatorNode : Validator, TestAPI
     /// for TestNominator
     protected ulong txs_to_nominate;
 
-    /// If the enrollments will be renewed continuouly or not
-    private bool recurring_enrollment = false;
-
     ///
     mixin TestNodeMixin!();
 
@@ -1787,27 +1784,11 @@ public class TestValidatorNode : Validator, TestAPI
     /// ditto
     public override Enrollment setRecurringEnrollment (bool doIt)
     {
-        this.recurring_enrollment = doIt;
-        if (this.recurring_enrollment)
+        this.config.validator.recurring_enrollment = doIt;
+        if (this.config.validator.recurring_enrollment)
             return this.checkAndEnroll(this.ledger.getBlockHeight());
 
         return Enrollment.init;
-    }
-
-    /// ditto
-    protected override void onAcceptedBlock (in Block block,
-        bool validators_changed) @safe
-    {
-        auto cur_offset = this.clock.networkTime() - this.params.GenesisTimestamp;
-        if (!this.config.validator.recurring_enrollment &&
-            this.recurring_enrollment &&
-            this.config.validator.recurring_enrollment &&
-                block.header.time_offset > cur_offset - 3 * this.params.BlockInterval.total!"seconds")
-        {
-            this.checkAndEnroll(this.ledger.getBlockHeight());
-        }
-
-        super.onAcceptedBlock(block, validators_changed);
     }
 
     /// ditto


### PR DESCRIPTION
Constness here doesn't bring us anything and is actually detrimental in some case (e.g. when writing tests).
It also prevents some dynamic reconfiguration via HTTP endpoint (e.g. when we want to expose a mean to disable the node via the admin interface).