### PR TITLE
Registry with UTXO instead of PublicKey

### DIFF
--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -1562,11 +1562,23 @@ public class AgoraFlashNode : FlashNode
 
         foreach (pair; this.getManagedKeys())
         {
+            // TODO: This should use UTXO instead of PublicKey
+            // We should change `managed_keys` to be a set of UTXO hash
+            Hash utxo_key;
+            UTXO utxo;
+            this.network.findUTXO(pair.key, utxo_key, utxo);
+            if(utxo_key == Hash.init)
+            {
+                log.fatal("Couldn't find the UTXO for this node: {}.", pair.key);
+                assert(0);
+            }
+
             RegistryPayload payload =
             {
                 data:
                 {
-                    public_key : pair.key,
+                    utxo_key : utxo_key,
+                    utxo : utxo,
                     addresses : addresses,
                     seq : time(null)
                 }
@@ -1625,7 +1637,13 @@ public class AgoraFlashNode : FlashNode
 
         log.info("getFlashClient searching peer: {}", peer_pk);
 
-        auto payload = this.registry_client.getValidator(peer_pk);
+        // TODO: This should use UTXO instead of PublicKey
+        // We should change `managed_keys` to be a set of UTXO hash
+        Hash utxo_key;
+        UTXO utxo;
+        this.network.findUTXO(peer_pk, utxo_key, utxo);
+        auto payload = this.registry_client.getValidator(utxo_key);
+
         if (payload == RegistryPayload.init)
         {
             log.warn("Could not find mapping in registry for key {}", peer_pk);

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -77,9 +77,6 @@ public class NetworkManager
         /// Hash of the output used as collateral, only set if the node is a Validator
         Hash utxo;
 
-        /// PublicKey of the node. TODO: Remove and just use utxo.
-        PublicKey key;
-
         /// Client
         NetworkClient client;
     }
@@ -242,7 +239,6 @@ public class NetworkManager
 
             NodeConnInfo node = {
                 is_validator : is_validator,
-                key : key,
                 utxo: utxo,
                 client : client
             };
@@ -615,7 +611,15 @@ public class NetworkManager
             const req_delay = this.clock.localTime() - req_start;
             const dist_delay = req_delay / 2;  // divide evently
             const offset = (node_time - dist_delay) - req_start;
-            offsets ~= TimeInfo(node.key, node_time, req_delay, offset);
+
+            UTXO utxo_value;
+            this.getEnrollmentUTXO(node.utxo, utxo_value);
+            if(utxo_value == UTXO.init)
+            {
+                log.fatal("Couldn't find the UTXO for this node: {}.", node.utxo);
+                assert(0);
+            }
+            offsets ~= TimeInfo(utxo_value.output.address, node_time, req_delay, offset);
         }
 
         // we heard from at least one quorum slice

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -255,6 +255,7 @@ public class FullNode : API
         this.utxo_set = this.makeUTXOSet();
         this.pool = this.makeTransactionPool();
         this.enroll_man = this.makeEnrollmentManager();
+        this.network.setEnrollmentUTXOGetter(&this.getEnrollmentUTXO);
         this.transaction_relayer = this.makeTransactionRelayer();
         const ulong StackMaxTotalSize = 16_384;
         const ulong StackMaxItemSize = 512;
@@ -594,6 +595,28 @@ public class FullNode : API
                 commons_budget,
                 config.consensus,
                 config.node.block_interval_sec.seconds);
+    }
+
+    /***************************************************************************
+
+        Get the enrolled UTXO of this validator
+
+        Params:
+            utxo_key = key for a UTXO used in enrollment
+            utxo = will contain the UTXO for the `utxo_key`
+
+    ***************************************************************************/
+
+    public void getEnrollmentUTXO (ref Hash utxo_key, out UTXO utxo)
+        @trusted nothrow
+    {
+        if (utxo_key == Hash.init)
+            utxo_key = this.enroll_man.getEnrollmentKey();
+
+        if (utxo_key == Hash.init)
+            return;
+
+        this.utxo_set.peekUTXO(utxo_key, utxo);
     }
 
     /// Returns a newly constructed StatsServer

--- a/source/agora/registry/API.d
+++ b/source/agora/registry/API.d
@@ -14,6 +14,7 @@
 module agora.registry.API;
 
 import agora.common.Types;
+import agora.consensus.data.UTXO;
 import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.crypto.Schnorr: Signature;
@@ -24,8 +25,11 @@ import vibe.web.rest;
 ///
 public struct RegistryPayloadData
 {
-    /// the public key that we want to register
-    public PublicKey public_key;
+    /// the hash of the UTXO that we want to register
+    public Hash utxo_key;
+
+    /// the UTXO that we want to register
+    public UTXO utxo;
 
     /// network addresses associated with the public key
     public const(Address)[] addresses;
@@ -66,8 +70,7 @@ public interface NameRegistryAPI
         Get network addresses corresponding to a public key
 
         Params:
-            public_key = the public key that was used to register
-                         the network addresses
+            key = the key that was used to register the network addresses
 
         Returns:
             Network addresses associated with the `public_key`
@@ -77,7 +80,7 @@ public interface NameRegistryAPI
 
     ***************************************************************************/
 
-    public const(RegistryPayload) getValidator (PublicKey public_key);
+    public const(RegistryPayload) getValidator (Hash hash);
 
     /***************************************************************************
 


### PR DESCRIPTION
When referring to the nodes individually, we should then use the UTXO instead of the public key because public keys are not currently unique.

Relates to #1309 