### PR TITLE
Export agora symbols for better debugging and stack traces

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -69,6 +69,8 @@
     "dflags": [ "-extern-std=c++14", "-preview=in" ],
     "lflags-posix": [ "-lstdc++", "-lsqlite3" ],
     "lflags-windows": [  "sqlite3.lib", "/nodefaultlib:msvcetd.lib" ],
+    "lflags-linux": [ "--export-dynamic" ],
+    "lflags-osx": [ "-export_dynamic" ],
     "libs-windows": [ "iphlpapi" ],
     "buildRequirements": [ "allowWarnings" ],
 


### PR DESCRIPTION
this exports additional ~30k symbols on my machine

```
[omer@archlinux agora]$ nm ./build/agora-no-export | wc -l
46684
[omer@archlinux agora]$ nm ./build/agora | wc -l
75213
```