### PR TITLE
stats.Utils: Remove unused vibe.vibe import

### DIFF
--- a/source/agora/stats/Utils.d
+++ b/source/agora/stats/Utils.d
@@ -15,7 +15,6 @@ module agora.stats.Utils;
 
 public import ocean.util.prometheus.collector.Collector;
 import ocean.util.prometheus.collector.CollectorRegistry;
-import vibe.vibe;
 
 import std.stdio;
 


### PR DESCRIPTION
```
This creates a dependency from Agora to essentially all of vibe.d,
but Vibe is not actually used in this module.
```

This is a blocker for https://github.com/bosagora/faucet/pull/56