### PR TITLE
Ledger: Replay every block if stateDB is inconsistent

### DIFF
--- a/source/agora/consensus/state/UTXOCache.d
+++ b/source/agora/consensus/state/UTXOCache.d
@@ -220,6 +220,14 @@ abstract class UTXOCache
     ***************************************************************************/
 
     protected abstract void add (in Hash utxo, UTXO value) @safe;
+
+    /***************************************************************************
+
+        Clear the UTXO cache
+
+    ***************************************************************************/
+
+    public abstract void clear () @safe;
 }
 
 /*******************************************************************************
@@ -316,5 +324,16 @@ public class TestUTXOSet : UTXOCache
             if (key_val.value.output.lock.bytes[] == pubkey[])
                 utxos[key_val.key] = key_val.value;
         return utxos;
+    }
+
+    /***************************************************************************
+
+        Clear the UTXO cache
+
+    ***************************************************************************/
+
+    public override void clear () @trusted
+    {
+        this.storage.clear();
     }
 }

--- a/source/agora/consensus/state/UTXODB.d
+++ b/source/agora/consensus/state/UTXODB.d
@@ -182,4 +182,15 @@ package class UTXODB
     {
         db.execute("DELETE FROM utxo WHERE hash = ?", key);
     }
+
+    /***************************************************************************
+
+        Clear the UTXO database
+
+    ***************************************************************************/
+
+    public void clear () @trusted
+    {
+        db.execute("DELETE FROM utxo");
+    }
 }

--- a/source/agora/consensus/state/UTXOSet.d
+++ b/source/agora/consensus/state/UTXOSet.d
@@ -92,6 +92,12 @@ public class UTXOSet : UTXOCache
     {
         this.utxo_db[utxo] = value;
     }
+
+    ///
+    public override void clear () @safe
+    {
+        this.utxo_db.clear();
+    }
 }
 
 /// Thread safe version of the UTXOSet, should only be used for testing
@@ -164,4 +170,7 @@ unittest
     // test for getting UTXOs for the second KeyPair
     utxos = utxo_set.getUTXOs(key_pairs[1].address);
     assert(utxos.length == 1);
+
+    utxos.clear();
+    assert(utxos.length == 0);
 }


### PR DESCRIPTION
Since both UTXOSet and EnrollmentManager use the same DB if one of
their state is off, the other one can not be trusted either. In that case
we drop both UTXOSet and EnrollmentManager state and replay the whole
chain.