### PR TITLE
Network discovery unit test: add assert info 

### DIFF
--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -102,7 +102,7 @@ unittest
         mixin ForwardCtor!();
 
         /// GET /public_key
-        protected override Identity getPublicKey (PublicKey key = PublicKey.init) 
+        protected override Identity getPublicKey (PublicKey key = PublicKey.init)
             nothrow @trusted
         {
             atomicOp!"+="(call_count, 1);

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -146,5 +146,6 @@ unittest
     // All nodes should've banned impersonator_node
     foreach (node; network.nodes)
         if (node != impersonator_node)
-            assert(node.client.isBanned(impersonator_node.address));
+            assert(node.client.isBanned(impersonator_node.address),
+                format!"Node %s did not ban %s"(node.address, impersonator_node.address));
 }


### PR DESCRIPTION
Log the node that did not ban the impersonator and the address of the impersonator. This is to help debug why it failed recently here: https://github.com/bosagora/agora/pull/2168/checks?check_run_id=2788531702