### PR TITLE
Revert #2081 to get rid of the SEGV in integration test

### DIFF
--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -516,8 +516,8 @@ unittest
     testAssert(PrepareRes4, scpPrettify(&env, &getQSet));
 
     /** SCP CONFIRM */
-    env.statement.pledges = env.statement.pledges.init;
     env.statement.pledges.type_ = SCPStatementType.SCP_ST_CONFIRM;
+    env.statement.pledges.confirm_ = SCPStatement._pledges_t._confirm_t.init; // must initialize
     env.statement.pledges.confirm_.ballot = ballot;
     env.statement.pledges.confirm_.nPrepared = 42;
     env.statement.pledges.confirm_.nCommit = 100;
@@ -550,8 +550,8 @@ unittest
     static immutable ExtRes3 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x7b56...bd2a, quorum: { thresh: 2, nodes: [boa1xp9rtxss...fs7r, boa1xpc2ugml...p0w2], subqs: [] } }, commit: { counter: 0, value: <un-deserializable> }, nh: 100 } }, sig: 0x0000...be78 }`;
 
     /** SCP EXTERNALIZE */
-    env.statement.pledges = env.statement.pledges.init;
     env.statement.pledges.type_ = SCPStatementType.SCP_ST_EXTERNALIZE;
+    env.statement.pledges.externalize_ = SCPStatement._pledges_t._externalize_t.init; // must initialize
     env.statement.pledges.externalize_.commit = ballot;
     env.statement.pledges.externalize_.nH = 100;
 
@@ -572,8 +572,8 @@ unittest
     static immutable NomRes2 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Nominate { qset: { hash: 0x7b56...bd2a, quorum: <unknown> }, votes: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }], accepted: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }] } }, sig: 0x0000...be78 }`;
 
     /** SCP NOMINATE */
-    env.statement.pledges = env.statement.pledges.init;
     env.statement.pledges.type_ = SCPStatementType.SCP_ST_NOMINATE;
+    env.statement.pledges.nominate_ = SCPNomination.init; // must initialize
 
     auto value = cd.serializeFull[].toVec();
 

--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -104,90 +104,6 @@ struct SCPStatement {
             SCPNomination nominate_;
         }
 
-        ~this () @trusted nothrow
-        {
-            final switch (this.type_)
-            {
-                case SCPStatementType.SCP_ST_PREPARE:
-                    destroy(this.prepare_);
-                    break;
-                case SCPStatementType.SCP_ST_CONFIRM:
-                    destroy(this.confirm_);
-                    break;
-                case SCPStatementType.SCP_ST_EXTERNALIZE:
-                    destroy(this.externalize_);
-                    break;
-                case SCPStatementType.SCP_ST_NOMINATE:
-                    destroy(this.nominate_);
-                    break;
-            }
-        }
-
-        this (ref return scope inout _pledges_t rhs) inout @trusted nothrow @nogc pure
-        {
-            this.type_ = rhs.type_;
-            if (this.type_== SCPStatementType.SCP_ST_PREPARE)
-                this.prepare_ = rhs.prepare_;
-            else if (this.type_== SCPStatementType.SCP_ST_CONFIRM)
-                this.confirm_ = rhs.confirm_;
-            else if (this.type_== SCPStatementType.SCP_ST_EXTERNALIZE)
-                this.externalize_ = rhs.externalize_;
-            else if (this.type_== SCPStatementType.SCP_ST_NOMINATE)
-                this.nominate_ = rhs.nominate_;
-        }
-
-        this (T) (auto ref T field)
-        {
-            static if (is(T : typeof(this.prepare_)))
-            {
-                this.type_ = SCPStatementType.SCP_ST_PREPARE;
-                this.prepare_ = field;
-            }
-            else static if (is(T : typeof(this.confirm_)))
-            {
-                this.type_ = SCPStatementType.SCP_ST_CONFIRM;
-                this.confirm_ = field;
-            }
-            else static if (is(T : typeof(this.externalize_)))
-            {
-                this.type_ = SCPStatementType.SCP_ST_EXTERNALIZE;
-                this.externalize_ = field;
-            }
-            else static if (is(T : typeof(this.nominate_)))
-            {
-                this.type_ = SCPStatementType.SCP_ST_NOMINATE;
-                this.nominate_ = field;
-            }
-            else
-                static assert(0, "Unsupported statement type: " ~ T.stringof ~ " " ~ typeof(this).stringof);
-        }
-
-        this (T) (auto ref T field) const
-        {
-            static if (is(T : typeof(this.prepare_)))
-            {
-                this.type_ = SCPStatementType.SCP_ST_PREPARE;
-                this.prepare_ = field;
-            }
-            else static if (is(T : typeof(this.confirm_)))
-            {
-                this.type_ = SCPStatementType.SCP_ST_CONFIRM;
-                this.confirm_ = field;
-            }
-            else static if (is(T : typeof(this.externalize_)))
-            {
-                this.type_ = SCPStatementType.SCP_ST_EXTERNALIZE;
-                this.externalize_ = field;
-            }
-            else static if (is(T : typeof(this.nominate_)))
-            {
-                this.type_ = SCPStatementType.SCP_ST_NOMINATE;
-                this.nominate_ = field;
-            }
-            else
-                static assert(0, "Unsupported statement type: " ~ T.stringof ~ " " ~ typeof(this).stringof);
-        }
-
         /// Call `func` with one of the message types depending on the `type_`.
         /// Whether or not this call is @safe depends on the @safety of `func`
         extern(D) auto apply (alias func, T...)(auto ref T args) const
@@ -316,14 +232,72 @@ struct SCPStatement {
             final switch (type)
             {
             case SCPStatementType.SCP_ST_PREPARE:
-                return QT(deserializeFull!(typeof(QT.prepare_))(dg, opts));
+                return enableNRVO!(QT, SCPStatementType.SCP_ST_PREPARE)(dg, opts);
             case SCPStatementType.SCP_ST_CONFIRM:
-                return QT(deserializeFull!(typeof(QT.confirm_))(dg, opts));
+                return enableNRVO!(QT, SCPStatementType.SCP_ST_CONFIRM)(dg, opts);
             case SCPStatementType.SCP_ST_EXTERNALIZE:
-                return QT(deserializeFull!(typeof(QT.externalize_))(dg, opts));
+                return enableNRVO!(QT, SCPStatementType.SCP_ST_EXTERNALIZE)(dg, opts);
             case SCPStatementType.SCP_ST_NOMINATE:
-                return QT(deserializeFull!(typeof(QT.nominate_))(dg, opts));
+                return enableNRVO!(QT, SCPStatementType.SCP_ST_NOMINATE)(dg, opts);
             }
+        }
+
+        /***********************************************************************
+
+            Allow `fromBinary` to do NRVO
+
+            We need to initialize using a literal to account for type
+            constructors, but we can't initialize the `union` in a generic way
+            (because we need to use a different name based on the `type`).
+            The normal solution is to put it in a `switch`, but since we
+            declare multiple variable (one per `switch` branch),
+            NRVO is disabled.
+            The solution is to use `static if` to ensure the compiler only sees
+            one temporary and does NRVO on this function, which in turn enables
+            NRVO on the caller.
+
+            See_Also:
+              https://forum.dlang.org/thread/miuevyfxbujwrhghmiuw@forum.dlang.org
+
+        ***********************************************************************/
+
+        extern(D) private static QT enableNRVO (QT, SCPStatementType type) (
+            scope DeserializeDg dg, in DeserializerOptions opts) @safe
+        {
+            static if (type == SCPStatementType.SCP_ST_PREPARE)
+            {
+                QT ret = {
+                    type_: type,
+                    prepare_: deserializeFull!(typeof(QT.prepare_))(dg, opts)
+                };
+                return ret;
+            }
+            else static if (type == SCPStatementType.SCP_ST_CONFIRM)
+            {
+                QT ret = {
+                    type_: type,
+                    confirm_: deserializeFull!(typeof(QT.confirm_))(dg, opts)
+                };
+                return ret;
+            }
+            else static if (type == SCPStatementType.SCP_ST_EXTERNALIZE)
+            {
+                QT ret = {
+                    type_: type,
+                    externalize_: deserializeFull!(typeof(QT.externalize_))(dg, opts)
+                };
+                return ret;
+            }
+            else static if (type == SCPStatementType.SCP_ST_NOMINATE)
+            {
+                QT ret = {
+                    type_: type,
+                    nominate_: deserializeFull!(typeof(QT.nominate_))(dg, opts)
+                };
+                return ret;
+            }
+            else
+                static assert(0, "Unsupported statement type: " ~ type.stringof);
         }
     }
 
@@ -332,23 +306,12 @@ struct SCPStatement {
     _pledges_t pledges;
 }
 
-// pledges.init is equal to default init of all union members
-unittest
-{
-    SCPStatement stat;
-    assert(stat.pledges.prepare_ == stat.pledges.prepare_.init);
-    assert(stat.pledges.confirm_ == stat.pledges.confirm_.init);
-    assert(stat.pledges.externalize_ == stat.pledges.externalize_.init);
-    assert(stat.pledges.nominate_ == stat.pledges.nominate_.init);
-}
-
 static assert(SCPStatement.sizeof == 200);
 static assert(Signature.sizeof == 64);
 
 struct SCPEnvelope {
   SCPStatement statement;
   Signature signature;
-  ~this() @safe nothrow {}
 }
 
 static assert(SCPEnvelope.sizeof == 264);

--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -273,7 +273,7 @@ struct SCPStatement {
             public void computeHash (scope HashDg dg) const @trusted @nogc nothrow
             {
                 hashPart(this.type_, dg);
-                final switch (this.type_)
+                switch (this.type_)
                 {
                 case SCPStatementType.SCP_ST_PREPARE:
                     return hashPart(this.prepare_, dg);
@@ -283,6 +283,8 @@ struct SCPStatement {
                     return hashPart(this.externalize_, dg);
                 case SCPStatementType.SCP_ST_NOMINATE:
                     return hashPart(this.nominate_, dg);
+                default:
+                    assert(0);
                 }
             }
         }
@@ -291,7 +293,7 @@ struct SCPStatement {
         extern(D) void serialize (scope SerializeDg dg) const @trusted
         {
             serializePart(this.type_, dg);
-            final switch (this.type_)
+            switch (this.type_)
             {
             case SCPStatementType.SCP_ST_PREPARE:
                 return serializePart(this.prepare_, dg);
@@ -301,6 +303,8 @@ struct SCPStatement {
                 return serializePart(this.externalize_, dg);
             case SCPStatementType.SCP_ST_NOMINATE:
                 return serializePart(this.nominate_, dg);
+            default:
+                assert(0);
             }
         }
 
@@ -309,7 +313,7 @@ struct SCPStatement {
             in DeserializerOptions opts) @safe
         {
             auto type = deserializeFull!(typeof(QT.type_))(dg, opts);
-            switch (type)
+            final switch (type)
             {
             case SCPStatementType.SCP_ST_PREPARE:
                 return QT(deserializeFull!(typeof(QT.prepare_))(dg, opts));
@@ -319,8 +323,6 @@ struct SCPStatement {
                 return QT(deserializeFull!(typeof(QT.externalize_))(dg, opts));
             case SCPStatementType.SCP_ST_NOMINATE:
                 return QT(deserializeFull!(typeof(QT.nominate_))(dg, opts));
-            default:
-                throw new Exception("Unrecognized envelope type");
             }
         }
     }
@@ -328,33 +330,6 @@ struct SCPStatement {
     NodeID nodeID;
     uint64_t slotIndex;
     _pledges_t pledges;
-}
-
-// should not be able to deserialize an invalid _pledges_t
-unittest
-{
-    import std.stdio;
-    auto type = cast(SCPStatementType) -1; // Unknown
-    ubyte[] sered = serializeFull(type);
-    try
-    {
-        deserializeFull!(SCPStatement._pledges_t)(sered);
-        assert(0);
-    }
-    catch (Exception e)
-    {
-        assert(e.msg == "Unrecognized envelope type");
-    }
-
-    try
-    {
-        SCPStatement._pledges_t.fromString(Json.emptyObject.toString());
-        assert(0);
-    }
-    catch (Exception e)
-    {
-        assert(e.msg == "Unrecognized envelope type");
-    }
 }
 
 // pledges.init is equal to default init of all union members

--- a/source/scpd/types/Utils.d
+++ b/source/scpd/types/Utils.d
@@ -31,9 +31,14 @@ public inout(opaque_vec!()) toVec (scope ref inout(Hash) data) nothrow @nogc
 /// Ditto
 public inout(opaque_vec!()) toVec (scope inout ubyte[] data) nothrow @nogc
 {
-    inout opaque_vec!() ret;
-    foreach (elem; data)
-        ret.base.push_back(cast(ubyte) elem);
+    inout opaque_vec!() ret =
+    {
+        base: {
+            _start: data.ptr,
+            _end: data.ptr + data.length,
+            _end_of_storage: data.ptr + data.length,
+        },
+    };
     return ret;
 }
 

--- a/source/scpp/extra/DUtils.cpp
+++ b/source/scpp/extra/DUtils.cpp
@@ -141,13 +141,6 @@ CPPOBJECTINST(std::set<PublicKey>);
 CPPOBJECTINST(std::set<SCPBallot>);
 CPPOBJECTINST(std::set<unsigned int>);
 
-CPPOBJECTINST(std::vector<unsigned char>);
-CPPOBJECTINST(std::vector<Value>);
-CPPOBJECTINST(std::vector<PublicKey>);
-CPPOBJECTINST(std::vector<SCPQuorumSet>);
-CPPOBJECTINST(std::vector<SCPEnvelope>);
-CPPOBJECTINST(std::vector<Slot::HistoricalStatement>);
-
 #define CPPUNIQUEPTRINST(T) CPPDEFAULTCTORINST(std::unique_ptr<T>) \
                             CPPDTORINST(std::unique_ptr<T>)        \
                             CPPSIZEOFINST(std::unique_ptr<T>)


### PR DESCRIPTION
Seems to trigger only on Linux, so I suppose the bindings are wrong.