### PR TITLE
Nominator: Externalize block via the node's acceptBlock method

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -408,7 +408,7 @@ public class Validator : FullNode, API
         return new Nominator(
             this.params, this.config.validator.key_pair, clock, network, ledger,
             enroll_man, taskman, this.config.node.data_dir,
-            this.config.validator.nomination_interval);
+            this.config.validator.nomination_interval, &this.acceptBlock);
     }
 
     /***************************************************************************

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1804,7 +1804,7 @@ public class TestValidatorNode : Validator, TestAPI
         return new TestNominator(
             this.params, this.config.validator.key_pair, args,
             this.config.node.data_dir, this.config.validator.nomination_interval,
-            this.txs_to_nominate, this.test_start_time);
+            &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
     }
 
     /// Provides a unittest-adjusted clock source for the node

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -102,7 +102,7 @@ class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new ByzantineNominator(
             this.params, this.config.validator.key_pair, args,
             this.config.node.data_dir, this.config.validator.nomination_interval,
-            this.txs_to_nominate, this.test_start_time, reason);
+            &this.acceptBlock, this.txs_to_nominate, this.test_start_time, reason);
     }
 }
 
@@ -162,7 +162,8 @@ private class SpyingValidator : TestValidatorNode
         return new SpyNominator(
             this.params, this.config.validator.key_pair, args,
             this.config.node.data_dir, this.config.validator.nomination_interval,
-            this.txs_to_nominate, this.test_start_time, this.envelope_type_counts);
+            &this.acceptBlock, this.txs_to_nominate, this.test_start_time,
+            this.envelope_type_counts);
     }
 }
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -251,7 +251,8 @@ unittest
             return new BadNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.config.node.data_dir, this.config.validator.nomination_interval,
-                this.txs_to_nominate, this.test_start_time, this.runCount);
+                &this.acceptBlock, this.txs_to_nominate, this.test_start_time,
+                this.runCount);
         }
     }
 

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -105,7 +105,7 @@ private class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new BadBlockSigningNominator(
             this.params, this.config.validator.key_pair, args,
             this.config.node.data_dir, this.config.validator.nomination_interval,
-            this.txs_to_nominate, this.test_start_time, reason);
+            &this.acceptBlock, this.txs_to_nominate, this.test_start_time, reason);
     }
 }
 

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -114,7 +114,7 @@ private class BadNominatingVN : TestValidatorNode
         return new BadNominator(
             this.params, this.config.validator.key_pair, args,
             this.config.node.data_dir, this.config.validator.nomination_interval,
-            this.txs_to_nominate, this.test_start_time);
+            &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
     }
 }
 

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -75,7 +75,7 @@ unittest
             return new CustomNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.config.node.data_dir, this.config.validator.nomination_interval,
-                this.txs_to_nominate, this.test_start_time);
+                &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
         }
     }
 

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -76,7 +76,7 @@ private class TestNode () : TestValidatorNode
         return new DoesNotExternalizeBlockNominator(
             this.params, this.config.validator.key_pair, args,
             this.config.node.data_dir, this.config.validator.nomination_interval,
-            this.txs_to_nominate, this.test_start_time);
+            &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
     }
 }
 

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -115,7 +115,7 @@ unittest
             return new ReNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.config.node.data_dir, this.config.validator.nomination_interval,
-                this.txs_to_nominate, this.test_start_time);
+                &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
         }
     }
 

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -194,7 +194,7 @@ unittest
             return new SocialDistancingNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.config.node.data_dir, this.config.validator.nomination_interval,
-                this.txs_to_nominate, this.test_start_time);
+                &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
         }
 
     }


### PR DESCRIPTION
Before this change, the Nominator would directly externalize things through the Ledger.
The major downside of this approach is that any kind of special handling done by the
FullNode.acceptBlock (and Validator.acceptBlock) method is bypassed.
This became obvious then the stats were moved out of the Ledger and were not recorded anymore,
but it also means that the network whitelisting code of the FullNode was bypassed.