### PR TITLE
Logger: Re-use configureLogger in AdminInterface

### DIFF
--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -66,7 +66,7 @@ public Listeners runNode (Config config)
     {
         if (settings.name.length == 0 || settings.name == "vibe")
             setVibeLogLevel(settings.level);
-        configureLogger(settings);
+        configureLogger(settings, true);
     }
 
     auto log = Logger(__MODULE__);

--- a/source/agora/node/admin/AdminInterface.d
+++ b/source/agora/node/admin/AdminInterface.d
@@ -100,36 +100,25 @@ public class AdminInterface : NodeControlAPI
         Nullable!(LogLevel) level, Nullable!bool additive,
         Nullable!bool console, Nullable!string file) @trusted
     {
-        import ocean.util.log.AppendConsole;
-
-        Ocean.Logger logger = name == "root" ? Ocean.Log.root :
-            Ocean.Log.lookup(name);
+        LoggerConfig config;
+        config.name = name == "root" ? null : name;
 
         if (!additive.isNull())
-            logger.additive = additive.get();
+            config.additive = additive.get();
         if (!level.isNull())
-            logger.level(level.get(), propagate);
+            config.level = level.get();
+        if (!console.isNull())
+            config.console = console.get();
+        if (!file.isNull())
+            config.file = file.get();
+        // No buffer_size
 
         // If either parameter was provided, clear the list of appender
         // It would be better if we had a way to remove a specific appender,
         // e.g. set `console=false` would disable console but leave file intact,
         // but the Logger API doesn't expose this. It would also complicate
         // matters if we wanted to have multiple file outputs.
-        if (!console.isNull() || !file.isNull())
-            logger.clear();
-
-        if (!console.isNull())
-        {
-            auto appender = new AppendConsole();
-            appender.layout(new AgoraLayout());
-            logger.add(appender);
-        }
-        if (!file.isNull())
-        {
-            auto appender = new PhobosFileAppender(file.get());
-            appender.layout(new AgoraLayout());
-            logger.add(appender);
-        }
+        configureLogger(config, !console.isNull() || !file.isNull());
     }
 
     /***************************************************************************

--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -183,17 +183,19 @@ public struct LoggerConfig
 
     Params:
         settings = Configuration to apply
+        clear    = Whether the to clear the logger or reconfigure only
 
 ***************************************************************************/
 
-public void configureLogger (in LoggerConfig settings)
+public void configureLogger (in LoggerConfig settings, bool clear)
 {
 	auto log = settings.name ? Log.lookup(settings.name) : Log.root;
 
+    if (clear)
+        log.clear();
+
     if (settings.buffer_size)
         log.buffer(new char[](settings.buffer_size));
-
-    log.clear();
 
 	// if console/file/syslog is specifically set, don't inherit other
     // appenders (unless we have been specifically asked to be additive)


### PR DESCRIPTION
This just needed a tiny change to configureLogger interface,
but in the rush of implementing the endpoint, that wasn't noticed.