### PR TITLE
Fixes Issue1516: Simplify `preimage` cache

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -1910,7 +1910,6 @@ unittest
     foreach (idx, kp; pairs)
     {
         auto cycle = PreImageCycle(kp.secret, params.ValidatorCycle);
-        cycle.populate(kp.secret, false);
         const seed = cycle[Height(params.ValidatorCycle)];
         cycles ~= cycle;
         auto enroll = EnrollmentManager.makeEnrollment(


### PR DESCRIPTION
`PreimageCycle` had a `populate` function that was only being used in
test code. This has been removed to simplify the code and testing of the
preimage cache code. Test code is added to check that the `seeds` and
`preimages` are correctly populated when the `PreimageCycle` is accessed
via the `opIndex` which takes a `Height` parameter. It also checks that
the nonce is correctly used beyond the first batch of preimages.