### PR TITLE
Simplify SCP store by re-using the cache DB

### DIFF
--- a/source/agora/consensus/SCPEnvelopeStore.d
+++ b/source/agora/consensus/SCPEnvelopeStore.d
@@ -25,7 +25,6 @@ import d2sqlite3.sqlite3;
 
 import scpd.types.Stellar_SCP;
 
-import std.file : exists;
 import std.range;
 
 
@@ -43,19 +42,15 @@ public class SCPEnvelopeStore
         Constructor
 
         Params:
-            db_path = path to the database file, or in-memory storage if
-                      :memory: was passed
+            db = Cache database to store SCP envelopes
 
     ***************************************************************************/
 
-    public this (in string db_path)
+    public this (ManagedDatabase db)
     {
         this.log = Logger(__MODULE__);
-        const db_exists = db_path.exists;
-        if (db_exists)
-            log.info("Loading database from: {}", db_path);
-
-        this.db = new ManagedDatabase(db_path);
+        assert(db !is null);
+        this.db = db;
 
         this.db.execute("CREATE TABLE IF NOT EXISTS scp_envelopes " ~
             "(seq INTEGER PRIMARY KEY AUTOINCREMENT, envelope BLOB NOT NULL)");
@@ -175,7 +170,7 @@ public class SCPEnvelopeStore
 /// add & opApply & remove tests
 unittest
 {
-    auto envelope_store = new SCPEnvelopeStore(":memory:");
+    auto envelope_store = new SCPEnvelopeStore(new ManagedDatabase(":memory:"));
 
     SCPEnvelope[] envelopes;
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -163,7 +163,7 @@ extern(D):
 
     public this (immutable(ConsensusParams) params, KeyPair key_pair,
         Clock clock, NetworkManager network, ValidatingLedger ledger,
-        EnrollmentManager enroll_man, ITaskManager taskman, string data_dir,
+        EnrollmentManager enroll_man, ITaskManager taskman, ManagedDatabase cacheDB,
         Duration nomination_interval,
         bool delegate (const ref Block) @safe externalize)
     {
@@ -182,7 +182,7 @@ extern(D):
         this.taskman = taskman;
         this.ledger = ledger;
         this.enroll_man = enroll_man;
-        this.scp_envelope_store = this.makeSCPEnvelopeStore(data_dir);
+        this.scp_envelope_store = new SCPEnvelopeStore(cacheDB);
         this.restoreSCPState();
         this.nomination_interval = nomination_interval;
         this.acceptBlock = externalize;
@@ -645,23 +645,6 @@ extern(D):
             this.scp_envelope_store.add(env);
 
         ManagedDatabase.commitBatch();
-    }
-
-    /***************************************************************************
-
-        Returns an instance of an SCPEnvelopeStore
-
-        Params:
-            data_dir = path to the data directory
-
-        Returns:
-            the SCPEnvelopeStore instance
-
-    ***************************************************************************/
-
-    protected SCPEnvelopeStore makeSCPEnvelopeStore (string data_dir)
-    {
-        return new SCPEnvelopeStore(buildPath(data_dir, "scp_envelopes.dat"));
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -407,7 +407,7 @@ public class Validator : FullNode, API
     {
         return new Nominator(
             this.params, this.config.validator.key_pair, clock, network, ledger,
-            enroll_man, taskman, this.config.node.data_dir,
+            enroll_man, taskman, this.cacheDB,
             this.config.validator.nomination_interval, &this.acceptBlock);
     }
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -520,18 +520,6 @@ extern(D):
 
         return true;
     }
-
-    // set the DB instance of SCPEnvelopeStore
-    protected void setSCPEnvelopeStore (SCPEnvelopeStore envelope_store)
-    {
-        this.scp_envelope_store = envelope_store;
-    }
-
-    // return a SCPEnvelopeStore backed by an in-memory SQLite db
-    protected override SCPEnvelopeStore makeSCPEnvelopeStore (string data_dir)
-    {
-        return new SCPEnvelopeStore(":memory:");
-    }
 }
 
 /// We use a pair of (key, client) rather than a hashmap client[key],
@@ -1803,7 +1791,7 @@ public class TestValidatorNode : Validator, TestAPI
     {
         return new TestNominator(
             this.params, this.config.validator.key_pair, args,
-            this.config.node.data_dir, this.config.validator.nomination_interval,
+            this.cacheDB, this.config.validator.nomination_interval,
             &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
     }
 

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -101,7 +101,7 @@ class ByzantineNode (ByzantineReason reason) : TestValidatorNode
     {
         return new ByzantineNominator(
             this.params, this.config.validator.key_pair, args,
-            this.config.node.data_dir, this.config.validator.nomination_interval,
+            this.cacheDB, this.config.validator.nomination_interval,
             &this.acceptBlock, this.txs_to_nominate, this.test_start_time, reason);
     }
 }
@@ -161,7 +161,7 @@ private class SpyingValidator : TestValidatorNode
     {
         return new SpyNominator(
             this.params, this.config.validator.key_pair, args,
-            this.config.node.data_dir, this.config.validator.nomination_interval,
+            this.cacheDB, this.config.validator.nomination_interval,
             &this.acceptBlock, this.txs_to_nominate, this.test_start_time,
             this.envelope_type_counts);
     }

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -250,7 +250,7 @@ unittest
         {
             return new BadNominator(
                 this.params, this.config.validator.key_pair, args,
-                this.config.node.data_dir, this.config.validator.nomination_interval,
+                this.cacheDB, this.config.validator.nomination_interval,
                 &this.acceptBlock, this.txs_to_nominate, this.test_start_time,
                 this.runCount);
         }

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -104,7 +104,7 @@ private class ByzantineNode (ByzantineReason reason) : TestValidatorNode
     {
         return new BadBlockSigningNominator(
             this.params, this.config.validator.key_pair, args,
-            this.config.node.data_dir, this.config.validator.nomination_interval,
+            this.cacheDB, this.config.validator.nomination_interval,
             &this.acceptBlock, this.txs_to_nominate, this.test_start_time, reason);
     }
 }

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -113,7 +113,7 @@ private class BadNominatingVN : TestValidatorNode
     {
         return new BadNominator(
             this.params, this.config.validator.key_pair, args,
-            this.config.node.data_dir, this.config.validator.nomination_interval,
+            this.cacheDB, this.config.validator.nomination_interval,
             &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
     }
 }

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -74,7 +74,7 @@ unittest
         {
             return new CustomNominator(
                 this.params, this.config.validator.key_pair, args,
-                this.config.node.data_dir, this.config.validator.nomination_interval,
+                this.cacheDB, this.config.validator.nomination_interval,
                 &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
         }
     }

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -75,7 +75,7 @@ private class TestNode () : TestValidatorNode
     {
         return new DoesNotExternalizeBlockNominator(
             this.params, this.config.validator.key_pair, args,
-            this.config.node.data_dir, this.config.validator.nomination_interval,
+            this.cacheDB, this.config.validator.nomination_interval,
             &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
     }
 }

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -193,7 +193,7 @@ unittest
         {
             return new SocialDistancingNominator(
                 this.params, this.config.validator.key_pair, args,
-                this.config.node.data_dir, this.config.validator.nomination_interval,
+                this.cacheDB, this.config.validator.nomination_interval,
                 &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
         }
 


### PR DESCRIPTION
We recently moved dependency injection of the level of the database,
which considerably simplifies the amount of code duplication and
work needed to do testing. The SCP cache was originally forgotten in that process,
this commit rectifies this.