### PR TITLE
KeyPair: Remove 'const' on members

### DIFF
--- a/source/agora/crypto/Key.d
+++ b/source/agora/crypto/Key.d
@@ -58,10 +58,10 @@ public struct KeyPair
     @safe:
 
     /// Public key
-    public const PublicKey address;
+    public PublicKey address;
 
     /// Secret key
-    public const SecretKey secret;
+    public SecretKey secret;
 
     /// Create a keypair from a `SecretKey`
     public static KeyPair fromSeed (const SecretKey seed) nothrow @nogc


### PR DESCRIPTION
The original intent was to make it read-only,
but the result was that we could not store KeyPair
in an associative array.