### PR TITLE
Fix to use the validator's pre-image when generating the encryption key.

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -454,7 +454,8 @@ public class Validator : FullNode, API
 
     public AdminInterface makeAdminInterface ()
     {
-        return new AdminInterface(this.config.validator.key_pair, this.clock);
+        return new AdminInterface(this.config.validator.key_pair, this.clock,
+            this.enroll_man);
     }
 
     /***************************************************************************


### PR DESCRIPTION
The encrypted key is used to vote in Votera.
To prevent this pre-image from being pre-released, add the PreimageRevealPeriod + 1 height.

Related to #2074 