### PR TITLE
Network unit test: Prevent race condition failure

### DIFF
--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -151,7 +151,10 @@ unittest
     assert(last_node.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => last_node.putTransaction(tx));
+    // Trigger generation of block
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
+    // Make sure the client we will check is in sync with others (except for byzantine)
+    network.assertSameBlocks(iota(1, GenesisValidators), Height(1));
     assertValidatorsBitmask(last_node.getAllBlocks()[1]);
 }
 
@@ -170,7 +173,10 @@ unittest
     assert(last_node.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
     txes.each!(tx => last_node.putTransaction(tx));
+    // Trigger generation of block
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
+    // Make sure the client we will check is in sync with others (except for byzantine)
+    network.assertSameBlocks(iota(1, GenesisValidators), Height(1));
     assertValidatorsBitmask(last_node.getAllBlocks()[1]);
 }
 


### PR DESCRIPTION
In `InvalidBlockSigByzantine` when we check the signature bitmask of the
last client we need to make sure that it has been given enough time to
have received all signatures from the other non-byzantine clients.
We can do this by waiting till the blocks are the same on our
non-byzantine clients before checking the bitmask.