### PR TITLE
Network unit test:Fix flakey Ledger test

### DIFF
--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -120,7 +120,7 @@ unittest
     Transaction[] txs;
 
     // create enough tx's for a single block
-    txs = blocks[0].spendable().map!(txb => txb
+    txs = blocks[0].spendable().takeExactly(1).map!(txb => txb
         .deduct(Amount.UnitPerCoin).sign()).array();
 
     // send it to one node
@@ -184,7 +184,7 @@ unittest
     void createAndExpectNewBlock (Height new_height)
     {
         // create enough tx's for a single block
-        txs = blocks[new_height - 1].spendable().map!(txb => txb
+        txs = blocks[new_height - 1].spendable().takeExactly(1).map!(txb => txb
             .deduct(Amount.UnitPerCoin).sign()).array();
 
         // send it to one node

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -149,7 +149,7 @@ unittest
     auto nodes = network.clients;
     auto last_node = nodes[$ - 1];
     assert(last_node.getQuorumConfig().threshold == 5); // We should need 5 nodes
-    auto txes = genesisSpendable().map!(txb => txb.sign()).array();
+    auto txes = genesisSpendable().takeExactly(1).map!(txb => txb.sign()).array();
     txes.each!(tx => last_node.putTransaction(tx));
     // Trigger generation of block
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
@@ -171,7 +171,7 @@ unittest
     auto nodes = network.clients;
     auto last_node = nodes[$ - 1];
     assert(last_node.getQuorumConfig().threshold == 5); // We should need 5 nodes
-    auto txes = genesisSpendable().map!(txb => txb.sign()).array();
+    auto txes = genesisSpendable().takeExactly(1).map!(txb => txb.sign()).array();
     txes.each!(tx => last_node.putTransaction(tx));
     // Trigger generation of block
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -163,7 +163,7 @@ unittest
     auto blocks = picky_node.getBlocksFrom(0, 2);
     assert(blocks.length == 1);
 
-    auto txs = blocks[0].spendable().map!(txb => txb.sign());
+    auto txs = blocks[0].spendable().takeExactly(1).map!(txb => txb.sign());
     txs.each!(tx => node.putTransaction(tx));
     Thread.sleep(1.seconds);
     txs.each!(tx => assert(!picky_node.hasTransactionHash(tx.hashFull())));

--- a/source/agora/test/VariableBlockSize.d
+++ b/source/agora/test/VariableBlockSize.d
@@ -40,7 +40,9 @@ unittest
     auto height = Height(0);
     // variable number of txs for each block
     only(1, 3, 4).each!((i) {
-        txs.takeExactly(i).each!(tx => network.clients[0].putTransaction(tx));
+        txs.takeExactly(i).each!(tx =>
+            network.clients.each!(node =>
+                node.putTransaction(tx)));
         txs = txs.drop(i);
         height++;
         network.expectHeightAndPreImg(height, GenesisBlock.header, 5.seconds);


### PR DESCRIPTION
Sometimes this test was failing due to not all `txs` being included in
the block that was externalized. The compare of expected and actual txs
caused an assert in the test. It now waits for all the nodes to have
the txs before initializing the block being externalized.