### PR TITLE
Fix TransactionReplacement test as CoinBase is not always at index 0

### DIFF
--- a/source/agora/test/TransactionReplacement.d
+++ b/source/agora/test/TransactionReplacement.d
@@ -81,5 +81,5 @@ unittest
 
     // verify that the transaction with fee 13000 is the only one inncluded in the block
     assert(block.txs.length == 2); // Coinbase + our transaction
-    assert(block.txs[1] == txs[4]);
+    assert(block.txs.filter!(tx => tx.type == TxType.Payment).front() == txs[4]);
 }


### PR DESCRIPTION
My last minutes changes in PR1881 led to some spurious failures,
as Coinbase seems to not be consistently the first entry in the block.