### PR TITLE
Part of #1658: Correct random seed calculation

### DIFF
--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -573,6 +573,49 @@ public bool isGenesisBlockValid (in Block genesis_block)
 
 version (unittest)
 {
+    import agora.consensus.PreImage;
+    import std.array;
+    import std.range;
+
+    PreImageCycle[] wellKnownPreimageCycles;
+    ulong[PublicKey] publicKeyToIndex;
+
+    public ref PreImageCycle getWellKnownPreimages (KeyPair kp) @safe nothrow
+    {
+        const uint Cycle = 20;
+        if (kp.address !in publicKeyToIndex)
+        {
+            publicKeyToIndex[kp.address] = wellKnownPreimageCycles.length;
+            wellKnownPreimageCycles ~= PreImageCycle(kp.secret, Cycle);
+        }
+        return wellKnownPreimageCycles[publicKeyToIndex[kp.address]];
+    }
+
+    public Hash[] wellKnownPreimages (Keys)(Height height, Keys key_pairs) @safe nothrow
+    in
+    {
+        static assert(isInputRange!Keys);
+        static assert (is(ElementType!Keys : KeyPair));
+    }
+    do
+    {
+        return key_pairs.map!(kp => getWellKnownPreimages(kp)[height]).array;
+    }
+
+    // Check that cached cycles can handle being used with previous cycle heights
+    unittest
+    {
+        auto only_node2 = only(WK.Keys.NODE2);
+        Hash[] preimages_height_0 = wellKnownPreimages(Height(0), only_node2);
+        Hash[] preimages_height_1 = wellKnownPreimages(Height(1), only_node2);
+        // fetch from previous height within the first cycle
+        assert(wellKnownPreimages(Height(0), only_node2) == preimages_height_0);
+        // preimage from second cycle
+        Hash[] preimages_height_21 = wellKnownPreimages(Height(21), only_node2);
+        // check we can fetch preimages from previous cycle
+        assert(wellKnownPreimages(Height(1), only_node2) == preimages_height_1);
+    }
+
     public string isValidcheck (in Block block, Engine engine, Height prev_height,
         Hash prev_hash, scope UTXOFinder findUTXO,
         size_t enrolled_validators, scope FeeChecker checkFee,
@@ -946,7 +989,7 @@ unittest
                               "3864fc1c8fd1469f4be80b853764da53f6a5b41661");
     uint[] missing_validators = [];
 
-    auto block3 = makeNewTestBlock(block2, txs_3, preimage_root, genesis_validator_keys, enrollments,
+    auto block3 = makeNewTestBlock(block2, txs_3, genesis_validator_keys, enrollments,
         missing_validators);
     block3.assertValid(engine, block2.header.height, hashFull(block2.header), findUTXO,
         Enrollment.MinValidatorCount, checker, findGenesisEnrollments);
@@ -1086,7 +1129,7 @@ unittest
                                   "3864fc1c8fd1469f4be80b853764da53f6a5b41661");
         uint[] missing_validators = [];
 
-        auto block3 = makeNewTestBlock(block2, txs_3, preimage_root, genesis_validator_keys, enrollments,
+        auto block3 = makeNewTestBlock(block2, txs_3, genesis_validator_keys, enrollments,
             missing_validators);
         assert(block3.header.enrollments.length == Enrollment.MinValidatorCount);
         block3.assertValid(engine, block2.header.height, hashFull(block2.header),

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -169,9 +169,9 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
             WK.Keys.NODE2.address,
             WK.Keys.C.address,
+            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE4.address,
         ]),
@@ -179,8 +179,8 @@ unittest
         // 1
         QuorumConfig(6, [
             WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address,
             WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
             WK.Keys.C.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
@@ -190,8 +190,8 @@ unittest
         // 2
         QuorumConfig(6, [
             WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address,
             WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
             WK.Keys.C.address,
             WK.Keys.NODE3.address,
             WK.Keys.A.address,
@@ -203,8 +203,8 @@ unittest
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address,
             WK.Keys.NODE6.address,
+            WK.Keys.NODE2.address,
             WK.Keys.C.address,
-            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE4.address,
         ]),
@@ -223,6 +223,17 @@ unittest
         // 5
         QuorumConfig(6, [
             WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address,
+            WK.Keys.NODE6.address,
+            WK.Keys.NODE2.address,
+            WK.Keys.C.address,
+            WK.Keys.A.address,
+            WK.Keys.NODE4.address,
+        ]),
+
+        // 6
+        QuorumConfig(6, [
+            WK.Keys.NODE7.address,
             WK.Keys.NODE6.address,
             WK.Keys.NODE2.address,
             WK.Keys.C.address,
@@ -231,21 +242,10 @@ unittest
             WK.Keys.NODE4.address,
         ]),
 
-        // 6
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
-
         // 7
         QuorumConfig(6, [
-            WK.Keys.NODE7.address,
             WK.Keys.NODE5.address,
+            WK.Keys.NODE6.address,
             WK.Keys.NODE2.address,
             WK.Keys.C.address,
             WK.Keys.NODE3.address,
@@ -282,17 +282,17 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address,
+            WK.Keys.NODE6.address,
             WK.Keys.NODE2.address,
             WK.Keys.C.address,
-            WK.Keys.NODE3.address,
             WK.Keys.A.address,
             WK.Keys.NODE4.address,
         ]),
 
         // 1
         QuorumConfig(6, [
+            WK.Keys.NODE7.address,
             WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
             WK.Keys.NODE2.address,
             WK.Keys.C.address,
             WK.Keys.NODE3.address,
@@ -303,7 +303,7 @@ unittest
         // 2
         QuorumConfig(6, [
             WK.Keys.NODE7.address,
-            WK.Keys.NODE6.address,
+            WK.Keys.NODE5.address,
             WK.Keys.NODE2.address,
             WK.Keys.C.address,
             WK.Keys.NODE3.address,
@@ -315,17 +315,6 @@ unittest
         QuorumConfig(6, [
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
-
-        // 4
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE6.address,
             WK.Keys.NODE2.address,
             WK.Keys.C.address,
             WK.Keys.NODE3.address,
@@ -333,7 +322,29 @@ unittest
             WK.Keys.NODE4.address,
         ]),
 
+        // 4
+        QuorumConfig(6, [
+            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address,
+            WK.Keys.NODE6.address,
+            WK.Keys.NODE2.address,
+            WK.Keys.C.address,
+            WK.Keys.NODE3.address,
+            WK.Keys.A.address,
+        ]),
+
         // 5
+        QuorumConfig(6, [
+            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address,
+            WK.Keys.NODE6.address,
+            WK.Keys.NODE2.address,
+            WK.Keys.C.address,
+            WK.Keys.NODE3.address,
+            WK.Keys.A.address,
+        ]),
+
+        // 6
         QuorumConfig(6, [
             WK.Keys.NODE7.address,
             WK.Keys.NODE5.address,
@@ -344,20 +355,9 @@ unittest
             WK.Keys.NODE4.address,
         ]),
 
-        // 6
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
-
         // 7
         QuorumConfig(6, [
-            WK.Keys.NODE7.address,
+            WK.Keys.NODE5.address,
             WK.Keys.NODE6.address,
             WK.Keys.NODE2.address,
             WK.Keys.C.address,


### PR DESCRIPTION
The random seed was incorrectly including `Hash.init` as the first item
hashed. It should only be the `preimage`s of the active validators.
The unit tests were also bypassing the testing of the random seed as the
tests did not have the `preimage`s available. Now there is a `preimage`
cache created using the `well known keypairs` which is used in the tests
to simulate `preimage`s being revealed.