### PR TITLE
Remove two Exception-swallowing `scope (failure)`

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1220,8 +1220,6 @@ extern(D):
     public override void setupTimer (ulong slot_idx, int timer_type,
         milliseconds timeout, CPPDelegate!SCPCallback* callback)
     {
-        scope (failure) assert(0);
-
         const type = cast(TimerType) timer_type;
         assert(type >= TimerType.min && type <= TimerType.max);
         if (auto timer = this.active_timers[type])

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -47,6 +47,7 @@ private int main (string[] args)
     CommandLine cmdln;
 
     stAssertError = new AssertError("You should not see this");
+    assertHandler = &handleAssertion;
 
     try
     {


### PR DESCRIPTION
We're seeing the assert in `UTXODB.find` triggered in the live system.
However, due to the usage of `scope (failure)`, we don't actually know what the error is.