### PR TITLE
NetworkClient: Use separate logger per validator

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -183,6 +183,7 @@ public class NetworkManager
                     }
 
                     key = id.key;
+                    client.setIdentity(id.key);
                     break;
                 }
                 catch (Exception ex)


### PR DESCRIPTION
This coupled with the ability to dynamically (re)configure logger will
make it easier to track down what is going on with a particular peer.