### PR TITLE
Merge EM.getRandomSeed into Ledger.getRandomSeed

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -579,46 +579,6 @@ public class EnrollmentManager
 
     /***************************************************************************
 
-        Generate the random seed reduced from the preimages for the provided
-        block height.
-
-        Params:
-            keys = the utxo keys to look up (must be sorted)
-            height = the desired block height to look up the images for
-
-        Returns:
-            the random seed
-
-    ***************************************************************************/
-
-    public Hash getRandomSeed (Keys)(Keys keys, in Height height) @safe
-    in
-    {
-        static assert (isInputRange!Keys);
-        static assert (is(ElementType!Keys : Hash));
-        assert(keys.length != 0);
-        assert(keys.isStrictlyMonotonic!((a, b) => a < b));
-    }
-    do
-    {
-        Hash getPreimage (Hash key)
-        {
-            const preimage = this.validator_set.getPreimageAt(key, height);
-            // We could have a misbehaving validator that does not reveal
-            // its preimages in real world. In order to deal with the validator,
-            // We implement the slashing protocol.
-            if (preimage == PreImageInfo.init)
-            {
-                log.info("No preimage at height {} for validator key {}", height.value, key);
-            }
-            return preimage.hash;
-        }
-
-        return createRandomSeed(keys.map!(key => getPreimage(key)).filter!(p => p != Hash.init));
-    }
-
-    /***************************************************************************
-
         Get validator's pre-image from the validator set.
 
         Params:
@@ -1341,16 +1301,6 @@ unittest
 
         assert(man.addPreimage(preimage));
     }
-
-    utxos.sort();  // must be sorted by enrollment key
-    assert(man.getRandomSeed(utxos, Height(1)) ==
-        Hash(`0xe22f972c54cc95ccce9595561005b76da44260c3943880a4fa8919c5d3d9c9aecdd0c92429a46402f59a26a137de9007fe8232b5f471cf9b0e5410e21554348f`));
-
-    assert(man.getRandomSeed(utxos, Height(params.ValidatorCycle / 2)) ==
-        Hash(`0x006752a88c7c5fa1ef921d717e98a8dc6fdc1250485ed08b7f35cb30ebec7f0d8459cfd0eb67342a8144e81910d1a85b36390f8369e3a5cdde0ad0569d64d607`));
-
-    assert(man.getRandomSeed(utxos, Height(params.ValidatorCycle)) ==
-        Hash(`0x2367765f757f438eb7c47413b5078305830bcdc19bf6fe28d5400d69a8275b68231b8a9c7fdf773b3e314af3172f5810d246b1c70a8d477d8adb8becdfb74dde`));
 }
 
 // Tests for get/set a enrollment key

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -551,34 +551,6 @@ public Block makeNewBlock (Transactions)(const ref Block prev_block,
     return block;
 }
 
-/***************************************************************************
-
-    Create the block random seed from the provided pre-images
-
-    It might be that not all validators provide their `pre-image` and in
-    that case the length of the preimages can be less than the number of
-    active validators.
-
-    Params:
-        preimages = preimages sorted by the utxo keys of the validators
-
-    Returns:
-        Hash of all provided pre-images or Hash.init if an exception is thrown
-
-***************************************************************************/
-
-
-public static Hash createRandomSeed (Preimages)(Preimages preimages) @safe
-in
-{
-    static assert (isInputRange!Preimages);
-}
-do
-{
-    assert(preimages.count != 0);
-    return preimages.reduce!((a , b) => hashMulti(a, b));
-}
-
 /// only used in unittests with some defaults
 version (unittest)
 {
@@ -597,7 +569,7 @@ version (unittest)
         assert(revealed.length == key_pairs.length - missing_validators.length);
         try
         {
-            Hash random_seed = createRandomSeed(pre_images);
+            Hash random_seed = pre_images.reduce!((a, b) => hashMulti(a, b));
 
             // the time_offset passed to makeNewBlock should really be
             // prev_block.header.time_offset + ConsensusParams.BlockInterval instead of


### PR DESCRIPTION
This should simplify the random seed code, and make sure we always acquire it in the same way, without silently ignoring some validators.
Marking as a draft for now as I'd like to test it some more and it will trigger other bugs (namely, `receiveEnvelope` might throw, and since it blocks...).