### PR TITLE
Issue1248 sorted tx inputs output tx type at output level

### DIFF
--- a/doc/Database.md
+++ b/doc/Database.md
@@ -11,14 +11,14 @@ For more informations, see [this description](https://github.com/bosagora/agora/
 
 Our oldest table, only contain binary serialized data, should be changed to a readable format.
 
-| Field name      | SQL Type | D type    | Attributes  | Comment                                                |
-|-----------------|----------|-----------|-------------|--------------------------------------------------------|
-| `hash`          | TEXT     | string    | PRIMARY KEY | The hash of the UTXO (`hashMulti(txhash, index)`)      |
-| `unlock_height` | INTEGER  | Height    | NOT NULL    | See `UTXO` struct                                      |
-| `type`          | INTEGER  | TxType    | NOT NULL    | See `UTXO` struct                                      |
-| `amount`        | INTEGER  | Amount    | NOT NULL    | See `Output` struct                                    |
-| `locktype`      | INTEGER  | LockType  | NOT NULL    | See `Lock` struct                                      |
-| `lock`          | BLOB     | ubyte[]   | NOT NULL    | See `Lock` struct                                      |
+| Field name      | SQL Type | D type      | Attributes  | Comment                                                |
+|-----------------|----------|-------------|-------------|--------------------------------------------------------|
+| `hash`          | TEXT     | string      | PRIMARY KEY | The hash of the UTXO (`hashMulti(txhash, index)`)      |
+| `unlock_height` | INTEGER  | Height      | NOT NULL    | See `UTXO` struct                                      |
+| `type`          | INTEGER  | OutputType | NOT NULL    | See `UTXO` struct                                      |
+| `amount`        | INTEGER  | Amount      | NOT NULL    | See `Output` struct                                    |
+| `locktype`      | INTEGER  | LockType    | NOT NULL    | See `Lock` struct                                      |
+| `lock`          | BLOB     | ubyte[]     | NOT NULL    | See `Lock` struct                                      |
 
 ### `validator` table
 

--- a/source/agora/cli/client/SendTxProcess.d
+++ b/source/agora/cli/client/SendTxProcess.d
@@ -184,8 +184,7 @@ public int sendTxProcess (string[] args, ref string[] outputs,
     // create the transaction
     auto key_pair = KeyPair.fromSeed(SecretKey.fromString(op.key));
 
-    Transaction tx = Transaction(TxType.Payment,
-        [Input(Hash.fromString(op.txhash), op.index)],
+    Transaction tx = Transaction([Input(Hash.fromString(op.txhash), op.index)],
         [Output(Amount(op.amount), PublicKey.fromString(op.address))]);
 
     auto signature = key_pair.sign(tx);
@@ -267,8 +266,7 @@ unittest
     });
     assert (res == CLIENT_SUCCESS);
 
-    Transaction tx = Transaction(TxType.Payment,
-        [Input(Hash.fromString(txhash), index)],
+    Transaction tx = Transaction([Input(Hash.fromString(txhash), index)],
         [Output(Amount(amount), PublicKey.fromString(address))]);
     Hash send_txhash = hashFull(tx);
     auto key_pair = KeyPair.fromSeed(SecretKey.fromString(key));

--- a/source/agora/cli/client/SendTxProcess.d
+++ b/source/agora/cli/client/SendTxProcess.d
@@ -184,12 +184,9 @@ public int sendTxProcess (string[] args, ref string[] outputs,
     // create the transaction
     auto key_pair = KeyPair.fromSeed(SecretKey.fromString(op.key));
 
-    Transaction tx =
-    {
-        TxType.Payment,
+    Transaction tx = Transaction(TxType.Payment,
         [Input(Hash.fromString(op.txhash), op.index)],
-        [Output(Amount(op.amount), PublicKey.fromString(op.address))]
-    };
+        [Output(Amount(op.amount), PublicKey.fromString(op.address))]);
 
     auto signature = key_pair.sign(tx);
     tx.inputs[0].unlock = genKeyUnlock(signature);
@@ -270,12 +267,9 @@ unittest
     });
     assert (res == CLIENT_SUCCESS);
 
-    Transaction tx =
-    {
-        TxType.Payment,
+    Transaction tx = Transaction(TxType.Payment,
         [Input(Hash.fromString(txhash), index)],
-        [Output(Amount(amount), PublicKey.fromString(address))]
-    };
+        [Output(Amount(amount), PublicKey.fromString(address))]);
     Hash send_txhash = hashFull(tx);
     auto key_pair = KeyPair.fromSeed(SecretKey.fromString(key));
     tx.inputs[0].unlock = genKeyUnlock(key_pair.sign(send_txhash[]));

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -997,7 +997,7 @@ unittest
         .enumerate
         .map!(tup => tup.value
             .refund(pairs[tup.index].address)
-            .sign(TxType.Freeze))
+            .sign(OutputType.Freeze))
         .each!((tx) {
             utxo_set.put(tx);
             utxo_hashes ~= UTXO.getHash(tx.hashFull(), 0);
@@ -1140,7 +1140,7 @@ unittest
         .enumerate
         .map!(tup => tup.value
             .refund(pairs[tup.index].address)
-            .sign(TxType.Freeze))
+            .sign(OutputType.Freeze))
         .each!((tx) {
             utxo_set.put(tx);
             utxo_hashes ~= UTXO.getHash(tx.hashFull(), 0);
@@ -1231,7 +1231,7 @@ unittest
         new immutable(ConsensusParams)(validator_cycle));
 
     scope utxo_set = new UTXOSet(man.db);
-    genesisSpendable().map!(txb => txb.refund(key_pair.address).sign(TxType.Freeze))
+    genesisSpendable().map!(txb => txb.refund(key_pair.address).sign(OutputType.Freeze))
         .each!(tx => utxo_set.updateUTXOCache(tx, Height(1), man.params.CommonsBudgetAddress));
     auto utxos = utxo_set.getUTXOs(key_pair.address);
 
@@ -1298,7 +1298,7 @@ unittest
         .enumerate
         .map!(tup => tup.value
             .refund(pairs[tup.index].address)
-            .sign(TxType.Freeze))
+            .sign(OutputType.Freeze))
         .each!((tx) {
             storage.put(tx);
             utxos ~= UTXO.getHash(tx.hashFull(), 0);
@@ -1342,7 +1342,7 @@ unittest
 
     auto utxo_set = new TestUTXOSet;
     genesisSpendable()
-        .map!(txb => txb.refund(WK.Keys.A.address).sign(TxType.Freeze))
+        .map!(txb => txb.refund(WK.Keys.A.address).sign(OutputType.Freeze))
         .each!(tx => utxo_set.put(tx));
     auto man = new EnrollmentManager(WK.Keys.A,
         new immutable(ConsensusParams)(10));
@@ -1362,7 +1362,7 @@ unittest
     scope utxo_set = new TestUTXOSet;
     KeyPair key_pair = KeyPair.random();
 
-    genesisSpendable().map!(txb => txb.refund(key_pair.address).sign(TxType.Freeze))
+    genesisSpendable().map!(txb => txb.refund(key_pair.address).sign(OutputType.Freeze))
         .each!(tx => utxo_set.put(tx));
     Hash[] utxo_hashes = utxo_set.keys;
 
@@ -1404,7 +1404,7 @@ unittest
     auto man = new EnrollmentManager(key_pair, params);
 
     scope utxo_set = new UTXOSet(man.db);
-    genesisSpendable().map!(txb => txb.refund(key_pair.address).sign(TxType.Freeze))
+    genesisSpendable().map!(txb => txb.refund(key_pair.address).sign(OutputType.Freeze))
         .each!(tx => utxo_set.updateUTXOCache(tx, Height(1), man.params.CommonsBudgetAddress));
     auto utxos = utxo_set.getUTXOs(key_pair.address);
     Hash[] utxo_hashes = utxos.keys;
@@ -1473,7 +1473,7 @@ unittest
     auto utxo_set = new TestUTXOSet;
     genesisSpendable()
         .enumerate.map!(tup => tup.value
-            .refund(WK.Keys[tup.index].address).sign(TxType.Freeze))
+            .refund(WK.Keys[tup.index].address).sign(OutputType.Freeze))
         .each!((tx) {
             utxo_set.put(tx);
             utxos ~= UTXO.getHash(tx.hashFull(), 0);

--- a/source/agora/consensus/EnrollmentPool.d
+++ b/source/agora/consensus/EnrollmentPool.d
@@ -369,7 +369,7 @@ unittest
         return false;
     }
 
-    genesisSpendable().map!(txb => txb.refund(key_pair.address).sign(TxType.Freeze))
+    genesisSpendable().map!(txb => txb.refund(key_pair.address).sign(OutputType.Freeze))
         .each!(tx => storage.put(tx));
 
     // Add enrollments

--- a/source/agora/consensus/Fee.d
+++ b/source/agora/consensus/Fee.d
@@ -558,12 +558,10 @@ unittest
 
     auto fee_man = new FeeManager();
 
-    Transaction freeze_tx = {
+    Transaction freeze_tx = Transaction(
         TxType.Freeze,
-        outputs: [
-            Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address),
-        ]
-    };
+        null, // no inputs
+        [ Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address) ]);
 
     auto utxo_set = new TestUTXOSet;
     utxo_set.put(freeze_tx);
@@ -571,23 +569,16 @@ unittest
     Hash txhash = hashFull(freeze_tx);
     Hash stake_hash = UTXO.getHash(txhash, 0);
 
-    Transaction gen_tx = {
+    Transaction gen_tx = Transaction(
         TxType.Payment,
-        outputs: [
-            Output(Amount(2_000_000L), WK.Keys.NODE2.address),
-        ]
-    };
+        null, // no inputs
+        [ Output(Amount(2_000_000L), WK.Keys.NODE2.address) ]);
     utxo_set.put(gen_tx);
 
-    Transaction spend_tx = {
+    Transaction spend_tx = Transaction(
         TxType.Payment,
-        inputs: [
-            Input(gen_tx.hashFull(), 0)
-        ],
-        outputs: [
-            Output(Amount(1_000_000L), WK.Keys.NODE2.address),
-        ]
-    };
+        [ Input(gen_tx.hashFull(), 0)],
+        [ Output(Amount(1_000_000L), WK.Keys.NODE2.address) ]);
 
     UTXO utxo;
     assert(utxo_set.peekUTXO(spend_tx.inputs[0].utxo, utxo));

--- a/source/agora/consensus/Fee.d
+++ b/source/agora/consensus/Fee.d
@@ -457,7 +457,7 @@ public class FeeManager
         foreach (const ref tx; tx_set)
         {
             // Coinbase TXs are not subject to fees
-            if (tx.type == TxType.Coinbase)
+            if (tx.isCoinbaseTx)
                 continue;
 
             Amount tot_in, tot_out;
@@ -502,12 +502,12 @@ public class FeeManager
 
         Amount double_stake = Amount.MinFreezeAmount; assert(double_stake.mul(2));
         auto frozen_txs = [
-            Transaction(TxType.Freeze, [], [Output(Amount.MinFreezeAmount,
-                WK.Keys[0].address)]),
-            Transaction(TxType.Freeze, [], [Output(Amount.MinFreezeAmount,
-                WK.Keys[0].address)]),
-            Transaction(TxType.Freeze, [], [Output(double_stake,
-                WK.Keys[0].address)]),
+            Transaction([], [Output(Amount.MinFreezeAmount,
+                WK.Keys[0].address, OutputType.Freeze)]),
+            Transaction([], [Output(Amount.MinFreezeAmount,
+                WK.Keys[0].address, OutputType.Freeze)]),
+            Transaction([], [Output(double_stake,
+                WK.Keys[0].address, OutputType.Freeze)]),
         ];
 
         frozen_txs.each!(tx => utxoset.put(tx));
@@ -559,8 +559,7 @@ unittest
     auto fee_man = new FeeManager();
 
     Transaction freeze_tx = Transaction(
-        TxType.Freeze,
-        [ Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address) ]);
+        [ Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address, OutputType.Freeze) ]);
 
     auto utxo_set = new TestUTXOSet;
     utxo_set.put(freeze_tx);
@@ -569,12 +568,10 @@ unittest
     Hash stake_hash = UTXO.getHash(txhash, 0);
 
     Transaction gen_tx = Transaction(
-        TxType.Payment,
         [ Output(Amount(2_000_000L), WK.Keys.NODE2.address) ]);
     utxo_set.put(gen_tx);
 
     Transaction spend_tx = Transaction(
-        TxType.Payment,
         [ Input(gen_tx.hashFull(), 0)],
         [ Output(Amount(1_000_000L), WK.Keys.NODE2.address) ]);
 

--- a/source/agora/consensus/Fee.d
+++ b/source/agora/consensus/Fee.d
@@ -560,7 +560,6 @@ unittest
 
     Transaction freeze_tx = Transaction(
         TxType.Freeze,
-        null, // no inputs
         [ Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address) ]);
 
     auto utxo_set = new TestUTXOSet;
@@ -571,7 +570,6 @@ unittest
 
     Transaction gen_tx = Transaction(
         TxType.Payment,
-        null, // no inputs
         [ Output(Amount(2_000_000L), WK.Keys.NODE2.address) ]);
     utxo_set.put(gen_tx);
 

--- a/source/agora/consensus/Quorum.d
+++ b/source/agora/consensus/Quorum.d
@@ -490,7 +490,7 @@ private QuorumConfig[PublicKey] buildTestQuorums (Range)(Range amounts,
     TestUTXOSet storage = new TestUTXOSet;
     foreach (idx, const ref amount; amounts.save.enumerate)
     {
-        Transaction tx = Transaction(TxType.Freeze, null, [ Output(amount, keys[idx]) ]);
+        Transaction tx = Transaction([ Output(amount, keys[idx], OutputType.Freeze) ]);
 
         // simulating our own UTXO hashes to make the tests stable
         Hash txhash = hashMulti(id, idx, amount);
@@ -498,7 +498,6 @@ private QuorumConfig[PublicKey] buildTestQuorums (Range)(Range amounts,
         {
             Hash h = UTXO.getHash(txhash, out_idx);
             UTXO v = {
-                type: tx.type,
                 output: output_
             };
             storage[txhash] = v;

--- a/source/agora/consensus/Quorum.d
+++ b/source/agora/consensus/Quorum.d
@@ -490,11 +490,7 @@ private QuorumConfig[PublicKey] buildTestQuorums (Range)(Range amounts,
     TestUTXOSet storage = new TestUTXOSet;
     foreach (idx, const ref amount; amounts.save.enumerate)
     {
-        Transaction tx =
-        {
-            type : TxType.Freeze,
-            outputs: [Output(amount, keys[idx])]
-        };
+        Transaction tx = Transaction(TxType.Freeze, null, [ Output(amount, keys[idx]) ]);
 
         // simulating our own UTXO hashes to make the tests stable
         Hash txhash = hashMulti(id, idx, amount);

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -129,7 +129,7 @@ unittest
     PublicKey pubkey = PublicKey.fromString(address);
 
     Output[1] outputs = [ Output(Amount(100), pubkey) ];
-    Transaction tx = Transaction(TxType.Payment, [], outputs[]);
+    Transaction tx = Transaction(outputs[]);
     BlockHeader header = { merkle_root : tx.hashFull() };
 
     auto hash = hashFull(header);
@@ -436,13 +436,13 @@ public struct Block
     /// Returns a range of any freeze transactions in this block
     public auto frozens () const @safe pure nothrow
     {
-        return this.txs.filter!(tx => tx.type == TxType.Freeze);
+        return this.txs.filter!(tx => tx.isFreezeTx);
     }
 
     /// Returns a range of any payment transactions in this block
     public auto payments () const @safe pure nothrow
     {
-        return this.txs.filter!(tx => tx.type == TxType.Payment);
+        return this.txs.filter!(tx => tx.isPaymentTx);
     }
 }
 
@@ -458,7 +458,6 @@ unittest
     PublicKey pubkey = PublicKey.fromString(address);
 
     Transaction tx = Transaction(
-        TxType.Payment,
         [
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
@@ -696,7 +695,7 @@ unittest
     Hash last_hash = Hash.init;
     for (int idx = 0; idx < 8; idx++)
     {
-        auto tx = Transaction(TxType.Payment, [Input(last_hash, 0)],[Output(Amount(100_000), key_pairs[idx+1].address)]);
+        auto tx = Transaction([Input(last_hash, 0)],[Output(Amount(100_000), key_pairs[idx+1].address)]);
         last_hash = hashFull(tx);
         tx.inputs[0].unlock = genKeyUnlock(
             key_pairs[idx].sign(last_hash[]));
@@ -766,7 +765,7 @@ unittest
 
     foreach (amount; 0 .. 9)
     {
-        txs ~= Transaction(TxType.Payment,
+        txs ~= Transaction(
             [Input(Hash.init, 0)],
             [Output(Amount(amount + 1), kp.address)]);
         hashes ~= hashFull(txs[$ - 1]);

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -459,7 +459,6 @@ unittest
 
     Transaction tx = Transaction(
         TxType.Payment,
-        null, // no inputs
         [
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
             Output(Amount(62_500_000L * 10_000_000L), pubkey),

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -129,7 +129,7 @@ unittest
     PublicKey pubkey = PublicKey.fromString(address);
 
     Output[1] outputs = [ Output(Amount(100), pubkey) ];
-    Transaction tx = { outputs: outputs[] };
+    Transaction tx = Transaction(TxType.Payment, [], outputs[]);
     BlockHeader header = { merkle_root : tx.hashFull() };
 
     auto hash = hashFull(header);
@@ -457,10 +457,10 @@ unittest
     immutable address = `boa1xrra39xpg5q9zwhsq6u7pw508z2let6dj8r5lr4q0d0nff240fvd27yme3h`;
     PublicKey pubkey = PublicKey.fromString(address);
 
-    Transaction tx =
-    {
+    Transaction tx = Transaction(
         TxType.Payment,
-        outputs: [
+        null, // no inputs
+        [
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
@@ -468,9 +468,8 @@ unittest
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
             Output(Amount(62_500_000L * 10_000_000L), pubkey),
-            Output(Amount(62_500_000L * 10_000_000L), pubkey),
-        ],
-    };
+            Output(Amount(62_500_000L * 10_000_000L), pubkey)
+        ]);
 
     auto validators = typeof(BlockHeader.validators)(6);
     validators[0] = true;
@@ -695,11 +694,10 @@ unittest
     ];
 
     // Create transactions.
-    Transaction tx;
     Hash last_hash = Hash.init;
     for (int idx = 0; idx < 8; idx++)
     {
-        tx = Transaction(TxType.Payment, [Input(last_hash, 0)],[Output(Amount(100_000), key_pairs[idx+1].address)]);
+        auto tx = Transaction(TxType.Payment, [Input(last_hash, 0)],[Output(Amount(100_000), key_pairs[idx+1].address)]);
         last_hash = hashFull(tx);
         tx.inputs[0].unlock = genKeyUnlock(
             key_pairs[idx].sign(last_hash[]));

--- a/source/agora/consensus/data/UTXO.d
+++ b/source/agora/consensus/data/UTXO.d
@@ -26,9 +26,6 @@ public struct UTXO
     /// Height of the block to be unlock
     ulong unlock_height;
 
-    /// Transaction type
-    TxType type;
-
     /// Unspend transaction output
     Output output;
 

--- a/source/agora/consensus/data/genesis/Coinnet.d
+++ b/source/agora/consensus/data/genesis/Coinnet.d
@@ -109,9 +109,9 @@ private immutable Hash GenesisMerkleRoot = GenesisMerkleTree[$ - 1];
 ///
 private immutable Transaction[] GenesisTransactions =
     [
-        {
+        Transaction(
             TxType.Payment,
-            outputs: [
+            [
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
@@ -120,19 +120,17 @@ private immutable Transaction[] GenesisTransactions =
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
-            ],
-        },
-        {
+            ]),
+        Transaction(
             TxType.Freeze,
-            outputs: [
+            [
                 Output(Amount(2_000_000L * 10_000_000L), NODE2_ADDRESS),
                 Output(Amount(2_000_000L * 10_000_000L), NODE3_ADDRESS),
                 Output(Amount(2_000_000L * 10_000_000L), NODE4_ADDRESS),
                 Output(Amount(2_000_000L * 10_000_000L), NODE5_ADDRESS),
                 Output(Amount(2_000_000L * 10_000_000L), NODE6_ADDRESS),
                 Output(Amount(2_000_000L * 10_000_000L), NODE7_ADDRESS),
-            ],
-        },
+            ])
     ];
 
 private immutable Hash[] GenesisMerkleTree = [

--- a/source/agora/consensus/data/genesis/Coinnet.d
+++ b/source/agora/consensus/data/genesis/Coinnet.d
@@ -110,7 +110,6 @@ private immutable Hash GenesisMerkleRoot = GenesisMerkleTree[$ - 1];
 private immutable Transaction[] GenesisTransactions =
     [
         Transaction(
-            TxType.Payment,
             [
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
@@ -122,14 +121,13 @@ private immutable Transaction[] GenesisTransactions =
                 Output(Amount(54_750_000L * 10_000_000L), GenesisOutputAddress),
             ]),
         Transaction(
-            TxType.Freeze,
             [
-                Output(Amount(2_000_000L * 10_000_000L), NODE2_ADDRESS),
-                Output(Amount(2_000_000L * 10_000_000L), NODE3_ADDRESS),
-                Output(Amount(2_000_000L * 10_000_000L), NODE4_ADDRESS),
-                Output(Amount(2_000_000L * 10_000_000L), NODE5_ADDRESS),
-                Output(Amount(2_000_000L * 10_000_000L), NODE6_ADDRESS),
-                Output(Amount(2_000_000L * 10_000_000L), NODE7_ADDRESS),
+                Output(Amount(2_000_000L * 10_000_000L), NODE2_ADDRESS, OutputType.Freeze),
+                Output(Amount(2_000_000L * 10_000_000L), NODE3_ADDRESS, OutputType.Freeze),
+                Output(Amount(2_000_000L * 10_000_000L), NODE4_ADDRESS, OutputType.Freeze),
+                Output(Amount(2_000_000L * 10_000_000L), NODE5_ADDRESS, OutputType.Freeze),
+                Output(Amount(2_000_000L * 10_000_000L), NODE6_ADDRESS, OutputType.Freeze),
+                Output(Amount(2_000_000L * 10_000_000L), NODE7_ADDRESS, OutputType.Freeze),
             ])
     ];
 

--- a/source/agora/consensus/data/genesis/Test.d
+++ b/source/agora/consensus/data/genesis/Test.d
@@ -97,20 +97,19 @@ public immutable Block GenesisBlock = {
     },
     merkle_tree: GenesisMerkleTree,
     txs: [
-        {
+        Transaction(
             TxType.Freeze,
-            outputs: [
+            [
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE3.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE4.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE5.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE6.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE7.address),
-            ],
-        },
-        {
+            ]),
+        Transaction(
             TxType.Payment,
-            outputs: [
+            [
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),
@@ -119,8 +118,7 @@ public immutable Block GenesisBlock = {
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),
-            ],
-        },
+            ]),
     ],
 };
 

--- a/source/agora/consensus/data/genesis/Test.d
+++ b/source/agora/consensus/data/genesis/Test.d
@@ -100,6 +100,8 @@ public immutable Block GenesisBlock = {
         Transaction(
             TxType.Freeze,
             [
+                // If we want these in order NODE2, NODE3 .. NODE7
+                // then we need to make sure the value of the Public key is in same order
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE3.address),
                 Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE4.address),

--- a/source/agora/consensus/data/genesis/Test.d
+++ b/source/agora/consensus/data/genesis/Test.d
@@ -98,19 +98,17 @@ public immutable Block GenesisBlock = {
     merkle_tree: GenesisMerkleTree,
     txs: [
         Transaction(
-            TxType.Freeze,
             [
                 // If we want these in order NODE2, NODE3 .. NODE7
                 // then we need to make sure the value of the Public key is in same order
-                Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address),
-                Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE3.address),
-                Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE4.address),
-                Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE5.address),
-                Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE6.address),
-                Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE7.address),
+                Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE2.address, OutputType.Freeze),
+                Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE3.address, OutputType.Freeze),
+                Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE4.address, OutputType.Freeze),
+                Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE5.address, OutputType.Freeze),
+                Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE6.address, OutputType.Freeze),
+                Output(Amount(2_000_000L * 10_000_000L), WK.Keys.NODE7.address, OutputType.Freeze),
             ]),
         Transaction(
-            TxType.Payment,
             [
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),
                 Output(Amount(61_000_000L * 10_000_000L), GenesisOutputAddress),

--- a/source/agora/consensus/data/genesis/package.d
+++ b/source/agora/consensus/data/genesis/package.d
@@ -63,7 +63,7 @@ version (unittest)
     }
 }
 
-/// Check the Coinnet Genesis Block enrollments (prints replacement enrollments if needed for agora.consensus.data.genesis.Coinnet.d)
+/// Check the Coinnet Genesis Block enrollments (prints replacement enrollments if needed for agora.consensus.data.genesis.Test.d)
 /// This will not be used for the final Coinnet GenesisBlock which will use unknown key secrets. But can be useful for now.
 unittest
 {
@@ -84,7 +84,7 @@ unittest
 
 }
 
-/// Check the Test Genesis Block enrollments (prints replacement enrollments if needed for agora.consensus.data.genesis.Test.d)
+/// Check the Test Genesis Block enrollments (prints replacement enrollments if needed for agora.consensus.data.genesis.Coinnet.d)
 unittest
 {
     import agora.consensus.data.genesis.Coinnet;

--- a/source/agora/consensus/data/genesis/package.d
+++ b/source/agora/consensus/data/genesis/package.d
@@ -100,7 +100,7 @@ version (unittest) public NodeEnrollment[] checkGenesisEnrollments (
     in Block genesisBlock, in KeyPair[] keys, uint cycle_length)
 {
     import agora.consensus.data.Enrollment;
-    import agora.consensus.data.Transaction : Transaction, TxType;
+    import agora.consensus.data.Transaction : Transaction;
     import agora.consensus.data.UTXO;
     import agora.consensus.EnrollmentManager;
     import std.format;
@@ -108,7 +108,7 @@ version (unittest) public NodeEnrollment[] checkGenesisEnrollments (
     import std.conv;
     import std.algorithm;
 
-    auto freeze_tx = genesisBlock.txs.filter!(tx => tx.type == TxType.Freeze).front;
+    auto freeze_tx = genesisBlock.txs.filter!(tx => tx.isFreezeTx).front;
     Output[] sorted_freeze_outputs = freeze_tx.outputs.dup.sort.array;
     assert(sorted_freeze_outputs == freeze_tx.outputs);
     Hash txhash = hashFull(freeze_tx);

--- a/source/agora/consensus/state/UTXODB.d
+++ b/source/agora/consensus/state/UTXODB.d
@@ -91,12 +91,12 @@ package class UTXODB
             foreach (row; results)
             {
                 auto unlock_height = Height(row.peek!ulong(0));
-                auto type = row.peek!TxType(1);
                 // DMD BUG: Cannot construct the object directly, `inout` bug
                 Output output;
+                output.type = row.peek!OutputType(1);
                 output.value = Amount(row.peek!ulong(2));
                 output.lock  = Lock(row.peek!(LockType)(3), row.peek!(ubyte[])(4));
-                value = UTXO(unlock_height, type, output);
+                value = UTXO(unlock_height, output);
                 return true;
             }
             return false;
@@ -135,14 +135,13 @@ package class UTXODB
         {
             auto hash = Hash(row.peek!(const(char)[], PeekMode.slice)(0));
             auto unlock_height = Height(row.peek!ulong(1));
-            auto type = row.peek!TxType(2);
             // DMD BUG, see above
             Output output;
+            output.type = row.peek!OutputType(2);
             output.value = Amount(row.peek!ulong(3));
             output.lock  = Lock(LockType.Key, row.peek!(ubyte[])(4));
             UTXO value = {
                 unlock_height: unlock_height,
-                type: type,
                 output: output,
             };
             utxos[hash] = value;
@@ -165,7 +164,7 @@ package class UTXODB
     {
         db.execute("INSERT INTO utxo (hash, unlock_height, type, amount, locktype, lock) " ~
                    "VALUES (?, ?, ?, ?, ?, ?)",
-                   key, value.unlock_height, value.type,
+                   key, value.unlock_height, value.output.type,
                    value.output.value, value.output.lock.type, value.output.lock.bytes);
     }
 

--- a/source/agora/consensus/state/UTXOSet.d
+++ b/source/agora/consensus/state/UTXOSet.d
@@ -129,9 +129,8 @@ unittest
 
     // create the first transaction
     Transaction tx1 = Transaction(
-        TxType.Freeze,
         [Input(Hash.init, 0)],
-        [Output(Amount.MinFreezeAmount, key_pairs[0].address)]
+        [Output(Amount.MinFreezeAmount, key_pairs[0].address, OutputType.Freeze)]
     );
     utxo_set.updateUTXOCache(tx1, Height(0), TESTNET.CommonsBudgetAddress);
     Hash hash1 = hashFull(tx1);
@@ -143,17 +142,15 @@ unittest
 
     // create the second transaction
     Transaction tx2 = Transaction(
-        TxType.Freeze,
         [Input(Hash.init, 0)],
-        [Output(Amount(100_000 * 10_000_000L), key_pairs[0].address)]
+        [Output(Amount(100_000 * 10_000_000L), key_pairs[0].address, OutputType.Freeze)]
     );
     utxo_set.updateUTXOCache(tx2, Height(0), TESTNET.CommonsBudgetAddress);
 
     // create the third transaction
     Transaction tx3 = Transaction(
-        TxType.Freeze,
         [Input(Hash.init, 0)],
-        [Output(Amount.MinFreezeAmount, key_pairs[1].address)]
+        [Output(Amount.MinFreezeAmount, key_pairs[1].address, OutputType.Freeze)]
     );
     utxo_set.updateUTXOCache(tx3, Height(0), TESTNET.CommonsBudgetAddress);
 

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -784,7 +784,7 @@ unittest
 
     Hash[] utxos;
     genesisSpendable().take(8).enumerate
-        .map!(en => en.value.refund(WK.Keys[en.index].address).sign(TxType.Freeze))
+        .map!(en => en.value.refund(WK.Keys[en.index].address).sign(OutputType.Freeze))
         .each!((tx) {
             storage.put(tx);
             utxos ~= UTXO.getHash(tx.hashFull(), 0);

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -484,6 +484,7 @@ unittest
         Output zeroOutput =
             Output(Amount.invalid(0), WK.Keys[0].address);
         block.txs[0].outputs ~= zeroOutput;
+        block.txs[0].outputs.sort;
         buildMerkleTree(block);
         assert(!block.isGenesisBlockValid());
     }
@@ -542,7 +543,7 @@ unittest
         [
             Output(normal_data_fee, fee_man.params.CommonsBudgetAddress),
             Output(Amount(40_000L * 10_000_000L), key_pair.address)
-        ],
+        ].sort.array,
         DataPayload(normal_data)
     );
 
@@ -901,6 +902,7 @@ unittest
 
     KeyPair keypair = KeyPair.random();
     Transaction[] txs_2;
+    Output[] no_outputs;
     foreach (idx, pre_tx; txs_1)
     {
         Input input = Input(hashFull(pre_tx), 0);
@@ -930,7 +932,7 @@ unittest
             output.lock = genKeyLock(keypair.address);
             tx.outputs ~= output;
         }
-
+        tx.outputs.sort;
         tx.inputs[0].unlock = VTx.signUnlock(gen_key, tx);
         txs_2 ~= tx;
     }
@@ -1030,6 +1032,7 @@ unittest
 
     KeyPair keypair = KeyPair.random();
     Transaction[] txs_2;
+    Output[] no_outputs;
     foreach (idx, pre_tx; txs_1)
     {
         Transaction tx = Transaction(
@@ -1049,7 +1052,7 @@ unittest
             foreach (_; 0 .. 8)
                 tx.outputs ~= Output(Amount(100), keypair.address);
         }
-
+        tx.outputs.sort;
         tx.inputs[0].unlock = VTx.signUnlock(gen_key, tx);
         txs_2 ~= tx;
     }

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -410,12 +410,9 @@ unittest
 
     Transaction makeNewTx ()
     {
-        Transaction new_tx =
-        {
+        Transaction new_tx = Transaction(
             TxType.Payment,
-            inputs: [],
-            outputs: [Output(Amount(100), KeyPair.random().address)]
-        };
+            [Output(Amount(100), KeyPair.random().address)]);
         return new_tx;
     }
 
@@ -908,11 +905,11 @@ unittest
     {
         Input input = Input(hashFull(pre_tx), 0);
 
-        Transaction tx =
-        {
+        Transaction tx = Transaction(
             TxType.Freeze,
             [input],
-        };
+            null
+        );
         if (idx > 3)
             tx.type = TxType.Payment;
 
@@ -950,12 +947,10 @@ unittest
     {
         Input input = Input(hashFull(txs_2[7]), idx);
 
-        Transaction tx =
-        {
+        Transaction tx = Transaction(
             TxType.Payment,
             [input],
-            [Output(Amount(1), keypair2.address)]
-        };
+            [Output(Amount(1), keypair2.address)]);
         tx.inputs[0].unlock = VTx.signUnlock(keypair, tx);
         txs_3 ~= tx;
     }
@@ -1037,11 +1032,10 @@ unittest
     Transaction[] txs_2;
     foreach (idx, pre_tx; txs_1)
     {
-        Transaction tx =
-        {
+        Transaction tx = Transaction(
             TxType.Freeze,
             [Input(hashFull(pre_tx), 0)],
-        };
+            null);
 
         if (idx <= 2)
         {
@@ -1073,12 +1067,10 @@ unittest
         Transaction[] txs_3;
         foreach (idx; 0 .. 8)
         {
-            Transaction tx =
-            {
+            Transaction tx = Transaction(
                 TxType.Payment,
                 [Input(hashFull(txs_2[$-4]), idx)],
-                [Output(Amount(1), keypair2.address)]
-            };
+                [Output(Amount(1), keypair2.address)]);
             tx.inputs[0].unlock = VTx.signUnlock(keypair, tx);
             txs_3 ~= tx;
         }
@@ -1099,12 +1091,10 @@ unittest
         Transaction[] txs_3;
         foreach (idx; 0 .. 8)
         {
-            Transaction tx =
-            {
+            Transaction tx = Transaction(
                 TxType.Payment,
                 [Input(hashFull(txs_2[$-3]), idx)],
-                [Output(Amount(1), keypair2.address)]
-            };
+                [Output(Amount(1), keypair2.address)]);
             tx.inputs[0].unlock = VTx.signUnlock(keypair, tx);
             txs_3 ~= tx;
         }
@@ -1143,12 +1133,10 @@ unittest
         Transaction[] txs_3;
         foreach (idx; 0 .. 8)
         {
-            Transaction tx =
-            {
+            Transaction tx = Transaction(
                 TxType.Payment,
                 [Input(hashFull(txs_2[$-1]), idx)],
-                [Output(Amount(1), keypair2.address)]
-            };
+                [Output(Amount(1), keypair2.address)]);
             tx.inputs[0].unlock = VTx.signUnlock(keypair, tx);
             txs_3 ~= tx;
         }

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -66,6 +66,7 @@ public string isInvalidReason (in Enrollment enrollment,
         return "Enrollment: UTXO is not frozen";
 
     Point address = utxo_set_value.output.address;
+
     if (!address.isValid())
         return "Enrollment: Address is not a valid point on Curve25519";
 

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -62,7 +62,7 @@ public string isInvalidReason (in Enrollment enrollment,
     if (!findUTXO(enrollment.utxo_key, utxo_set_value))
         return "Enrollment: UTXO not found";
 
-    if (utxo_set_value.type != typeof(utxo_set_value.type).Freeze)
+    if (utxo_set_value.output.type != OutputType.Freeze)
         return "Enrollment: UTXO is not frozen";
 
     Point address = utxo_set_value.output.address;
@@ -126,25 +126,21 @@ unittest
 
     // normal frozen transaction
     Transaction tx1 = Transaction(
-        TxType.Freeze, null,
-        [Output(Amount.MinFreezeAmount, key_pairs[0].address)]
+        [Output(Amount.MinFreezeAmount, key_pairs[0].address, OutputType.Freeze)]
     );
 
     // payment transaction
     Transaction tx2 = Transaction(
-        TxType.Payment, null,
         [Output(Amount.MinFreezeAmount, key_pairs[1].address)]
     );
 
     // Insufficient freeze amount transaction
     Transaction tx3 = Transaction(
-        TxType.Freeze, null,
-        [Output(Amount(1), key_pairs[2].address)]
+        [Output(Amount(1), key_pairs[2].address, OutputType.Freeze)]
     );
 
     // normal freeze amount transaction
     Transaction tx4 = Transaction(
-        TxType.Freeze, null,
         [Output(Amount.MinFreezeAmount, key_pairs[3].address)]
     );
 
@@ -247,7 +243,7 @@ unittest
 
     Enrollment invalid;
     assert(isInvalidReason(invalid,
-        (in Hash, out UTXO utxo) { utxo.type = TxType.Freeze; return true; },
+        (in Hash, out UTXO utxo) { return true; },
         Height(0), null)
         == "Enrollment: Address is not a valid point on Curve25519");
 }

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -214,7 +214,7 @@ unittest
     scope checker = &payload_checker.check;
 
     // Creates the first transaction.
-    Transaction previousTx = { outputs: [ Output(Amount(100), key_pairs[0].address) ] };
+    Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount(100), key_pairs[0].address) ]);
 
     // Save
     Hash previousHash = hashFull(previousTx);
@@ -257,7 +257,7 @@ unittest
 {
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     KeyPair[] key_pairs = [KeyPair.random(), KeyPair.random()];
-    Transaction tx_1 = { outputs: [ Output(Amount(1000), key_pairs[0].address) ] };
+    Transaction tx_1 = Transaction(TxType.Payment, [ Output(Amount(1000), key_pairs[0].address) ]);
     Hash tx_1_hash = hashFull(tx_1);
 
     scope payload_checker = new FeeManager();
@@ -267,13 +267,11 @@ unittest
     storage.put(tx_1);
 
     // Creates the second transaction.
-    Transaction tx_2 =
-    {
+    Transaction tx_2 = Transaction(
         TxType.Payment,
-        inputs  : [Input(tx_1_hash, 0)],
+        [Input(tx_1_hash, 0)],
         // oops
-        outputs : [Output(Amount.invalid(-400_000), key_pairs[1].address)]
-    };
+        [Output(Amount.invalid(-400_000), key_pairs[1].address)]);
 
     tx_2.inputs[0].unlock = signUnlock(key_pairs[0], tx_2);
 
@@ -281,12 +279,10 @@ unittest
 
     // Creates the third transaction.
     // Reject a transaction whose output value is zero
-    Transaction tx_3 =
-    {
+    Transaction tx_3 = Transaction(
         TxType.Payment,
-        inputs  : [Input(tx_1_hash, 0)],
-        outputs : [Output(Amount.invalid(0), key_pairs[1].address)]
-    };
+        [Input(tx_1_hash, 0)],
+        [Output(Amount.invalid(0), key_pairs[1].address)]);
 
     tx_3.inputs[0].unlock = signUnlock(key_pairs[0], tx_3);
 
@@ -309,7 +305,7 @@ unittest
     scope checker = &payload_checker.check;
 
     // Create the first transaction.
-    Transaction genesisTx = { outputs: [ Output(Amount(100_000), key_pairs[0].address) ] };
+    Transaction genesisTx = Transaction(TxType.Payment, [ Output(Amount(100_000), key_pairs[0].address) ]);
     Hash genesisHash = hashFull(genesisTx);
     storage.put(genesisTx);
 
@@ -367,8 +363,7 @@ unittest
     {
         storage.clear;
         // Create the previous transaction with type `TxType.Payment`
-        Transaction previousTx =
-            { outputs: [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ] };
+        Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ]);
         previousHash = hashFull(previousTx);
         foreach (idx, output; previousTx.outputs)
         {
@@ -398,7 +393,7 @@ unittest
     {
         storage.clear;
         // Create the previous transaction with type `TxType.Payment`
-        Transaction previousTx = { outputs: [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ] };
+        Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ]);
         previousHash = hashFull(previousTx);
         foreach (idx, output; previousTx.outputs)
         {
@@ -428,7 +423,7 @@ unittest
     {
         storage.clear;
         // Create the previous transaction with type `TxType.Payment`
-        Transaction previousTx = { outputs: [ Output(Amount(100_000_000_000L), key_pairs[0].address) ] };
+        Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount(100_000_000_000L), key_pairs[0].address) ]);
         previousHash = hashFull(previousTx);
         foreach (idx, output; previousTx.outputs)
         {
@@ -457,7 +452,7 @@ unittest
     // Second transaction is valid.
     {
         // Create the previous transaction with type `TxType.Payment`
-        Transaction previousTx = { outputs: [ Output(Amount(500_000_000_000L), key_pairs[0].address) ] };
+        Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount(500_000_000_000L), key_pairs[0].address) ]);
         previousHash = hashFull(previousTx);
         foreach (idx, output; previousTx.outputs)
         {
@@ -523,8 +518,8 @@ unittest
     // Expected Status : melted
     {
         height = 0;
-        Transaction previousTx =
-            { outputs: [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ] };
+        Transaction previousTx = Transaction(
+            TxType.Payment, [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ]);
 
         // Save to UTXOSet
         previousHash = hashFull(previousTx);
@@ -678,7 +673,7 @@ unittest
         format("Tx having no input should not pass validation. tx: %s", oneTx));
 
     // create a transaction
-    Transaction firstTx = { outputs: [ Output(Amount(100_1000), key_pair.address) ] };
+    Transaction firstTx = Transaction(TxType.Payment, [ Output(Amount(100_1000), key_pair.address) ]);
     Hash firstHash = hashFull(firstTx);
     storage.put(firstTx);
 
@@ -1054,7 +1049,7 @@ unittest
 
     KeyPair kp = KeyPair.random();
 
-    Transaction prev_tx = { outputs: [Output(Amount(100), kp.address)] };
+    Transaction prev_tx = Transaction(TxType.Payment, [Output(Amount(100), kp.address)]);
     storage.put(prev_tx);
 
     Transaction tx = Transaction(

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -64,7 +64,7 @@ public string isInvalidReason (
     import std.algorithm;
     import std.conv;
 
-    if (tx.type != TxType.Coinbase && tx.inputs.length == 0)
+    if (!tx.isCoinbaseTx && tx.inputs.length == 0)
         return "Transaction: No input";
 
     if (tx.outputs.length == 0)
@@ -89,16 +89,9 @@ public string isInvalidReason (
         if (output.value == Amount(0))
             return "Transaction: Value of output is 0";
 
-        // Each output of a freezing transaction must have at least
-        // `Amount.MinFreezeAmount`, save for the first one which
-        // will be considered a refund if it is less than that.
-        if (tx.type == TxType.Freeze &&
-            output.value < Amount.MinFreezeAmount)
-            {
-                if (tx.outputs.length == 1 ||
-                    tx.outputs.count!(o => o.value < Amount.MinFreezeAmount) > 1)
-                    return "Transaction: All non-refund outputs must be over the minimum freezing amount";
-            }
+        // Each freeze output of a transaction must have at least `Amount.MinFreezeAmount`.
+        if (output.type == OutputType.Freeze && output.value < Amount.MinFreezeAmount)
+            return "Transaction: All non-refund outputs must be over the minimum freezing amount";
     }
 
     const tx_hash = hashFull(tx);
@@ -129,8 +122,11 @@ public string isInvalidReason (
 
     Amount sum_unspent;
 
-    if (tx.type == TxType.Freeze)
+    if (tx.isFreezeTx)
     {
+        if (tx.outputs.count!(o => o.type == OutputType.Payment) > 1)
+            return "Transaction: Freeze cannot have multiple refund payment outputs";
+
         if (tx.payload.bytes.length != 0)
             return "Transaction: Freeze cannot have data payload";
 
@@ -140,14 +136,15 @@ public string isInvalidReason (
             if (auto fail_reason = isInvalidInput(input, utxo_value, sum_unspent))
                 return fail_reason;
 
-            if (utxo_value.type == TxType.Freeze)
-                return "Transaction: Can't freeze an already frozen transaction";
+            if (utxo_value.output.type == OutputType.Freeze)
+                return "Transaction: Can't freeze an already frozen input";
         }
 
         if (sum_unspent.integral() < Amount.MinFreezeAmount.integral())
             return "Transaction: available when the amount is at least 40,000 BOA";
     }
-    else if (tx.type == TxType.Payment)
+    // The
+    else if (tx.isPaymentTx)
     {
         uint count_freeze = 0;
         foreach (input; tx.inputs)
@@ -158,11 +155,11 @@ public string isInvalidReason (
 
             // when status is frozen, it will begin to melt
             // In this case, all inputs must be frozen.
-            if (utxo_value.type == TxType.Freeze)
+            if (utxo_value.output.type == OutputType.Freeze)
                 count_freeze++;
 
             // when status is (frozen->melting->melted) or (frozen->melting)
-            if (utxo_value.type == TxType.Payment)
+            if (utxo_value.output.type == OutputType.Payment)
             {
                 // when status is still melting
                 if (height < utxo_value.unlock_height)
@@ -175,8 +172,10 @@ public string isInvalidReason (
             return "Transaction: Rejected combined inputs (freeze & payment)";
 
     }
-    else if (tx.type == TxType.Coinbase)
+    else if (tx.isCoinbaseTx)
     {
+        if (tx.outputs.any!(o => o.type != OutputType.Coinbase))
+            return "Transaction: If an output is Coinbase they all should be";
         if (tx.inputs.length != 1)
             return "Transaction: Coinbase transactions must" ~
                 "include a single Input";
@@ -188,12 +187,12 @@ public string isInvalidReason (
             return "Transaction: Coinbase transactions can't include payload";
     }
     else
-        return "Transaction: Invalid transaction type";
+        return "Transaction: Invalid output types";
 
     Amount new_unspent;
     if (!tx.getSumOutput(new_unspent))
         return "Transaction: Referenced Output(s) overflow";
-    if (tx.type != TxType.Coinbase && !sum_unspent.sub(new_unspent))
+    if (!tx.isCoinbaseTx && !sum_unspent.sub(new_unspent))
         return "Transaction: Output(s) are higher than Input(s)";
     // NOTE: Make sure fees are always checked last
     return checkFee(tx, sum_unspent);
@@ -227,7 +226,7 @@ unittest
     scope checker = &payload_checker.check;
 
     // Creates the first transaction.
-    Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount(100), key_pairs[0].address) ]);
+    Transaction previousTx = Transaction([ Output(Amount(100), key_pairs[0].address) ]);
 
     // Save
     Hash previousHash = hashFull(previousTx);
@@ -235,7 +234,6 @@ unittest
 
     // Creates the second transaction.
     Transaction secondTx = Transaction(
-        TxType.Payment,
         [
             Input(previousHash, 0)
         ],
@@ -272,7 +270,7 @@ unittest
 {
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     KeyPair[] key_pairs = [KeyPair.random(), KeyPair.random()];
-    Transaction tx_1 = Transaction(TxType.Payment, [ Output(Amount(1000), key_pairs[0].address) ]);
+    Transaction tx_1 = Transaction([ Output(Amount(1000), key_pairs[0].address) ]);
     Hash tx_1_hash = hashFull(tx_1);
 
     scope payload_checker = new FeeManager();
@@ -283,7 +281,6 @@ unittest
 
     // Creates the second transaction.
     Transaction tx_2 = Transaction(
-        TxType.Payment,
         [Input(tx_1_hash, 0)],
         // oops
         [Output(Amount.invalid(-400_000), key_pairs[1].address)]);
@@ -295,7 +292,6 @@ unittest
     // Creates the third transaction.
     // Reject a transaction whose output value is zero
     Transaction tx_3 = Transaction(
-        TxType.Payment,
         [Input(tx_1_hash, 0)],
         [Output(Amount.invalid(0), key_pairs[1].address)]);
 
@@ -320,13 +316,12 @@ unittest
     scope checker = &payload_checker.check;
 
     // Create the first transaction.
-    Transaction genesisTx = Transaction(TxType.Payment, [ Output(Amount(100_000), key_pairs[0].address) ]);
+    Transaction genesisTx = Transaction([ Output(Amount(100_000), key_pairs[0].address) ]);
     Hash genesisHash = hashFull(genesisTx);
     storage.put(genesisTx);
 
     // Create the second transaction.
     Transaction tx1 = Transaction(
-        TxType.Payment,
         [
             Input(genesisHash, 0)
         ],
@@ -344,7 +339,6 @@ unittest
            format("Transaction signature is not validated %s", tx1));
 
     Transaction tx2 = Transaction(
-        TxType.Payment,
         [
             Input(tx1Hash, 0)
         ],
@@ -377,25 +371,22 @@ unittest
     // Second transaction is valid.
     {
         storage.clear;
-        // Create the previous transaction with type `TxType.Payment`
-        Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ]);
+        // Create the previous transaction with type `OutputType.Payment`
+        Transaction previousTx = Transaction([ Output(Amount.MinFreezeAmount, key_pairs[0].address) ]);
         previousHash = hashFull(previousTx);
         foreach (idx, output; previousTx.outputs)
         {
             const Hash utxo_hash = hashMulti(previousHash, idx);
             const UTXO utxo_value = {
                 unlock_height: 0,
-                type: TxType.Payment,
                 output: output
             };
             storage[utxo_hash] = utxo_value;
         }
 
         // Creates the freezing transaction.
-        secondTx = Transaction(
-            TxType.Freeze,
-            [Input(previousHash, 0)],
-            [Output(Amount.MinFreezeAmount, key_pairs[1].address)]
+        secondTx = Transaction([Input(previousHash, 0)],
+            [Output(Amount.MinFreezeAmount, key_pairs[1].address, OutputType.Freeze)]
         );
         secondTx.inputs[0].unlock = signUnlock(key_pairs[0], secondTx);
 
@@ -407,15 +398,14 @@ unittest
     // Second transaction is invalid.
     {
         storage.clear;
-        // Create the previous transaction with type `TxType.Payment`
-        Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ]);
+        // Create the previous transaction with type `OutputType.Payment`
+        Transaction previousTx = Transaction([ Output(Amount.MinFreezeAmount, key_pairs[0].address, OutputType.Payment) ]);
         previousHash = hashFull(previousTx);
         foreach (idx, output; previousTx.outputs)
         {
             const Hash utxo_hash = hashMulti(previousHash, idx);
             const UTXO utxo_value = {
                 unlock_height: 0,
-                type: TxType.Freeze,
                 output: output
             };
             storage[utxo_hash] = utxo_value;
@@ -423,9 +413,8 @@ unittest
 
         // Creates the freezing transaction.
         secondTx = Transaction(
-            TxType.Freeze,
             [Input(previousHash, 0)],
-            [Output(Amount.MinFreezeAmount, key_pairs[1].address)]
+            [Output(Amount.MinFreezeAmount, key_pairs[1].address, OutputType.Freeze)]
         );
         secondTx.inputs[0].unlock = signUnlock(key_pairs[0], secondTx);
 
@@ -437,15 +426,14 @@ unittest
     // Second transaction is invalid.
     {
         storage.clear;
-        // Create the previous transaction with type `TxType.Payment`
-        Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount(100_000_000_000L), key_pairs[0].address) ]);
+        // Create the previous transaction with type `OutputType.Payment`
+        Transaction previousTx = Transaction([ Output(Amount(100_000_000_000L), key_pairs[0].address) ]);
         previousHash = hashFull(previousTx);
         foreach (idx, output; previousTx.outputs)
         {
             const Hash utxo_hash = hashMulti(previousHash, idx);
             const UTXO utxo_value = {
                 unlock_height: 0,
-                type: TxType.Payment,
                 output: output
             };
             storage[utxo_hash] = utxo_value;
@@ -453,9 +441,8 @@ unittest
 
         // Creates the freezing transaction.
         secondTx = Transaction(
-            TxType.Freeze,
             [Input(previousHash, 0)],
-            [Output(Amount(100_000_000_000L), key_pairs[1].address)]
+            [Output(Amount(100_000_000_000L), key_pairs[1].address, OutputType.Freeze)]
         );
         secondTx.inputs[0].unlock = signUnlock(key_pairs[0], secondTx);
 
@@ -466,15 +453,14 @@ unittest
     // When the privious transaction with too many amount at freezings.
     // Second transaction is valid.
     {
-        // Create the previous transaction with type `TxType.Payment`
-        Transaction previousTx = Transaction(TxType.Payment, [ Output(Amount(500_000_000_000L), key_pairs[0].address) ]);
+        // Create the previous transaction with type `OutputType.Payment`
+        Transaction previousTx = Transaction([ Output(Amount(500_000_000_000L), key_pairs[0].address) ]);
         previousHash = hashFull(previousTx);
         foreach (idx, output; previousTx.outputs)
         {
             const Hash utxo_hash = hashMulti(previousHash, idx);
             const UTXO utxo_value = {
                 unlock_height: 0,
-                type: TxType.Payment,
                 output: output
             };
             storage[utxo_hash] = utxo_value;
@@ -482,9 +468,8 @@ unittest
 
         // Creates the freezing transaction.
         secondTx = Transaction(
-            TxType.Freeze,
             [Input(previousHash, 0)],
-            [Output(Amount(500_000_000_000L), key_pairs[1].address)]
+            [Output(Amount(500_000_000_000L), key_pairs[1].address, OutputType.Freeze)]
         );
         secondTx.inputs[0].unlock = signUnlock(key_pairs[0], secondTx);
 
@@ -528,13 +513,13 @@ unittest
     Hash thirdHash;
     Hash fifthHash;
 
-    // Create the previous transaction with type `TxType.Payment`
+    // Create the previous transaction with type `OutputType.Payment`
     // Expected height : 0
     // Expected Status : melted
     {
         height = 0;
         Transaction previousTx = Transaction(
-            TxType.Payment, [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ]);
+            [ Output(Amount.MinFreezeAmount, key_pairs[0].address) ]);
 
         // Save to UTXOSet
         previousHash = hashFull(previousTx);
@@ -543,7 +528,6 @@ unittest
             const Hash utxo_hash = hashMulti(previousHash, idx);
             const UTXO utxo_value = {
                 unlock_height: height+1,
-                type: TxType.Payment,
                 output: output
             };
             storage[utxo_hash] = utxo_value;
@@ -558,9 +542,8 @@ unittest
     {
         height = 1;
         secondTx = Transaction(
-            TxType.Freeze,
             [Input(previousHash, 0)],
-            [Output(Amount.MinFreezeAmount, key_pairs[1].address)]
+            [Output(Amount.MinFreezeAmount, key_pairs[1].address, OutputType.Freeze)]
         );
         secondTx.inputs[0].unlock = signUnlock(key_pairs[0], secondTx);
 
@@ -574,7 +557,6 @@ unittest
             const Hash utxo_hash = hashMulti(secondHash, idx);
             const UTXO utxo_value = {
                 unlock_height: height+1,
-                type: TxType.Freeze,
                 output: output
             };
             storage[utxo_hash] = utxo_value;
@@ -588,9 +570,7 @@ unittest
     // Expected Status : melting
     {
         height = 2;
-        thirdTx = Transaction(
-            TxType.Payment,
-            [Input(secondHash, 0)],
+        thirdTx = Transaction([Input(secondHash, 0)],
             [Output(Amount.MinFreezeAmount, key_pairs[2].address)]
         );
         thirdTx.inputs[0].unlock = signUnlock(key_pairs[1], thirdTx);
@@ -605,7 +585,6 @@ unittest
             const Hash utxo_hash = hashMulti(thirdHash, idx);
             const UTXO utxo_value = {
                 unlock_height: height+2016,
-                type: TxType.Payment,
                 output: output
             };
             storage[utxo_hash] = utxo_value;
@@ -619,9 +598,7 @@ unittest
     // Expected Status : melting
     {
         height = 2+2015;  //  this is melting, not melted
-        fourthTx = Transaction(
-            TxType.Payment,
-            [Input(thirdHash, 0)],
+        fourthTx = Transaction([Input(thirdHash, 0)],
             [Output(Amount.MinFreezeAmount, key_pairs[3].address)]
         );
         fourthTx.inputs[0].unlock = signUnlock(key_pairs[2], fourthTx);
@@ -638,8 +615,7 @@ unittest
     {
         height = 2+2016;  //  this is melted
         fifthTx = Transaction(
-            TxType.Payment,
-            [Input(thirdHash, 0)],
+                [Input(thirdHash, 0)],
             [Output(Amount.MinFreezeAmount, key_pairs[3].address)]
         );
         fifthTx.inputs[0].unlock = signUnlock(key_pairs[2], fourthTx);
@@ -654,7 +630,6 @@ unittest
             const Hash utxo_hash = hashMulti(fifthHash, idx);
             const UTXO utxo_value = {
                 unlock_height: height+1,
-                type: TxType.Payment,
                 output: output
             };
             storage[utxo_hash] = utxo_value;
@@ -677,7 +652,6 @@ unittest
 
     // create a transaction having no input
     Transaction oneTx = Transaction(
-        TxType.Payment,
         [],
         [Output(Amount(50), key_pair.address)]
     );
@@ -688,13 +662,12 @@ unittest
         format("Tx having no input should not pass validation. tx: %s", oneTx));
 
     // create a transaction
-    Transaction firstTx = Transaction(TxType.Payment, [ Output(Amount(100_1000), key_pair.address) ]);
+    Transaction firstTx = Transaction([ Output(Amount(100_1000), key_pair.address) ]);
     Hash firstHash = hashFull(firstTx);
     storage.put(firstTx);
 
     // create a transaction having no output
     Transaction secondTx = Transaction(
-        TxType.Payment,
         [Input(firstHash, 0)],
         []
     );
@@ -717,7 +690,6 @@ unittest
 
     // create the first transaction.
     Transaction firstTx = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 0)],
         [Output(Amount(100), key_pairs[0].address)]
     );
@@ -726,16 +698,14 @@ unittest
 
     // create the second transaction.
     Transaction secondTx = Transaction(
-        TxType.Freeze,
         [Input(Hash.init, 0)],
-        [Output(Amount(100), key_pairs[0].address)]
+        [Output(Amount(100), key_pairs[0].address, OutputType.Freeze)]
     );
     Hash secondHash = hashFull(secondTx);
     storage.put(secondTx);
 
     // create the third transaction
     Transaction thirdTx = Transaction(
-        TxType.Payment,
         [Input(firstHash, 0), Input(secondHash, 0)],
         [Output(Amount(100), key_pairs[1].address)]
     );
@@ -749,22 +719,20 @@ unittest
         format("Tx having combined inputs should not pass validation. tx: %s", thirdTx));
 }
 
-/// test for unknown transaction type
+/// test for unknown transaction output type
 unittest
 {
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     Transaction[Hash] storage;
-    TxType unknown_type = cast(TxType)100; // any number is OK for test except 0 and 1
+    OutputType unknown_type = cast(OutputType)100; // picking value beyond enum range
     KeyPair key_pair = KeyPair.random;
 
     scope payload_checker = new FeeManager();
     scope checker = &payload_checker.check;
 
     // create a transaction having unknown transaction type
-    Transaction firstTx = Transaction(
-        unknown_type,
-        [Input(Hash.init, 0)],
-        [Output(Amount(100), key_pair.address)]
+    Transaction firstTx = Transaction([Input(Hash.init, 0)],
+        [Output(Amount(100), key_pair.address, unknown_type)]
     );
     Hash firstHash = hashFull(firstTx);
     storage[firstHash] = firstTx;
@@ -786,7 +754,6 @@ unittest
 
     // create the first transaction
     auto firstTx = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 0)],
         [Output(Amount.MaxUnitSupply, key_pairs[0].address)]
     );
@@ -795,7 +762,6 @@ unittest
 
     // create the second transaction
     auto secondTx = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 0)],
         [Output(Amount(100), key_pairs[0].address)]
     );
@@ -804,7 +770,6 @@ unittest
 
     // create the third transaction
     auto thirdTx = Transaction(
-        TxType.Payment,
         [Input(firstHash, 0), Input(secondHash, 0)],
         [Output(Amount(100), key_pairs[1].address)]
     );
@@ -819,9 +784,8 @@ unittest
 
     // create the fourth transaction
     auto fourthTx = Transaction(
-        TxType.Freeze,
         [Input(firstHash, 0), Input(secondHash, 0)],
-        [Output(Amount(100), key_pairs[1].address)]
+        [Output(Amount(100), key_pairs[1].address, OutputType.Freeze)]
     );
     storage.put(fourthTx);
     auto fourthHash = hashFull(fourthTx);
@@ -845,7 +809,6 @@ unittest
 
     // create the first transaction
     auto firstTx = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 0)],
         [Output(Amount(100), key_pairs[0].address)]
     );
@@ -854,7 +817,6 @@ unittest
 
     // create the second transaction
     auto secondTx = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 0)],
         [Output(Amount(100), key_pairs[0].address)]
     );
@@ -863,7 +825,6 @@ unittest
 
     // create the third transaction
     auto thirdTx = Transaction(
-        TxType.Payment,
         [Input(firstHash, 0), Input(secondHash, 0)],
         [Output(Amount.MaxUnitSupply, key_pairs[1].address),
             Output(Amount(100), key_pairs[1].address)]
@@ -890,7 +851,6 @@ unittest
 
     // create the payment transaction.
     Transaction paymentTx = Transaction(
-        TxType.Payment,
         [Input(Hash.init)],
         [Output(Amount(80_000L * 10_000_000L), key_pair.address)]
     );
@@ -899,9 +859,8 @@ unittest
 
     // create the frozen transaction.
     Transaction frozenTx = Transaction(
-        TxType.Freeze,
         [Input(Hash.init)],
-        [Output(Amount(80_000L * 10_000_000L), key_pair.address)]
+        [Output(Amount(80_000L * 10_000_000L), key_pair.address, OutputType.Freeze)]
     );
     storage.put(frozenTx);
     Hash frozen_utxo = UTXO.getHash(frozenTx.hashFull(), 0);
@@ -930,7 +889,6 @@ unittest
     // Test 1. Too large data
     // create a transaction with large data
     dataTx = Transaction(
-        TxType.Payment,
         [Input(payment_utxo)],
         [
             Output(large_data_fee, payload_checker.params.CommonsBudgetAddress),
@@ -949,7 +907,6 @@ unittest
     // Test 2. With not enough fee
     // create a transaction with not enough fee
     dataTx = Transaction(
-        TxType.Payment,
         [Input(payment_utxo)],
         [Output(Amount(80_000L * 10_000_000L - normal_data_fee.integral + 1),
             key_pair.address)],
@@ -967,7 +924,6 @@ unittest
     Amount rem_amount = paymentTx.outputs[0].value;
     rem_amount.sub(normal_data_fee);
     dataTx = Transaction(
-        TxType.Payment,
         [Input(payment_utxo)],
         [Output(rem_amount, key_pair.address)],
         DataPayload(normal_data)
@@ -983,7 +939,6 @@ unittest
     // Test 5. Using frozen input
     // create the data transaction.
     dataTx = Transaction(
-        TxType.Payment,
         [Input(frozen_utxo)],
         [
             Output(Amount(40_000L * 10_000_000L), key_pair.address)
@@ -1001,10 +956,9 @@ unittest
     // Test 6. The transaction with the type of Freeze
     // create the data transaction.
     dataTx = Transaction(
-        TxType.Freeze,
         [Input(payment_utxo)],
         [
-            Output(Amount(40_000L * 10_000_000L), key_pair.address)
+            Output(Amount(40_000L * 10_000_000L), key_pair.address, OutputType.Freeze)
         ],
         DataPayload(normal_data)
     );
@@ -1028,11 +982,9 @@ unittest
 
     // Only output transaction
     auto tx = Transaction(
-        TxType.Coinbase,
-        [],
         [
-            Output(Amount(2826), key_pair.address),
-            Output(Amount(3895), key_pair.address),
+            Output(Amount(2826), key_pair.address, OutputType.Coinbase),
+            Output(Amount(3895), key_pair.address, OutputType.Coinbase),
         ].sort.array,
     );
     // No input
@@ -1063,11 +1015,11 @@ unittest
 
     KeyPair kp = KeyPair.random();
 
-    Transaction prev_tx = Transaction(TxType.Payment, [Output(Amount(100), kp.address)]);
+    Transaction prev_tx = Transaction([Output(Amount(100), kp.address)]);
     storage.put(prev_tx);
 
     Transaction tx = Transaction(
-        TxType.Payment, [Input(hashFull(prev_tx), 0)],
+        [Input(hashFull(prev_tx), 0)],
         [Output(Amount(50), kp.address)]);
 
     // effectively disabled lock

--- a/source/agora/flash/Scripts.d
+++ b/source/agora/flash/Scripts.d
@@ -180,13 +180,12 @@ public Unlock createUnlockSettle (Signature sig, in ulong seq_id)
 public Transaction createFundingTx (in Hash utxo, in Amount capacity,
     in Point pair_pk) @safe nothrow
 {
-    Transaction funding_tx = {
-        type: TxType.Payment,
-        inputs: [Input(utxo)],
-        outputs: [
+    Transaction funding_tx = Transaction(
+        TxType.Payment,
+        [Input(utxo)],
+        [
             Output(capacity,
-                Lock(LockType.Key, pair_pk[].dup))]
-    };
+                Lock(LockType.Key, pair_pk[].dup))]);
 
     return funding_tx;
 }
@@ -211,11 +210,10 @@ public Transaction createFundingTx (in Hash utxo, in Amount capacity,
 public Transaction createClosingTx (in Hash utxo, in Output[] outputs)
     @safe nothrow
 {
-    Transaction closing_tx = {
-        type: TxType.Payment,
-        inputs: [Input(utxo)],
-        outputs: outputs.dup,
-    };
+    Transaction closing_tx = Transaction(
+        TxType.Payment,
+        [Input(utxo)],
+        outputs.dup);
 
     return closing_tx;
 }
@@ -239,11 +237,10 @@ public Transaction createClosingTx (in Hash utxo, in Output[] outputs)
 public Transaction createSettleTx (in Transaction prev_tx,
     in uint settle_age, in Output[] outputs) @safe nothrow
 {
-    Transaction settle_tx = {
-        type: TxType.Payment,
-        inputs: [Input(prev_tx, 0 /* index */, settle_age)],
-        outputs: outputs.dup,
-    };
+    Transaction settle_tx = Transaction(
+        TxType.Payment,
+        [Input(prev_tx, 0 /* index */, settle_age)],
+        outputs.dup);
 
     return settle_tx;
 }
@@ -273,12 +270,10 @@ public Transaction createUpdateTx (in ChannelConfig chan_conf,
         chan_conf.funding_tx_hash, chan_conf.pair_pk, seq_id,
         chan_conf.num_peers);
 
-    Transaction update_tx = {
-        type: TxType.Payment,
-        inputs: [Input(prev_tx, 0 /* index */, 0 /* unlock age */)],
-        outputs: [
-            Output(chan_conf.capacity, Lock)]
-    };
+    Transaction update_tx = Transaction(
+        TxType.Payment,
+        [ Input(prev_tx, 0 /* index */, 0 /* unlock age */)] ,
+        [ Output(chan_conf.capacity, Lock) ]);
 
     return update_tx;
 }
@@ -528,8 +523,8 @@ unittest
     import agora.script.Engine;
     import std.stdio;
 
-    const Transaction bad_tx = { lock_height : Height(99) };
-    const Transaction tx = { lock_height : Height(100) };
+    const Transaction bad_tx = Transaction(Height(99));
+    const Transaction tx = Transaction(Height(100));
     const Hash wrong_secret = hashFull(99);
     const Hash secret = hashFull(42);
     auto hash = hashFull(secret);

--- a/source/agora/flash/Scripts.d
+++ b/source/agora/flash/Scripts.d
@@ -181,7 +181,6 @@ public Transaction createFundingTx (in Hash utxo, in Amount capacity,
     in Point pair_pk) @safe nothrow
 {
     Transaction funding_tx = Transaction(
-        TxType.Payment,
         [Input(utxo)],
         [
             Output(capacity,
@@ -211,7 +210,6 @@ public Transaction createClosingTx (in Hash utxo, in Output[] outputs)
     @safe nothrow
 {
     Transaction closing_tx = Transaction(
-        TxType.Payment,
         [Input(utxo)],
         outputs.dup);
 
@@ -238,7 +236,6 @@ public Transaction createSettleTx (in Transaction prev_tx,
     in uint settle_age, in Output[] outputs) @safe nothrow
 {
     Transaction settle_tx = Transaction(
-        TxType.Payment,
         [Input(prev_tx, 0 /* index */, settle_age)],
         outputs.dup);
 
@@ -271,7 +268,6 @@ public Transaction createUpdateTx (in ChannelConfig chan_conf,
         chan_conf.num_peers);
 
     Transaction update_tx = Transaction(
-        TxType.Payment,
         [ Input(prev_tx, 0 /* index */, 0 /* unlock age */)] ,
         [ Output(chan_conf.capacity, Lock) ]);
 

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -586,7 +586,7 @@ public class Ledger
             foreach (pair; payouts.byKeyValue())
                 if (pair.value > Amount(0))
                     coinbase_tx.outputs ~= Output(pair.value, pair.key);
-
+        coinbase_tx.outputs.sort;
         return coinbase_tx.outputs.length > 0 ? [coinbase_tx] : [];
     }
 
@@ -1537,7 +1537,7 @@ version (unittest)
 ///
 unittest
 {
-    scope ledger = new TestLedger(WK.Keys.NODE2);
+    scope ledger = new TestLedger(WK.Keys.NODE3);
     assert(ledger.getBlockHeight() == 0);
 
     auto blocks = ledger.getBlocksFrom(Height(0)).take(10);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -425,16 +425,14 @@ public class Ledger
 
             auto remain_amount = Amount(utxo_value.output.value);
             remain_amount.sub(this.params.SlashPenaltyAmount);
-            Transaction slashing_tx =
-            {
+            Transaction slashing_tx = Transaction(
                 TxType.Payment,
-                inputs: [Input(utxo)],
-                outputs: [
+                [Input(utxo)],
+                [
                     Output(this.params.SlashPenaltyAmount,
                         this.params.CommonsBudgetAddress),
                     Output(remain_amount, utxo_value.output.address),
-                ],
-            };
+                ]);
             this.utxo_set.updateUTXOCache(slashing_tx, block.header.height,
                 this.params.CommonsBudgetAddress);
         }
@@ -2187,7 +2185,7 @@ unittest
         data.tx_set = data.tx_set[0 .. $ - 1];
         assert(ledger.validateConsensusData(data) == "Invalid Coinbase transaction");
         // Add Invalid coinbase TX
-        data.tx_set ~= Transaction(TxType.Coinbase).hashFull();
+        data.tx_set ~= Transaction(TxType.Coinbase, null).hashFull();
         assert(ledger.validateConsensusData(data) == "Invalid Coinbase transaction");
 
         ledger.prepareNominatingSet(data, Block.TxsInTestBlock, mock_clock.networkTime());

--- a/source/agora/node/TransactionPool.d
+++ b/source/agora/node/TransactionPool.d
@@ -648,17 +648,17 @@ unittest
     Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(0), KeyPair.random.address)]);
+        [Output(Amount(0), WK.Keys.FR.address)]);
 
     Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]);
+        [Output(Amount(0), WK.Keys.UK.address)]);
 
     Transaction tx3 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]);
+        [Output(Amount(0), WK.Keys.NL.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));
@@ -679,17 +679,17 @@ unittest
     Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(0), KeyPair.random.address)]);
+        [Output(Amount(0), WK.Keys.ZA.address)]);
 
     Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0), Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]);
+        [Output(Amount(0), WK.Keys.ZC.address)]);
 
     Transaction tx3 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]);
+        [Output(Amount(0), WK.Keys.ZD.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));
@@ -733,11 +733,11 @@ unittest
     Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(2), KeyPair.random.address)]);
+        [Output(Amount(2), WK.Keys.US.address)]);
 
     Transaction tx2 = Transaction(TxType.Payment,
         [Input(Hash.init, 0), Input(Hash.init, 1)],
-        [Output(Amount(1), KeyPair.random.address)]);
+        [Output(Amount(1), WK.Keys.KR.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));
@@ -797,17 +797,17 @@ unittest
 
     // parent transaction
     Transaction tx1 = Transaction(TxType.Payment, [Input(genesis_tx.hashFull(), 0)],
-        [Output(Amount(1000), KeyPair.random.address)]);
+        [Output(Amount(1000), WK.Keys.KR.address)]);
 
     utxo_set.put(tx1);
 
     // double spent transaction, transaction trying to spend parent
     Transaction tx2 = Transaction(TxType.Payment, [Input(tx1.hashFull(), 0)],
-        [Output(Amount(200), KeyPair.random.address)]);
+        [Output(Amount(200), WK.Keys.NZ.address)]);
 
     // double spent transaction, trying to spend parent
     Transaction tx3 = Transaction(TxType.Payment, [Input(tx1.hashFull(), 0)],
-        [Output(Amount(100), KeyPair.random.address)]);
+        [Output(Amount(100), WK.Keys.AU.address)]);
 
     assert(pool.add(tx2));
     assert(pool.add(tx3));
@@ -836,12 +836,12 @@ unittest
     Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(2), KeyPair.random.address)]);
+        [Output(Amount(2), WK.Keys.GE.address)]);
 
     Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(1), KeyPair.random.address)]);
+        [Output(Amount(1), WK.Keys.CA.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));

--- a/source/agora/node/TransactionPool.d
+++ b/source/agora/node/TransactionPool.d
@@ -614,20 +614,16 @@ unittest
     auto pool = new TransactionPool();
 
     // create first transaction
-    Transaction tx1 =
-    {
+    Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(0), WK.Keys.A.address)]
-    };
+        [Output(Amount(0), WK.Keys.A.address)]);
 
     // create second transaction
-    Transaction tx2 =
-    {
+    Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(0), WK.Keys.C.address)]
-    };
+        [Output(Amount(0), WK.Keys.C.address)]);
 
     // add txs to the pool
     assert(pool.add(tx1));
@@ -649,26 +645,20 @@ unittest
 {
     auto pool = new TransactionPool();
 
-    Transaction tx1 =
-    {
+    Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(0), KeyPair.random.address)]
-    };
+        [Output(Amount(0), KeyPair.random.address)]);
 
-    Transaction tx2 =
-    {
+    Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]
-    };
+        [Output(Amount(0), KeyPair.random.address)]);
 
-    Transaction tx3 =
-    {
+    Transaction tx3 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]
-    };
+        [Output(Amount(0), KeyPair.random.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));
@@ -686,26 +676,20 @@ unittest
 {
     auto pool = new TransactionPool();
 
-    Transaction tx1 =
-    {
+    Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(0), KeyPair.random.address)]
-    };
+        [Output(Amount(0), KeyPair.random.address)]);
 
-    Transaction tx2 =
-    {
+    Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0), Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]
-    };
+        [Output(Amount(0), KeyPair.random.address)]);
 
-    Transaction tx3 =
-    {
+    Transaction tx3 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(0), KeyPair.random.address)]
-    };
+        [Output(Amount(0), KeyPair.random.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));
@@ -746,19 +730,14 @@ unittest
 
     auto pool = new TransactionPool(new ManagedDatabase(":memory:"), &selector);
 
-    Transaction tx1 =
-    {
+    Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(2), KeyPair.random.address)]
-    };
+        [Output(Amount(2), KeyPair.random.address)]);
 
-    Transaction tx2 =
-    {
-        TxType.Payment,
+    Transaction tx2 = Transaction(TxType.Payment,
         [Input(Hash.init, 0), Input(Hash.init, 1)],
-        [Output(Amount(1), KeyPair.random.address)]
-    };
+        [Output(Amount(1), KeyPair.random.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));
@@ -817,30 +796,18 @@ unittest
     auto genesis_tx = GenesisBlock.txs.filter!(tx => tx.type == TxType.Payment).array()[0];
 
     // parent transaction
-    Transaction tx1 =
-    {
-        TxType.Payment,
-        [Input(genesis_tx.hashFull(), 0)],
-        [Output(Amount(1000), KeyPair.random.address)]
-    };
+    Transaction tx1 = Transaction(TxType.Payment, [Input(genesis_tx.hashFull(), 0)],
+        [Output(Amount(1000), KeyPair.random.address)]);
 
     utxo_set.put(tx1);
 
     // double spent transaction, transaction trying to spend parent
-    Transaction tx2 =
-    {
-        TxType.Payment,
-        [Input(tx1.hashFull(), 0)],
-        [Output(Amount(200), KeyPair.random.address)]
-    };
+    Transaction tx2 = Transaction(TxType.Payment, [Input(tx1.hashFull(), 0)],
+        [Output(Amount(200), KeyPair.random.address)]);
 
     // double spent transaction, trying to spend parent
-    Transaction tx3 =
-    {
-        TxType.Payment,
-        [Input(tx1.hashFull(), 0)],
-        [Output(Amount(100), KeyPair.random.address)]
-    };
+    Transaction tx3 = Transaction(TxType.Payment, [Input(tx1.hashFull(), 0)],
+        [Output(Amount(100), KeyPair.random.address)]);
 
     assert(pool.add(tx2));
     assert(pool.add(tx3));
@@ -866,19 +833,15 @@ unittest
 {
     auto pool = new TransactionPool();
 
-    Transaction tx1 =
-    {
+    Transaction tx1 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 0)],
-        [Output(Amount(2), KeyPair.random.address)]
-    };
+        [Output(Amount(2), KeyPair.random.address)]);
 
-    Transaction tx2 =
-    {
+    Transaction tx2 = Transaction(
         TxType.Payment,
         [Input(Hash.init, 1)],
-        [Output(Amount(1), KeyPair.random.address)]
-    };
+        [Output(Amount(1), KeyPair.random.address)]);
 
     assert(pool.add(tx1));
     assert(pool.add(tx2));

--- a/source/agora/node/TransactionPool.d
+++ b/source/agora/node/TransactionPool.d
@@ -411,7 +411,7 @@ public class TransactionPool
     private bool isValidTransaction (in Transaction tx) @trusted
     {
         // Transaction pool should never deal with CoinBase TXs
-        assert(tx.type != TxType.Coinbase);
+        assert(!tx.isCoinbaseTx);
         return !this.hasTransactionHash(tx.hashFull());
     }
 
@@ -615,13 +615,11 @@ unittest
 
     // create first transaction
     Transaction tx1 = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 0)],
         [Output(Amount(0), WK.Keys.A.address)]);
 
     // create second transaction
     Transaction tx2 = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 0)],
         [Output(Amount(0), WK.Keys.C.address)]);
 
@@ -646,17 +644,14 @@ unittest
     auto pool = new TransactionPool();
 
     Transaction tx1 = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 0)],
         [Output(Amount(0), WK.Keys.FR.address)]);
 
     Transaction tx2 = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 1)],
         [Output(Amount(0), WK.Keys.UK.address)]);
 
     Transaction tx3 = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 1)],
         [Output(Amount(0), WK.Keys.NL.address)]);
 
@@ -677,17 +672,14 @@ unittest
     auto pool = new TransactionPool();
 
     Transaction tx1 = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 0)],
         [Output(Amount(0), WK.Keys.ZA.address)]);
 
     Transaction tx2 = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 0), Input(Hash.init, 1)],
         [Output(Amount(0), WK.Keys.ZC.address)]);
 
     Transaction tx3 = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 1)],
         [Output(Amount(0), WK.Keys.ZD.address)]);
 
@@ -731,12 +723,10 @@ unittest
     auto pool = new TransactionPool(new ManagedDatabase(":memory:"), &selector);
 
     Transaction tx1 = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 0)],
         [Output(Amount(2), WK.Keys.US.address)]);
 
-    Transaction tx2 = Transaction(TxType.Payment,
-        [Input(Hash.init, 0), Input(Hash.init, 1)],
+    Transaction tx2 = Transaction([Input(Hash.init, 0), Input(Hash.init, 1)],
         [Output(Amount(1), WK.Keys.KR.address)]);
 
     assert(pool.add(tx1));
@@ -793,20 +783,20 @@ unittest
         };
     auto pool = new TransactionPool(new ManagedDatabase(":memory:"), selector);
 
-    auto genesis_tx = GenesisBlock.txs.filter!(tx => tx.type == TxType.Payment).array()[0];
+    auto genesis_tx = GenesisBlock.txs.filter!(tx => tx.isPaymentTx).array()[0];
 
     // parent transaction
-    Transaction tx1 = Transaction(TxType.Payment, [Input(genesis_tx.hashFull(), 0)],
+    Transaction tx1 = Transaction([Input(genesis_tx.hashFull(), 0)],
         [Output(Amount(1000), WK.Keys.KR.address)]);
 
     utxo_set.put(tx1);
 
     // double spent transaction, transaction trying to spend parent
-    Transaction tx2 = Transaction(TxType.Payment, [Input(tx1.hashFull(), 0)],
+    Transaction tx2 = Transaction([Input(tx1.hashFull(), 0)],
         [Output(Amount(200), WK.Keys.NZ.address)]);
 
     // double spent transaction, trying to spend parent
-    Transaction tx3 = Transaction(TxType.Payment, [Input(tx1.hashFull(), 0)],
+    Transaction tx3 = Transaction([Input(tx1.hashFull(), 0)],
         [Output(Amount(100), WK.Keys.AU.address)]);
 
     assert(pool.add(tx2));
@@ -834,12 +824,10 @@ unittest
     auto pool = new TransactionPool();
 
     Transaction tx1 = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 0)],
         [Output(Amount(2), WK.Keys.GE.address)]);
 
     Transaction tx2 = Transaction(
-        TxType.Payment,
         [Input(Hash.init, 1)],
         [Output(Amount(1), WK.Keys.CA.address)]);
 

--- a/source/agora/node/TransactionRelayer.d
+++ b/source/agora/node/TransactionRelayer.d
@@ -398,12 +398,10 @@ public class TransactionRelayerFeeImp : TransactionRelayer
         auto genesis_tx = GenesisBlock.txs.filter!(tx => tx.type == TxType.Payment).front;
         Amount amount = genesis_tx.outputs[gen_out_ind].value;
         amount.mustSub(fee);
-        Transaction tx =
-        {
+        Transaction tx = Transaction(
             TxType.Payment,
             [Input(genesis_tx.hashFull(), gen_out_ind)],
-            [Output(amount, KeyPair.random.address)]
-        };
+            [Output(amount, KeyPair.random.address)]);
 
         return tx;
     }

--- a/source/agora/node/TransactionRelayer.d
+++ b/source/agora/node/TransactionRelayer.d
@@ -393,6 +393,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
     {
         import agora.consensus.data.genesis.Test;
         import agora.crypto.Key;
+        import agora.utils.Test;
         import std.array;
 
         auto genesis_tx = GenesisBlock.txs.filter!(tx => tx.type == TxType.Payment).front;
@@ -401,7 +402,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
         Transaction tx = Transaction(
             TxType.Payment,
             [Input(genesis_tx.hashFull(), gen_out_ind)],
-            [Output(amount, KeyPair.random.address)]);
+            [Output(amount, WK.Keys.AA.address)]);
 
         return tx;
     }

--- a/source/agora/node/TransactionRelayer.d
+++ b/source/agora/node/TransactionRelayer.d
@@ -396,12 +396,11 @@ public class TransactionRelayerFeeImp : TransactionRelayer
         import agora.utils.Test;
         import std.array;
 
-        auto genesis_tx = GenesisBlock.txs.filter!(tx => tx.type == TxType.Payment).front;
+        auto genesis_tx = GenesisBlock.txs.filter!(tx => tx.isPaymentTx).front;
         Amount amount = genesis_tx.outputs[gen_out_ind].value;
         amount.mustSub(fee);
         Transaction tx = Transaction(
-            TxType.Payment,
-            [Input(genesis_tx.hashFull(), gen_out_ind)],
+                [Input(genesis_tx.hashFull(), gen_out_ind)],
             [Output(amount, WK.Keys.AA.address)]);
 
         return tx;
@@ -425,7 +424,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
         Config config = {node: node_config};
         auto transaction_relayer = new TransactionRelayerFeeImp(config);
 
-        transaction_relayer.utxo_set.put(GenesisBlock.txs.filter!(tx => tx.type == TxType.Payment).array()[0]);
+        transaction_relayer.utxo_set.put(GenesisBlock.txs.filter!(tx => tx.isPaymentTx).array()[0]);
         auto tx_size = getTX(0, Amount(0)).sizeInBytes();
 
         // transaction fee too low

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -605,7 +605,7 @@ public class Validator : FullNode, API
         const pub_key = this.config.validator.key_pair.address;
         foreach (key, utxo; this.utxo_set.getUTXOs(pub_key))
         {
-            if (utxo.type == TxType.Freeze &&
+            if (utxo.output.type == OutputType.Freeze &&
                 utxo.output.value.integral() >= Amount.MinFreezeAmount.integral())
                 return key;
         }

--- a/source/agora/script/Engine.d
+++ b/source/agora/script/Engine.d
@@ -1603,7 +1603,7 @@ unittest
     //   <sig>
 
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
-    const Transaction tx = Transaction(TxType.Payment, [Input.init], null);
+    const Transaction tx = Transaction([Input.init], null);
     test!("==")(engine.execute(
         Lock(LockType.Script, [OP.CHECK_SEQ_SIG]), Unlock.init, tx, tx.inputs[0]),
         "CHECK_SEQ_SIG opcode requires 4 items on the stack");

--- a/source/agora/script/Engine.d
+++ b/source/agora/script/Engine.d
@@ -1603,7 +1603,7 @@ unittest
     //   <sig>
 
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
-    const Transaction tx = { inputs : [Input.init] };
+    const Transaction tx = Transaction(TxType.Payment, [Input.init], null);
     test!("==")(engine.execute(
         Lock(LockType.Script, [OP.CHECK_SEQ_SIG]), Unlock.init, tx, tx.inputs[0]),
         "CHECK_SEQ_SIG opcode requires 4 items on the stack");
@@ -1765,8 +1765,8 @@ unittest
     const height_11 = nativeToLittleEndian(ulong(11));
 
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
-    const Transaction tx_10 = { lock_height : Height(10) };
-    const Transaction tx_11 = { lock_height : Height(11) };
+    const Transaction tx_10 = Transaction(Height(10));
+    const Transaction tx_11 = Transaction(Height(11));
     test!("==")(engine.execute(
         Lock(LockType.Script,
             toPushOpcode(height_9)

--- a/source/agora/script/Lock.d
+++ b/source/agora/script/Lock.d
@@ -72,6 +72,30 @@ public struct Lock
     {
         return this.type.sizeof + this.bytes.length * this.bytes[0].sizeof;
     }
+
+    /// Support for sorting
+    public int opCmp ( const typeof(this) rhs ) const nothrow @safe @nogc
+    {
+        import std.algorithm;
+
+        if (cast(int)this.type == cast(int)rhs.type)
+            return cmp(this.bytes, rhs.bytes);
+        return cast(int)this.type < cast(int)rhs.type ? -1 : 1;
+    }
+}
+
+unittest
+{
+    import std.algorithm;
+    import std.array;
+
+    auto lock1 = Lock(LockType.Key,     [153, 223, 171, 200, 195, 76, 197, 30, 122, 135, 199, 165, 59, 248, 20, 63, 104, 203, 140, 183, 177, 199, 208, 11, 136, 169, 69, 145, 67, 250, 64, 156]);
+    auto lock2 = Lock(LockType.Key,     [153, 223, 171, 100, 195, 76, 197, 30, 122, 135, 199, 165, 59, 248, 20, 63, 104, 203, 140, 183, 177, 199, 208, 11, 136, 169, 69, 145, 67, 250, 64, 156]);
+    auto lock3 = Lock(LockType.KeyHash, [153, 223, 171, 250, 195, 76, 197, 30, 122, 135, 199, 165, 59, 248, 20, 63, 104, 203, 140, 183, 177, 199, 208, 11, 136, 169, 69, 145, 67, 250, 64, 156]);
+    auto lock4 = Lock(LockType.Key,     [153, 223, 171, 250, 195, 76, 197, 30, 122, 135, 199, 165, 59, 248, 20, 63, 104, 203, 140, 183, 177, 199, 208, 11, 136, 169, 69, 145, 67, 250, 64, 156]);
+    auto locks = [ lock1, lock2, lock3, lock4];
+    locks.sort();
+    assert(locks == [ lock2, lock1, lock4, lock3 ]);
 }
 
 unittest

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -36,7 +36,7 @@ private class SameKeyValidator : TestValidatorNode
             this.config.validator.key_pair.address);
         foreach (key, utxo; utxos)
         {
-            if (utxo.type == TxType.Freeze &&
+            if (utxo.output.type == OutputType.Freeze &&
                 utxo.output.value.integral() >= Amount.MinFreezeAmount.integral())
             {
                 utxo_hashes ~= key;
@@ -131,7 +131,7 @@ unittest
     auto freeze_txs = freezable
         .enumerate
         .map!(pair => pair.value.refund(WK.Keys.NODE2.address)
-            .sign(TxType.Freeze))
+            .sign(OutputType.Freeze))
         .array;
     assert(freeze_txs.length == 8);
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -48,9 +48,6 @@ unittest
     network.waitForPreimages(network.blocks[0].header.enrollments,
         Height(GenesisValidatorCycle));
 
-    // // Re-enroll the Genesis validators
-    // iota(GenesisValidators).each!(idx => network.enroll(idx));
-
     network.generateBlocks(iota(GenesisValidators),
         Height(GenesisValidatorCycle));
 

--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -53,8 +53,7 @@ unittest
         // add next block
         blocks ~= node_1.getBlocksFrom(new_height, 1);
 
-        auto cb_txs = blocks[$-1].txs.filter!(tx => tx.type == TxType.Coinbase)
-            .array;
+        auto cb_txs = blocks[$-1].txs.filter!(tx => tx.isCoinbaseTx) .array;
         assert(cb_txs.length == 1);
         auto cb_outs = cb_txs[0].outputs;
 
@@ -197,8 +196,7 @@ unittest
         // add next block
         blocks ~= valid_node.getBlocksFrom(new_height, 1);
 
-        auto cb_txs = blocks[$-1].txs.filter!(tx => tx.type == TxType.Coinbase)
-            .array;
+        auto cb_txs = blocks[$-1].txs.filter!(tx => tx.isCoinbaseTx).array;
         assert(cb_txs.length == 1);
         auto cb_outs = cb_txs[0].outputs;
 

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -50,6 +50,7 @@ import agora.utils.Log;
 import geod24.LocalRest : Listener;
 import geod24.Registry;
 
+import std.algorithm;
 import std.conv;
 import std.exception;
 
@@ -1389,8 +1390,8 @@ unittest
     auto block12 = node_1.getBlocksFrom(12, 1)[0];
     assert(block12.txs[0] == bob.getClosingTx(bob_pubkey, bob_charlie_chan_id_2));
     assert(block12.txs[0].outputs.length == 2);
-    assert(block12.txs[0].outputs[0].value == Amount(8000)); // No fees
-    assert(block12.txs[0].outputs[1].value == Amount(2000));
+    assert(block12.txs[0].outputs.count!(o => o.value == Amount(8000)) == 1); // No fees
+    assert(block12.txs[0].outputs.count!(o => o.value == Amount(2000)) == 1);
 
     assert(alice.beginCollaborativeClose(alice_pubkey, alice_bob_chan_id).error
         == ErrorCode.None);
@@ -1400,8 +1401,8 @@ unittest
     auto block13 = node_1.getBlocksFrom(13, 1)[0];
     assert(block13.txs[0] == alice.getClosingTx(alice_pubkey, alice_bob_chan_id));
     assert(block13.txs[0].outputs.length == 2);
-    assert(block13.txs[0].outputs[0].value == Amount(7990)); // Fees
-    assert(block13.txs[0].outputs[1].value == Amount(2010));
+    assert(block13.txs[0].outputs.count!(o => o.value == Amount(7990)) == 1); // Fees
+    assert(block13.txs[0].outputs.count!(o => o.value == Amount(2010)) == 1);
 
     assert(bob.beginCollaborativeClose(bob_pubkey, bob_charlie_chan_id).error
         == ErrorCode.None);

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -215,7 +215,7 @@ unittest
     auto reason = txs[0].isInvalidReason(new Engine(16_384, 512),
         (in Hash utxo, out UTXO value)
         {
-            value = UTXO(0, TxType.Payment, txs[0].outputs[0]);
+            value = UTXO(0, txs[0].outputs[0]);
             return true;
         }, Height(0),
         checker);
@@ -248,7 +248,7 @@ unittest
     freezeAmount.mustSub(1_000.coins);
     auto tx = network.blocks[0].spendable
         .map!(txb => txb
-              .draw(freezeAmount, WK.Keys.AA.address.only).sign(TxType.Freeze)
+              .draw(freezeAmount, WK.Keys.AA.address.only).sign(OutputType.Freeze)
         ).front;
 
     assert(tx.outputs.length == 2);

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -243,7 +243,7 @@ unittest
     // Create a freezing tx with two outputs:
     // 1) A refund of 1k
     // 2) A very large frozen amount (60.999k)
-    Amount freezeAmount = network.blocks[0].txs[1].outputs[0].value;
+    Amount freezeAmount = network.blocks[0].frozens.front.outputs[0].value;
     // Must be under Amount.MinFreezeAmount so that the refund isn't frozen
     freezeAmount.mustSub(1_000.coins);
     auto tx = network.blocks[0].spendable
@@ -259,7 +259,7 @@ unittest
     const b1 = network.clients[0].getBlock(1);
     assert(b1.txs.length == 1);
 
-    // Now spend the refund transaction
+    // Now spend the refund transaction (output index is 0 as it is sorted and lock is same value but ammount is less)
     auto tx2 = TxBuilder(b1.txs[0], 0).sign();
     assert(tx2.outputs.length == 1);
 

--- a/source/agora/test/LockHeight.d
+++ b/source/agora/test/LockHeight.d
@@ -38,12 +38,10 @@ unittest
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     const Height UnlockHeight_2 = Height(2);
-    auto unlock_2_txs = txs.map!(tx => TxBuilder(tx).sign(TxType.Payment,
-        null, UnlockHeight_2)).array();
+    auto unlock_2_txs = txs.map!(tx => TxBuilder(tx).sign(OutputType.Payment, null, UnlockHeight_2)).array();
 
     const Height UnlockHeight_3 = Height(3);
-    auto unlock_3_txs = txs.map!(tx => TxBuilder(tx).sign(TxType.Payment,
-        null, UnlockHeight_3)).array();
+    auto unlock_3_txs = txs.map!(tx => TxBuilder(tx).sign(OutputType.Payment, null, UnlockHeight_3)).array();
 
     assert(unlock_2_txs != unlock_3_txs);
 

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -20,7 +20,7 @@ void manyValidators (size_t validators)
     import agora.test.Base : TestConf, GenesisValidators, GenesisValidatorCycle,
         makeTestNetwork, TestAPIManager;
     import agora.common.Types : Height;
-    import agora.consensus.data.Transaction : TxType;
+    import agora.consensus.data.Transaction;
     import agora.utils.Test : genesisSpendable, retryFor;
     import std.algorithm;
     import std.format;
@@ -48,7 +48,7 @@ void manyValidators (size_t validators)
     {
         // prepare frozen outputs for outsider validators to enroll
         genesisSpendable().dropExactly(1).takeExactly(1)
-            .map!(txb => txb.split(keys).sign(TxType.Freeze))
+            .map!(txb => txb.split(keys).sign(OutputType.Freeze))
             .each!(tx => network.clients[0].putTransaction(tx));
     }
 

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -61,7 +61,7 @@ unittest
 
     // Freeze outputs for outsiders
     genesisSpendable.drop(2).takeExactly(1)
-        .map!(txb => txb.split(keys).sign(TxType.Freeze))
+        .map!(txb => txb.split(keys).sign(OutputType.Freeze))
         .each!(tx => nodes[0].putTransaction(tx));
 
     // at block height 19 the freeze tx's are available

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -143,7 +143,7 @@ unittest
 
     // prepare frozen outputs for outsider validators to enroll
     genesisSpendable().dropExactly(1).takeExactly(1)
-        .map!(txb => txb.split(keys).sign(TxType.Freeze))
+        .map!(txb => txb.split(keys).sign(OutputType.Freeze))
         .each!(tx => network.clients[0].putTransaction(tx));
 
     // block 19

--- a/source/agora/test/RestoreSlashingInfo.d
+++ b/source/agora/test/RestoreSlashingInfo.d
@@ -57,7 +57,7 @@ unittest
     // prepare frozen outputs for outsider validators to enroll
     blocks[0].spendable().drop(1).takeExactly(1)
         .map!(txb => txb
-            .split(keys).sign(TxType.Freeze))
+            .split(keys).sign(OutputType.Freeze))
             .each!(tx => set_a[0].putTransaction(tx));
 
     network.generateBlocks(Height(GenesisValidatorCycle - 1));

--- a/source/agora/test/Script.d
+++ b/source/agora/test/Script.d
@@ -56,7 +56,7 @@ unittest
         ~ [ubyte(32)] ~ WK.Keys.Genesis.address[] ~ [ubyte(OP.CHECK_SIG)]);
 
     auto lock_txs = block_5.txs
-        .filter!(tx => tx.type == TxType.Payment)
+        .filter!(tx => tx.isPaymentTx)
         .map!(tx => iota(tx.outputs.length)
             .map!(idx => TxBuilder(tx, cast(uint)idx, lock)))
         .joiner().map!(txb => txb.sign());
@@ -74,12 +74,12 @@ unittest
 
     const lock_height_2 = Height(2);
     auto unlock_height_2 = block_6.spendable()
-        .map!(txb => txb.sign(TxType.Payment, null, lock_height_2, 0,
+        .map!(txb => txb.sign(OutputType.Payment, null, lock_height_2, 0,
             &keyUnlocker));
 
     const lock_height_3 = Height(3);
     auto unlock_height_3 = block_6.spendable()
-        .map!(txb => txb.sign(TxType.Payment, null, lock_height_3, 0,
+        .map!(txb => txb.sign(OutputType.Payment, null, lock_height_3, 0,
             &keyUnlocker)).array;
 
     // txs with unlock height 2 should be rejected by the lock script
@@ -164,13 +164,13 @@ unittest
     const uint UnlockAge_2 = 2;
     auto age_2_txs = iota(cast(uint)txs[3].outputs.length)
         .map!(idx => TxBuilder(txs[3], idx)
-            .sign(TxType.Payment, null, Height(0), UnlockAge_2, &keyUnlocker))
+            .sign(OutputType.Payment, null, Height(0), UnlockAge_2, &keyUnlocker))
         .array();
 
     const uint UnlockAge_3 = 3;
     auto age_3_txs = iota(cast(uint)txs[3].outputs.length)
         .map!(idx => TxBuilder(txs[3], idx)
-            .sign(TxType.Payment, null, Height(0), UnlockAge_3, &keyUnlocker))
+            .sign(OutputType.Payment, null, Height(0), UnlockAge_3, &keyUnlocker))
         .array();
 
     age_2_txs.each!(tx => node_1.putTransaction(tx));
@@ -235,7 +235,7 @@ unittest
     // using IF branch
     auto true_a_txs = iota(cast(uint)txs[3].outputs.length)
         .map!(idx => TxBuilder(txs[3], idx)
-            .sign(TxType.Payment, null, Height(0), 0,
+            .sign(OutputType.Payment, null, Height(0), 0,
                 (in Transaction tx, in OutputRef out_ref) @safe nothrow
                 {
                     auto sig = kp_a.sign(tx);
@@ -246,7 +246,7 @@ unittest
     // ditto, but different key-pair
     auto true_b_txs = iota(cast(uint)txs[3].outputs.length)
         .map!(idx => TxBuilder(txs[3], idx)
-            .sign(TxType.Payment, null, Height(0), 0,
+            .sign(OutputType.Payment, null, Height(0), 0,
                 (in Transaction tx, in OutputRef out_ref) @safe nothrow
                 {
                     auto sig = kp_b.sign(tx);
@@ -265,7 +265,7 @@ unittest
     // using ELSE branch
     auto false_a_txs = iota(cast(uint)txs[4].outputs.length)
         .map!(idx => TxBuilder(txs[4], idx)
-            .sign(TxType.Payment, null, Height(0), 0,
+            .sign(OutputType.Payment, null, Height(0), 0,
                 (in Transaction tx, in OutputRef out_ref) @safe nothrow
                 {
                     auto sig = kp_a.sign(tx);
@@ -276,7 +276,7 @@ unittest
     // ditto, but different key-pair
     auto false_b_txs = iota(cast(uint)txs[4].outputs.length)
         .map!(idx => TxBuilder(txs[4], idx)
-            .sign(TxType.Payment, null, Height(0), 0,
+            .sign(OutputType.Payment, null, Height(0), 0,
                 (in Transaction tx, in OutputRef out_ref) @safe nothrow
                 {
                     auto sig = kp_b.sign(tx);

--- a/source/agora/test/TimeBlockInterval.d
+++ b/source/agora/test/TimeBlockInterval.d
@@ -34,7 +34,7 @@ unittest
     auto node_1 = nodes[0];
 
     auto spendable = network.blocks[0].txs
-        .filter!(tx => tx.type == TxType.Payment)
+        .filter!(tx => tx.isPaymentTx)
         .map!(tx => iota(tx.outputs.length)
             .map!(idx => TxBuilder(tx, cast(uint)idx)))
         .joiner().take(8).array;

--- a/source/agora/test/TransactionReplacement.d
+++ b/source/agora/test/TransactionReplacement.d
@@ -80,7 +80,7 @@ unittest
     network.expectHeight(Height(1));
     const block = node1.getBlock(Height(1));
 
-    // verify that the transaction with fee 13000 is the only one inncluded in the block
+    // verify that the transaction with fee 13000 is the only one included in the block
     assert(block.txs.length == 2); // Coinbase + our transaction
     assert(block.txs.filter!(tx => tx.type == TxType.Payment).front() == txs[4]);
 }

--- a/source/agora/test/TransactionReplacement.d
+++ b/source/agora/test/TransactionReplacement.d
@@ -22,6 +22,7 @@ import agora.consensus.data.Transaction;
 import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.test.Base;
+import agora.utils.Test;
 
 import core.thread.osthread : Thread;
 
@@ -43,7 +44,7 @@ unittest
 
     auto input_tx = GenesisBlock.txs.filter!(tx => tx.type == TxType.Payment).front();
     Amount input_tx_amount = input_tx.outputs[0].value;
-    auto output_addr = KeyPair.random.address;
+    auto output_addr = WK.Keys.AA.address;
 
     // create double spend transactions with fees 10000, 10100 .. 13000
     auto txs = [Amount(10000), Amount(10100), Amount(10200), Amount(11000), Amount(13000)]

--- a/source/agora/test/TransactionReplacement.d
+++ b/source/agora/test/TransactionReplacement.d
@@ -42,7 +42,7 @@ unittest
     auto node0 = nodes[0];
     auto node1 = nodes[1];
 
-    auto input_tx = GenesisBlock.txs.filter!(tx => tx.type == TxType.Payment).front();
+    auto input_tx = GenesisBlock.txs.filter!(tx => tx.isPaymentTx).front();
     Amount input_tx_amount = input_tx.outputs[0].value;
     auto output_addr = WK.Keys.AA.address;
 
@@ -82,5 +82,5 @@ unittest
 
     // verify that the transaction with fee 13000 is the only one included in the block
     assert(block.txs.length == 2); // Coinbase + our transaction
-    assert(block.txs.filter!(tx => tx.type == TxType.Payment).front() == txs[4]);
+    assert(block.txs.filter!(tx => tx.isPaymentTx).front() == txs[4]);
 }

--- a/source/agora/test/UnlockAge.d
+++ b/source/agora/test/UnlockAge.d
@@ -50,8 +50,7 @@ unittest
     auto txs_1 = split_up[1].map!(txb => txb.sign()).array;
     auto txs_2 = split_up[2].map!(txb => txb.sign()).array;
     const uint UnlockAge_3 = 3;
-    auto age_3_txs = split_up[3].map!(txb => txb.sign(TxType.Payment,
-        null, Height(0), UnlockAge_3)).array();
+    auto age_3_txs = split_up[3].map!(txb => txb.sign(OutputType.Payment, null, Height(0), UnlockAge_3)).array();
 
     age_3_txs.each!(tx => node_1.putTransaction(tx));  // rejected, wrong age
     txs_0.each!(tx => node_1.putTransaction(tx));      // accepted

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -61,7 +61,7 @@ version(none) unittest
     // prepare frozen outputs for outsider validators to enroll
     blocks[0].spendable().drop(1)
         .map!(txb => txb
-            .split(keys).sign(TxType.Freeze))
+            .split(keys).sign(OutputType.Freeze))
         .each!(tx => set_a[0].putTransaction(tx));
 
     // wait for other nodes to get to same block height

--- a/source/agora/test/VariableBlockSize.d
+++ b/source/agora/test/VariableBlockSize.d
@@ -31,7 +31,7 @@ unittest
     network.waitForDiscovery();
 
     auto spendable = network.blocks[0].txs
-        .filter!(tx => tx.type == TxType.Payment)
+        .filter!(tx => tx.isPaymentTx)
         .map!(tx => iota(tx.outputs.length)
             .map!(idx => TxBuilder(tx, cast(uint)idx)))
         .joiner().take(8).array;

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -308,8 +308,8 @@ private struct OutputFmt
     {
         try
         {
-            formattedWrite(sink, "%s(%s)",
-                PubKeyFmt(this.value.address), AmountFmt(this.value.value));
+            formattedWrite(sink, "%s(%s)<%s>",
+                PubKeyFmt(this.value.address), AmountFmt(this.value.value), this.value.type);
         }
         catch (Exception ex)
         {
@@ -344,12 +344,13 @@ private struct TransactionFmt
 
             if (this.value.inputs.length)
                 formattedWrite(sink, "Type : %s, Inputs (%d):%s%(%(%s, %),\n%)\n",
-                    this.value.type,
+                    this.value.isPaymentTx ? "Payment" : this.value.isFreezeTx ? "Freeze" : "Coinbase",
                     this.value.inputs.length,
                     this.value.inputs.length > InputPerLine ? "\n" : " ",
                     this.value.inputs.map!(v => InputFmt(v)).chunks(InputPerLine));
             else
-                formattedWrite(sink, "Type : %s, Inputs: None\n", this.value.type);
+                formattedWrite(sink, "Type : %s, Inputs: None\n",
+                    this.value.isPaymentTx ? "Payment" : this.value.isFreezeTx ? "Freeze" : "Coinbase",);
 
             formattedWrite(sink, "Outputs (%d):%s%(%(%s, %),\n%)",
                 this.value.outputs.length,
@@ -559,8 +560,7 @@ Outputs (1): boa1xzgenes5...gm67(61,000,000)
     }
 
     const Block second_block = makeNewBlock(GenesisBlock,
-        genesisSpendable().take(2).map!(txb => txb.sign(TxType.Payment,
-            null, Height(0), 0, &unlocker)), 0, Hash.init, genesis_validator_keys.length);
+        genesisSpendable().take(2).map!(txb => txb.sign(OutputType.Payment, null, Height(0), 0, &unlocker)), 0, Hash.init, genesis_validator_keys.length);
 
     auto validators = BitField!ubyte(2);
     validators[1] = true;

--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -275,7 +275,7 @@ unittest
 public auto spendable (const ref Block block) @safe pure nothrow
 {
     return block.txs
-        .filter!(tx => tx.type == TxType.Payment)
+        .filter!(tx => tx.isPaymentTx)
         .map!(tx => iota(tx.outputs.length).map!(idx => TxBuilder(tx, cast(uint)idx)))
         .joiner();
 }

--- a/tests/unit/BlockStorage.d
+++ b/tests/unit/BlockStorage.d
@@ -50,8 +50,7 @@ private void main ()
     foreach (idx; 1 .. count)
     {
         tx = Transaction(
-            TxType.Payment,
-            [
+                [
                 Input(gen_tx_hash, 0)
             ],
             [


### PR DESCRIPTION
To enable a spendable refund output in a freeze transaction we set the `Payment`, `Freeze` or `Coinbase` enum on each output.

Note that only the last commit is for the output tx type update.