### PR TITLE
Flash: Streamline Point/PublicKey usage & co

### DIFF
--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -110,7 +110,7 @@ public class Channel
 
     /// @WORKAROUND@: LocalRest issue with timings and sleep not working until
     /// node ctor is done (see Flash restart tests)
-    private FlashAPI delegate (in Point peer_pk, Duration timeout) getFlashClient;
+    private FlashAPI delegate (in PublicKey peer_pk, Duration timeout) getFlashClient;
 
     /// Retry delay algorithm
     private Backoff backoff;
@@ -203,7 +203,7 @@ public class Channel
         OnChannelNotify onChannelNotify,
         OnPaymentComplete onPaymentComplete,
         OnUpdateComplete onUpdateComplete,
-        FlashAPI delegate (in Point peer_pk, Duration timeout) getFlashClient,
+        FlashAPI delegate (in PublicKey peer_pk, Duration timeout) getFlashClient,
         ManagedDatabase db)
     {
         this.db = db;
@@ -248,16 +248,16 @@ public class Channel
 
     ***************************************************************************/
 
-    public static Channel[Hash][Point] loadChannels (FlashConfig flash_conf,
+    public static Channel[Hash][PublicKey] loadChannels (FlashConfig flash_conf,
         ManagedDatabase db,
-        FlashAPI delegate (in Point peer_pk, Duration timeout) getFlashClient,
+        FlashAPI delegate (in PublicKey peer_pk, Duration timeout) getFlashClient,
         Engine engine, ITaskManager taskman,
         void delegate (Transaction) txPublisher, PaymentRouter paymentRouter,
         OnChannelNotify onChannelNotify,
         OnPaymentComplete onPaymentComplete,
         OnUpdateComplete onUpdateComplete )
     {
-        Channel[Hash][Point] channels;
+        Channel[Hash][PublicKey] channels;
 
         db.execute("CREATE TABLE IF NOT EXISTS channels " ~
             "(key BLOB NOT NULL, chan_id BLOB NOT NULL, data BLOB NOT NULL, " ~
@@ -2253,7 +2253,7 @@ private mixin template ChannelMetadata ()
     public bool is_owner;
 
     /// The public key of the counter-party (for logging)
-    public Point peer_pk;
+    public PublicKey peer_pk;
 
     /// Our private nonce for the first trigger tx
     public PrivateNonce priv_nonce;

--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -108,8 +108,7 @@ public class Channel
     /// Ditto
     private OnUpdateComplete onUpdateComplete;
 
-    /// @WORKAROUND@: LocalRest issue with timings and sleep not working until
-    /// node ctor is done (see Flash restart tests)
+    /// Fetch the Flash Client for the peer
     private FlashAPI delegate (in PublicKey peer_pk, Duration timeout) getFlashClient;
 
     /// Retry delay algorithm
@@ -524,8 +523,8 @@ public class Channel
         if (this.getState == ChannelState.Closed)
             return;
 
-        // if it's a preloaded channel we can only retrieve the flash client
-        // once the event loop is running (LocalRest issue)
+        // Peer might not registered yet at the time we construct
+        // the Channel, so we might need to re-try here in the event loop.
         if (this.peer is null)
         {
             this.peer = getFlashClient(this.peer_pk, this.flash_conf.timeout);

--- a/source/agora/flash/Config.d
+++ b/source/agora/flash/Config.d
@@ -83,13 +83,13 @@ public struct ChannelConfig
     public Hash gen_hash;
 
     /// Public key of the funder of the channel.
-    public Point funder_pk;
+    public PublicKey funder_pk;
 
     /// Public key of the counter-party to the channel.
-    public Point peer_pk;
+    public PublicKey peer_pk;
 
     /// Sum of `funder_pk + peer_pk`.
-    public Point pair_pk;
+    public PublicKey pair_pk;
 
     /// Total number of co-signers needed to make update/settlement transactions
     /// in this channel.
@@ -98,7 +98,7 @@ public struct ChannelConfig
     /// The public key sum used for validating Update transactions.
     /// This key is derived and remains static throughout the
     /// lifetime of the channel.
-    public /*const*/ Point update_pair_pk;
+    public /*const*/ PublicKey update_pair_pk;
 
     /// The funding transaction from which the trigger transaction may spend.
     /// This transaction is unsigned - only the funder may sign & send it

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -390,24 +390,14 @@ public abstract class FlashNode : FlashControlAPI
     /// Handle an outgoing gossip event
     private void handleGossip (GossipEvent event)
     {
+        foreach (peer; this.known_peers.byKeyValue)
         final switch (event.type) with (GossipType)
         {
         case Open:
-            foreach (pair; this.known_peers.byKeyValue)
-            {
-                static ChannelConfig[1] open_buffer;
-                open_buffer[0] = event.open;
-                pair.value.gossipChannelsOpen(open_buffer[]);
-            }
+            peer.value.gossipChannelsOpen([event.open].staticArray);
             break;
-
         case Update:
-            foreach (pair; this.known_peers.byKeyValue)
-            {
-                static ChannelUpdate[1] update_buffer;
-                update_buffer[0] = event.update;
-                pair.value.gossipChannelUpdates(update_buffer[]);
-            }
+            peer.value.gossipChannelUpdates([event.update].staticArray);
             break;
         }
     }

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -261,19 +261,10 @@ public abstract class FlashNode : FlashControlAPI
 
     public override ChannelConfig[] getManagedChannels (PublicKey[] keys) @safe
     {
-        PublicKey[] filtered;
-        if (keys.length)
-            filtered = this.channels.byKey.filter!(k => keys.canFind(k)).array;
-        else
-            filtered = this.channels.byKey.array;
-        sort(filtered);
-
-        ChannelConfig[] all;
-        foreach (key; filtered)
-            foreach (chan; this.channels[key])
-                all ~= chan.conf;
-
-        return all;
+        auto filtered = sort(this.channels.byKey
+            .filter!(k => !keys.length || keys.canFind(k)).array);
+        return filtered.map!(key =>
+            this.channels[key].byValue.map!(chan => chan.conf)).joiner().array;
     }
 
     /***************************************************************************

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -241,10 +241,8 @@ public abstract class FlashNode : FlashControlAPI
         auto secret = SecretKey(scalar);
         auto address = PublicKey(scalar.toPoint()[]);
         this.managed_keys[address] = secret;
-        Channel[Hash] def;
-        this.channels[address] = def;
-        DList!ChannelConfig def2;
-        this.pending_channels[address] = def2;
+        this.channels[address] = typeof(this.channels[address]).init;
+        this.pending_channels[address] = typeof(this.pending_channels[address]).init;
     }
 
     /***************************************************************************

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -194,7 +194,7 @@ public class TestFlashNode : ThinFlashNode, TestFlashAPI
     }
 
     ///
-    protected override TestFlashAPI getFlashClient (in Point peer_pk,
+    protected override TestFlashAPI getFlashClient (in PublicKey peer_pk,
         Duration timeout) @trusted
     {
         if (auto peer = peer_pk in this.known_peers)
@@ -320,7 +320,7 @@ public class FlashNodeFactory (FlashListenerType = FlashListener)
     private Registry!TestFlashListenerAPI listener_registry;
 
     /// list of flash addresses
-    private Point[] addresses;
+    private PublicKey[] addresses;
 
     /// list of listener addresses
     private string[] listener_addresses;
@@ -374,11 +374,12 @@ public class FlashNodeFactory (FlashListenerType = FlashListener)
             &this.flash_registry, &this.listener_registry,
             10.seconds);  // timeout from main thread
 
-        this.addresses ~= pair.V;
+        auto pk = PublicKey(pair.V);
+        this.addresses ~= pk;
         this.nodes ~= api;
-        this.flash_registry.register(pair.V.to!string, api.listener());
+        this.flash_registry.register(pk.to!string, api.listener());
         api.start();
-        const key_pair = KeyPair(PublicKey(pair.V), SecretKey(pair.v));
+        const key_pair = KeyPair(pk, SecretKey(pair.v));
         api.registerKey(key_pair.secret);
 
         return api;


### PR DESCRIPTION
`FlashAPI` already uses `PublicKey`, prefer `PublicKey` over `Point`

More will probably follow.