### PR TITLE
Fixes issue 2128: Network tests - Remove override of `prepareNominatingSet`

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -296,16 +296,6 @@ extern(D):
 
         Check whether we're ready to nominate a new block.
 
-        Overriden in unittests to get fine-grained control
-        of when blocks are created:
-
-        - We may want to create blocks faster than `BlockIntervalSeconds`
-          in order to speed up the unittests.
-        - We may want to wait until we have a specific number of TXs in the
-          pool before we start nominating. Otherwise timing issues may cause
-          the unittest nodes to nominate wildly different transaction sets,
-          skewing the assumptions in the tests and causing failures.
-
         Returns:
             true if the validator is ready to start nominating
 

--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -25,14 +25,12 @@ import core.thread;
 /// test node banning after putTransaction fails a number of times
 unittest
 {
-    const txs_to_nominate = 8;
     TestConf conf =
     {
         full_nodes : 1,
         retry_delay : 10.msecs,
         max_retries : 10,
-        txs_to_nominate : txs_to_nominate,
-        max_failed_requests : 4 * txs_to_nominate
+        max_failed_requests : 32
     };
 
     auto network = makeTestNetwork!TestAPIManager(conf);

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -102,7 +102,7 @@ class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new ByzantineNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.txs_to_nominate, this.test_start_time, reason);
+            &this.acceptBlock, this.test_start_time, reason);
     }
 }
 
@@ -162,7 +162,7 @@ private class SpyingValidator : TestValidatorNode
         return new SpyNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.txs_to_nominate, this.test_start_time,
+            &this.acceptBlock, this.test_start_time,
             this.envelope_type_counts);
     }
 }

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -90,7 +90,6 @@ private class SameKeyNodeAPIManager : TestAPIManager
 unittest
 {
     TestConf conf = {
-        txs_to_nominate : 0, // zero allows any number of txs for nomination
         recurring_enrollment : false
     };
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -248,7 +248,7 @@ unittest
             return new BadNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock, this.txs_to_nominate, this.test_start_time,
+                &this.acceptBlock, this.test_start_time,
                 this.runCount);
         }
     }

--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -225,7 +225,6 @@ unittest
     import core.thread;
 
     TestConf conf = {
-        txs_to_nominate : 1,
         payout_period : 1,
         quorum_threshold : 100
     };

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -539,7 +539,7 @@ private class FlashListener : TestFlashListenerAPI
 //version (none)
 unittest
 {
-    TestConf conf = { txs_to_nominate : 1, payout_period : 100 };
+    TestConf conf = { payout_period : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -645,7 +645,7 @@ unittest
 //version (none)
 unittest
 {
-    TestConf conf = { txs_to_nominate : 1, payout_period : 100 };
+    TestConf conf = { payout_period : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -777,7 +777,7 @@ unittest
         }
     }
 
-    TestConf conf = { txs_to_nominate : 1, payout_period : 100 };
+    TestConf conf = { payout_period : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -885,7 +885,7 @@ unittest
 //version (none)
 unittest
 {
-    TestConf conf = { txs_to_nominate : 1, payout_period : 100 };
+    TestConf conf = { payout_period : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1032,7 +1032,7 @@ unittest
 /// Test path probing
 unittest
 {
-    TestConf conf = { txs_to_nominate : 1, payout_period : 100 };
+    TestConf conf = { payout_period : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1206,7 +1206,7 @@ unittest
 /// Test path probing
 unittest
 {
-    TestConf conf = { txs_to_nominate : 1, payout_period : 100 };
+    TestConf conf = { payout_period : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1432,7 +1432,7 @@ unittest
         }
     }
 
-    TestConf conf = { txs_to_nominate : 1, payout_period : 100 };
+    TestConf conf = { payout_period : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1514,7 +1514,7 @@ unittest
 //version (none)
 unittest
 {
-    TestConf conf = { txs_to_nominate : 1, payout_period : 100 };
+    TestConf conf = { payout_period : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1605,7 +1605,7 @@ unittest
 /// test various error cases
 unittest
 {
-    TestConf conf = { txs_to_nominate : 1, payout_period : 100 };
+    TestConf conf = { payout_period : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1807,7 +1807,7 @@ unittest
         }
     }
 
-    TestConf conf = { txs_to_nominate : 1, payout_period : 100 };
+    TestConf conf = { payout_period : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1921,7 +1921,7 @@ unittest
         }
     }
 
-    TestConf conf = { txs_to_nominate : 1, payout_period : 100 };
+    TestConf conf = { payout_period : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -106,7 +106,7 @@ private class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new BadBlockSigningNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.txs_to_nominate, this.test_start_time, reason);
+            &this.acceptBlock, this.test_start_time, reason);
     }
 }
 
@@ -140,7 +140,7 @@ private class ByzantineManager (ByzantineReason reason) : TestAPIManager
 /// The block should only have 5 / 6 block signatures added
 unittest
 {
-    TestConf conf = { quorum_threshold : 83 , txs_to_nominate : 1 };
+    TestConf conf = { quorum_threshold : 83 };
     auto network = makeTestNetwork!(ByzantineManager!(ByzantineReason.BadSignature))(conf);
     network.start();
     scope(exit) network.shutdown();
@@ -159,7 +159,7 @@ unittest
 /// The block should only have 5 / 6 block signatures added
 unittest
 {
-    TestConf conf = { quorum_threshold : 83 , txs_to_nominate : 1 };
+    TestConf conf = { quorum_threshold : 83 };
     auto network = makeTestNetwork!(ByzantineManager!(ByzantineReason.BadCommitmentR))(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -233,8 +233,7 @@ unittest
 // See https://github.com/bosagora/agora/issues/1440
 unittest
 {
-    TestConf conf = { txs_to_nominate: 1 };
-    auto network = makeTestNetwork!TestAPIManager(conf);
+    auto network = makeTestNetwork!TestAPIManager(TestConf.init);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();

--- a/source/agora/test/ManyBlocks.d
+++ b/source/agora/test/ManyBlocks.d
@@ -25,10 +25,7 @@ import agora.test.Base;
 /// Simple test
 unittest
 {
-    TestConf conf = {
-        txs_to_nominate : 1,
-        quorum_threshold : 100
-    };
+    TestConf conf = { quorum_threshold : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -28,8 +28,7 @@ void manyValidators (size_t validators)
     import core.time : seconds;
     import agora.crypto.Key;
 
-    TestConf conf = { outsider_validators : validators - GenesisValidators,
-        txs_to_nominate : 0 };
+    TestConf conf = { outsider_validators : validators - GenesisValidators };
 
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -114,7 +114,7 @@ private class BadNominatingVN : TestValidatorNode
         return new BadNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
+            &this.acceptBlock, this.test_start_time);
     }
 }
 

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -75,7 +75,7 @@ unittest
             return new CustomNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
+                &this.acceptBlock, this.test_start_time);
         }
     }
 

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -76,7 +76,7 @@ private class TestNode () : TestValidatorNode
         return new DoesNotExternalizeBlockNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
+            &this.acceptBlock, this.test_start_time);
     }
 }
 
@@ -106,8 +106,7 @@ private class NodeManager (): TestAPIManager
 /// All nodes should have same blocks given enough time for periodic catchup to take place
 unittest
 {
-    TestConf conf = { txs_to_nominate : 1 };
-    auto network = makeTestNetwork!(NodeManager!())(conf);
+    auto network = makeTestNetwork!(NodeManager!())(TestConf.init);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -38,7 +38,6 @@ import core.time;
 unittest
 {
     TestConf conf = { outsider_validators : 3,
-        txs_to_nominate : 0,  // zero allows any number of txs for nomination
         recurring_enrollment : false,
     };
     auto network = makeTestNetwork!TestAPIManager(conf);

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -43,8 +43,7 @@ unittest
     TestConf conf = {
         recurring_enrollment : false,
         outsider_validators : 2,
-        max_listeners : 7,
-        txs_to_nominate : 0 };
+        max_listeners : 7 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -83,7 +83,7 @@ unittest
             return new ReNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
+                &this.acceptBlock, this.test_start_time);
         }
     }
 

--- a/source/agora/test/RestoreSlashingInfo.d
+++ b/source/agora/test/RestoreSlashingInfo.d
@@ -33,7 +33,6 @@ unittest
     TestConf conf = {
         timeout : 10.seconds,
         outsider_validators : 3,
-        txs_to_nominate : 0, // zero allows any number of txs for nomination
         recurring_enrollment : false
     };
     auto network = makeTestNetwork!TestAPIManager(conf);

--- a/source/agora/test/Simple.d
+++ b/source/agora/test/Simple.d
@@ -28,10 +28,7 @@ import agora.test.Base;
 /// Simple test
 unittest
 {
-    TestConf conf = {
-        txs_to_nominate : 1,
-    };
-    auto network = makeTestNetwork!TestAPIManager(conf);
+    auto network = makeTestNetwork!TestAPIManager(TestConf.init);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();

--- a/source/agora/test/TimeBlockInterval.d
+++ b/source/agora/test/TimeBlockInterval.d
@@ -20,48 +20,28 @@ import agora.consensus.data.Transaction;
 import agora.crypto.Hash;
 import agora.test.Base;
 
+import std.range;
+import std.algorithm;
+
 ///
 unittest
 {
-    TestConf conf = { txs_to_nominate : 2, block_interval_sec : 10 };
+    TestConf conf = { block_interval_sec : 10 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.clients;
-    auto node_1 = nodes[0];
+    auto node_1 = network.clients.front;
 
-    auto spendable = network.blocks[0].txs
-        .filter!(tx => tx.isPayment)
-        .map!(tx => iota(tx.outputs.length)
-            .map!(idx => TxBuilder(tx, cast(uint)idx)))
-        .joiner().take(8).array;
-
-    auto txs = spendable
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
-        .array;
-
-    // 8 transactions is enough for 4 blocks with 2 txs each
-    txs.each!(tx => nodes[0].putTransaction(tx));
-
-    // check for propagation
-    nodes.each!(node =>
-       txs.each!(tx =>
-           node.hasAcceptedTxHash(hashFull(tx)).retryFor(4.seconds)
-    ));
-
-    // time updated, block height 1
-    const b0 = nodes[0].getBlocksFrom(0, 2)[0];
-
-    void checkHeight(Height height)
-    {
-        network.waitForPreimages(b0.header.enrollments, height, 30.seconds);
-        network.setTimeFor(height);
-        network.assertSameBlocks(height);
-    }
-
-    // Check for adding blocks 1 to 4
-    [1, 2, 3, 4].each!(h => checkHeight(Height(h)));
+    auto startTime = node_1.getNetworkTime();
+    // create 8 txs enough for 4 blocks with 2 txs each
+    genesisSpendable.map!(txb =>
+        txb.sign())
+        .chunks(2).enumerate.each!((en) {
+            en.value.each!(tx => node_1.putTransaction(tx));
+            network.expectHeightAndPreImg(Height(en.index + 1));
+        });
+    assert(node_1.getNetworkTime() >= startTime + (4 * conf.block_interval_sec));
 }

--- a/source/agora/test/TimeDrift.d
+++ b/source/agora/test/TimeDrift.d
@@ -27,9 +27,7 @@ import std.range;
 ///
 unittest
 {
-    TestConf conf = { txs_to_nominate : 2,
-        block_interval_sec : 1, max_quorum_nodes : 5, quorum_threshold : 100
-    };
+    TestConf conf = { block_interval_sec : 1, max_quorum_nodes : 5, quorum_threshold : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/TransactionReplacement.d
+++ b/source/agora/test/TransactionReplacement.d
@@ -29,10 +29,7 @@ import core.thread.osthread : Thread;
 ///
 unittest
 {
-    TestConf conf = {
-        txs_to_nominate : 0,
-    };
-    auto network = makeTestNetwork!TestAPIManager(conf);
+    auto network = makeTestNetwork!TestAPIManager(TestConf.init);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -35,7 +35,6 @@ version(none) unittest
     TestConf conf = {
         timeout : 10.seconds,
         outsider_validators : 3,
-        txs_to_nominate : 0, // zero allows any number of txs for nomination
         recurring_enrollment : false
     };
     auto network = makeTestNetwork!TestAPIManager(conf);

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -194,7 +194,7 @@ unittest
             return new SocialDistancingNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock, this.txs_to_nominate, this.test_start_time);
+                &this.acceptBlock, this.test_start_time);
         }
 
     }


### PR DESCRIPTION
When testing we want to be as close to production behavior as possible.
This removes the txs_to_nominate config option and makes use of
mockClock only to set the time for nomination. This is much closer to
the real life case where nomination is triggered by time and not number
of transactions.