### PR TITLE
Fixes issue1248: Sort the tx inputs and outputs

### DIFF
--- a/source/agora/cli/client/SendTxProcess.d
+++ b/source/agora/cli/client/SendTxProcess.d
@@ -184,12 +184,9 @@ public int sendTxProcess (string[] args, ref string[] outputs,
     // create the transaction
     auto key_pair = KeyPair.fromSeed(SecretKey.fromString(op.key));
 
-    Transaction tx =
-    {
-        TxType.Payment,
+    Transaction tx = Transaction(TxType.Payment,
         [Input(Hash.fromString(op.txhash), op.index)],
-        [Output(Amount(op.amount), PublicKey.fromString(op.address))]
-    };
+        [Output(Amount(op.amount), PublicKey.fromString(op.address))]);
 
     auto signature = key_pair.sign(tx);
     tx.inputs[0].unlock = genKeyUnlock(signature);
@@ -270,12 +267,9 @@ unittest
     });
     assert (res == CLIENT_SUCCESS);
 
-    Transaction tx =
-    {
-        TxType.Payment,
+    Transaction tx = Transaction(TxType.Payment,
         [Input(Hash.fromString(txhash), index)],
-        [Output(Amount(amount), PublicKey.fromString(address))]
-    };
+        [Output(Amount(amount), PublicKey.fromString(address))]);
     Hash send_txhash = hashFull(tx);
     auto key_pair = KeyPair.fromSeed(SecretKey.fromString(key));
     tx.inputs[0].unlock = genKeyUnlock(key_pair.sign(send_txhash[]));

--- a/source/agora/consensus/Fee.d
+++ b/source/agora/consensus/Fee.d
@@ -558,12 +558,10 @@ unittest
 
     auto fee_man = new FeeManager();
 
-    Transaction freeze_tx = {
+    Transaction freeze_tx = Transaction(
         TxType.Freeze,
-        outputs: [
-            Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address),
-        ]
-    };
+        null, // no inputs
+        [ Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address) ]);
 
     auto utxo_set = new TestUTXOSet;
     utxo_set.put(freeze_tx);
@@ -571,23 +569,16 @@ unittest
     Hash txhash = hashFull(freeze_tx);
     Hash stake_hash = UTXO.getHash(txhash, 0);
 
-    Transaction gen_tx = {
+    Transaction gen_tx = Transaction(
         TxType.Payment,
-        outputs: [
-            Output(Amount(2_000_000L), WK.Keys.NODE2.address),
-        ]
-    };
+        null, // no inputs
+        [ Output(Amount(2_000_000L), WK.Keys.NODE2.address) ]);
     utxo_set.put(gen_tx);
 
-    Transaction spend_tx = {
+    Transaction spend_tx = Transaction(
         TxType.Payment,
-        inputs: [
-            Input(gen_tx.hashFull(), 0)
-        ],
-        outputs: [
-            Output(Amount(1_000_000L), WK.Keys.NODE2.address),
-        ]
-    };
+        [ Input(gen_tx.hashFull(), 0)],
+        [ Output(Amount(1_000_000L), WK.Keys.NODE2.address) ]);
 
     UTXO utxo;
     assert(utxo_set.peekUTXO(spend_tx.inputs[0].utxo, utxo));

--- a/source/agora/consensus/Fee.d
+++ b/source/agora/consensus/Fee.d
@@ -560,7 +560,6 @@ unittest
 
     Transaction freeze_tx = Transaction(
         TxType.Freeze,
-        null, // no inputs
         [ Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address) ]);
 
     auto utxo_set = new TestUTXOSet;
@@ -571,7 +570,6 @@ unittest
 
     Transaction gen_tx = Transaction(
         TxType.Payment,
-        null, // no inputs
         [ Output(Amount(2_000_000L), WK.Keys.NODE2.address) ]);
     utxo_set.put(gen_tx);
 

--- a/source/agora/consensus/Quorum.d
+++ b/source/agora/consensus/Quorum.d
@@ -490,11 +490,7 @@ private QuorumConfig[PublicKey] buildTestQuorums (Range)(Range amounts,
     TestUTXOSet storage = new TestUTXOSet;
     foreach (idx, const ref amount; amounts.save.enumerate)
     {
-        Transaction tx =
-        {
-            type : TxType.Freeze,
-            outputs: [Output(amount, keys[idx])]
-        };
+        Transaction tx = Transaction(TxType.Freeze, null, [ Output(amount, keys[idx]) ]);
 
         // simulating our own UTXO hashes to make the tests stable
         Hash txhash = hashMulti(id, idx, amount);

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -459,7 +459,6 @@ unittest
 
     Transaction tx = Transaction(
         TxType.Payment,
-        null, // no inputs
         [
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
             Output(Amount(62_500_000L * 10_000_000L), pubkey),

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -129,7 +129,7 @@ unittest
     PublicKey pubkey = PublicKey.fromString(address);
 
     Output[1] outputs = [ Output(Amount(100), pubkey) ];
-    Transaction tx = { outputs: outputs[] };
+    Transaction tx = Transaction(TxType.Payment, [], outputs[]);
     BlockHeader header = { merkle_root : tx.hashFull() };
 
     auto hash = hashFull(header);
@@ -457,10 +457,10 @@ unittest
     immutable address = `boa1xrra39xpg5q9zwhsq6u7pw508z2let6dj8r5lr4q0d0nff240fvd27yme3h`;
     PublicKey pubkey = PublicKey.fromString(address);
 
-    Transaction tx =
-    {
+    Transaction tx = Transaction(
         TxType.Payment,
-        outputs: [
+        null, // no inputs
+        [
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
@@ -468,9 +468,8 @@ unittest
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
-            Output(Amount(62_500_000L * 10_000_000L), pubkey),
-        ],
-    };
+            Output(Amount(62_500_000L * 10_000_000L), pubkey)
+        ]);
 
     auto validators = typeof(BlockHeader.validators)(6);
     validators[0] = true;
@@ -695,11 +694,10 @@ unittest
     ];
 
     // Create transactions.
-    Transaction tx;
     Hash last_hash = Hash.init;
     for (int idx = 0; idx < 8; idx++)
     {
-        tx = Transaction(TxType.Payment, [Input(last_hash, 0)],[Output(Amount(100_000), key_pairs[idx+1].address)]);
+        auto tx = Transaction(TxType.Payment, [Input(last_hash, 0)],[Output(Amount(100_000), key_pairs[idx+1].address)]);
         last_hash = hashFull(tx);
         tx.inputs[0].unlock = genKeyUnlock(
             key_pairs[idx].sign(last_hash[]));

--- a/source/agora/consensus/data/genesis/Coinnet.d
+++ b/source/agora/consensus/data/genesis/Coinnet.d
@@ -109,9 +109,9 @@ private immutable Hash GenesisMerkleRoot = GenesisMerkleTree[$ - 1];
 ///
 private immutable Transaction[] GenesisTransactions =
     [
-        {
+        Transaction(
             TxType.Payment,
-            outputs: [
+            [
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
@@ -120,19 +120,17 @@ private immutable Transaction[] GenesisTransactions =
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
-            ],
-        },
-        {
+            ]),
+        Transaction(
             TxType.Freeze,
-            outputs: [
+            [
                 Output(Amount(2_000_000L * 10_000_000L), NODE2_ADDRESS),
                 Output(Amount(2_000_000L * 10_000_000L), NODE3_ADDRESS),
                 Output(Amount(2_000_000L * 10_000_000L), NODE4_ADDRESS),
                 Output(Amount(2_000_000L * 10_000_000L), NODE5_ADDRESS),
                 Output(Amount(2_000_000L * 10_000_000L), NODE6_ADDRESS),
                 Output(Amount(2_000_000L * 10_000_000L), NODE7_ADDRESS),
-            ],
-        },
+            ])
     ];
 
 private immutable Hash[] GenesisMerkleTree = [

--- a/source/agora/consensus/data/genesis/Test.d
+++ b/source/agora/consensus/data/genesis/Test.d
@@ -97,20 +97,19 @@ public immutable Block GenesisBlock = {
     },
     merkle_tree: GenesisMerkleTree,
     txs: [
-        {
+        Transaction(
             TxType.Freeze,
-            outputs: [
+            [
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE3.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE4.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE5.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE6.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE7.address),
-            ],
-        },
-        {
+            ]),
+        Transaction(
             TxType.Payment,
-            outputs: [
+            [
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),
@@ -119,8 +118,7 @@ public immutable Block GenesisBlock = {
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),
-            ],
-        },
+            ]),
     ],
 };
 

--- a/source/agora/consensus/data/genesis/Test.d
+++ b/source/agora/consensus/data/genesis/Test.d
@@ -100,6 +100,8 @@ public immutable Block GenesisBlock = {
         Transaction(
             TxType.Freeze,
             [
+                // If we want these in order NODE2, NODE3 .. NODE7
+                // then we need to make sure the value of the Public key is in same order
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE3.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE4.address),

--- a/source/agora/consensus/data/genesis/package.d
+++ b/source/agora/consensus/data/genesis/package.d
@@ -63,7 +63,7 @@ version (unittest)
     }
 }
 
-/// Check the Coinnet Genesis Block enrollments (prints replacement enrollments if needed for agora.consensus.data.genesis.Coinnet.d)
+/// Check the Coinnet Genesis Block enrollments (prints replacement enrollments if needed for agora.consensus.data.genesis.Test.d)
 /// This will not be used for the final Coinnet GenesisBlock which will use unknown key secrets. But can be useful for now.
 unittest
 {
@@ -84,7 +84,7 @@ unittest
 
 }
 
-/// Check the Test Genesis Block enrollments (prints replacement enrollments if needed for agora.consensus.data.genesis.Test.d)
+/// Check the Test Genesis Block enrollments (prints replacement enrollments if needed for agora.consensus.data.genesis.Coinnet.d)
 unittest
 {
     import agora.consensus.data.genesis.Coinnet;

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -484,6 +484,7 @@ unittest
         Output zeroOutput =
             Output(Amount.invalid(0), WK.Keys[0].address);
         block.txs[0].outputs ~= zeroOutput;
+        block.txs[0].outputs.sort;
         buildMerkleTree(block);
         assert(!block.isGenesisBlockValid());
     }
@@ -542,7 +543,7 @@ unittest
         [
             Output(normal_data_fee, fee_man.params.CommonsBudgetAddress),
             Output(Amount(40_000L * 10_000_000L), key_pair.address)
-        ],
+        ].sort.array,
         DataPayload(normal_data)
     );
 
@@ -901,6 +902,7 @@ unittest
 
     KeyPair keypair = KeyPair.random();
     Transaction[] txs_2;
+    Output[] no_outputs;
     foreach (idx, pre_tx; txs_1)
     {
         Input input = Input(hashFull(pre_tx), 0);
@@ -930,7 +932,7 @@ unittest
             output.lock = genKeyLock(keypair.address);
             tx.outputs ~= output;
         }
-
+        tx.outputs.sort;
         tx.inputs[0].unlock = VTx.signUnlock(gen_key, tx);
         txs_2 ~= tx;
     }
@@ -1030,6 +1032,7 @@ unittest
 
     KeyPair keypair = KeyPair.random();
     Transaction[] txs_2;
+    Output[] no_outputs;
     foreach (idx, pre_tx; txs_1)
     {
         Transaction tx = Transaction(
@@ -1049,7 +1052,7 @@ unittest
             foreach (_; 0 .. 8)
                 tx.outputs ~= Output(Amount(100), keypair.address);
         }
-
+        tx.outputs.sort;
         tx.inputs[0].unlock = VTx.signUnlock(gen_key, tx);
         txs_2 ~= tx;
     }

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -410,12 +410,9 @@ unittest
 
     Transaction makeNewTx ()
     {
-        Transaction new_tx =
-        {
+        Transaction new_tx = Transaction(
             TxType.Payment,
-            inputs: [],
-            outputs: [Output(Amount(100), KeyPair.random().address)]
-        };
+            [Output(Amount(100), KeyPair.random().address)]);
         return new_tx;
     }
 
@@ -908,11 +905,11 @@ unittest
     {
         Input input = Input(hashFull(pre_tx), 0);
 
-        Transaction tx =
-        {
+        Transaction tx = Transaction(
             TxType.Freeze,
             [input],
-        };
+            null
+        );
         if (idx > 3)
             tx.type = TxType.Payment;
 
@@ -950,12 +947,10 @@ unittest
     {
         Input input = Input(hashFull(txs_2[7]), idx);
 
-        Transaction tx =
-        {
+        Transaction tx = Transaction(
             TxType.Payment,
             [input],
-            [Output(Amount(1), keypair2.address)]
-        };
+            [Output(Amount(1), keypair2.address)]);
         tx.inputs[0].unlock = VTx.signUnlock(keypair, tx);
         txs_3 ~= tx;
     }
@@ -1037,11 +1032,10 @@ unittest
     Transaction[] txs_2;
     foreach (idx, pre_tx; txs_1)
     {
-        Transaction tx =
-        {
+        Transaction tx = Transaction(
             TxType.Freeze,
             [Input(hashFull(pre_tx), 0)],
-        };
+            null);
 
         if (idx <= 2)
         {
@@ -1073,12 +1067,10 @@ unittest
         Transaction[] txs_3;
         foreach (idx; 0 .. 8)
         {
-            Transaction tx =
-            {
+            Transaction tx = Transaction(
                 TxType.Payment,
                 [Input(hashFull(txs_2[$-4]), idx)],
-                [Output(Amount(1), keypair2.address)]
-            };
+                [Output(Amount(1), keypair2.address)]);
             tx.inputs[0].unlock = VTx.signUnlock(keypair, tx);
             txs_3 ~= tx;
         }
@@ -1099,12 +1091,10 @@ unittest
         Transaction[] txs_3;
         foreach (idx; 0 .. 8)
         {
-            Transaction tx =
-            {
+            Transaction tx = Transaction(
                 TxType.Payment,
                 [Input(hashFull(txs_2[$-3]), idx)],
-                [Output(Amount(1), keypair2.address)]
-            };
+                [Output(Amount(1), keypair2.address)]);
             tx.inputs[0].unlock = VTx.signUnlock(keypair, tx);
             txs_3 ~= tx;
         }
@@ -1143,12 +1133,10 @@ unittest
         Transaction[] txs_3;
         foreach (idx; 0 .. 8)
         {
-            Transaction tx =
-            {
+            Transaction tx = Transaction(
                 TxType.Payment,
                 [Input(hashFull(txs_2[$-1]), idx)],
-                [Output(Amount(1), keypair2.address)]
-            };
+                [Output(Amount(1), keypair2.address)]);
             tx.inputs[0].unlock = VTx.signUnlock(keypair, tx);
             txs_3 ~= tx;
         }

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -66,6 +66,7 @@ public string isInvalidReason (in Enrollment enrollment,
         return "Enrollment: UTXO is not frozen";
 
     Point address = utxo_set_value.output.address;
+
     if (!address.isValid())
         return "Enrollment: Address is not a valid point on Curve25519";
 

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -214,7 +214,7 @@ unittest
     scope checker = &payload_checker.check;
 
     // Creates the first transaction.
-    Transaction previousTx = { outputs: [ Output(Amount(100), key_pairs[0].address) ] };
+    Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount(100), key_pairs[0].address) ]);
 
     // Save
     Hash previousHash = hashFull(previousTx);
@@ -257,7 +257,7 @@ unittest
 {
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     KeyPair[] key_pairs = [KeyPair.random(), KeyPair.random()];
-    Transaction tx_1 = { outputs: [ Output(Amount(1000), key_pairs[0].address) ] };
+    Transaction tx_1 = Transaction(TxType.Payment, [ Output(Amount(1000), key_pairs[0].address) ]);
     Hash tx_1_hash = hashFull(tx_1);
 
     scope payload_checker = new FeeManager();
@@ -267,13 +267,11 @@ unittest
     storage.put(tx_1);
 
     // Creates the second transaction.
-    Transaction tx_2 =
-    {
+    Transaction tx_2 = Transaction(
         TxType.Payment,
-        inputs  : [Input(tx_1_hash, 0)],
+        [Input(tx_1_hash, 0)],
         // oops
-        outputs : [Output(Amount.invalid(-400_000), key_pairs[1].address)]
-    };
+        [Output(Amount.invalid(-400_000), key_pairs[1].address)]);
 
     tx_2.inputs[0].unlock = signUnlock(key_pairs[0], tx_2);
 
@@ -281,12 +279,10 @@ unittest
 
     // Creates the third transaction.
     // Reject a transaction whose output value is zero
-    Transaction tx_3 =
-    {
+    Transaction tx_3 = Transaction(
         TxType.Payment,
-        inputs  : [Input(tx_1_hash, 0)],
-        outputs : [Output(Amount.invalid(0), key_pairs[1].address)]
-    };
+        [Input(tx_1_hash, 0)],
+        [Output(Amount.invalid(0), key_pairs[1].address)]);
 
     tx_3.inputs[0].unlock = signUnlock(key_pairs[0], tx_3);
 
@@ -309,7 +305,7 @@ unittest
     scope checker = &payload_checker.check;
 
     // Create the first transaction.
-    Transaction genesisTx = { outputs: [ Output(Amount(100_000), key_pairs[0].address) ] };
+    Transaction genesisTx = Transaction(TxType.Payment, [ Output(Amount(100_000), key_pairs[0].address) ]);
     Hash genesisHash = hashFull(genesisTx);
     storage.put(genesisTx);
 
@@ -367,8 +363,7 @@ unittest
     {
         storage.clear;
         // Create the previous transaction with type `TxType.Payment`
-        Transaction previousTx =
-            { outputs: [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ] };
+        Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ]);
         previousHash = hashFull(previousTx);
         foreach (idx, output; previousTx.outputs)
         {
@@ -398,7 +393,7 @@ unittest
     {
         storage.clear;
         // Create the previous transaction with type `TxType.Payment`
-        Transaction previousTx = { outputs: [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ] };
+        Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ]);
         previousHash = hashFull(previousTx);
         foreach (idx, output; previousTx.outputs)
         {
@@ -428,7 +423,7 @@ unittest
     {
         storage.clear;
         // Create the previous transaction with type `TxType.Payment`
-        Transaction previousTx = { outputs: [ Output(Amount(100_000_000_000L), key_pairs[0].address) ] };
+        Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount(100_000_000_000L), key_pairs[0].address) ]);
         previousHash = hashFull(previousTx);
         foreach (idx, output; previousTx.outputs)
         {
@@ -457,7 +452,7 @@ unittest
     // Second transaction is valid.
     {
         // Create the previous transaction with type `TxType.Payment`
-        Transaction previousTx = { outputs: [ Output(Amount(500_000_000_000L), key_pairs[0].address) ] };
+        Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount(500_000_000_000L), key_pairs[0].address) ]);
         previousHash = hashFull(previousTx);
         foreach (idx, output; previousTx.outputs)
         {
@@ -523,8 +518,8 @@ unittest
     // Expected Status : melted
     {
         height = 0;
-        Transaction previousTx =
-            { outputs: [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ] };
+        Transaction previousTx = Transaction(
+            TxType.Payment, [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ]);
 
         // Save to UTXOSet
         previousHash = hashFull(previousTx);
@@ -678,7 +673,7 @@ unittest
         format("Tx having no input should not pass validation. tx: %s", oneTx));
 
     // create a transaction
-    Transaction firstTx = { outputs: [ Output(Amount(100_1000), key_pair.address) ] };
+    Transaction firstTx = Transaction(TxType.Payment, [ Output(Amount(100_1000), key_pair.address) ]);
     Hash firstHash = hashFull(firstTx);
     storage.put(firstTx);
 
@@ -1054,7 +1049,7 @@ unittest
 
     KeyPair kp = KeyPair.random();
 
-    Transaction prev_tx = { outputs: [Output(Amount(100), kp.address)] };
+    Transaction prev_tx = Transaction(TxType.Payment, [Output(Amount(100), kp.address)]);
     storage.put(prev_tx);
 
     Transaction tx = Transaction(

--- a/source/agora/flash/Scripts.d
+++ b/source/agora/flash/Scripts.d
@@ -180,13 +180,12 @@ public Unlock createUnlockSettle (Signature sig, in ulong seq_id)
 public Transaction createFundingTx (in Hash utxo, in Amount capacity,
     in Point pair_pk) @safe nothrow
 {
-    Transaction funding_tx = {
-        type: TxType.Payment,
-        inputs: [Input(utxo)],
-        outputs: [
+    Transaction funding_tx = Transaction(
+        TxType.Payment,
+        [Input(utxo)],
+        [
             Output(capacity,
-                Lock(LockType.Key, pair_pk[].dup))]
-    };
+                Lock(LockType.Key, pair_pk[].dup))]);
 
     return funding_tx;
 }
@@ -211,11 +210,10 @@ public Transaction createFundingTx (in Hash utxo, in Amount capacity,
 public Transaction createClosingTx (in Hash utxo, in Output[] outputs)
     @safe nothrow
 {
-    Transaction closing_tx = {
-        type: TxType.Payment,
-        inputs: [Input(utxo)],
-        outputs: outputs.dup,
-    };
+    Transaction closing_tx = Transaction(
+        TxType.Payment,
+        [Input(utxo)],
+        outputs.dup);
 
     return closing_tx;
 }
@@ -239,11 +237,10 @@ public Transaction createClosingTx (in Hash utxo, in Output[] outputs)
 public Transaction createSettleTx (in Transaction prev_tx,
     in uint settle_age, in Output[] outputs) @safe nothrow
 {
-    Transaction settle_tx = {
-        type: TxType.Payment,
-        inputs: [Input(prev_tx, 0 /* index */, settle_age)],
-        outputs: outputs.dup,
-    };
+    Transaction settle_tx = Transaction(
+        TxType.Payment,
+        [Input(prev_tx, 0 /* index */, settle_age)],
+        outputs.dup);
 
     return settle_tx;
 }
@@ -273,12 +270,10 @@ public Transaction createUpdateTx (in ChannelConfig chan_conf,
         chan_conf.funding_tx_hash, chan_conf.pair_pk, seq_id,
         chan_conf.num_peers);
 
-    Transaction update_tx = {
-        type: TxType.Payment,
-        inputs: [Input(prev_tx, 0 /* index */, 0 /* unlock age */)],
-        outputs: [
-            Output(chan_conf.capacity, Lock)]
-    };
+    Transaction update_tx = Transaction(
+        TxType.Payment,
+        [ Input(prev_tx, 0 /* index */, 0 /* unlock age */)] ,
+        [ Output(chan_conf.capacity, Lock) ]);
 
     return update_tx;
 }
@@ -528,8 +523,8 @@ unittest
     import agora.script.Engine;
     import std.stdio;
 
-    const Transaction bad_tx = { lock_height : Height(99) };
-    const Transaction tx = { lock_height : Height(100) };
+    const Transaction bad_tx = Transaction(Height(99));
+    const Transaction tx = Transaction(Height(100));
     const Hash wrong_secret = hashFull(99);
     const Hash secret = hashFull(42);
     auto hash = hashFull(secret);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -586,7 +586,7 @@ public class Ledger
             foreach (pair; payouts.byKeyValue())
                 if (pair.value > Amount(0))
                     coinbase_tx.outputs ~= Output(pair.value, pair.key);
-
+        coinbase_tx.outputs.sort;
         return coinbase_tx.outputs.length > 0 ? [coinbase_tx] : [];
     }
 
@@ -1537,7 +1537,7 @@ version (unittest)
 ///
 unittest
 {
-    scope ledger = new TestLedger(WK.Keys.NODE2);
+    scope ledger = new TestLedger(WK.Keys.NODE3);
     assert(ledger.getBlockHeight() == 0);
 
     auto blocks = ledger.getBlocksFrom(Height(0)).take(10);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -425,16 +425,14 @@ public class Ledger
 
             auto remain_amount = Amount(utxo_value.output.value);
             remain_amount.sub(this.params.SlashPenaltyAmount);
-            Transaction slashing_tx =
-            {
+            Transaction slashing_tx = Transaction(
                 TxType.Payment,
-                inputs: [Input(utxo)],
-                outputs: [
+                [Input(utxo)],
+                [
                     Output(this.params.SlashPenaltyAmount,
                         this.params.CommonsBudgetAddress),
                     Output(remain_amount, utxo_value.output.address),
-                ],
-            };
+                ]);
             this.utxo_set.updateUTXOCache(slashing_tx, block.header.height,
                 this.params.CommonsBudgetAddress);
         }
@@ -2187,7 +2185,7 @@ unittest
         data.tx_set = data.tx_set[0 .. $ - 1];
         assert(ledger.validateConsensusData(data) == "Invalid Coinbase transaction");
         // Add Invalid coinbase TX
-        data.tx_set ~= Transaction(TxType.Coinbase).hashFull();
+        data.tx_set ~= Transaction(TxType.Coinbase, null).hashFull();
         assert(ledger.validateConsensusData(data) == "Invalid Coinbase transaction");
 
         ledger.prepareNominatingSet(data, Block.TxsInTestBlock, mock_clock.networkTime());

--- a/source/agora/node/TransactionPool.d
+++ b/source/agora/node/TransactionPool.d
@@ -648,17 +648,17 @@ unittest
     Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(0), KeyPair.random.address)]);
+        [Output(Amount(0), WK.Keys.FR.address)]);
 
     Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]);
+        [Output(Amount(0), WK.Keys.UK.address)]);
 
     Transaction tx3 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]);
+        [Output(Amount(0), WK.Keys.NL.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));
@@ -679,17 +679,17 @@ unittest
     Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(0), KeyPair.random.address)]);
+        [Output(Amount(0), WK.Keys.ZA.address)]);
 
     Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0), Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]);
+        [Output(Amount(0), WK.Keys.ZC.address)]);
 
     Transaction tx3 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]);
+        [Output(Amount(0), WK.Keys.ZD.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));
@@ -733,11 +733,11 @@ unittest
     Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(2), KeyPair.random.address)]);
+        [Output(Amount(2), WK.Keys.US.address)]);
 
     Transaction tx2 = Transaction(TxType.Payment,
         [Input(Hash.init, 0), Input(Hash.init, 1)],
-        [Output(Amount(1), KeyPair.random.address)]);
+        [Output(Amount(1), WK.Keys.KR.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));
@@ -797,17 +797,17 @@ unittest
 
     // parent transaction
     Transaction tx1 = Transaction(TxType.Payment, [Input(genesis_tx.hashFull(), 0)],
-        [Output(Amount(1000), KeyPair.random.address)]);
+        [Output(Amount(1000), WK.Keys.KR.address)]);
 
     utxo_set.put(tx1);
 
     // double spent transaction, transaction trying to spend parent
     Transaction tx2 = Transaction(TxType.Payment, [Input(tx1.hashFull(), 0)],
-        [Output(Amount(200), KeyPair.random.address)]);
+        [Output(Amount(200), WK.Keys.NZ.address)]);
 
     // double spent transaction, trying to spend parent
     Transaction tx3 = Transaction(TxType.Payment, [Input(tx1.hashFull(), 0)],
-        [Output(Amount(100), KeyPair.random.address)]);
+        [Output(Amount(100), WK.Keys.AU.address)]);
 
     assert(pool.add(tx2));
     assert(pool.add(tx3));
@@ -836,12 +836,12 @@ unittest
     Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(2), KeyPair.random.address)]);
+        [Output(Amount(2), WK.Keys.GE.address)]);
 
     Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(1), KeyPair.random.address)]);
+        [Output(Amount(1), WK.Keys.CA.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));

--- a/source/agora/node/TransactionPool.d
+++ b/source/agora/node/TransactionPool.d
@@ -614,20 +614,16 @@ unittest
     auto pool = new TransactionPool();
 
     // create first transaction
-    Transaction tx1 =
-    {
+    Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(0), WK.Keys.A.address)]
-    };
+        [Output(Amount(0), WK.Keys.A.address)]);
 
     // create second transaction
-    Transaction tx2 =
-    {
+    Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(0), WK.Keys.C.address)]
-    };
+        [Output(Amount(0), WK.Keys.C.address)]);
 
     // add txs to the pool
     assert(pool.add(tx1));
@@ -649,26 +645,20 @@ unittest
 {
     auto pool = new TransactionPool();
 
-    Transaction tx1 =
-    {
+    Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(0), KeyPair.random.address)]
-    };
+        [Output(Amount(0), KeyPair.random.address)]);
 
-    Transaction tx2 =
-    {
+    Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]
-    };
+        [Output(Amount(0), KeyPair.random.address)]);
 
-    Transaction tx3 =
-    {
+    Transaction tx3 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]
-    };
+        [Output(Amount(0), KeyPair.random.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));
@@ -686,26 +676,20 @@ unittest
 {
     auto pool = new TransactionPool();
 
-    Transaction tx1 =
-    {
+    Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(0), KeyPair.random.address)]
-    };
+        [Output(Amount(0), KeyPair.random.address)]);
 
-    Transaction tx2 =
-    {
+    Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0), Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]
-    };
+        [Output(Amount(0), KeyPair.random.address)]);
 
-    Transaction tx3 =
-    {
+    Transaction tx3 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]
-    };
+        [Output(Amount(0), KeyPair.random.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));
@@ -746,19 +730,14 @@ unittest
 
     auto pool = new TransactionPool(new ManagedDatabase(":memory:"), &selector);
 
-    Transaction tx1 =
-    {
+    Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(2), KeyPair.random.address)]
-    };
+        [Output(Amount(2), KeyPair.random.address)]);
 
-    Transaction tx2 =
-    {
-        TxType.Payment,
+    Transaction tx2 = Transaction(TxType.Payment,
         [Input(Hash.init, 0), Input(Hash.init, 1)],
-        [Output(Amount(1), KeyPair.random.address)]
-    };
+        [Output(Amount(1), KeyPair.random.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));
@@ -817,30 +796,18 @@ unittest
     auto genesis_tx = GenesisBlock.txs.filter!(tx => tx.type == TxType.Payment).array()[0];
 
     // parent transaction
-    Transaction tx1 =
-    {
-        TxType.Payment,
-        [Input(genesis_tx.hashFull(), 0)],
-        [Output(Amount(1000), KeyPair.random.address)]
-    };
+    Transaction tx1 = Transaction(TxType.Payment, [Input(genesis_tx.hashFull(), 0)],
+        [Output(Amount(1000), KeyPair.random.address)]);
 
     utxo_set.put(tx1);
 
     // double spent transaction, transaction trying to spend parent
-    Transaction tx2 =
-    {
-        TxType.Payment,
-        [Input(tx1.hashFull(), 0)],
-        [Output(Amount(200), KeyPair.random.address)]
-    };
+    Transaction tx2 = Transaction(TxType.Payment, [Input(tx1.hashFull(), 0)],
+        [Output(Amount(200), KeyPair.random.address)]);
 
     // double spent transaction, trying to spend parent
-    Transaction tx3 =
-    {
-        TxType.Payment,
-        [Input(tx1.hashFull(), 0)],
-        [Output(Amount(100), KeyPair.random.address)]
-    };
+    Transaction tx3 = Transaction(TxType.Payment, [Input(tx1.hashFull(), 0)],
+        [Output(Amount(100), KeyPair.random.address)]);
 
     assert(pool.add(tx2));
     assert(pool.add(tx3));
@@ -866,19 +833,15 @@ unittest
 {
     auto pool = new TransactionPool();
 
-    Transaction tx1 =
-    {
+    Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(2), KeyPair.random.address)]
-    };
+        [Output(Amount(2), KeyPair.random.address)]);
 
-    Transaction tx2 =
-    {
+    Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(1), KeyPair.random.address)]
-    };
+        [Output(Amount(1), KeyPair.random.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));

--- a/source/agora/node/TransactionRelayer.d
+++ b/source/agora/node/TransactionRelayer.d
@@ -398,12 +398,10 @@ public class TransactionRelayerFeeImp : TransactionRelayer
         auto genesis_tx = GenesisBlock.txs.filter!(tx => tx.type == TxType.Payment).front;
         Amount amount = genesis_tx.outputs[gen_out_ind].value;
         amount.mustSub(fee);
-        Transaction tx =
-        {
+        Transaction tx = Transaction(
             TxType.Payment,
             [Input(genesis_tx.hashFull(), gen_out_ind)],
-            [Output(amount, KeyPair.random.address)]
-        };
+            [Output(amount, KeyPair.random.address)]);
 
         return tx;
     }

--- a/source/agora/node/TransactionRelayer.d
+++ b/source/agora/node/TransactionRelayer.d
@@ -393,6 +393,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
     {
         import agora.consensus.data.genesis.Test;
         import agora.crypto.Key;
+        import agora.utils.Test;
         import std.array;
 
         auto genesis_tx = GenesisBlock.txs.filter!(tx => tx.type == TxType.Payment).front;
@@ -401,7 +402,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
         Transaction tx = Transaction(
             TxType.Payment,
             [Input(genesis_tx.hashFull(), gen_out_ind)],
-            [Output(amount, KeyPair.random.address)]);
+            [Output(amount, WK.Keys.AA.address)]);
 
         return tx;
     }

--- a/source/agora/script/Engine.d
+++ b/source/agora/script/Engine.d
@@ -1603,7 +1603,7 @@ unittest
     //   <sig>
 
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
-    const Transaction tx = { inputs : [Input.init] };
+    const Transaction tx = Transaction(TxType.Payment, [Input.init], null);
     test!("==")(engine.execute(
         Lock(LockType.Script, [OP.CHECK_SEQ_SIG]), Unlock.init, tx, tx.inputs[0]),
         "CHECK_SEQ_SIG opcode requires 4 items on the stack");
@@ -1765,8 +1765,8 @@ unittest
     const height_11 = nativeToLittleEndian(ulong(11));
 
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
-    const Transaction tx_10 = { lock_height : Height(10) };
-    const Transaction tx_11 = { lock_height : Height(11) };
+    const Transaction tx_10 = Transaction(Height(10));
+    const Transaction tx_11 = Transaction(Height(11));
     test!("==")(engine.execute(
         Lock(LockType.Script,
             toPushOpcode(height_9)

--- a/source/agora/script/Lock.d
+++ b/source/agora/script/Lock.d
@@ -72,6 +72,30 @@ public struct Lock
     {
         return this.type.sizeof + this.bytes.length * this.bytes[0].sizeof;
     }
+
+    /// Support for sorting
+    public int opCmp ( const typeof(this) rhs ) const nothrow @safe @nogc
+    {
+        import std.algorithm;
+
+        if (cast(int)this.type == cast(int)rhs.type)
+            return cmp(this.bytes, rhs.bytes);
+        return cast(int)this.type < cast(int)rhs.type ? -1 : 1;
+    }
+}
+
+unittest
+{
+    import std.algorithm;
+    import std.array;
+
+    auto lock1 = Lock(LockType.Key,     [153, 223, 171, 200, 195, 76, 197, 30, 122, 135, 199, 165, 59, 248, 20, 63, 104, 203, 140, 183, 177, 199, 208, 11, 136, 169, 69, 145, 67, 250, 64, 156]);
+    auto lock2 = Lock(LockType.Key,     [153, 223, 171, 100, 195, 76, 197, 30, 122, 135, 199, 165, 59, 248, 20, 63, 104, 203, 140, 183, 177, 199, 208, 11, 136, 169, 69, 145, 67, 250, 64, 156]);
+    auto lock3 = Lock(LockType.KeyHash, [153, 223, 171, 250, 195, 76, 197, 30, 122, 135, 199, 165, 59, 248, 20, 63, 104, 203, 140, 183, 177, 199, 208, 11, 136, 169, 69, 145, 67, 250, 64, 156]);
+    auto lock4 = Lock(LockType.Key,     [153, 223, 171, 250, 195, 76, 197, 30, 122, 135, 199, 165, 59, 248, 20, 63, 104, 203, 140, 183, 177, 199, 208, 11, 136, 169, 69, 145, 67, 250, 64, 156]);
+    auto locks = [ lock1, lock2, lock3, lock4];
+    locks.sort();
+    assert(locks == [ lock2, lock1, lock4, lock3 ]);
 }
 
 unittest

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -48,9 +48,6 @@ unittest
     network.waitForPreimages(network.blocks[0].header.enrollments,
         Height(GenesisValidatorCycle));
 
-    // // Re-enroll the Genesis validators
-    // iota(GenesisValidators).each!(idx => network.enroll(idx));
-
     network.generateBlocks(iota(GenesisValidators),
         Height(GenesisValidatorCycle));
 

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -50,6 +50,7 @@ import agora.utils.Log;
 import geod24.LocalRest : Listener;
 import geod24.Registry;
 
+import std.algorithm;
 import std.conv;
 import std.exception;
 
@@ -1389,8 +1390,8 @@ unittest
     auto block12 = node_1.getBlocksFrom(12, 1)[0];
     assert(block12.txs[0] == bob.getClosingTx(bob_pubkey, bob_charlie_chan_id_2));
     assert(block12.txs[0].outputs.length == 2);
-    assert(block12.txs[0].outputs[0].value == Amount(8000)); // No fees
-    assert(block12.txs[0].outputs[1].value == Amount(2000));
+    assert(block12.txs[0].outputs.count!(o => o.value == Amount(8000)) == 1); // No fees
+    assert(block12.txs[0].outputs.count!(o => o.value == Amount(2000)) == 1);
 
     assert(alice.beginCollaborativeClose(alice_pubkey, alice_bob_chan_id).error
         == ErrorCode.None);
@@ -1400,8 +1401,8 @@ unittest
     auto block13 = node_1.getBlocksFrom(13, 1)[0];
     assert(block13.txs[0] == alice.getClosingTx(alice_pubkey, alice_bob_chan_id));
     assert(block13.txs[0].outputs.length == 2);
-    assert(block13.txs[0].outputs[0].value == Amount(7990)); // Fees
-    assert(block13.txs[0].outputs[1].value == Amount(2010));
+    assert(block13.txs[0].outputs.count!(o => o.value == Amount(7990)) == 1); // Fees
+    assert(block13.txs[0].outputs.count!(o => o.value == Amount(2010)) == 1);
 
     assert(bob.beginCollaborativeClose(bob_pubkey, bob_charlie_chan_id).error
         == ErrorCode.None);

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -243,7 +243,7 @@ unittest
     // Create a freezing tx with two outputs:
     // 1) A refund of 1k
     // 2) A very large frozen amount (60.999k)
-    Amount freezeAmount = network.blocks[0].txs[1].outputs[0].value;
+    Amount freezeAmount = network.blocks[0].frozens.front.outputs[0].value;
     // Must be under Amount.MinFreezeAmount so that the refund isn't frozen
     freezeAmount.mustSub(1_000.coins);
     auto tx = network.blocks[0].spendable
@@ -259,7 +259,7 @@ unittest
     const b1 = network.clients[0].getBlock(1);
     assert(b1.txs.length == 1);
 
-    // Now spend the refund transaction
+    // Now spend the refund transaction (output index is 0 as it is sorted and lock is same value but ammount is less)
     auto tx2 = TxBuilder(b1.txs[0], 0).sign();
     assert(tx2.outputs.length == 1);
 

--- a/source/agora/test/TransactionReplacement.d
+++ b/source/agora/test/TransactionReplacement.d
@@ -80,7 +80,7 @@ unittest
     network.expectHeight(Height(1));
     const block = node1.getBlock(Height(1));
 
-    // verify that the transaction with fee 13000 is the only one inncluded in the block
+    // verify that the transaction with fee 13000 is the only one included in the block
     assert(block.txs.length == 2); // Coinbase + our transaction
     assert(block.txs.filter!(tx => tx.type == TxType.Payment).front() == txs[4]);
 }

--- a/source/agora/test/TransactionReplacement.d
+++ b/source/agora/test/TransactionReplacement.d
@@ -22,6 +22,7 @@ import agora.consensus.data.Transaction;
 import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.test.Base;
+import agora.utils.Test;
 
 import core.thread.osthread : Thread;
 
@@ -43,7 +44,7 @@ unittest
 
     auto input_tx = GenesisBlock.txs.filter!(tx => tx.type == TxType.Payment).front();
     Amount input_tx_amount = input_tx.outputs[0].value;
-    auto output_addr = KeyPair.random.address;
+    auto output_addr = WK.Keys.AA.address;
 
     // create double spend transactions with fees 10000, 10100 .. 13000
     auto txs = [Amount(10000), Amount(10100), Amount(10200), Amount(11000), Amount(13000)]


### PR DESCRIPTION
The idea is to have a defined order for the inputs and outputs within a transaction. This is to make it deterministic so matches will more easily be made during nomination consensus and also make it not possible to re-arrange the transaction contents to create new hashes..
