### PR TITLE
Integration: Use 'none' config file for Faucet

### DIFF
--- a/tests/system/docker-compose.yml
+++ b/tests/system/docker-compose.yml
@@ -92,4 +92,4 @@ services:
       - node-5
       - node-6
       - node-7
-    command: http://node-7:7826
+    command: [ "-c", "none", "http://node-7:7826" ]


### PR DESCRIPTION
See bosagora/faucet#81 and bosagora/faucet#83 .