### PR TITLE
Minor serialization fixes for transaction

### DIFF
--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -90,6 +90,10 @@ public struct Transaction
     /// The data to store
     public ubyte[] payload;
 
+    /// This transaction may only be included in a block with `height >= lock_height`.
+    /// Note that another tx with a lower lock time could double-spend this tx.
+    public Height lock_height = Height(0);
+
     /// The size of the Transaction object
     public ulong sizeInBytes () const nothrow pure @nogc
     {
@@ -101,9 +105,11 @@ public struct Transaction
         return size;
     }
 
-    /// This transaction may only be included in a block with `height >= lock_height`.
-    /// Note that another tx with a lower lock time could double-spend this tx.
-    public Height lock_height = Height(0);
+    /// Support for sorting transactions
+    public int opCmp (in Transaction other) const nothrow @nogc
+    {
+        return hashFull(this).opCmp(hashFull(other));
+    }
 
     /***************************************************************************
 
@@ -128,12 +134,6 @@ public struct Transaction
         serializePart(payload, dg);
 
         serializePart(this.lock_height, dg);
-    }
-
-    /// Support for sorting transactions
-    public int opCmp (in Transaction other) const nothrow @nogc
-    {
-        return hashFull(this).opCmp(hashFull(other));
     }
 
     pure nothrow @nogc:

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -111,31 +111,6 @@ public struct Transaction
         return hashFull(this).opCmp(hashFull(other));
     }
 
-    /***************************************************************************
-
-        Transactions Serialization
-
-        Params:
-            dg = Serialize function
-
-    ***************************************************************************/
-
-    public void serialize (scope SerializeDg dg) const
-    {
-        serializePart(this.inputs.length, dg);
-        foreach (const ref input; this.inputs)
-            serializePart(input, dg);
-
-        serializePart(this.outputs.length, dg);
-        assert(this.outputs.isSorted!((a, b) => a < b));
-        foreach (const ref output; this.outputs)
-            serializePart(output, dg);
-
-        serializePart(payload, dg);
-
-        serializePart(this.lock_height, dg);
-    }
-
     pure nothrow @nogc:
 
     /// A `Freeze` transaction is one that has one or more `Freeze` outputs


### PR DESCRIPTION
I was looking at #2137 and couldn't make sense of the failure. The only possible things I can think of would be caught by our `testSymmetry` check, so let's try to re-deploy again.