### PR TITLE
TxBuilder order inputs on signing

### DIFF
--- a/source/agora/test/VariableBlockSize.d
+++ b/source/agora/test/VariableBlockSize.d
@@ -40,7 +40,7 @@ unittest
     auto height = Height(0);
     // variable number of txs for each block
     only(1, 3, 4).each!((i) {
-        txs.take(i).each!(tx => network.clients[0].putTransaction(tx));
+        txs.takeExactly(i).each!(tx => network.clients[0].putTransaction(tx));
         txs = txs.drop(i);
         height++;
         network.expectHeightAndPreImg(height, GenesisBlock.header, 5.seconds);

--- a/source/agora/utils/TxBuilder.d
+++ b/source/agora/utils/TxBuilder.d
@@ -274,9 +274,10 @@ public struct TxBuilder
         // Finalize the transaction by adding inputs
         foreach (ref in_; this.inputs)
             this.data.inputs ~= Input(in_.hash, Unlock.init, unlock_age);
+        this.data.inputs.sort;
 
-        foreach (ref o_; this.data.outputs)
-            o_.type = outputs_type;
+        foreach (ref o; this.data.outputs)
+            o.type = outputs_type;
 
         // Add the refund output if needed
         if (this.leftover.value > Amount(0))
@@ -285,13 +286,11 @@ public struct TxBuilder
                 this.data.outputs = [ Output(this.leftover.value, this.leftover.lock, OutputType.Freeze) ];
             else
                 this.data.outputs = [ Output(this.leftover.value, this.leftover.lock, OutputType.Payment) ] ~ this.data.outputs;
-            this.data.outputs.sort;
         }
+        this.data.outputs.sort;
         this.data.payload = data;
 
-        // Get the hash to sign
-        const txHash = this.data.hashFull();
-        // Sign all inputs using WK keys
+        // Sign all inputs using unlocker
         foreach (idx, ref in_; this.inputs)
             this.data.inputs[idx].unlock = unlocker(this.data, in_);
 

--- a/source/agora/utils/TxBuilder.d
+++ b/source/agora/utils/TxBuilder.d
@@ -523,7 +523,9 @@ unittest
 
     // This transaction has 4 txs (3 targets + 1 refund)
     assert(result.inputs.length == 8);
+    assert(result.inputs.isSorted);
     assert(result.outputs.length == 4);
+    assert(result.outputs.isSorted);
 
     // 488M / 3
     assert(result.outputs.count!(o => o.value == Amount(162_666_666_6666_666L)) == 3);


### PR DESCRIPTION
When we generate `Transaction`s it is now required that the `input`s are
ordered by their `utxo` values.
In `TxBuilder` this was not the case and the Faucet was found to be
generating some txs with invalid `input`s in the `Transaction`s.

Fixes #2156 