### PR TITLE
Remove dependency to 'ocean.core.Test'

### DIFF
--- a/source/agora/consensus/Quorum.d
+++ b/source/agora/consensus/Quorum.d
@@ -32,8 +32,6 @@ import scpd.types.Utils;
 import scpd.types.XDRBase;
 import scpd.quorum.QuorumTracker;
 
-import ocean.core.Test;
-
 import std.algorithm;
 import std.array;
 import std.conv;
@@ -129,7 +127,7 @@ unittest
         hashFull(1), QuorumParams.init, 0);
     verifyQuorumsSanity(quorums);
     verifyQuorumsIntersect(quorums);
-    test!"=="(countNodeInclusions(quorums, keys), [1]);
+    assert(countNodeInclusions(quorums, keys) == [1]);
 }
 
 // 2 nodes
@@ -140,7 +138,7 @@ unittest
         hashFull(1), QuorumParams.init, 1);
     verifyQuorumsSanity(quorums);
     verifyQuorumsIntersect(quorums);
-    test!"=="(countNodeInclusions(quorums, keys), [2, 2]);
+    assert(countNodeInclusions(quorums, keys) == [2, 2]);
 }
 
 // 3 nodes with equal stakes
@@ -151,7 +149,7 @@ unittest
         hashFull(1), QuorumParams.init, 2);
     verifyQuorumsSanity(quorums);
     verifyQuorumsIntersect(quorums);
-    test!"=="(countNodeInclusions(quorums, keys), [3, 3, 3]);
+    assert(countNodeInclusions(quorums, keys) == [3, 3, 3]);
 }
 
 // 4 nodes with equal stakes
@@ -162,7 +160,7 @@ unittest
         hashFull(1), QuorumParams.init, 3);
     verifyQuorumsSanity(quorums);
     verifyQuorumsIntersect(quorums);
-    test!"=="(countNodeInclusions(quorums, keys), [4, 4, 4, 4]);
+    assert(countNodeInclusions(quorums, keys) == [4, 4, 4, 4]);
 }
 
 // 8 nodes with equal stakes
@@ -173,13 +171,13 @@ unittest
         hashFull(1), QuorumParams.init, 4);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
-    test!"=="(countNodeInclusions(quorums_1, keys), [6, 5, 8, 8, 7, 8, 8, 6]);
+    assert(countNodeInclusions(quorums_1, keys) == [6, 5, 8, 8, 7, 8, 8, 6]);
 
     auto quorums_2 = buildTestQuorums(Amount.MinFreezeAmount.repeat(8), keys,
         hashFull(2), QuorumParams.init, 5);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
-    test!"=="(countNodeInclusions(quorums_2, keys), [7, 8, 7, 7, 8, 7, 7, 5]);
+    assert(countNodeInclusions(quorums_2, keys) == [7, 8, 7, 7, 8, 7, 7, 5]);
 }
 
 // 16 nodes with equal stakes
@@ -190,14 +188,14 @@ unittest
         hashFull(1), QuorumParams.init, 6);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
-    test!"=="(countNodeInclusions(quorums_1, keys),
+    assert(countNodeInclusions(quorums_1, keys) ==
         [5, 8, 5, 9, 8, 7, 5, 7, 6, 8, 9, 7, 6, 7, 11, 4]);
 
     auto quorums_2 = buildTestQuorums(Amount.MinFreezeAmount.repeat(16), keys,
         hashFull(2), QuorumParams.init, 7);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
-    test!"=="(countNodeInclusions(quorums_2, keys),
+    assert(countNodeInclusions(quorums_2, keys) ==
         [5, 5, 4, 6, 4, 8, 7, 11, 7, 9, 10, 10, 7, 6, 6, 7]);
 }
 
@@ -211,14 +209,14 @@ unittest
         QuorumParams.init, 8);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
-    test!"=="(countNodeInclusions(quorums_1, keys),
+    assert(countNodeInclusions(quorums_1, keys) ==
         [4, 3, 9, 4, 6, 6, 8, 5, 3, 8, 9, 10, 8, 9, 9, 11]);
 
     auto quorums_2 = buildTestQuorums(amounts, keys, hashFull(2),
         QuorumParams.init, 9);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
-    test!"=="(countNodeInclusions(quorums_2, keys),
+    assert(countNodeInclusions(quorums_2, keys) ==
         [4, 2, 7, 8, 8, 5, 5, 5, 9, 7, 9, 8, 8, 8, 10, 9]);
 }
 
@@ -232,14 +230,14 @@ unittest
         QuorumParams.init, 10);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
-    test!"=="(countNodeInclusions(quorums_1, keys),
+    assert(countNodeInclusions(quorums_1, keys) ==
         [16, 4, 6, 5, 9, 6, 7, 6, 5, 5, 6, 6, 6, 5, 5, 15]);
 
     auto quorums_2 = buildTestQuorums(amounts, keys, hashFull(2),
         QuorumParams.init, 11);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
-    test!"=="(countNodeInclusions(quorums_2, keys),
+    assert(countNodeInclusions(quorums_2, keys) ==
         [16, 8, 3, 4, 6, 2, 9, 5, 4, 7, 5, 7, 9, 9, 2, 16]);
 }
 
@@ -255,7 +253,7 @@ unittest
     // verified to work but disabled because it runs slow with a
     // non-max threshold (~20 seconds)
     //verifyQuorumsIntersect(quorums_1);
-    test!"=="(countNodeInclusions(quorums_1, keys),
+    assert(countNodeInclusions(quorums_1, keys) ==
         [31, 7, 9, 5, 5, 4, 4, 7, 6, 6, 5, 7, 6, 5, 6, 4, 7, 5, 6, 6, 7, 1, 6,
          2, 6, 5, 5, 6, 8, 4, 2, 31]);
 
@@ -265,7 +263,7 @@ unittest
     // verified to work but disabled because it runs slow with a
     // non-max threshold (~20 seconds)
     //verifyQuorumsIntersect(quorums_2);
-    test!"=="(countNodeInclusions(quorums_2, keys),
+    assert(countNodeInclusions(quorums_2, keys) ==
         [31, 7, 4, 9, 6, 5, 8, 3, 4, 6, 6, 8, 3, 3, 7, 7, 8, 4, 4, 7, 5, 5, 6,
          6, 2, 6, 5, 2, 6, 6, 3, 32]);
 }
@@ -282,7 +280,7 @@ unittest
     // verified to work but disabled because it runs slow with a
     // non-max threshold (~20 minutes)
     //verifyQuorumsIntersect(quorums_1);
-    test!"=="(countNodeInclusions(quorums_1, keys),
+    assert(countNodeInclusions(quorums_1, keys) ==
         [62, 5, 2, 5, 5, 3, 6, 7, 4, 7, 5, 5, 8, 2, 2, 5, 7, 7, 4, 4, 5, 5,
          3, 10, 3, 8, 2, 6, 6, 7, 4, 4, 4, 7, 8, 6, 7, 4, 5, 6, 4, 7, 7, 9,
          6, 7, 5, 5, 6, 2, 7, 4, 6, 6, 3, 6, 6, 4, 5, 5, 5, 3, 3, 62]);
@@ -293,7 +291,7 @@ unittest
     // verified to work but disabled because it runs slow with a
     // non-max threshold (~20 minutes)
     //verifyQuorumsIntersect(quorums_2);
-    test!"=="(countNodeInclusions(quorums_2, keys),
+    assert(countNodeInclusions(quorums_2, keys) ==
         [64, 7, 4, 3, 1, 4, 1, 7, 5, 3, 4, 7, 5, 5, 10, 3, 6, 4, 5, 6, 2, 5, 4,
          7, 5, 5, 8, 6, 6, 3, 7, 10, 4, 8, 7, 6, 4, 3, 4, 4, 6, 6, 3, 6, 7, 4,
          8, 3, 7, 7, 2, 10, 5, 7, 6, 4, 4, 4, 3, 8, 6, 3, 6, 61]);
@@ -310,7 +308,7 @@ unittest
     verifyQuorumsSanity(quorums_1);
     // not verified to work.
     //verifyQuorumsIntersect(quorums_1);
-    test!"=="(countNodeInclusions(quorums_1, keys),
+    assert(countNodeInclusions(quorums_1, keys) ==
         [125, 7, 7, 9, 2, 8, 6, 4, 5, 4, 4, 3, 6, 3, 3, 3, 2, 6, 3, 3, 2, 3, 2,
          8, 4, 5, 6, 5, 7, 5, 3, 8, 4, 3, 8, 6, 3, 5, 7, 5, 4, 3, 2, 4, 3, 5, 8,
          3, 11, 3, 6, 6, 9, 4, 7, 8, 7, 4, 8, 7, 8, 5, 3, 4, 3, 5, 8, 6, 6, 3,
@@ -323,7 +321,7 @@ unittest
     verifyQuorumsSanity(quorums_2);
     // not verified to work.
     //verifyQuorumsIntersect(quorums_2);
-    test!"=="(countNodeInclusions(quorums_2, keys),
+    assert(countNodeInclusions(quorums_2, keys) ==
         [122, 4, 8, 4, 10, 6, 3, 5, 5, 6, 7, 4, 6, 4, 4, 4, 3, 5, 6, 3, 4, 2,
          8, 6, 3, 3, 3, 5, 5, 8, 6, 3, 4, 7, 6, 8, 3, 4, 4, 4, 5, 6, 3, 4, 7,
          4, 7, 5, 2, 7, 3, 7, 5, 7, 3, 2, 5, 6, 5, 4, 7, 6, 2, 2, 4, 5, 6, 6,
@@ -341,9 +339,9 @@ unittest
         hashFull(1), qp_1, 18);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
-    quorums_1.byValue.each!(qc => test!"<="(qc.nodes.length, 4));
-    quorums_1.byValue.each!(qc => test!"=="(qc.threshold, 4));
-    test!"=="(countNodeInclusions(quorums_1, keys),
+    quorums_1.byValue.each!(qc => assert(qc.nodes.length <= 4));
+    quorums_1.byValue.each!(qc => assert(qc.threshold == 4));
+    assert(countNodeInclusions(quorums_1, keys) ==
         [3, 4, 5, 5, 3, 2, 6, 4, 2, 6]);
 
     QuorumParams qp_2 = { MaxQuorumNodes : 8, QuorumThreshold : 80 };
@@ -351,9 +349,9 @@ unittest
         hashFull(1), qp_2, 19);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
-    quorums_2.byValue.each!(qc => test!"<="(qc.nodes.length, 8));
-    quorums_2.byValue.each!(qc => test!"=="(qc.threshold, 7));
-    test!"=="(countNodeInclusions(quorums_2, keys),
+    quorums_2.byValue.each!(qc => assert(qc.nodes.length <= 8));
+    quorums_2.byValue.each!(qc => assert(qc.threshold == 7));
+    assert(countNodeInclusions(quorums_2, keys) ==
         [6, 9, 9, 7, 6, 9, 10, 8, 8, 8]);
 
     QuorumParams qp_3 = { MaxQuorumNodes : 8, QuorumThreshold : 60 };
@@ -361,9 +359,9 @@ unittest
         hashFull(1), qp_3, 20);
     verifyQuorumsSanity(quorums_3);
     verifyQuorumsIntersect(quorums_3);
-    quorums_3.byValue.each!(qc => test!"<="(qc.nodes.length, 8));
-    quorums_3.byValue.each!(qc => test!"=="(qc.threshold, 5));
-    test!"=="(countNodeInclusions(quorums_3, keys),
+    quorums_3.byValue.each!(qc => assert(qc.nodes.length <= 8));
+    quorums_3.byValue.each!(qc => assert(qc.threshold == 5));
+    assert(countNodeInclusions(quorums_3, keys),
         [9, 7, 6, 9, 8, 7, 10, 9, 5, 10]);
 }
 
@@ -393,9 +391,9 @@ private ulong toShortHash (in Hash hash) @trusted nothrow
 unittest
 {
     const hash1 = hashMulti(WK.Keys.A.address, 1);
-    test!"=="(toShortHash(hash1), 501230441541515792);
+    assert(toShortHash(hash1) == 501230441541515792);
     const hash2 = hashMulti(WK.Keys.A.address, 2);
-    test!"=="(toShortHash(hash2), 9723839611455071876);
+    assert(toShortHash(hash2) == 9723839611455071876);
 }
 
 /*******************************************************************************

--- a/source/agora/consensus/data/genesis/package.d
+++ b/source/agora/consensus/data/genesis/package.d
@@ -74,13 +74,11 @@ unittest
     import std.array;
     import std.conv;
 
-    import ocean.core.Test;
-
     auto sorted_enrollments = checkGenesisEnrollments(GenesisBlock, [ WK.Keys.NODE2, WK.Keys.NODE3, WK.Keys.NODE4,
         WK.Keys.NODE5, WK.Keys.NODE6, WK.Keys.NODE7 ], 20);
 
     // For unit tests we want the index of the nodes to match the order of the enrollments
-    test!"=="(genesis_validator_keys.map!(k => k.address).array, sorted_enrollments.map!(e => e.key).array);
+    assert(genesis_validator_keys.map!(k => k.address).array == sorted_enrollments.map!(e => e.key).array);
 
     checkGenesisTransactions(GenesisBlock);
     assert(GenesisBlock.isGenesisBlockInvalidReason() == null);

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -1016,7 +1016,6 @@ unittest
 /// transaction-level absolute time lock
 unittest
 {
-    import ocean.core.Test;
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     scope storage = new TestUTXOSet;
     scope payload_checker = new FeeManager();
@@ -1034,17 +1033,17 @@ unittest
     // effectively disabled lock
     tx.lock_height = Height(0);
     tx.inputs[0].unlock = signUnlock(kp, tx);
-    test!"=="(tx.isInvalidReason(engine, storage.getUTXOFinder(), Height(0), checker), null);
-    test!"=="(tx.isInvalidReason(engine, storage.getUTXOFinder(), Height(1024), checker), null);
+    assert(tx.isInvalidReason(engine, storage.getUTXOFinder(), Height(0), checker) is null);
+    assert(tx.isInvalidReason(engine, storage.getUTXOFinder(), Height(1024), checker) is null);
 
     tx.lock_height = Height(10);
     tx.inputs[0].unlock = signUnlock(kp, tx);
-    test!"=="(tx.isInvalidReason(engine, storage.getUTXOFinder(), Height(0), checker),
+    assert(tx.isInvalidReason(engine, storage.getUTXOFinder(), Height(0), checker) ==
         "Transaction: Not unlocked for this height");
-    test!"=="(tx.isInvalidReason(engine, storage.getUTXOFinder(), Height(9), checker),
+    assert(tx.isInvalidReason(engine, storage.getUTXOFinder(), Height(9), checker) ==
         "Transaction: Not unlocked for this height");
-    test!"=="(tx.isInvalidReason(engine, storage.getUTXOFinder(), Height(10), checker),
+    assert(tx.isInvalidReason(engine, storage.getUTXOFinder(), Height(10), checker) ==
         null);
-    test!"=="(tx.isInvalidReason(engine, storage.getUTXOFinder(), Height(1024), checker),
+    assert(tx.isInvalidReason(engine, storage.getUTXOFinder(), Height(1024), checker) ==
         null);
 }

--- a/source/agora/flash/Scripts.d
+++ b/source/agora/flash/Scripts.d
@@ -27,11 +27,6 @@ import agora.script.Script;
 
 import std.bitmanip;
 
-version (unittest)
-{
-    import ocean.core.Test;
-}
-
 /*******************************************************************************
 
     Create a Flash lock script.
@@ -538,28 +533,28 @@ unittest
     auto recv_sig = sign(recv_kp, tx);
     auto bad_tx_send_sig = sign(send_kp, bad_tx);
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         lock_script,
-        createUnlockHTLC(recv_sig, secret), tx, Input.init),
-        null);  // receiver can unlock with secret + signature
+        createUnlockHTLC(recv_sig, secret), tx, Input.init)
+        is null);  // receiver can unlock with secret + signature
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         lock_script,
-        createUnlockHTLC(send_sig, secret), tx, Input.init),
-        "Script failed");  // wrong signature (expected receiver sig)
+        createUnlockHTLC(send_sig, secret), tx, Input.init)
+        == "Script failed");  // wrong signature (expected receiver sig)
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         lock_script,
-        createUnlockHTLC(send_sig, wrong_secret), tx, Input.init),
-        null);  // sender can unlock with ELSE branch + timelock + signature
+        createUnlockHTLC(send_sig, wrong_secret), tx, Input.init)
+        is null);  // sender can unlock with ELSE branch + timelock + signature
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         lock_script,
-        createUnlockHTLC(recv_sig, wrong_secret), tx, Input.init),
-        "Script failed");  // wrong signature (expected sender key)
+        createUnlockHTLC(recv_sig, wrong_secret), tx, Input.init)
+        == "Script failed");  // wrong signature (expected sender key)
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         lock_script,
-        createUnlockHTLC(bad_tx_send_sig, wrong_secret), bad_tx, Input.init),
-        "VERIFY_LOCK_HEIGHT height lock of transaction is too low");  // timelock is wrong
+        createUnlockHTLC(bad_tx_send_sig, wrong_secret), bad_tx, Input.init)
+        == "VERIFY_LOCK_HEIGHT height lock of transaction is too low");  // timelock is wrong
 }

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -63,7 +63,6 @@ version (unittest)
 {
     import agora.consensus.data.genesis.Test: genesis_validator_keys;
     import agora.utils.Test;
-    import ocean.core.Test;
 }
 
 /// Ditto
@@ -2110,8 +2109,8 @@ unittest
 
     ConsensusData data;
     ledger.prepareNominatingSet(data, Block.TxsInTestBlock, mock_clock.networkTime());
-    test!"=="(data.missing_validators.length, 2);
-    test!"=="(data.missing_validators, skip_indexes);
+    assert(data.missing_validators.length == 2);
+    assert(data.missing_validators == skip_indexes);
 
     // check validity of slashing information
     assert(ledger.validateSlashingData(Height(22), data) == null);

--- a/source/agora/script/Engine.d
+++ b/source/agora/script/Engine.d
@@ -40,7 +40,6 @@ version (unittest)
 {
     import agora.crypto.Schnorr;
     import agora.utils.Test;
-    import ocean.core.Test;
     import std.stdio : writefln, writeln;  // avoid importing LockType
 }
 
@@ -1100,40 +1099,40 @@ version (unittest)
 unittest
 {
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [OP.DUP]), Unlock.init, Transaction.init,
-            Input.init),
+            Input.init) ==
         "DUP opcode requires an item on the stack");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [1, 2, OP.CHECK_EQUAL]), Unlock.init,
-            Transaction.init, Input.init),
+            Transaction.init, Input.init) ==
         "CHECK_EQUAL opcode requires two items on the stack");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [1, 1, OP.DUP, OP.CHECK_EQUAL]), Unlock.init,
-            Transaction.init, Input.init),
-        null);  // CHECK_EQUAL will always succeed after an OP.DUP
+            Transaction.init, Input.init)
+        is null);  // CHECK_EQUAL will always succeed after an OP.DUP
 }
 
 // OP.HASH
 unittest
 {
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [OP.HASH]), Unlock.init, Transaction.init,
-            Input.init),
+            Input.init) ==
         "HASH opcode requires an item on the stack");
     const ubyte[] bytes = [42];
     const Hash hash = HashNoLength(bytes).hashFull();
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             toPushOpcode(bytes)
             ~ [ubyte(OP.HASH)]
             ~ toPushOpcode(hash[])
             ~ [ubyte(OP.CHECK_EQUAL)]),
-        Unlock.init, Transaction.init, Input.init),
-        null);
+        Unlock.init, Transaction.init, Input.init)
+        is null);
 }
 
 // OP.CHECK_EQUAL
@@ -1141,22 +1140,22 @@ unittest
 {
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     const Transaction tx;
-    test!("==")(engine.execute(
-        Lock(LockType.Script, [OP.CHECK_EQUAL]), Unlock.init, tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.Script, [OP.CHECK_EQUAL]), Unlock.init, tx, Input.init) ==
         "CHECK_EQUAL opcode requires two items on the stack");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [1, 1, OP.CHECK_EQUAL]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "CHECK_EQUAL opcode requires two items on the stack");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [1, 1, 1, 1, OP.CHECK_EQUAL]),
-        Unlock.init, tx, Input.init),
-        null);
-    test!("==")(engine.execute(
+        Unlock.init, tx, Input.init)
+        is null);
+    assert(engine.execute(
         Lock(LockType.Script,
             [1, 2, 1, 1, OP.CHECK_EQUAL]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Script failed");
 }
 
@@ -1165,22 +1164,22 @@ unittest
 {
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     const Transaction tx;
-    test!("==")(engine.execute(
-        Lock(LockType.Script, [OP.VERIFY_EQUAL]), Unlock.init, tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.Script, [OP.VERIFY_EQUAL]), Unlock.init, tx, Input.init) ==
         "VERIFY_EQUAL opcode requires two items on the stack");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [1, 1, OP.VERIFY_EQUAL]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "VERIFY_EQUAL opcode requires two items on the stack");
-    test!("==")(engine.execute(   // OP.TRUE needed as VERIFY does not push to stack
+    assert(engine.execute(   // OP.TRUE needed as VERIFY does not push to stack
         Lock(LockType.Script,
             [1, 1, 1, 1, OP.VERIFY_EQUAL, OP.TRUE]),
-        Unlock.init, tx, Input.init),
-        null);
-    test!("==")(engine.execute(
+        Unlock.init, tx, Input.init)
+        is null);
+    assert(engine.execute(
         Lock(LockType.Script,
             [1, 2, 1, 1, OP.VERIFY_EQUAL, OP.TRUE]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "VERIFY_EQUAL operation failed");
 }
 
@@ -1189,48 +1188,48 @@ unittest
 {
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     const Transaction tx;
-    test!("==")(engine.execute(
-        Lock(LockType.Script, [OP.CHECK_SIG]), Unlock.init, tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.Script, [OP.CHECK_SIG]), Unlock.init, tx, Input.init) ==
         "CHECK_SIG opcode requires two items on the stack");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [1, 1, OP.CHECK_SIG]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "CHECK_SIG opcode requires two items on the stack");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [1, 1, 1, 1, OP.CHECK_SIG]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "CHECK_SIG opcode requires 32-byte public key on the stack");
 
     // invalid key (crypto_core_ed25519_is_valid_point() fails)
     Point invalid_key;
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [ubyte(1), ubyte(1)]
             ~ [ubyte(32)] ~ invalid_key[]
-            ~ [ubyte(OP.CHECK_SIG)]), Unlock.init, tx, Input.init),
+            ~ [ubyte(OP.CHECK_SIG)]), Unlock.init, tx, Input.init) ==
         "CHECK_SIG 32-byte public key on the stack is invalid");
 
     Point valid_key = Point.fromString(
         "0x44404b654d6ddf71e2446eada6acd1f462348b1b17272ff8f36dda3248e08c81");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [ubyte(1), ubyte(1)]
             ~ [ubyte(32)] ~ valid_key[]
-            ~ [ubyte(OP.CHECK_SIG)]), Unlock.init, tx, Input.init),
+            ~ [ubyte(OP.CHECK_SIG)]), Unlock.init, tx, Input.init) ==
         "CHECK_SIG opcode requires 64-byte signature on the stack");
 
     Signature invalid_sig;
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [ubyte(64)] ~ invalid_sig.toBlob()[]
             ~ [ubyte(32)] ~ valid_key[]
-            ~ [ubyte(OP.CHECK_SIG)]), Unlock.init, tx, Input.init),
+            ~ [ubyte(OP.CHECK_SIG)]), Unlock.init, tx, Input.init) ==
         "Script failed");
     const Pair kp = Pair.random();
     const sig = sign(kp, tx);
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [ubyte(64)] ~ sig.toBlob()[]
             ~ [ubyte(32)] ~ kp.V[]
-            ~ [ubyte(OP.CHECK_SIG)]), Unlock.init, tx, Input.init),
-        null);
+            ~ [ubyte(OP.CHECK_SIG)]), Unlock.init, tx, Input.init)
+        is null);
 }
 
 // OP.VERIFY_SIG
@@ -1238,53 +1237,53 @@ unittest
 {
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     const Transaction tx;
-    test!("==")(engine.execute(
-        Lock(LockType.Script, [OP.VERIFY_SIG]), Unlock.init, tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.Script, [OP.VERIFY_SIG]), Unlock.init, tx, Input.init) ==
         "VERIFY_SIG opcode requires two items on the stack");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [OP.PUSH_BYTES_1, 1, OP.VERIFY_SIG]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "VERIFY_SIG opcode requires two items on the stack");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [OP.PUSH_BYTES_1, 1, OP.PUSH_BYTES_1, 1, OP.VERIFY_SIG]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "VERIFY_SIG opcode requires 32-byte public key on the stack");
 
     // invalid key (crypto_core_ed25519_is_valid_point() fails)
     Point invalid_key;
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [ubyte(OP.PUSH_BYTES_1), ubyte(1)]
             ~ [ubyte(32)] ~ invalid_key[]
-            ~ [ubyte(OP.VERIFY_SIG)]), Unlock.init, tx, Input.init),
+            ~ [ubyte(OP.VERIFY_SIG)]), Unlock.init, tx, Input.init) ==
         "VERIFY_SIG 32-byte public key on the stack is invalid");
 
     Point valid_key = Point.fromString(
         "0x44404b654d6ddf71e2446eada6acd1f462348b1b17272ff8f36dda3248e08c81");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [ubyte(OP.PUSH_BYTES_1), ubyte(1)]
             ~ [ubyte(32)] ~ valid_key[]
-            ~ [ubyte(OP.VERIFY_SIG)]), Unlock.init, tx, Input.init),
+            ~ [ubyte(OP.VERIFY_SIG)]), Unlock.init, tx, Input.init) ==
         "VERIFY_SIG opcode requires 64-byte signature on the stack");
 
     Signature invalid_sig;
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [ubyte(64)] ~ invalid_sig.toBlob()[]
             ~ [ubyte(32)] ~ valid_key[]
-            ~ [ubyte(OP.VERIFY_SIG)]), Unlock.init, tx, Input.init),
+            ~ [ubyte(OP.VERIFY_SIG)]), Unlock.init, tx, Input.init) ==
         "VERIFY_SIG signature failed validation");
     const Pair kp = Pair.random();
     const sig = sign(kp, tx);
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [ubyte(64)] ~ sig.toBlob()[]
             ~ [ubyte(32)] ~ kp.V[]
-            ~ [ubyte(OP.VERIFY_SIG)]), Unlock.init, tx, Input.init),
+            ~ [ubyte(OP.VERIFY_SIG)]), Unlock.init, tx, Input.init) ==
         "Script failed");  // VERIFY_SIG does not push TRUE to the stack
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [ubyte(64)] ~ sig.toBlob()[]
             ~ [ubyte(32)] ~ kp.V[]
-            ~ [ubyte(OP.VERIFY_SIG)]), Unlock([ubyte(OP.TRUE)]), tx, Input.init),
-        null);
+            ~ [ubyte(OP.VERIFY_SIG)]), Unlock([ubyte(OP.TRUE)]), tx, Input.init)
+        is null);
 }
 
 // OP.CHECK_MULTI_SIG / OP.VERIFY_MULTI_SIG
@@ -1292,42 +1291,42 @@ unittest
 {
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     const Transaction tx;
-    test!("==")(engine.execute(
-        Lock(LockType.Script, [OP.CHECK_MULTI_SIG]), Unlock.init, tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.Script, [OP.CHECK_MULTI_SIG]), Unlock.init, tx, Input.init) ==
         "CHECK_MULTI_SIG opcode requires at minimum four items on the stack");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [OP.PUSH_NUM_1, OP.PUSH_NUM_1, OP.PUSH_NUM_1, OP.CHECK_MULTI_SIG]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "CHECK_MULTI_SIG opcode requires at minimum four items on the stack");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [OP.PUSH_NUM_1, OP.PUSH_NUM_1, OP.PUSH_NUM_1, OP.PUSH_NUM_1,
                 OP.CHECK_MULTI_SIG]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "CHECK_MULTI_SIG opcode requires 32-byte public key on the stack");
     // invalid key (crypto_core_ed25519_is_valid_point() fails)
     Point invalid_key;
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_1)]  // required sigs
             ~ [ubyte(32)] ~ invalid_key[]
             ~ [ubyte(OP.PUSH_NUM_1)]  // number of keys
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ Signature.init.toBlob()[]),
-        tx, Input.init),
+        tx, Input.init) ==
         "CHECK_MULTI_SIG 32-byte public key on the stack is invalid");
     // valid key, invalid signature
     Point valid_key = Point.fromString(
         "0x44404b654d6ddf71e2446eada6acd1f462348b1b17272ff8f36dda3248e08c81");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_1)]  // required sigs
             ~ [ubyte(32)] ~ valid_key[]
             ~ [ubyte(OP.PUSH_NUM_1)]  // number of keys
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ Signature.init.toBlob()[]),
-        tx, Input.init),
+        tx, Input.init) ==
         "Script failed");
 
     const Pair kp1 = Pair.random();
@@ -1342,16 +1341,16 @@ unittest
     const sig5 = sign(kp5, tx);
 
     // valid key + signature
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_1)]  // required sigs
             ~ [ubyte(32)] ~ kp1.V[]
             ~ [ubyte(OP.PUSH_NUM_1)]  // number of keys
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ sig1.toBlob()[]),
-        tx, Input.init),
-        null);
-    test!("==")(engine.execute(
+        tx, Input.init)
+        is null);
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_2)]  // fails: more sigs than keys
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1359,9 +1358,9 @@ unittest
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ sig1.toBlob()[]
              ~ [ubyte(64)] ~ sig2.toBlob()[]),
-        tx, Input.init),
+        tx, Input.init) ==
         "CHECK_MULTI_SIG opcode cannot accept more signatures than there are keys");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_2)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1369,10 +1368,10 @@ unittest
             ~ [ubyte(OP.PUSH_NUM_2)]  // number of keys
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ sig1.toBlob()[]),  // fails: not enough sigs pushed
-        tx, Input.init),
+        tx, Input.init) ==
         "CHECK_MULTI_SIG not enough signatures on the stack");
     // valid
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_2)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1381,10 +1380,10 @@ unittest
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ sig1.toBlob()[]
              ~ [ubyte(64)] ~ sig2.toBlob()[]),
-        tx, Input.init),
-        null);
+        tx, Input.init)
+        is null);
     // invalid order
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_2)]  // number of sigs
             ~ [ubyte(32)] ~ kp2.V[]
@@ -1393,10 +1392,10 @@ unittest
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ sig1.toBlob()[]
              ~ [ubyte(64)] ~ sig2.toBlob()[]),
-        tx, Input.init),
+        tx, Input.init) ==
         "Script failed");
     // ditto invalid order
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_2)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1405,10 +1404,10 @@ unittest
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ sig2.toBlob()[]
              ~ [ubyte(64)] ~ sig1.toBlob()[]),
-        tx, Input.init),
+        tx, Input.init) ==
         "Script failed");
     // 1 of 2 is ok
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_1)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1416,10 +1415,10 @@ unittest
             ~ [ubyte(OP.PUSH_NUM_2)]  // number of keys
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ sig1.toBlob()[]),
-        tx, Input.init),
-        null);
+        tx, Input.init)
+        is null);
     // ditto 1 of 2 is ok
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_1)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1427,10 +1426,10 @@ unittest
             ~ [ubyte(OP.PUSH_NUM_2)]  // number of keys
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ sig2.toBlob()[]),
-        tx, Input.init),
-        null);
+        tx, Input.init)
+        is null);
     // 1 of 5: any sig is enough
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_1)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1441,10 +1440,10 @@ unittest
             ~ [ubyte(OP.PUSH_NUM_5)]  // number of keys
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ sig1.toBlob()[]),
-        tx, Input.init),
-        null);
+        tx, Input.init)
+        is null);
     // 1 of 5: ditto
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_1)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1455,10 +1454,10 @@ unittest
             ~ [ubyte(OP.PUSH_NUM_5)]  // number of keys
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ sig2.toBlob()[]),
-        tx, Input.init),
-        null);
+        tx, Input.init)
+        is null);
     // 2 of 5: ok when sigs are in the same order
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_2)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1470,10 +1469,10 @@ unittest
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ sig1.toBlob()[]
              ~ [ubyte(64)] ~ sig5.toBlob()[]),
-        tx, Input.init),
-        null);
+        tx, Input.init)
+        is null);
     // 2 of 5: fails when sigs are in the wrong order
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_2)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1485,10 +1484,10 @@ unittest
             ~ [ubyte(OP.CHECK_MULTI_SIG)]),
         Unlock([ubyte(64)] ~ sig5.toBlob()[]
              ~ [ubyte(64)] ~ sig1.toBlob()[]),
-        tx, Input.init),
+        tx, Input.init) ==
         "Script failed");
     // 3 of 5: ok when sigs are in the same order
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_2)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1501,10 +1500,10 @@ unittest
         Unlock([ubyte(64)] ~ sig1.toBlob()[]
              ~ [ubyte(64)] ~ sig3.toBlob()[]
              ~ [ubyte(64)] ~ sig5.toBlob()[]),
-        tx, Input.init),
-        null);
+        tx, Input.init)
+        is null);
     // 3 of 5: fails when sigs are in the wrong order
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_2)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1517,10 +1516,10 @@ unittest
         Unlock([ubyte(64)] ~ sig1.toBlob()[]
              ~ [ubyte(64)] ~ sig5.toBlob()[]
              ~ [ubyte(64)] ~ sig3.toBlob()[]),
-        tx, Input.init),
+        tx, Input.init) ==
         "Script failed");
     // 5 of 5: ok when sigs are in the same order
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_5)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1535,10 +1534,10 @@ unittest
              ~ [ubyte(64)] ~ sig3.toBlob()[]
              ~ [ubyte(64)] ~ sig4.toBlob()[]
              ~ [ubyte(64)] ~ sig5.toBlob()[]),
-        tx, Input.init),
-        null);
+        tx, Input.init)
+        is null);
     // 5 of 5: fails when sigs are in the wrong order
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_5)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1553,10 +1552,10 @@ unittest
              ~ [ubyte(64)] ~ sig2.toBlob()[]
              ~ [ubyte(64)] ~ sig4.toBlob()[]
              ~ [ubyte(64)] ~ sig5.toBlob()[]),
-        tx, Input.init),
+        tx, Input.init) ==
         "Script failed");
     // ditto but with VERIFY_MULTI_SIG
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(OP.PUSH_NUM_2)]  // number of sigs
             ~ [ubyte(32)] ~ kp1.V[]
@@ -1569,7 +1568,7 @@ unittest
         Unlock([ubyte(64)] ~ sig1.toBlob()[]
              ~ [ubyte(64)] ~ sig5.toBlob()[]
              ~ [ubyte(64)] ~ sig3.toBlob()[]),
-        tx, Input.init),
+        tx, Input.init) ==
         "VERIFY_MULTI_SIG signature failed validation");
 }
 
@@ -1589,20 +1588,20 @@ unittest
 
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     const Transaction tx = Transaction([Input.init], null);
-    test!("==")(engine.execute(
-        Lock(LockType.Script, [OP.CHECK_SEQ_SIG]), Unlock.init, tx, tx.inputs[0]),
+    assert(engine.execute(
+        Lock(LockType.Script, [OP.CHECK_SEQ_SIG]), Unlock.init, tx, tx.inputs[0]) ==
         "CHECK_SEQ_SIG opcode requires 4 items on the stack");
-    test!("==")(engine.execute(
-        Lock(LockType.Script, [OP.VERIFY_SEQ_SIG]), Unlock.init, tx, tx.inputs[0]),
+    assert(engine.execute(
+        Lock(LockType.Script, [OP.VERIFY_SEQ_SIG]), Unlock.init, tx, tx.inputs[0]) ==
         "VERIFY_SEQ_SIG opcode requires 4 items on the stack");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [1, 42, 1, 42, 1, 42, OP.CHECK_SEQ_SIG]),
-        Unlock.init, tx, tx.inputs[0]),
+        Unlock.init, tx, tx.inputs[0]) ==
         "CHECK_SEQ_SIG opcode requires 4 items on the stack");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [1, 42, 1, 42, 1, 42, 1, 42, OP.CHECK_SEQ_SIG]),
-        Unlock.init, tx, tx.inputs[0]),
+        Unlock.init, tx, tx.inputs[0]) ==
         "CHECK_SEQ_SIG opcode requires 8-byte minimum sequence on the stack");
 
     const seq_0 = ulong(0);
@@ -1610,30 +1609,30 @@ unittest
     const seq_0_bytes = nativeToLittleEndian(seq_0);
     const seq_1_bytes = nativeToLittleEndian(seq_1);
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(1), ubyte(1)]  // wrong pubkey size
             ~ toPushOpcode(seq_0_bytes)
             ~ [ubyte(OP.CHECK_SEQ_SIG)]),
         Unlock(
             [ubyte(64)] ~ Signature.init.toBlob()[]
-            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0]),
+            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0]) ==
         "CHECK_SEQ_SIG opcode requires 32-byte public key on the stack");
 
     // invalid key (crypto_core_ed25519_is_valid_point() fails)
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(32)] ~ Point.init[]  // size ok, form is wrong
             ~ toPushOpcode(seq_0_bytes)
             ~ [ubyte(OP.CHECK_SEQ_SIG)]),
         Unlock(
             [ubyte(64)] ~ Signature.init.toBlob()[]
-            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0]),
+            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0]) ==
         "CHECK_SEQ_SIG 32-byte public key on the stack is invalid");
 
     Point rand_key = Point.fromString(
         "0x44404b654d6ddf71e2446eada6acd1f462348b1b17272ff8f36dda3248e08c81");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(32)] ~ rand_key[]
             ~ toPushOpcode(seq_0_bytes)
@@ -1641,65 +1640,65 @@ unittest
         Unlock(
             [ubyte(64)] ~ Signature.init.toBlob()[]
             // wrong sequence size
-            ~ toPushOpcode(nativeToLittleEndian(ubyte(1)))), tx, tx.inputs[0]),
+            ~ toPushOpcode(nativeToLittleEndian(ubyte(1)))), tx, tx.inputs[0]) ==
         "CHECK_SEQ_SIG opcode requires 8-byte sequence on the stack");
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(32)] ~ rand_key[]
             ~ toPushOpcode(seq_0_bytes)
             ~ [ubyte(OP.CHECK_SEQ_SIG)]),
         Unlock(
             [ubyte(64)] ~ Signature.init.toBlob()[]
-            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0]),
+            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0]) ==
         "Script failed");
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(32)] ~ rand_key[]
             ~ toPushOpcode(seq_0_bytes)
             ~ [ubyte(OP.CHECK_SEQ_SIG)]),
         Unlock(
             [ubyte(1)] ~ [ubyte(1)]  // wrong signature size
-            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0]),
+            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0]) ==
         "CHECK_SEQ_SIG opcode requires 64-byte signature on the stack");
 
     const Pair kp = Pair.random();
     const bad_sig = sign(kp, tx);
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(32)] ~ rand_key[]
             ~ toPushOpcode(seq_0_bytes)
             ~ [ubyte(OP.CHECK_SEQ_SIG)]),
         Unlock(
             [ubyte(64)] ~ bad_sig.toBlob()[]
-            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0]),
+            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0]) ==
         "Script failed");  // still fails, signature didn't hash the sequence
 
     // create the proper signature which blanks the input and encodes the sequence
     const challenge_0 = getSequenceChallenge(tx, seq_0, 0);
     const seq_0_sig = sign(kp, challenge_0);
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(32)] ~ kp.V[]
             ~ toPushOpcode(seq_0_bytes)
             ~ [ubyte(OP.CHECK_SEQ_SIG)]),
         Unlock(
             [ubyte(64)] ~ seq_0_sig.toBlob()[]
-            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0]),
-        null);
+            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0])
+        is null);
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(32)] ~ kp.V[]
             ~ toPushOpcode(seq_1_bytes)
             ~ [ubyte(OP.CHECK_SEQ_SIG)]),
         Unlock(
             [ubyte(64)] ~ seq_0_sig.toBlob()[]
-            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0]),
+            ~ toPushOpcode(seq_0_bytes)), tx, tx.inputs[0]) ==
         "CHECK_SEQ_SIG sequence is not equal to or greater than min_sequence");
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(32)] ~ kp.V[]
             ~ toPushOpcode(seq_0_bytes)
@@ -1711,34 +1710,34 @@ unittest
 
     const challenge_1 = getSequenceChallenge(tx, seq_1, 0);
     const seq_1_sig = sign(kp, challenge_1);
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(32)] ~ kp.V[]
             ~ toPushOpcode(seq_0_bytes)
             ~ [ubyte(OP.CHECK_SEQ_SIG)]),
         Unlock(
             [ubyte(64)] ~ seq_1_sig.toBlob()[]
-            ~ toPushOpcode(seq_1_bytes)), tx, tx.inputs[0]),
-        null);
+            ~ toPushOpcode(seq_1_bytes)), tx, tx.inputs[0])
+        is null);
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(32)] ~ rand_key[]  // key mismatch
             ~ toPushOpcode(seq_0_bytes)
             ~ [ubyte(OP.VERIFY_SEQ_SIG)]),
         Unlock(
             [ubyte(64)] ~ seq_1_sig.toBlob()[]
-            ~ toPushOpcode(seq_1_bytes)), tx, tx.inputs[0]),
+            ~ toPushOpcode(seq_1_bytes)), tx, tx.inputs[0]) ==
         "VERIFY_SEQ_SIG signature failed validation");
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
               [ubyte(32)] ~ kp.V[]
             ~ toPushOpcode(seq_0_bytes)
             ~ [ubyte(OP.VERIFY_SEQ_SIG)]),
         Unlock(
             [ubyte(64)] ~ seq_0_sig.toBlob()[]
-            ~ toPushOpcode(seq_1_bytes)), tx, tx.inputs[0]),  // sig mismatch
+            ~ toPushOpcode(seq_1_bytes)), tx, tx.inputs[0]) ==  // sig mismatch
         "VERIFY_SEQ_SIG signature failed validation");
 }
 
@@ -1752,40 +1751,40 @@ unittest
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     const Transaction tx_10 = Transaction(Height(10));
     const Transaction tx_11 = Transaction(Height(11));
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             toPushOpcode(height_9)
             ~ [ubyte(OP.VERIFY_LOCK_HEIGHT), ubyte(OP.TRUE)]),
-        Unlock.init, tx_10, Input.init),
-        null);
-    test!("==")(engine.execute(
+        Unlock.init, tx_10, Input.init)
+        is null);
+    assert(engine.execute(
         Lock(LockType.Script,
             toPushOpcode(height_10)
             ~ [ubyte(OP.VERIFY_LOCK_HEIGHT), ubyte(OP.TRUE)]),
-        Unlock.init, tx_10, Input.init),  // tx with matching unlock height
-        null);
-    test!("==")(engine.execute(
+        Unlock.init, tx_10, Input.init)  // tx with matching unlock height
+        is null);
+    assert(engine.execute(
         Lock(LockType.Script,
             toPushOpcode(height_11)
             ~ [ubyte(OP.VERIFY_LOCK_HEIGHT), ubyte(OP.TRUE)]),
-        Unlock.init, tx_10, Input.init),
+        Unlock.init, tx_10, Input.init) ==
         "VERIFY_LOCK_HEIGHT height lock of transaction is too low");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             toPushOpcode(height_11)
             ~ [ubyte(OP.VERIFY_LOCK_HEIGHT), ubyte(OP.TRUE)]),
-        Unlock.init, tx_11, Input.init),  // tx with matching unlock height
-        null);
-    test!("==")(engine.execute(
+        Unlock.init, tx_11, Input.init)  // tx with matching unlock height
+        is null);
+    assert(engine.execute(
         Lock(LockType.Script,
             toPushOpcode(nativeToLittleEndian(ubyte(9)))
             ~ [ubyte(OP.VERIFY_LOCK_HEIGHT), ubyte(OP.TRUE)]),
-        Unlock.init, tx_10, Input.init),
+        Unlock.init, tx_10, Input.init) ==
         "VERIFY_LOCK_HEIGHT height lock must be an 8-byte number");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [ubyte(OP.VERIFY_LOCK_HEIGHT), ubyte(OP.TRUE)]),
-        Unlock.init, tx_10, Input.init),
+        Unlock.init, tx_10, Input.init) ==
         "VERIFY_LOCK_HEIGHT opcode requires a lock height on the stack");
 }
 
@@ -1800,40 +1799,40 @@ unittest
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     const Input input_10 = Input(Hash.init, 0, 10 /* unlock_age */);
     const Input input_11 = Input(Hash.init, 0, 11 /* unlock_age */);
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             toPushOpcode(age_9)
             ~ [ubyte(OP.VERIFY_UNLOCK_AGE), ubyte(OP.TRUE)]),
-        Unlock.init, Transaction.init, input_10),
-        null);
-    test!("==")(engine.execute(
+        Unlock.init, Transaction.init, input_10)
+        is null);
+    assert(engine.execute(
         Lock(LockType.Script,
             toPushOpcode(age_10)
             ~ [ubyte(OP.VERIFY_UNLOCK_AGE), ubyte(OP.TRUE)]),
-        Unlock.init, Transaction.init, input_10),  // input with matching unlock age
-        null);
-    test!("==")(engine.execute(
+        Unlock.init, Transaction.init, input_10)  // input with matching unlock age
+        is null);
+    assert(engine.execute(
         Lock(LockType.Script,
             toPushOpcode(age_11)
             ~ [ubyte(OP.VERIFY_UNLOCK_AGE), ubyte(OP.TRUE)]),
-        Unlock.init, Transaction.init, input_10),
+        Unlock.init, Transaction.init, input_10) ==
         "VERIFY_UNLOCK_AGE unlock age of input is too low");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             toPushOpcode(age_11)
             ~ [ubyte(OP.VERIFY_UNLOCK_AGE), ubyte(OP.TRUE)]),
-        Unlock.init, Transaction.init, input_11),  // input with matching unlock age
-        null);
-    test!("==")(engine.execute(
+        Unlock.init, Transaction.init, input_11)  // input with matching unlock age
+        is null);
+    assert(engine.execute(
         Lock(LockType.Script,
             toPushOpcode(age_overflow)
             ~ [ubyte(OP.VERIFY_UNLOCK_AGE), ubyte(OP.TRUE)]),
-        Unlock.init, Transaction.init, input_10),
+        Unlock.init, Transaction.init, input_10) ==
         "VERIFY_UNLOCK_AGE unlock age must be a 4-byte number");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [ubyte(OP.VERIFY_UNLOCK_AGE), ubyte(OP.TRUE)]),
-        Unlock.init, Transaction.init, input_10),
+        Unlock.init, Transaction.init, input_10) ==
         "VERIFY_UNLOCK_AGE opcode requires an unlock age on the stack");
 }
 
@@ -1845,32 +1844,32 @@ unittest
     const sig = sign(kp, tx);
 
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
-    test!("==")(engine.execute(
-        Lock(LockType.Key, kp.V[]), Unlock(sig.toBlob()[]), tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.Key, kp.V[]), Unlock(sig.toBlob()[]), tx, Input.init) ==
         null);
     const bad_sig = sign(kp, "foobar");
-    test!("==")(engine.execute(
-        Lock(LockType.Key, kp.V[]), Unlock(bad_sig.toBlob()[]), tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.Key, kp.V[]), Unlock(bad_sig.toBlob()[]), tx, Input.init) ==
         "LockType.Key signature in unlock script failed validation");
     const bad_key = Pair.random().V;
-    test!("==")(engine.execute(
-        Lock(LockType.Key, bad_key[]), Unlock(sig.toBlob()[]), tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.Key, bad_key[]), Unlock(sig.toBlob()[]), tx, Input.init) ==
         "LockType.Key signature in unlock script failed validation");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Key, ubyte(42).repeat(64).array),
-        Unlock(sig.toBlob()[]), tx, Input.init),
+        Unlock(sig.toBlob()[]), tx, Input.init) ==
         "LockType.Key requires 32-byte key argument in the lock script");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Key, ubyte(0).repeat(32).array),
-        Unlock(sig.toBlob()[]), tx, Input.init),
+        Unlock(sig.toBlob()[]), tx, Input.init) ==
         "LockType.Key 32-byte public key in lock script is invalid");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Key, kp.V[]),
-        Unlock(ubyte(42).repeat(32).array), tx, Input.init),
+        Unlock(ubyte(42).repeat(32).array), tx, Input.init) ==
         "LockType.Key requires a 64-byte signature in the unlock script");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Key, kp.V[]),
-        Unlock(ubyte(42).repeat(65).array), tx, Input.init),
+        Unlock(ubyte(42).repeat(65).array), tx, Input.init) ==
         "LockType.Key requires a 64-byte signature in the unlock script");
 }
 
@@ -1885,41 +1884,41 @@ unittest
     const sig2 = sign(kp2, tx);  // valid sig, but for a different key-pair
 
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
-    test!("==")(engine.execute(
-        Lock(LockType.KeyHash, key_hash[]), Unlock(sig.toBlob()[] ~ kp.V[]), tx, Input.init),
-        null);
+    assert(engine.execute(
+        Lock(LockType.KeyHash, key_hash[]), Unlock(sig.toBlob()[] ~ kp.V[]), tx, Input.init)
+        is null);
     const bad_sig = sign(kp, "foo");
-    test!("==")(engine.execute(
-        Lock(LockType.KeyHash, key_hash[]), Unlock(bad_sig.toBlob()[] ~ kp.V[]), tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.KeyHash, key_hash[]), Unlock(bad_sig.toBlob()[] ~ kp.V[]), tx, Input.init) ==
         "LockType.KeyHash signature in unlock script failed validation");
-    test!("==")(engine.execute(
-        Lock(LockType.KeyHash, key_hash[]), Unlock(sig2.toBlob()[] ~ kp2.V[]), tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.KeyHash, key_hash[]), Unlock(sig2.toBlob()[] ~ kp2.V[]), tx, Input.init) ==
         "LockType.KeyHash hash of key does not match key hash set in lock script");
     const bad_key = Pair.random().V;
-    test!("==")(engine.execute(
-        Lock(LockType.KeyHash, key_hash[]), Unlock(sig.toBlob()[] ~ bad_key[]), tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.KeyHash, key_hash[]), Unlock(sig.toBlob()[] ~ bad_key[]), tx, Input.init) ==
         "LockType.KeyHash hash of key does not match key hash set in lock script");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.KeyHash, ubyte(42).repeat(63).array),
-        Unlock(sig.toBlob()[] ~ kp.V[]), tx, Input.init),
+        Unlock(sig.toBlob()[] ~ kp.V[]), tx, Input.init) ==
         "LockType.KeyHash requires a 64-byte key hash argument in the lock script");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.KeyHash, ubyte(42).repeat(65).array),
-        Unlock(sig.toBlob()[] ~ kp.V[]), tx, Input.init),
+        Unlock(sig.toBlob()[] ~ kp.V[]), tx, Input.init) ==
         "LockType.KeyHash requires a 64-byte key hash argument in the lock script");
-    test!("==")(engine.execute(
-        Lock(LockType.KeyHash, key_hash[]), Unlock(sig.toBlob()[]), tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.KeyHash, key_hash[]), Unlock(sig.toBlob()[]), tx, Input.init) ==
         "LockType.KeyHash requires a 64-byte signature and a 32-byte key in the unlock script");
-    test!("==")(engine.execute(
-        Lock(LockType.KeyHash, key_hash[]), Unlock(kp.V[]), tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.KeyHash, key_hash[]), Unlock(kp.V[]), tx, Input.init) ==
         "LockType.KeyHash requires a 64-byte signature and a 32-byte key in the unlock script");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.KeyHash, key_hash[]), Unlock(sig.toBlob()[] ~ kp.V[] ~ [ubyte(0)]),
-        tx, Input.init),
+        tx, Input.init) ==
         "LockType.KeyHash requires a 64-byte signature and a 32-byte key in the unlock script");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.KeyHash, key_hash[]),
-        Unlock(sig.toBlob()[] ~ ubyte(0).repeat(32).array), tx, Input.init),
+        Unlock(sig.toBlob()[] ~ ubyte(0).repeat(32).array), tx, Input.init) ==
         "LockType.KeyHash public key in unlock script is invalid");
 }
 
@@ -1935,32 +1934,32 @@ unittest
     const Script unlock = createUnlockP2PKH(sig, kp.V);
 
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
-    test!("==")(engine.execute(
-        Lock(LockType.Script, lock[]), Unlock(unlock[]), tx, Input.init),
-        null);
+    assert(engine.execute(
+        Lock(LockType.Script, lock[]), Unlock(unlock[]), tx, Input.init)
+        is null);
     // simple push
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             ubyte(42).repeat(65).array.toPushOpcode
             ~ ubyte(42).repeat(65).array.toPushOpcode
             ~ [ubyte(OP.CHECK_EQUAL)]),
-        Unlock(unlock[]), tx, Input.init),
-        null);
+        Unlock(unlock[]), tx, Input.init)
+        is null);
 
     Script bad_key_unlock = createUnlockP2PKH(sig, Pair.random.V);
-    test!("==")(engine.execute(
-        Lock(LockType.Script, lock[]), Unlock(bad_key_unlock[]), tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.Script, lock[]), Unlock(bad_key_unlock[]), tx, Input.init) ==
         "VERIFY_EQUAL operation failed");
 
     // native script stack overflow test
     scope small = new Engine(TestStackMaxItemSize * 2, TestStackMaxItemSize);
-    test!("==")(small.execute(
+    assert(small.execute(
         Lock(LockType.Script, lock[]),
         Unlock(
             ubyte(42).repeat(TestStackMaxItemSize).array.toPushOpcode()
             ~ ubyte(42).repeat(TestStackMaxItemSize).array.toPushOpcode()
             ~ ubyte(42).repeat(TestStackMaxItemSize).array.toPushOpcode()), tx,
-        Input.init),
+        Input.init) ==
         "Stack overflow while executing PUSH_DATA_2");
 }
 
@@ -1978,53 +1977,53 @@ unittest
     // unlock is: <push(sig)> <redeem>
     // redeem is: check sig against the key embedded in the redeem script
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Redeem, redeem_hash[]),
         Unlock([ubyte(64)] ~ sig.toBlob()[] ~ toPushOpcode(redeem[])),
-        tx, Input.init),
-        null);
-    test!("==")(engine.execute(
+        tx, Input.init)
+        is null);
+    assert(engine.execute(
         Lock(LockType.Redeem, ubyte(42).repeat(32).array),
         Unlock([ubyte(64)] ~ sig.toBlob()[] ~ toPushOpcode(redeem[])),
-        tx, Input.init),
+        tx, Input.init) ==
         "LockType.Redeem requires 64-byte script hash in the lock script");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Redeem, ubyte(42).repeat(65).array),
         Unlock([ubyte(64)] ~ sig.toBlob()[] ~ toPushOpcode(redeem[])),
-        tx, Input.init),
+        tx, Input.init) ==
         "LockType.Redeem requires 64-byte script hash in the lock script");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Redeem, redeem_hash[]),
         Unlock(null),
-        tx, Input.init),
+        tx, Input.init) ==
         "LockType.Redeem requires unlock script to push a redeem script to the stack");
     scope small = new Engine(TestStackMaxItemSize * 2, TestStackMaxItemSize);
-    test!("==")(small.execute(
+    assert(small.execute(
         Lock(LockType.Redeem, redeem_hash[]),
         Unlock(ubyte(42).repeat(TestStackMaxItemSize * 2).array.toPushOpcode()),
-        tx, Input.init),
+        tx, Input.init) ==
         "PUSH_DATA_2 opcode payload size is not within StackMaxItemSize limits");
-    test!("==")(small.execute(
+    assert(small.execute(
         Lock(LockType.Redeem, redeem_hash[]),
         Unlock(
             ubyte(42).repeat(TestStackMaxItemSize).array.toPushOpcode()
             ~ ubyte(42).repeat(TestStackMaxItemSize).array.toPushOpcode()
             ~ ubyte(42).repeat(TestStackMaxItemSize).array.toPushOpcode()),
-        tx, Input.init),
+        tx, Input.init) ==
         "Stack overflow while executing PUSH_DATA_2");
     const Script wrong_redeem = makeScript([ubyte(32)] ~ Pair.random.V[]
         ~ [ubyte(OP.CHECK_SIG)]);
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Redeem, redeem_hash[]),
         Unlock([ubyte(64)] ~ sig.toBlob()[] ~ toPushOpcode(wrong_redeem[])),
-        tx, Input.init),
+        tx, Input.init) ==
         "LockType.Redeem unlock script pushed a redeem script which does "
         ~ "not match the redeem hash in the lock script");
     auto wrong_sig = sign(kp, "bad");
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Redeem, redeem_hash[]),
         Unlock([ubyte(64)] ~ wrong_sig.toBlob()[] ~ toPushOpcode(redeem[])),
-        tx, Input.init),
+        tx, Input.init) ==
         "Script failed");
 
     // note: a redeem script cannot contain an overflown payload size
@@ -2033,20 +2032,20 @@ unittest
     // the unlock script then the unlock script validation would have already
     // failed before the redeem script validation could ever fail.
     const Script bad_opcode_redeem = makeScript([ubyte(255)]);
-    test!("==")(small.execute(
+    assert(small.execute(
         Lock(LockType.Redeem, bad_opcode_redeem.hashFull()[]),
         Unlock(toPushOpcode(bad_opcode_redeem[])),
-        tx, Input.init),
+        tx, Input.init) ==
         "Script contains an unrecognized opcode");
 
     // however it may include opcodes which overflow the stack during execution.
     // here 1 byte => 64 bytes, causing a stack overflow
     scope tiny = new Engine(10, 10);
     const Script overflow_redeem = makeScript([OP.TRUE, OP.HASH]);
-    test!("==")(tiny.execute(
+    assert(tiny.execute(
         Lock(LockType.Redeem, overflow_redeem.hashFull()[]),
         Unlock(toPushOpcode(overflow_redeem[])),
-        tx, Input.init),
+        tx, Input.init) ==
         "Stack overflow while executing HASH");
 }
 
@@ -2063,18 +2062,18 @@ unittest
 
     const invalid_script = makeScript([255]);
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
-    test!("==")(engine.execute(
-        Lock(LockType.Script, lock[]), Unlock(unlock[]), tx, Input.init),
-        null);
+    assert(engine.execute(
+        Lock(LockType.Script, lock[]), Unlock(unlock[]), tx, Input.init)
+        is null);
     // invalid scripts / sigs
-    test!("==")(engine.execute(
-        Lock(LockType.Script, []), Unlock(unlock[]), tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.Script, []), Unlock(unlock[]), tx, Input.init) ==
         "Lock script must not be empty");
-    test!("==")(engine.execute(
-        Lock(LockType.Script, invalid_script[]), Unlock(unlock[]), tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.Script, invalid_script[]), Unlock(unlock[]), tx, Input.init) ==
         "Script contains an unrecognized opcode");
-    test!("==")(engine.execute(
-        Lock(LockType.Script, lock[]), Unlock(invalid_script[]), tx, Input.init),
+    assert(engine.execute(
+        Lock(LockType.Script, lock[]), Unlock(invalid_script[]), tx, Input.init) ==
         "Script contains an unrecognized opcode");
 }
 
@@ -2085,16 +2084,16 @@ unittest
     scope engine = new Engine(TestStackMaxTotalSize, TestStackMaxItemSize);
     const Transaction tx;
     const StackMaxItemSize = 512;
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [ubyte(1), ubyte(42)] ~ [ubyte(OP.TRUE)]),
-        Unlock.init, tx, Input.init),
-        null);
+        Unlock.init, tx, Input.init)
+        is null);
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, ubyte(42).repeat(TestStackMaxItemSize + 1)
             .array.toPushOpcode()
             ~ [ubyte(OP.TRUE)]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "PUSH_DATA_2 opcode payload size is not within StackMaxItemSize limits");
 
     const MaxItemPush = ubyte(42).repeat(TestStackMaxItemSize).array
@@ -2105,70 +2104,70 @@ unittest
 
     // overflow with PUSH_DATA_1
     scope tiny = new Engine(120, 77);
-    test!("==")(tiny.execute(
+    assert(tiny.execute(
         Lock(LockType.Script,
             ubyte(42).repeat(76).array.toPushOpcode()
             ~ ubyte(42).repeat(76).array.toPushOpcode()
             ~ ubyte(42).repeat(76).array.toPushOpcode()
             ~ [ubyte(OP.TRUE)]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Stack overflow while executing PUSH_DATA_1");
 
     // ditto with PUSH_DATA_2
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, MaxItemPush.repeat(MaxPushes + 1).joiner.array
             ~ [ubyte(OP.TRUE)]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Stack overflow while executing PUSH_DATA_2");
 
     // within limit, but missing OP.TRUE on stack
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, MaxItemPush.repeat(MaxPushes).joiner.array),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Script failed");
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, MaxItemPush.repeat(MaxPushes).joiner.array
             ~ [ubyte(OP.TRUE)]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Stack overflow while pushing TRUE to the stack");
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, MaxItemPush.repeat(MaxPushes).joiner.array
             ~ [ubyte(OP.FALSE)]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Stack overflow while pushing FALSE to the stack");
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, MaxItemPush.repeat(MaxPushes).joiner.array
             ~ [ubyte(1), ubyte(1)]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Stack overflow while executing PUSH_BYTES_*");
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, MaxItemPush.repeat(MaxPushes).joiner.array
             ~ [ubyte(1), ubyte(1)]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Stack overflow while executing PUSH_BYTES_*");
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, MaxItemPush.repeat(MaxPushes).joiner.array
             ~ [ubyte(OP.DUP)]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Stack overflow while executing DUP");
 
     // will fit, pops TestStackMaxItemSize and pushes 64 bytes
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, MaxItemPush.repeat(MaxPushes).joiner.array
             ~ [ubyte(OP.HASH), ubyte(OP.TRUE)]),
-        Unlock.init, tx, Input.init),
-        null);
+        Unlock.init, tx, Input.init)
+        is null);
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, MaxItemPush.repeat(MaxPushes - 1).joiner.array
             ~ [ubyte(1), ubyte(1)].repeat(TestStackMaxItemSize).joiner.array
             ~ ubyte(OP.HASH) ~ [ubyte(OP.TRUE)]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Stack overflow while executing HASH");
 
     // stack overflow in only one of the branches.
@@ -2184,12 +2183,12 @@ unittest
             ubyte(OP.TRUE),
          ubyte(OP.END_IF)]);
 
-    test!("==")(tiny.execute(
-        lock_if, Unlock([ubyte(OP.TRUE)]), tx, Input.init),
+    assert(tiny.execute(
+        lock_if, Unlock([ubyte(OP.TRUE)]), tx, Input.init) ==
         "Stack overflow while executing PUSH_DATA_1");
-    test!("==")(tiny.execute(
-        lock_if, Unlock([ubyte(OP.FALSE)]), tx, Input.init),
-        null);
+    assert(tiny.execute(
+        lock_if, Unlock([ubyte(OP.FALSE)]), tx, Input.init)
+        is null);
 }
 
 // IF, NOT_IF, ELSE, END_IF conditional logic
@@ -2199,59 +2198,59 @@ unittest
     const Transaction tx;
 
     // IF true => execute if branch
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [OP.TRUE, OP.IF, OP.TRUE, OP.ELSE, OP.FALSE, OP.END_IF]),
-        Unlock.init, tx, Input.init),
-        null);
+        Unlock.init, tx, Input.init)
+        is null);
 
     // IF false => execute else branch
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [OP.FALSE, OP.IF, OP.TRUE, OP.ELSE, OP.FALSE, OP.END_IF]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Script failed");
 
     // NOT_IF true => execute if branch
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [OP.FALSE, OP.NOT_IF, OP.TRUE, OP.ELSE, OP.FALSE, OP.END_IF]),
-        Unlock.init, tx, Input.init),
-        null);
+        Unlock.init, tx, Input.init)
+        is null);
 
     // NOT_IF false => execute else branch
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [OP.TRUE, OP.NOT_IF, OP.TRUE, OP.ELSE, OP.FALSE, OP.END_IF]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Script failed");
 
     // dangling IF / NOT_IF
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [OP.TRUE, OP.IF]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "IF / NOT_IF requires a closing END_IF");
 
     // ditto
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [OP.TRUE, OP.NOT_IF]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "IF / NOT_IF requires a closing END_IF");
 
     // unmatched ELSE
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [OP.TRUE, OP.ELSE]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Cannot have an ELSE without an associated IF / NOT_IF");
 
     // unmatched END_IF
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script,
             [OP.TRUE, OP.END_IF]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "Cannot have an END_IF without an associated IF / NOT_IF");
 
     /* nested conditionals */
@@ -2273,13 +2272,13 @@ unittest
                  OP.END_IF,
              OP.END_IF]);
 
-    test!("==")(engine.execute(lock_1, Unlock([OP.TRUE, OP.TRUE]), tx, Input.init),
-        null);
-    test!("==")(engine.execute(lock_1, Unlock([OP.TRUE, OP.FALSE]), tx, Input.init),
+    assert(engine.execute(lock_1, Unlock([OP.TRUE, OP.TRUE]), tx, Input.init)
+        is null);
+    assert(engine.execute(lock_1, Unlock([OP.TRUE, OP.FALSE]), tx, Input.init) ==
         "Script failed");
-    test!("==")(engine.execute(lock_1, Unlock([OP.FALSE, OP.TRUE]), tx, Input.init),
+    assert(engine.execute(lock_1, Unlock([OP.FALSE, OP.TRUE]), tx, Input.init) ==
         "Script failed");
-    test!("==")(engine.execute(lock_1, Unlock([OP.FALSE, OP.FALSE]), tx, Input.init),
+    assert(engine.execute(lock_1, Unlock([OP.FALSE, OP.FALSE]), tx, Input.init) ==
         "Script failed");
 
     // IF true => NOT_IF true => OP.TRUE
@@ -2300,28 +2299,28 @@ unittest
              OP.END_IF]);
 
     // note: remember that it's LIFO, second push is evaluted first!
-    test!("==")(engine.execute(lock_2, Unlock([OP.TRUE, OP.TRUE]), tx, Input.init),
+    assert(engine.execute(lock_2, Unlock([OP.TRUE, OP.TRUE]), tx, Input.init) ==
         "Script failed");
-    test!("==")(engine.execute(lock_2, Unlock([OP.TRUE, OP.FALSE]), tx, Input.init),
+    assert(engine.execute(lock_2, Unlock([OP.TRUE, OP.FALSE]), tx, Input.init) ==
         "Script failed");
-    test!("==")(engine.execute(lock_2, Unlock([OP.FALSE, OP.TRUE]), tx, Input.init),
+    assert(engine.execute(lock_2, Unlock([OP.FALSE, OP.TRUE]), tx, Input.init) ==
         null);
-    test!("==")(engine.execute(lock_2, Unlock([OP.FALSE, OP.FALSE]), tx, Input.init),
+    assert(engine.execute(lock_2, Unlock([OP.FALSE, OP.FALSE]), tx, Input.init) ==
         "Script failed");
 
     /* syntax checks */
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [OP.IF]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "IF/NOT_IF opcode requires an item on the stack");
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [ubyte(1), ubyte(2), OP.IF]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "IF/NOT_IF may only be used with OP.TRUE / OP.FALSE values");
 
-    test!("==")(engine.execute(
+    assert(engine.execute(
         Lock(LockType.Script, [OP.TRUE, OP.IF]),
-        Unlock.init, tx, Input.init),
+        Unlock.init, tx, Input.init) ==
         "IF / NOT_IF requires a closing END_IF");
 }

--- a/source/agora/script/ScopeCondition.d
+++ b/source/agora/script/ScopeCondition.d
@@ -129,8 +129,6 @@ public struct ScopeCondition
 ///
 nothrow @safe @nogc unittest
 {
-    import ocean.core.Test;
-
     ScopeCondition sc;
     assert(sc.empty());
     assert(sc.isTrue());

--- a/source/agora/script/Script.d
+++ b/source/agora/script/Script.d
@@ -20,8 +20,6 @@ import agora.crypto.Schnorr: Signature;
 import agora.script.Opcodes;
 import agora.script.Stack;
 
-import ocean.core.Test;
-
 import std.bitmanip;
 import std.conv;
 import std.range;
@@ -191,51 +189,49 @@ unittest
     Script result;
 
     // empty unlock scripts are syntactically valid
-    test!"=="(validateScriptSyntax(
-        ScriptType.Unlock, [], StackMaxItemSize, result), null);
+    assert(validateScriptSyntax(
+        ScriptType.Unlock, [], StackMaxItemSize, result) is null);
     // but not lock scripts (would otherwise cause fund loss)
-    test!"=="(validateScriptSyntax(
-        ScriptType.Lock, [], StackMaxItemSize, result),
+    assert(validateScriptSyntax(
+        ScriptType.Lock, [], StackMaxItemSize, result) ==
         "Lock script must not be empty");
 
     // only pushes are allowed for unlock
-    test!"=="(validateScriptSyntax(ScriptType.Unlock, [OP.FALSE], StackMaxItemSize,
-        result),
-        null);
-    test!"=="(validateScriptSyntax(ScriptType.Unlock,
+    assert(validateScriptSyntax(ScriptType.Unlock, [OP.FALSE], StackMaxItemSize, result)
+        is null);
+    assert(validateScriptSyntax(ScriptType.Unlock,
         [OP.PUSH_NUM_1, OP.PUSH_NUM_2, OP.PUSH_NUM_3, OP.PUSH_NUM_4, OP.PUSH_NUM_5],
-        StackMaxItemSize, result),
-        null);
-    test!"=="(validateScriptSyntax(ScriptType.Unlock, [OP.PUSH_BYTES_1, 1],
-        StackMaxItemSize, result), null);
-    test!"=="(validateScriptSyntax(ScriptType.Unlock, [OP.PUSH_BYTES_1, 1, OP.HASH],
-        StackMaxItemSize, result),
+        StackMaxItemSize, result)
+        is null);
+    assert(validateScriptSyntax(ScriptType.Unlock, [OP.PUSH_BYTES_1, 1],
+        StackMaxItemSize, result) is null);
+    assert(validateScriptSyntax(ScriptType.Unlock, [OP.PUSH_BYTES_1, 1, OP.HASH],
+        StackMaxItemSize, result) ==
         "Unlock script may only contain stack pushes");
 
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [255], StackMaxItemSize, result),
+    assert(validateScriptSyntax(ScriptType.Lock, [255], StackMaxItemSize, result) ==
         "Script contains an unrecognized opcode");
 
     // PUSH_BYTES_*
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [1], StackMaxItemSize, result),
+    assert(validateScriptSyntax(ScriptType.Lock, [1], StackMaxItemSize, result) ==
         "PUSH_BYTES_* opcode exceeds total script size");
     // 1-byte data payload
-    test!"=="(.validateScriptSyntax(ScriptType.Lock, [1, 255], StackMaxItemSize,
-        result), null);
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [2], StackMaxItemSize, result),
+    assert(.validateScriptSyntax(ScriptType.Lock, [1, 255], StackMaxItemSize, result)
+              is null);
+    assert(validateScriptSyntax(ScriptType.Lock, [2], StackMaxItemSize, result) ==
         "PUSH_BYTES_* opcode exceeds total script size");
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [2, 255], StackMaxItemSize,
-        result),
-        "PUSH_BYTES_* opcode exceeds total script size");
+    assert(validateScriptSyntax(ScriptType.Lock, [2, 255], StackMaxItemSize, result)
+        is "PUSH_BYTES_* opcode exceeds total script size");
     // 2-byte data payload
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [2, 255, 255], StackMaxItemSize,
-        result), null);
+    assert(validateScriptSyntax(ScriptType.Lock, [2, 255, 255], StackMaxItemSize, result)
+              is null);
     ubyte[75] payload_75;
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [ubyte(75)] ~ payload_75[0 .. 74],
-        StackMaxItemSize, result),
+    assert(validateScriptSyntax(ScriptType.Lock, [ubyte(75)] ~ payload_75[0 .. 74],
+        StackMaxItemSize, result) ==
         "PUSH_BYTES_* opcode exceeds total script size");
     // 75-byte data payload
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [ubyte(75)] ~ payload_75,
-        StackMaxItemSize, result), null);
+    assert(validateScriptSyntax(ScriptType.Lock, [ubyte(75)] ~ payload_75,
+        StackMaxItemSize, result) is null);
 
     // PUSH_DATA_*
     const ubyte[2] size_1 = nativeToLittleEndian(ushort(1));
@@ -244,46 +240,46 @@ unittest
     const ubyte[2] size_overflow = nativeToLittleEndian(
         ushort(StackMaxItemSize + 1));
 
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_1],
-        StackMaxItemSize, result),
+    assert(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_1],
+        StackMaxItemSize, result) ==
         "PUSH_DATA_1 opcode requires 1 byte(s) for the payload size");
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_1, 0],
-        StackMaxItemSize, result),
+    assert(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_1, 0],
+        StackMaxItemSize, result) ==
         "PUSH_DATA_1 opcode payload size is not within StackMaxItemSize limits");
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_1, 1],
-        StackMaxItemSize, result),
+    assert(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_1, 1],
+        StackMaxItemSize, result) ==
         "PUSH_DATA_1 opcode payload size exceeds total script size");
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_1, 1, 1],
-        StackMaxItemSize, result), null);
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_2],
-        StackMaxItemSize, result),
+    assert(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_1, 1, 1],
+        StackMaxItemSize, result) is null);
+    assert(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_2],
+        StackMaxItemSize, result) ==
         "PUSH_DATA_2 opcode requires 2 byte(s) for the payload size");
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_2, 0],
-        StackMaxItemSize, result),
+    assert(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_2, 0],
+        StackMaxItemSize, result) ==
         "PUSH_DATA_2 opcode requires 2 byte(s) for the payload size");
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_2, 0, 0],
-        StackMaxItemSize, result),
+    assert(validateScriptSyntax(ScriptType.Lock, [OP.PUSH_DATA_2, 0, 0],
+        StackMaxItemSize, result) ==
         "PUSH_DATA_2 opcode payload size is not within StackMaxItemSize limits");
-    test!"=="(validateScriptSyntax(ScriptType.Lock, [ubyte(OP.PUSH_DATA_2)] ~ size_1,
-        StackMaxItemSize, result),
+    assert(validateScriptSyntax(ScriptType.Lock, [ubyte(OP.PUSH_DATA_2)] ~ size_1,
+        StackMaxItemSize, result) ==
         "PUSH_DATA_2 opcode payload size exceeds total script size");
-    test!"=="(validateScriptSyntax(ScriptType.Lock,
+    assert(validateScriptSyntax(ScriptType.Lock,
         [ubyte(OP.PUSH_DATA_2)] ~ size_1 ~ [ubyte(1)], StackMaxItemSize,
-        result), null);
-    test!"=="(validateScriptSyntax(ScriptType.Lock,
+        result) is null);
+    assert(validateScriptSyntax(ScriptType.Lock,
         [ubyte(OP.PUSH_DATA_2)] ~ size_max ~ max_payload, StackMaxItemSize,
-        result), null);
-    test!"=="(validateScriptSyntax(ScriptType.Lock,
+        result) is null);
+    assert(validateScriptSyntax(ScriptType.Lock,
         [ubyte(OP.PUSH_DATA_2)] ~ size_overflow ~ max_payload,
-        StackMaxItemSize, result),
+        StackMaxItemSize, result) ==
         "PUSH_DATA_2 opcode payload size is not within StackMaxItemSize limits");
-    test!"=="(validateScriptSyntax(ScriptType.Lock,
+    assert(validateScriptSyntax(ScriptType.Lock,
         [ubyte(OP.PUSH_DATA_2)] ~ size_max ~ max_payload ~ OP.HASH,
-        StackMaxItemSize, result),
-        null);
-    test!"=="(validateScriptSyntax(ScriptType.Lock,
+        StackMaxItemSize, result)
+        is null);
+    assert(validateScriptSyntax(ScriptType.Lock,
         [ubyte(OP.PUSH_DATA_2)] ~ size_max ~ max_payload ~ ubyte(255),
-        StackMaxItemSize, result),
+        StackMaxItemSize, result) ==
         "Script contains an unrecognized opcode");
 }
 
@@ -434,16 +430,16 @@ public ubyte[] toPushOpcode (in ubyte[] data) pure nothrow @safe
 }
 
 ///
-/*pure @safe nothrow*/ // test!() is missing attributes
+pure @safe nothrow
 unittest
 {
     import std.array;
     import std.range;
-    test!("==")(ubyte(42).repeat(75).array.toPushOpcode(),
+    assert(ubyte(42).repeat(75).array.toPushOpcode() ==
         [75] ~ 42.repeat(75).array);
-    test!("==")(ubyte(42).repeat(255).array.toPushOpcode(),
+    assert(ubyte(42).repeat(255).array.toPushOpcode() ==
         [76, 255] ~ 42.repeat(255).array);
-    test!("==")(ubyte(42).repeat(500).array.toPushOpcode(),
+    assert(ubyte(42).repeat(500).array.toPushOpcode() ==
         [77, 244, 1] ~ 42.repeat(500).array);  // little-endian form
 }
 

--- a/source/agora/script/Stack.d
+++ b/source/agora/script/Stack.d
@@ -29,7 +29,6 @@ import std.range;
 
 version (unittest)
 {
-    import ocean.core.Test;
     import std.stdio;
 }
 
@@ -240,10 +239,10 @@ unittest
     assert(stack.used_bytes == 0);
     stack.push([1, 2, 3]);
     assert(stack.count() == 1);
-    test!"=="(stack.used_bytes, 3);
+    assert(stack.used_bytes == 3);
     stack.push([255]);
     assert(stack.count() == 2);
-    test!"=="(stack.used_bytes, 4);
+    assert(stack.used_bytes == 4);
     assert(stack.peek() == [255]);
     assert(stack.count() == 2);     // did not consume
     assert(stack.peek() == [255]);  // ditto
@@ -252,18 +251,18 @@ unittest
     // copies disabled: either use 'ref' or explicitly do a 'copy()'
     static assert(!is(typeof( { Stack nogo = stack; } )));
     Stack copy = stack.copy();
-    test!("==")(copy.StackMaxTotalSize, stack.StackMaxTotalSize);
-    test!("==")(copy.StackMaxItemSize, stack.StackMaxItemSize);
-    test!("==")(copy.stack.empty(), stack.stack.empty());
-    test!("==")(copy.num_items, stack.num_items);
-    test!("==")(copy.used_bytes, stack.used_bytes);
+    assert(copy.StackMaxTotalSize == stack.StackMaxTotalSize);
+    assert(copy.StackMaxItemSize == stack.StackMaxItemSize);
+    assert(copy.stack.empty() == stack.stack.empty());
+    assert(copy.num_items == stack.num_items);
+    assert(copy.used_bytes == stack.used_bytes);
     assert(stack.pop() == [255]);
     assert(stack.count() == 1);
-    test!"=="(stack.used_bytes, 3);
+    assert(stack.used_bytes == 3);
     assert(!stack.empty());
     assert(stack.pop() == [1, 2, 3]);
     assert(stack.count() == 0);
-    test!"=="(stack.used_bytes, 0);
+    assert(stack.used_bytes == 0);
     assert(stack.empty());
     assert(copy.count() == 2);     // did not consume copy
     assert(copy.used_bytes == 4);  // ditto

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -25,8 +25,6 @@ import agora.test.Base;
 import core.thread;
 import core.time;
 
-import ocean.core.Test;
-
 /// test for enrollment process & revealing a pre-image periodically
 unittest
 {
@@ -121,7 +119,7 @@ unittest
     PreImageInfo preimage_26 = nodes[0].getPreimage(node0_utxo);
 
     // Check if the new pre-image is valid from the restarted node
-    test!"=="(preimage_26.isInvalidReason(b20_preimage), null);
+    assert(preimage_26.isInvalidReason(b20_preimage) is null);
 }
 
 // Situation: A pre-image already known by all nodes is sent on the network


### PR DESCRIPTION
```
Now that '-checkaction=context' is usable (and the default),
we do not need to use this function anymore and can rely on regular assert.
```