### PR TITLE
Ledger.acceptBlock: Properly check for the random seed

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -534,7 +534,7 @@ extern(D):
                 return;
             }
 
-            Hash random_seed = this.ledger.getExternalizedRandomSeed(
+            Hash random_seed = this.ledger.getRandomSeed(
                 last_block.header.height + 1, con_data.missing_validators);
 
             Transaction[] received_tx_set;
@@ -707,7 +707,7 @@ extern(D):
                 assert(0);  // this should never happen
         }();
 
-        const Hash random_seed = this.ledger.getExternalizedRandomSeed(
+        const Hash random_seed = this.ledger.getRandomSeed(
                 last_block.header.height + 1, con_data.missing_validators);
 
         Transaction[] signed_tx_set;
@@ -861,7 +861,7 @@ extern(D):
             assert(0, format!"Transaction set empty for slot %s"(height));
 
         log.info("Externalized consensus data set at {}: {}", height, prettify(data));
-        Hash random_seed = this.ledger.getExternalizedRandomSeed(
+        Hash random_seed = this.ledger.getRandomSeed(
             height, data.missing_validators);
         Transaction[] externalized_tx_set;
         if (auto fail_reason = this.ledger.getValidTXSet(data,

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -217,7 +217,7 @@ public class Ledger
 
     ***************************************************************************/
 
-    public Height getBlockHeight () @safe nothrow
+    public Height getBlockHeight () const scope @safe @nogc nothrow pure
     {
         return this.last_block.header.height;
     }

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -731,12 +731,14 @@ public class Ledger
                 &this.fee_man.check,
                 this.enroll_man.getEnrollmentFinder(),
                 this.enroll_man.validator_set.countActive(block.header.height + 1),
-                this.getRandomSeed(),
                 this.last_block.header.time_offset,
                 cast(ulong) this.clock.networkTime() - this.params.GenesisTimestamp,
                 block_time_offset_tolerance,
                 &this.getCoinbaseTX))
             return reason;
+
+        if (block.header.random_seed != this.getRandomSeed())
+            return "Block: Header's random seed does not match that of known pre-images";
 
         // Finally, validate the signatures
         Point sum_K;

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -205,9 +205,9 @@ public class Ledger
 
     ***************************************************************************/
 
-    public const(Block) getLastBlock () const @safe @nogc nothrow pure
+    public ref const(Block) getLastBlock () const scope @safe @nogc nothrow pure
     {
-        return last_block;
+        return this.last_block;
     }
 
     /***************************************************************************


### PR DESCRIPTION
The Ledger had two methods with similar name and use: getRandomSeed and getExternalizedRandomSeed.
The former was only used in Ledger.acceptBlock, while the later was used everywhere else the random
seed was needed. Upon closer inspection, it became obvious that 'getRandomSeed' was using
the presently-known Ledger state while getExternalizedRandomSeed had a much more predictable output.
In essence, 'getRandomSeed' could have been 'getCandidateRandomSeed'. This discrepancy could create
issues if a block which slashes a validator was externalized, but we received the pre-image in the
meantime, leading to a different random seed. With the removal of the former 'getRandomSeed' function,
we now have a predictable output (new state won't interfere).
In the process, the verbosely-name 'getExternalizedRandomSeed' was renamed to 'getRandomSeed'.