### PR TITLE
`Tx` setters for `inputs` and `outputs`

### DIFF
--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -56,8 +56,8 @@ public struct BlockHeader
     /// Schnorr multisig of all validators which signed this block
     public Signature signature;
 
-    /// Bitfield containing the validators' key indices which signed the block
     public BitField!ubyte validators;
+    /// Bitfield containing the validators' key indices which signed the block
 
     /// Block height (genesis is #0)
     public Height height;
@@ -204,6 +204,34 @@ public struct Block
                 this.header.merkle_root,
                 this.header.random_seed,
                 signature,
+                validators,
+                this.header.height,
+                this.header.enrollments.dup,
+                this.header.missing_validators.dup,
+                this.header.time_offset),
+            // TODO: Optimize this by using dup for txs also
+            this.txs.map!(tx =>
+                tx.serializeFull.deserializeFull!Transaction).array,
+            this.merkle_tree.dup);
+    }
+
+    /***************************************************************************
+
+        Returns:
+            a copy of this block
+
+    ***************************************************************************/
+
+    public Block dup () inout @safe
+    {
+        auto validators = BitField!ubyte(this.header.validators.length);
+        this.header.validators.enumerate.map!(en => validators[en.index] = en.value);
+        return immutable Block(
+            BlockHeader(
+                this.header.prev_block,
+                this.header.merkle_root,
+                this.header.random_seed,
+                this.header.signature,
                 validators,
                 this.header.height,
                 this.header.enrollments.dup,

--- a/source/agora/consensus/data/Params.d
+++ b/source/agora/consensus/data/Params.d
@@ -41,8 +41,11 @@ module agora.consensus.data.Params;
 import agora.common.Amount;
 import agora.consensus.data.Block;
 import agora.crypto.Key;
+import agora.crypto.Schnorr: Signature;
+import agora.consensus.data.Transaction;
 
 import core.time;
+import std.algorithm;
 
 /// Ditto
 public immutable class ConsensusParams
@@ -88,8 +91,8 @@ public immutable class ConsensusParams
                  ConsensusConfig config = ConsensusConfig.init,
                  Duration block_interval = 1.seconds)
     {
-        this.Genesis = genesis;
-        this.CommonsBudgetAddress = commons_budget_address,
+        this.Genesis = genesis.dup;
+        this.CommonsBudgetAddress = commons_budget_address;
         this.BlockInterval = block_interval;
         this.data = config;
     }
@@ -109,6 +112,12 @@ public immutable class ConsensusParams
         };
         this(GenesisBlock, CommonsBudget.address, config);
     }
+}
+
+unittest
+{
+    immutable params = new immutable(ConsensusParams)();
+    assert(params.Genesis.txs[0].outputs.count > 0);
 }
 
 /// Ditto

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -457,7 +457,8 @@ unittest
         assert(block.txs.any!(tx => tx.isFreeze));
 
         // Input empty check
-        block.txs[0].inputs ~= Input.init;
+        auto inputs = block.txs[0].inputs ~ Input.init;
+        block.txs[0].inputs = inputs;
         buildMerkleTree(block);
         assert(!block.isGenesisBlockValid());
 
@@ -473,8 +474,7 @@ unittest
         // disallow 0 amount
         Output zeroOutput =
             Output(Amount.invalid(0), WK.Keys[0].address);
-        block.txs[0].outputs ~= zeroOutput;
-        block.txs[0].outputs.sort;
+        block.txs[0].outputs = [ zeroOutput ];
         buildMerkleTree(block);
         assert(!block.isGenesisBlockValid());
     }
@@ -885,6 +885,7 @@ unittest
     foreach (idx, pre_tx; txs_1)
     {
         Input input = Input(hashFull(pre_tx), 0);
+        Output[] outputs = null;
 
         Transaction tx = Transaction([input], null);
         if (idx == 7)
@@ -895,7 +896,7 @@ unittest
                 output.value = Amount(100);
                 output.lock = genKeyLock(keypair.address);
                 output.type = OutputType.Payment;
-                tx.outputs ~= output;
+                outputs ~= output;
             }
         }
         else
@@ -904,9 +905,10 @@ unittest
             output.value = Amount.MinFreezeAmount;
             output.lock = genKeyLock(keypair.address);
             output.type = OutputType.Freeze;
-            tx.outputs ~= output;
+            outputs ~= output;
         }
-        tx.outputs.sort;
+        outputs.sort;
+        tx.outputs = outputs;
         tx.inputs[0].unlock = VTx.signUnlock(gen_key, tx);
         txs_2 ~= tx;
     }
@@ -1010,19 +1012,20 @@ unittest
         Transaction tx = Transaction(
             [Input(hashFull(pre_tx), 0)],
             null);
-
+        Output[] outputs;
         if (idx <= 2)
         {
-            tx.outputs ~= Output(Amount.MinFreezeAmount, keypair.address, OutputType.Freeze);
-            tx.outputs ~= Output(Amount.MinFreezeAmount, keypair.address, OutputType.Freeze);
-            tx.outputs ~= Output(Amount.MinFreezeAmount, keypair.address, OutputType.Freeze);
+            outputs ~= Output(Amount.MinFreezeAmount, keypair.address, OutputType.Freeze);
+            outputs ~= Output(Amount.MinFreezeAmount, keypair.address, OutputType.Freeze);
+            outputs ~= Output(Amount.MinFreezeAmount, keypair.address, OutputType.Freeze);
         }
         else
         {
             foreach (_; 0 .. 8)
-                tx.outputs ~= Output(Amount(100), keypair.address);
+                outputs ~= Output(Amount(100), keypair.address);
         }
-        tx.outputs.sort;
+        outputs.sort;
+        tx.outputs = outputs;
         tx.inputs[0].unlock = VTx.signUnlock(gen_key, tx);
         txs_2 ~= tx;
     }

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -249,16 +249,18 @@ unittest
     assert(secondTx.isValid(engine, storage.getUTXOFinder(), Height(0), checker),
            format("Transaction data is not validated %s", secondTx));
 
-    secondTx.outputs ~= Output(Amount(50), key_pairs[2].address);
-    secondTx.outputs.sort;
+    Output[] outputs = secondTx.outputs ~ Output(Amount(50), key_pairs[2].address);
+    outputs.sort;
+    secondTx.outputs = outputs;
     secondTx.inputs[0].unlock = signUnlock(key_pairs[0], secondTx);
 
     // It is validated. (the sum of `Output` == the sum of `Input`)
     assert(secondTx.isValid(engine, storage.getUTXOFinder(), Height(0), checker),
            format("Transaction data is not validated %s", secondTx));
 
-    secondTx.outputs ~= Output(Amount(50), key_pairs[3].address);
-    secondTx.outputs.sort;
+    outputs ~= Output(Amount(50), key_pairs[3].address);
+    outputs.sort;
+    secondTx.outputs = outputs;
     secondTx.inputs[0].unlock = signUnlock(key_pairs[0], secondTx);
 
     // It isn't validated. (the sum of `Output` > the sum of `Input`)
@@ -1000,7 +1002,7 @@ unittest
     assert(!isValid(tx, engine, utxoFinder, Height(0), checker));
 
     // Add the expected input, should validate
-    tx.inputs ~= Input(Height(0));
+    tx.inputs = [ Input(Height(0)) ];
     assert(isValid(tx, engine, utxoFinder, Height(0), checker));
 
     // Add some data, should not validate
@@ -1009,7 +1011,7 @@ unittest
     assert(!isValid(tx, engine, utxoFinder, Height(0), checker));
 
     // Remove the inputs, still should not validate
-    tx.inputs.length = 0;
+    tx.inputs = null;
     assert(!isValid(tx, engine, utxoFinder, Height(0), checker));
 }
 

--- a/source/agora/node/TransactionPool.d
+++ b/source/agora/node/TransactionPool.d
@@ -671,16 +671,18 @@ unittest
 {
     auto pool = new TransactionPool();
 
+    const hash1 = 1.hashFull;
+    const hash2 = 2.hashFull;
     Transaction tx1 = Transaction(
-        [Input(Hash.init, 0)],
+        [Input(hash1, 0)],
         [Output(Amount(0), WK.Keys.ZA.address)]);
 
     Transaction tx2 = Transaction(
-        [Input(Hash.init, 0), Input(Hash.init, 1)],
+        [Input(hash1, 0), Input(hash2, 1)],
         [Output(Amount(0), WK.Keys.ZC.address)]);
 
     Transaction tx3 = Transaction(
-        [Input(Hash.init, 1)],
+        [Input(hash2, 1)],
         [Output(Amount(0), WK.Keys.ZD.address)]);
 
     assert(pool.add(tx1));
@@ -722,11 +724,14 @@ unittest
 
     auto pool = new TransactionPool(new ManagedDatabase(":memory:"), &selector);
 
+    const hash1 = 1.hashFull;
+    const hash2 = 2.hashFull;
+
     Transaction tx1 = Transaction(
-        [Input(Hash.init, 0)],
+        [Input(hash1, 0)],
         [Output(Amount(2), WK.Keys.US.address)]);
 
-    Transaction tx2 = Transaction([Input(Hash.init, 0), Input(Hash.init, 1)],
+    Transaction tx2 = Transaction([Input(hash1, 0), Input(hash2, 1)],
         [Output(Amount(1), WK.Keys.KR.address)]);
 
     assert(pool.add(tx1));

--- a/tests/system/source/main.d
+++ b/tests/system/source/main.d
@@ -119,7 +119,7 @@ int main (string[] args)
     // Make sure the nodes use the test genesis block
     const blocks = clients[0].getBlocksFrom(0, 1);
     assert(blocks.length == 1);
-    assert(blocks[0] == TestGenesis.GenesisBlock, format!"%s Not using expected TestGenesis.GenesisBlock"(PREFIX));
+    assert(blocks[0] == TestGenesis.GenesisBlock, format!"%s Not using expected TestGenesis.GenesisBlock: \n%s"(PREFIX, blocks[0].prettify));
 
     auto target_height = 2;
     iota(target_height).each!(h => assertBlockHeightAtleast(h));


### PR DESCRIPTION
In the mutable `Transaction` constructor we sort the inputs and outputs
and in the immutable `Transaction` constructor we assert if given
unsorted `inputs` and `outputs`. There was still an issue if the zero
arg constructor was used and then unsorted `inputs` or `outputs` were
set. This adds setters that assert if the lists are not valid when set.