### PR TITLE
Issue1380 syntax check lock script

### DIFF
--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -92,6 +92,9 @@ public string isInvalidReason (
         // Each freeze output of a transaction must have at least `Amount.MinFreezeAmount`.
         if (output.type == OutputType.Freeze && output.value < Amount.MinFreezeAmount)
             return "Transaction: All non-refund outputs must be over the minimum freezing amount";
+
+        if (auto reason = validateLockSyntax(output.lock, engine.StackMaxItemSize))
+            return reason;
     }
 
     const tx_hash = hashFull(tx);
@@ -336,6 +339,14 @@ unittest
 
     assert(tx1.isValid(engine, storage.getUTXOFinder(), Height(0), checker),
            format("Transaction signature is not validated %s", tx1));
+
+    import agora.serialization.Serializer;
+    auto dupe = tx1.serializeFull.deserializeFull!Transaction;
+    assert(dupe.isValid(engine, storage.getUTXOFinder(), Height(0), checker),
+           format("Transaction signature is not validated %s", tx1));
+    dupe.outputs[0].lock.bytes.length = 0;
+    assert(dupe.isInvalidReason(engine, storage.getUTXOFinder(), Height(0), checker)
+        == "LockType.Key requires 32-byte key argument in the lock script");
 
     Transaction tx2 = Transaction(
         [

--- a/source/agora/script/Engine.d
+++ b/source/agora/script/Engine.d
@@ -57,7 +57,7 @@ public class Engine
     private immutable ulong StackMaxTotalSize;
 
     /// Maximum size of an item on the stack
-    private immutable ulong StackMaxItemSize;
+    public immutable ulong StackMaxItemSize;
 
     /***************************************************************************
 

--- a/source/agora/script/Engine.d
+++ b/source/agora/script/Engine.d
@@ -236,12 +236,12 @@ public class Engine
         assert(lock.type == LockType.Script);
 
         Script unlock_script;
-        if (auto error = validateScript(ScriptType.Unlock, unlock.bytes,
+        if (auto error = validateScriptSyntax(ScriptType.Unlock, unlock.bytes,
             this.StackMaxItemSize, unlock_script))
             return error;
 
         Script lock_script;
-        if (auto error = validateScript(ScriptType.Lock, lock.bytes,
+        if (auto error = validateScriptSyntax(ScriptType.Lock, lock.bytes,
             this.StackMaxItemSize, lock_script))
             return error;
 
@@ -293,7 +293,7 @@ public class Engine
         const Hash script_hash = Hash(lock.bytes);
 
         Script unlock_script;
-        if (auto error = validateScript(ScriptType.Unlock, unlock.bytes,
+        if (auto error = validateScriptSyntax(ScriptType.Unlock, unlock.bytes,
             this.StackMaxItemSize, unlock_script))
             return error;
 
@@ -310,7 +310,7 @@ public class Engine
                  ~ "which does not match the redeem hash in the lock script";
 
         Script redeem;
-        if (auto error = validateScript(ScriptType.Redeem, redeem_bytes,
+        if (auto error = validateScriptSyntax(ScriptType.Redeem, redeem_bytes,
             this.StackMaxItemSize, redeem))
             return error;
 

--- a/source/agora/script/Lock.d
+++ b/source/agora/script/Lock.d
@@ -35,6 +35,7 @@ import agora.common.Types;
 import agora.crypto.ECC;
 import agora.crypto.Key;
 import agora.crypto.Schnorr: Signature;
+import agora.script.Script;
 import agora.utils.Utility;
 import std.format;
 import std.traits : EnumMembers;
@@ -104,6 +105,117 @@ unittest
     assert(format("%s", Lock(LockType.Key, kp.address[])) ==
            format("%s", kp.address));
     assert(format("%s", Lock(LockType.Script, [42, 69, 250])) == "Lock(Script, 2a45fa)");
+}
+
+
+/*******************************************************************************
+
+    Validates the Lock script's syntax on its own. For user's safety,
+    Agora's protocol rules disallow accepting an Output with a syntactically
+    invalid Lock script. This prevents accidental loss of funds, for example
+    in cases where the lock script is ill-formed (e.g. missing END blocks,
+    dangling ELSE statements, etc).
+
+    The semantics of the lock script are not checked here as it requires
+    an unlock script to run it with. This responsibility lies within the
+    script execution engine.
+
+    Params:
+        lock = the lock to validate
+        StackMaxItemSize = maximum allowed payload size for a
+            stack push operation
+
+    Returns:
+        null if the lock is syntactically valid,
+        otherwise the string explaining the reason why it's invalid
+
+*******************************************************************************/
+
+public string validateLockSyntax (in Lock lock, in ulong StackMaxItemSize)
+    /*pure*/ nothrow @safe @nogc
+{
+    // assumed sizes
+    static assert(Point.sizeof == 32);
+    static assert(Hash.sizeof == 64);
+
+    final switch (lock.type)
+    {
+    case LockType.Key:
+        if (lock.bytes.length != Point.sizeof)
+            return "LockType.Key requires 32-byte key argument in the lock script";
+        const Point key = Point(lock.bytes);
+        if (!key.isValid())
+            return "LockType.Key 32-byte public key in lock script is invalid";
+
+        return null;
+
+    case LockType.KeyHash:
+        if (lock.bytes.length != Hash.sizeof)
+            return "LockType.KeyHash requires a 64-byte key hash argument in the lock script";
+
+        return null;
+
+    case LockType.Script:
+        Script _lock_script;
+        return validateScriptSyntax(ScriptType.Lock, lock.bytes, StackMaxItemSize,
+            _lock_script);
+
+    case LockType.Redeem:
+        if (lock.bytes.length != Hash.sizeof)
+            return "LockType.Redeem requires 64-byte script hash in the lock script";
+        return null;
+    }
+}
+
+///
+unittest
+{
+    import agora.script.Opcodes;
+    import std.bitmanip;
+    immutable StackMaxItemSize = 512;
+
+    /* LockType.Key */
+    Lock lock = { type : LockType.Key };
+    assert(validateLockSyntax(lock, StackMaxItemSize) ==
+        "LockType.Key requires 32-byte key argument in the lock script");
+    lock.bytes.length = Point.sizeof;
+    assert(validateLockSyntax(lock, StackMaxItemSize) ==
+        "LockType.Key 32-byte public key in lock script is invalid");
+    const rand_key = Scalar.random().toPoint();
+    lock.bytes = rand_key[];
+    assert(validateLockSyntax(lock, StackMaxItemSize) == null);
+
+    /* LockType.KeyHash */
+    lock.type = LockType.KeyHash;
+    lock.bytes.length = 0;
+    assert(validateLockSyntax(lock, StackMaxItemSize) ==
+        "LockType.KeyHash requires a 64-byte key hash argument in the lock script");
+    lock.bytes.length = Hash.sizeof;  // any 64-byte number is a valid hash
+    assert(validateLockSyntax(lock, StackMaxItemSize) == null);
+
+    /* LockType.Script */
+    lock.type = LockType.Script;
+    lock.bytes.length = 0;
+    assert(validateLockSyntax(lock, StackMaxItemSize) ==
+        "Lock script must not be empty");
+    const ubyte[2] no_overflow = nativeToLittleEndian(
+        ushort(StackMaxItemSize));
+    const ubyte[2] size_overflow = nativeToLittleEndian(
+        ushort(StackMaxItemSize + 1));
+    const ubyte[StackMaxItemSize] max_payload;
+    lock.bytes = [ubyte(OP.PUSH_DATA_2)] ~ size_overflow ~ max_payload;
+    assert(validateLockSyntax(lock, StackMaxItemSize) ==
+        "PUSH_DATA_2 opcode payload size is not within StackMaxItemSize limits");
+    lock.bytes = [ubyte(OP.PUSH_DATA_2)] ~ no_overflow ~ max_payload;
+    assert(validateLockSyntax(lock, StackMaxItemSize) == null);
+
+    /* LockType.Redeem */
+    lock.type = LockType.Redeem;
+    lock.bytes.length = 0;
+    assert(validateLockSyntax(lock, StackMaxItemSize) ==
+        "LockType.Redeem requires 64-byte script hash in the lock script");
+    lock.bytes.length = Hash.sizeof;  // any 64-byte number is a valid hash
+    assert(validateLockSyntax(lock, StackMaxItemSize) == null);
 }
 
 /// Contains a data tuple or a set of push opcodes

--- a/source/agora/script/Script.d
+++ b/source/agora/script/Script.d
@@ -48,7 +48,7 @@ public struct Script
 
     /***************************************************************************
 
-        Internal. Use the `validateScript()` free function to construct
+        Internal. Use the `validateScriptSyntax()` free function to construct
         a validated Script out of a byte array of opcodes.
 
         Params:
@@ -104,7 +104,7 @@ public struct Script
 
 *******************************************************************************/
 
-public string validateScript (in ScriptType type, in ubyte[] opcodes,
+public string validateScriptSyntax (in ScriptType type, in ubyte[] opcodes,
     in ulong StackMaxItemSize, out Script script) pure nothrow @safe @nogc
 {
     const(ubyte)[] bytes = opcodes[];
@@ -171,48 +171,48 @@ unittest
     Script result;
 
     // empty scripts are syntactically valid
-    test!"=="(validateScript(
+    test!"=="(validateScriptSyntax(
         ScriptType.Lock, [], StackMaxItemSize, result), null);
-    test!"=="(validateScript(
+    test!"=="(validateScriptSyntax(
         ScriptType.Unlock, [], StackMaxItemSize, result), null);
 
     // only pushes are allowed for unlock
-    test!"=="(validateScript(ScriptType.Unlock, [OP.FALSE], StackMaxItemSize,
+    test!"=="(validateScriptSyntax(ScriptType.Unlock, [OP.FALSE], StackMaxItemSize,
         result),
         null);
-    test!"=="(validateScript(ScriptType.Unlock,
+    test!"=="(validateScriptSyntax(ScriptType.Unlock,
         [OP.PUSH_NUM_1, OP.PUSH_NUM_2, OP.PUSH_NUM_3, OP.PUSH_NUM_4, OP.PUSH_NUM_5],
         StackMaxItemSize, result),
         null);
-    test!"=="(validateScript(ScriptType.Unlock, [OP.PUSH_BYTES_1, 1],
+    test!"=="(validateScriptSyntax(ScriptType.Unlock, [OP.PUSH_BYTES_1, 1],
         StackMaxItemSize, result), null);
-    test!"=="(validateScript(ScriptType.Unlock, [OP.PUSH_BYTES_1, 1, OP.HASH],
+    test!"=="(validateScriptSyntax(ScriptType.Unlock, [OP.PUSH_BYTES_1, 1, OP.HASH],
         StackMaxItemSize, result),
         "Unlock script may only contain stack pushes");
 
-    test!"=="(validateScript(ScriptType.Lock, [255], StackMaxItemSize, result),
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [255], StackMaxItemSize, result),
         "Script contains an unrecognized opcode");
 
     // PUSH_BYTES_*
-    test!"=="(validateScript(ScriptType.Lock, [1], StackMaxItemSize, result),
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [1], StackMaxItemSize, result),
         "PUSH_BYTES_* opcode exceeds total script size");
     // 1-byte data payload
-    test!"=="(.validateScript(ScriptType.Lock, [1, 255], StackMaxItemSize,
+    test!"=="(.validateScriptSyntax(ScriptType.Lock, [1, 255], StackMaxItemSize,
         result), null);
-    test!"=="(validateScript(ScriptType.Lock, [2], StackMaxItemSize, result),
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [2], StackMaxItemSize, result),
         "PUSH_BYTES_* opcode exceeds total script size");
-    test!"=="(validateScript(ScriptType.Lock, [2, 255], StackMaxItemSize,
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [2, 255], StackMaxItemSize,
         result),
         "PUSH_BYTES_* opcode exceeds total script size");
     // 2-byte data payload
-    test!"=="(validateScript(ScriptType.Lock, [2, 255, 255], StackMaxItemSize,
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [2, 255, 255], StackMaxItemSize,
         result), null);
     ubyte[75] payload_75;
-    test!"=="(validateScript(ScriptType.Lock, [ubyte(75)] ~ payload_75[0 .. 74],
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [ubyte(75)] ~ payload_75[0 .. 74],
         StackMaxItemSize, result),
         "PUSH_BYTES_* opcode exceeds total script size");
     // 75-byte data payload
-    test!"=="(validateScript(ScriptType.Lock, [ubyte(75)] ~ payload_75,
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [ubyte(75)] ~ payload_75,
         StackMaxItemSize, result), null);
 
     // PUSH_DATA_*
@@ -222,44 +222,44 @@ unittest
     const ubyte[2] size_overflow = nativeToLittleEndian(
         ushort(StackMaxItemSize + 1));
 
-    test!"=="(validateScript(ScriptType.Lock, [OP.PUSH_DATA_1],
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_1],
         StackMaxItemSize, result),
         "PUSH_DATA_1 opcode requires 1 byte(s) for the payload size");
-    test!"=="(validateScript(ScriptType.Lock, [OP.PUSH_DATA_1, 0],
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_1, 0],
         StackMaxItemSize, result),
         "PUSH_DATA_1 opcode payload size is not within StackMaxItemSize limits");
-    test!"=="(validateScript(ScriptType.Lock, [OP.PUSH_DATA_1, 1],
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_1, 1],
         StackMaxItemSize, result),
         "PUSH_DATA_1 opcode payload size exceeds total script size");
-    test!"=="(validateScript(ScriptType.Lock, [OP.PUSH_DATA_1, 1, 1],
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_1, 1, 1],
         StackMaxItemSize, result), null);
-    test!"=="(validateScript(ScriptType.Lock, [OP.PUSH_DATA_2],
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_2],
         StackMaxItemSize, result),
         "PUSH_DATA_2 opcode requires 2 byte(s) for the payload size");
-    test!"=="(validateScript(ScriptType.Lock, [OP.PUSH_DATA_2, 0],
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_2, 0],
         StackMaxItemSize, result),
         "PUSH_DATA_2 opcode requires 2 byte(s) for the payload size");
-    test!"=="(validateScript(ScriptType.Lock, [OP.PUSH_DATA_2, 0, 0],
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_2, 0, 0],
         StackMaxItemSize, result),
         "PUSH_DATA_2 opcode payload size is not within StackMaxItemSize limits");
-    test!"=="(validateScript(ScriptType.Lock, [ubyte(OP.PUSH_DATA_2)] ~ size_1,
+    test!"=="(validateScriptSyntax(ScriptType.Lock, [ubyte(OP.PUSH_DATA_2)] ~ size_1,
         StackMaxItemSize, result),
         "PUSH_DATA_2 opcode payload size exceeds total script size");
-    test!"=="(validateScript(ScriptType.Lock,
+    test!"=="(validateScriptSyntax(ScriptType.Lock,
         [ubyte(OP.PUSH_DATA_2)] ~ size_1 ~ [ubyte(1)], StackMaxItemSize,
         result), null);
-    test!"=="(validateScript(ScriptType.Lock,
+    test!"=="(validateScriptSyntax(ScriptType.Lock,
         [ubyte(OP.PUSH_DATA_2)] ~ size_max ~ max_payload, StackMaxItemSize,
         result), null);
-    test!"=="(validateScript(ScriptType.Lock,
+    test!"=="(validateScriptSyntax(ScriptType.Lock,
         [ubyte(OP.PUSH_DATA_2)] ~ size_overflow ~ max_payload,
         StackMaxItemSize, result),
         "PUSH_DATA_2 opcode payload size is not within StackMaxItemSize limits");
-    test!"=="(validateScript(ScriptType.Lock,
+    test!"=="(validateScriptSyntax(ScriptType.Lock,
         [ubyte(OP.PUSH_DATA_2)] ~ size_max ~ max_payload ~ OP.HASH,
         StackMaxItemSize, result),
         null);
-    test!"=="(validateScript(ScriptType.Lock,
+    test!"=="(validateScriptSyntax(ScriptType.Lock,
         [ubyte(OP.PUSH_DATA_2)] ~ size_max ~ max_payload ~ ubyte(255),
         StackMaxItemSize, result),
         "Script contains an unrecognized opcode");
@@ -368,9 +368,9 @@ unittest
     // sanity checks
     const key_hash = hashFull(kp.V);
     Script lock_script = createLockP2PKH(key_hash);
-    assert(validateScript(ScriptType.Lock, lock_script[], 512, result) is null);
+    assert(validateScriptSyntax(ScriptType.Lock, lock_script[], 512, result) is null);
     Script unlock_script = createUnlockP2PKH(sig, kp.V);
-    assert(validateScript(ScriptType.Unlock, unlock_script[], 512, result)
+    assert(validateScriptSyntax(ScriptType.Unlock, unlock_script[], 512, result)
         is null);
 }
 

--- a/source/agora/script/Script.d
+++ b/source/agora/script/Script.d
@@ -48,8 +48,8 @@ public struct Script
 
     /***************************************************************************
 
-        Internal. Use the `validateScriptSyntax()` free function to construct
-        a validated Script out of a byte array of opcodes.
+        Internal. Use the `validateScriptSyntax()` or `assumeValidated()`
+        functions to construct a validated Script out of a byte array of opcodes.
 
         Params:
             opcodes = the set of validated opcodes for this script type
@@ -59,6 +59,24 @@ public struct Script
     private this (const(ubyte)[] opcodes) pure nothrow @safe @nogc
     {
         this.opcodes = opcodes;
+    }
+
+    /***************************************************************************
+
+        Create a Script from pre-validated opcodes
+
+        Params:
+            opcodes = the set of assumed to be validated opcodes
+
+        Returns:
+            a Script with the given opcodes
+
+    ***************************************************************************/
+
+    public static Script assumeValidated (const(ubyte)[] opcodes)
+        pure nothrow @safe @nogc
+    {
+        return Script(opcodes);
     }
 
     /***************************************************************************

--- a/source/agora/utils/TxBuilder.d
+++ b/source/agora/utils/TxBuilder.d
@@ -114,14 +114,14 @@ public struct TxBuilder
     /// Ditto
     public this (const Transaction tx) @safe nothrow
     {
-        this(tx.outputs[0].address);
+        this(tx.outputs[0].lock);
         this.attach(tx);
     }
 
     /// Ditto
     public this (const Transaction tx, uint index) @safe nothrow
     {
-        this(tx.outputs[index].address);
+        this(tx.outputs[index].lock);
         this.attach(tx, index);
     }
 


### PR DESCRIPTION
To help prevent loss of funds due to syntax errors in lock scripts they should be validated when the transaction is validated, prior to being executed with the corresponding unlock script.
Taken over from PR https://github.com/bosagora/agora/pull/2060 which @AndrejMitrovic created but was not yet merged due to ci failures.