### PR TITLE
Mount debugfs in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY --from=Builder /root/packages/ /root/packages/
 RUN apk --no-cache add --allow-untrusted -X /root/packages/build/ ldc-runtime=1.26.0-r0 \
     && rm -rf /root/packages/
 RUN apk --no-cache add llvm-libunwind libgcc libsodium libstdc++ sqlite-libs
+RUN mount -t debugfs none /sys/kernel/debug
 COPY --from=Builder /root/agora/talos/build/ /usr/share/agora/talos/
 COPY --from=Builder /root/agora/build/agora /usr/local/bin/agora
 WORKDIR /agora/


### PR DESCRIPTION
To get #2118, we need to both run agora as root and mount debugfs inside the container