### PR TITLE
Use a queue for processing incoming envelopes

### DIFF
--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -47,7 +47,7 @@ unittest
         mixin ForwardCtor!();
 
         ///
-        override void restoreSCPState ()
+        override void restoreSCPState () @trusted
         {
             // on first boot the envelope store will be empty,
             // but on restart it should contain one or more envelopes


### PR DESCRIPTION
```
All incoming SCP envelopes are now added directly to a queue,
which is then consumed by a task. This prevents the clients from
blocking on `receiveEnvelope` calls (which itself might trigger
other `receiveEnvelope` calls), and avoid unnecessary delays.

Fixes #2021
```

This is a rebase of https://github.com/bosagora/agora/pull/2067 but instead of duplicating the store, we simply add a boolean to it.