### PR TITLE
Flash: Move settingUp notification to the point of actual state change

### DIFF
--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -493,6 +493,8 @@ public class Channel
     {
         this.state = ChannelState.SettingUp;
         assert(this.cur_seq_id == 0);
+        this.onChannelNotify(this.kp.address, this.conf.chan_id, this.state,
+            ErrorCode.None);
 
         // initial output allocates all the funds back to the channel creator
         const seq_id = 0;

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -1168,8 +1168,6 @@ public abstract class FlashNode : FlashControlAPI
             &this.putTransaction, &this.paymentRouter, &this.onChannelNotify,
             &this.onPaymentComplete, &this.onUpdateComplete, this.db);
         this.channels[reg_pk][chan_conf.chan_id] = channel;
-        this.listener.onChannelNotify(reg_pk, chan_conf.chan_id,
-            ChannelState.SettingUp, ErrorCode.None);
     }
 
     ///


### PR DESCRIPTION
Notifying listener before actually changing the state can
cause races.

Hopefully fixes #2153 