### PR TITLE
Fix #2077: Refactor catch / discovery task to be DRYer

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -248,21 +248,10 @@ public class Validator : FullNode, API
             this.checkAndEnroll(this.ledger.getBlockHeight());
     }
 
-    /***************************************************************************
-
-        Starts the periodic network discovery task.
-
-    ***************************************************************************/
-
-    protected override void startPeriodicDiscovery ()
+    /// Ditto
+    protected override void discoveryTask ()
     {
-        this.taskman.runTask(
-        ()
-        {
-            void discover () { this.network.discover(this.required_peer_keys); }
-            discover();  // avoid delay
-            this.timers ~= this.taskman.setTimer(5.seconds, &discover, Periodic.Yes);
-        });
+        this.network.discover(this.required_peer_keys);
     }
 
     /// GET /public_key


### PR DESCRIPTION
Those two functions could be refactored to have the timer start in the start method of the node.
~We loose the immediate firing which was explicitly done (see 'avoid delay'), but things will still work.~
EDIT: No, they didn't, and I restored it, and it's much better.
Additionally this fixes a bug where Validators did not respect the node.block_catchup_interval config field and always used 5 seconds.
Since we currently set this field to 2 seconds in the unittest, this should significantly speed up tests that rely on catch-up.