### PR TITLE
Change DataPayload to use Base64 when serializing JSON

### DIFF
--- a/source/agora/consensus/Fee.d
+++ b/source/agora/consensus/Fee.d
@@ -234,13 +234,13 @@ public class FeeManager
 
     public string check (in Transaction tx, Amount tx_fee) nothrow @safe
     {
-        if (tx.payload.data.length == 0)
+        if (tx.payload.bytes.length == 0)
             return null;
 
-        if (tx.payload.data.length > this.params.TxPayloadMaxSize)
+        if (tx.payload.bytes.length > this.params.TxPayloadMaxSize)
             return "Transaction: The size of the data payload is too large";
 
-        const required_fee = calculateDataFee(tx.payload.data.length,
+        const required_fee = calculateDataFee(tx.payload.bytes.length,
             this.params.TxPayloadFeeFactor);
         if (tx_fee < required_fee)
             return "Transaction: There is not enough data fee";
@@ -474,7 +474,7 @@ public class FeeManager
             // sum(inputs) - sum(outputs)
             tot_in.mustSub(tot_out);
             tot_fee.mustAdd(tot_in);
-            tot_data_fee.mustAdd(this.getDataFee(tx.payload.data.length));
+            tot_data_fee.mustAdd(this.getDataFee(tx.payload.bytes.length));
         }
         return null;
     }

--- a/source/agora/consensus/data/DataPayload.d
+++ b/source/agora/consensus/data/DataPayload.d
@@ -24,12 +24,12 @@ import std.range;
 public struct DataPayload
 {
     /// The byte array of transaction data
-    public const(ubyte)[] data;
+    public const(ubyte)[] bytes;
 
     /// The size of the data DataPayload object
     public ulong sizeInBytes () const nothrow pure @safe @nogc
     {
-        return this.data.length * this.data[0].sizeof;
+        return this.bytes.length * this.bytes[0].sizeof;
     }
     /***************************************************************************
 
@@ -42,7 +42,7 @@ public struct DataPayload
 
     public this (inout(ubyte)[] bin) inout pure nothrow @safe
     {
-        this.data = bin;
+        this.bytes = bin;
     }
 
     /***************************************************************************
@@ -56,7 +56,7 @@ public struct DataPayload
 
     public void computeHash (scope HashDg dg) const nothrow @nogc @safe
     {
-        hashPart(this.data, dg);
+        hashPart(this.bytes, dg);
     }
 
     /***************************************************************************
@@ -70,7 +70,7 @@ public struct DataPayload
 
     public void serialize (scope SerializeDg dg) const @safe
     {
-        serializePart(this.data, dg);
+        serializePart(this.bytes, dg);
     }
 
     /***************************************************************************
@@ -102,7 +102,7 @@ unittest
     assert(bytes == [3, 0, 1, 2]);
     auto new_data = deserializeFull!(DataPayload)(bytes);
 
-    assert(new_data.data == old_data.data);
+    assert(new_data.bytes == old_data.bytes);
 }
 
 unittest

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -355,8 +355,8 @@ unittest
     auto json_str = old_tx.serializeToJsonString();
 
     Transaction new_tx = deserializeJson!Transaction(json_str);
-    assert(new_tx.payload.data.length == old_tx.payload.data.length);
-    assert(new_tx.payload.data == old_tx.payload.data);
+    assert(new_tx.payload.bytes.length == old_tx.payload.bytes.length);
+    assert(new_tx.payload.bytes == old_tx.payload.bytes);
 }
 
 // Check exact same Coinbase TXs for different heights generate different hashes

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -290,7 +290,7 @@ public string isGenesisBlockInvalidReason (in Block block) nothrow @safe
         if (tx.outputs.length == 0)
             return "GenesisBlock: No output(s) in the transaction";
 
-        if (tx.payload.data.length != 0)
+        if (tx.payload.bytes.length != 0)
             return "GenesisBlock: The data payload cannot be stored";
 
         Hash tx_hash = tx.hashFull();

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -118,7 +118,7 @@ public string isInvalidReason (
 
     if (tx.type == TxType.Freeze)
     {
-        if (tx.payload.data.length != 0)
+        if (tx.payload.bytes.length != 0)
             return "Transaction: Freeze cannot have data payload";
 
         foreach (input; tx.inputs)
@@ -171,7 +171,7 @@ public string isInvalidReason (
         if (tx.inputs[0] != Input(height))
             return "Transaction: Coinbase transaction contains invalid input";
 
-        if (tx.payload.data.length != 0)
+        if (tx.payload.bytes.length != 0)
             return "Transaction: Coinbase transactions can't include payload";
     }
     else

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -1002,7 +1002,7 @@ public class Ledger
             {
                 tot_fee.add(sum_unspent);
                 tot_data_fee.add(
-                    this.fee_man.getDataFee(tx.payload.data.length));
+                    this.fee_man.getDataFee(tx.payload.bytes.length));
             }
             return err;
         };
@@ -1145,7 +1145,7 @@ public class ValidatingLedger : Ledger
                 {
                     tot_fee.add(sum_unspent);
                     tot_data_fee.add(
-                        this.fee_man.getDataFee(tx.payload.data.length));
+                        this.fee_man.getDataFee(tx.payload.bytes.length));
                 }
                 return err;
             };
@@ -1798,7 +1798,7 @@ unittest
     {
         assert(tx.type == TxType.Payment);
         assert(tx.outputs.length > 0);
-        assert(tx.payload.data == data);
+        assert(tx.payload.bytes == data);
     }
 
     // Generate a block to reuse transactions used for data storage


### PR DESCRIPTION
When DataPayload is serialized to JSON, change what is represented as HexString to Base64 expression.
This has been changed consistently with other types (Unlock, Lock, etc.).

Related to https://github.com/bosagora/stoa/issues/268