### PR TITLE
Issue2110: Prepare for type in Transaction outputs

### DIFF
--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -159,6 +159,26 @@ public struct Transaction
     {
         return hashFull(this).opCmp(hashFull(other));
     }
+
+    pure nothrow @nogc:
+
+    /// A `Freeze` transaction
+    public bool isFreeze () const
+    {
+        return this.type == TxType.Freeze;
+    }
+
+    /// A `Coinbase` transaction
+    public bool isCoinbase () const
+    {
+        return this.type == TxType.Coinbase;
+    }
+
+    /// A `Payment` transaction
+    public bool isPayment () const
+    {
+        return this.type == TxType.Payment;
+    }
 }
 
 unittest

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -238,7 +238,7 @@ public struct Output
     }
 
     /// Support for sorting
-    public int opCmp ( const typeof(this) rhs ) const nothrow @safe @nogc
+    public int opCmp (in typeof(this) rhs) const nothrow @safe @nogc
     {
         if (this.lock != rhs.lock)
             return this.lock < rhs.lock ? -1 : 1;
@@ -312,7 +312,7 @@ public struct Input
     }
 
     /// Support for sorting
-    public int opCmp ( const typeof(this) rhs ) const nothrow @safe @nogc
+    public int opCmp (in typeof(this) rhs) const nothrow @safe @nogc
     {
         return this.utxo.opCmp(rhs.utxo);
     }

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -288,12 +288,12 @@ public string isGenesisBlockInvalidReason (in Block block) nothrow @safe
             // disallow negative amounts
             if (!output.value.isValid())
                 return "GenesisBlock: Output(s) overflow or underflow"
-                    ~ "in the transaction";
+                    ~ " in the transaction";
 
             // disallow 0 amount
             if (output.value == Amount(0))
                 return "GenesisBlock: Value of output is 0"
-                    ~ "in the transaction";
+                    ~ " in the transaction";
 
             const UTXO utxo_value = {
                 unlock_height: 0,

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -259,9 +259,6 @@ public string isGenesisBlockInvalidReason (in Block block) nothrow @safe
         return "GenesisBlock: Header.prev_block is not empty";
 
     if (block.txs.length == 0)
-        return "GenesisBlock: Transaction(s) are empty";
-
-    if (block.txs.length == 0)
         return "GenesisBlock: Must contain at least one transaction";
 
     if (!block.txs.isSorted())

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -544,10 +544,8 @@ public class Ledger
     public Transaction[] getCoinbaseTX (in Height height, in Amount tot_fee, in Amount tot_data_fee,
         in uint[] missing_validators) nothrow @safe
     {
-        const next_height = this.getBlockHeight() + 1;
-
         UTXO[] stakes;
-        this.enroll_man.getValidatorStakes(next_height, &this.utxo_set.peekUTXO, stakes,
+        this.enroll_man.getValidatorStakes(height, &this.utxo_set.peekUTXO, stakes,
             missing_validators);
         const commons_fee = this.fee_man.getCommonsBudgetFee(tot_fee,
             tot_data_fee, stakes);
@@ -555,7 +553,7 @@ public class Ledger
         // An empty coinbase TX
         auto coinbase_tx = Transaction(
             TxType.Coinbase,
-            [Input(next_height)],
+            [Input(height)],
             [],
         );
 
@@ -565,7 +563,7 @@ public class Ledger
                 this.params.CommonsBudgetAddress);
 
         // pay the validator for the past blocks
-        if (auto payouts = this.fee_man.getAccumulatedFees(next_height))
+        if (auto payouts = this.fee_man.getAccumulatedFees(height))
             foreach (pair; payouts.byKeyValue())
                 if (pair.value > Amount(0))
                     coinbase_tx.outputs ~= Output(pair.value, pair.key);

--- a/source/agora/script/Lock.d
+++ b/source/agora/script/Lock.d
@@ -74,7 +74,7 @@ public struct Lock
     }
 
     /// Support for sorting
-    public int opCmp ( const typeof(this) rhs ) const nothrow @safe @nogc
+    public int opCmp (in typeof(this) rhs) const nothrow @safe @nogc
     {
         import std.algorithm;
 

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -19,6 +19,7 @@ import agora.common.Amount;
 import agora.common.Config;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
+import agora.consensus.data.genesis.Test: genesis_validator_keys;
 import agora.test.Base;
 
 import core.thread;
@@ -112,7 +113,7 @@ unittest
         .array;
 
     // 8 utxos for freezing, 24 utxos for creating a block later
-    txs ~= spendable[4].split(WK.Keys.NODE2.address.repeat(8)).sign();
+    txs ~= spendable[4].split(genesis_validator_keys[0].address.repeat(8)).sign();
     txs ~= spendable[5].split(WK.Keys.Z.address.repeat(8)).sign();
     txs ~= spendable[6].split(WK.Keys.Z.address.repeat(8)).sign();
     txs ~= spendable[7].split(WK.Keys.Z.address.repeat(8)).sign();
@@ -130,7 +131,7 @@ unittest
     // Create 8 freeze TXs
     auto freeze_txs = freezable
         .enumerate
-        .map!(pair => pair.value.refund(WK.Keys.NODE2.address)
+        .map!(pair => pair.value.refund(genesis_validator_keys[0].address)
             .sign(TxType.Freeze))
         .array;
     assert(freeze_txs.length == 8);


### PR DESCRIPTION
This takes the first few trivial commits from https://github.com/bosagora/agora/pull/2114 and includes a change to enable the update of the Faucet to use `Transaction.isPayment` function which replaces `TxType == Payment`.