### PR TITLE
Config: Parse genesis_timestamp, remove slash_penalty_amount

### DIFF
--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -579,6 +579,7 @@ node:
 private ConsensusConfig parseConsensusConfig (Node* node, in CommandLine cmdln)
 {
     const validator_cycle = get!(uint, "consensus", "validator_cycle")(cmdln, node);
+    const genesis_ts = get!(ulong, "consensus", "genesis_timestamp")(cmdln, node);
     const max_quorum_nodes = get!(uint, "consensus", "max_quorum_nodes")(cmdln, node);
     const quorum_threshold = get!(uint, "consensus", "quorum_threshold")(cmdln, node);
     const quorum_shuffle_interval = get!(uint, "consensus", "quorum_shuffle_interval")(cmdln, node);
@@ -593,6 +594,7 @@ private ConsensusConfig parseConsensusConfig (Node* node, in CommandLine cmdln)
 
     ConsensusConfig result = {
         validator_cycle: validator_cycle,
+        genesis_timestamp: genesis_ts,
         max_quorum_nodes: max_quorum_nodes,
         quorum_threshold: quorum_threshold,
         quorum_shuffle_interval: quorum_shuffle_interval,
@@ -624,6 +626,7 @@ consensus:
     validator_tx_fee_cut:      69
     payout_period:           9999
     slash_penalty_amount:   20000
+    genesis_timestamp:     424242
 `;
 
     auto node = Loader.fromString(conf_example).load();
@@ -637,6 +640,7 @@ consensus:
     assert(config.validator_tx_fee_cut == 69);
     assert(config.payout_period == 9999);
     assert(config.slash_penalty_amount == 20_000.coins);
+    assert(config.genesis_timestamp == 424242);
 }
 
 /// Parse the validator config section

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -587,7 +587,6 @@ private ConsensusConfig parseConsensusConfig (Node* node, in CommandLine cmdln)
     const tx_payload_fee_factor = get!(uint, "consensus", "tx_payload_fee_factor")(cmdln, node);
     const validator_tx_fee_cut = get!(ubyte, "consensus", "validator_tx_fee_cut")(cmdln, node);
     const payout_period = get!(uint, "consensus", "payout_period")(cmdln, node);
-    const slash_penalty_value = opt!(ulong, "node", "slash_penalty_amount")(cmdln, node);
 
     if (quorum_threshold < 1 || quorum_threshold > 100)
         throw new Exception("consensus.quorum_threshold is a percentage and must be between 1 and 100, included");
@@ -602,7 +601,6 @@ private ConsensusConfig parseConsensusConfig (Node* node, in CommandLine cmdln)
         tx_payload_fee_factor: tx_payload_fee_factor,
         validator_tx_fee_cut: validator_tx_fee_cut,
         payout_period: payout_period,
-        slash_penalty_amount : slash_penalty_value.coins,
     };
 
     return result;
@@ -625,7 +623,6 @@ consensus:
     tx_payload_fee_factor:   2100
     validator_tx_fee_cut:      69
     payout_period:           9999
-    slash_penalty_amount:   20000
     genesis_timestamp:     424242
 `;
 
@@ -639,7 +636,6 @@ consensus:
     assert(config.tx_payload_fee_factor == 2100);
     assert(config.validator_tx_fee_cut == 69);
     assert(config.payout_period == 9999);
-    assert(config.slash_penalty_amount == 20_000.coins);
     assert(config.genesis_timestamp == 424242);
 }
 

--- a/source/agora/consensus/data/Params.d
+++ b/source/agora/consensus/data/Params.d
@@ -59,6 +59,9 @@ public immutable class ConsensusParams
     /// Underlying data
     private ConsensusConfig data;
 
+    /// The amount of a penalty for slashed validators
+    public Amount SlashPenaltyAmount = 10_000.coins;
+
     mixin ROProperty!("ValidatorCycle", "validator_cycle");
     mixin ROProperty!("MaxQuorumNodes", "max_quorum_nodes");
     mixin ROProperty!("QuorumThreshold", "quorum_threshold");
@@ -67,7 +70,6 @@ public immutable class ConsensusParams
     mixin ROProperty!("TxPayloadFeeFactor", "tx_payload_fee_factor");
     mixin ROProperty!("ValidatorTXFeeCut", "validator_tx_fee_cut");
     mixin ROProperty!("PayoutPeriod", "payout_period");
-    mixin ROProperty!("SlashPenaltyAmount", "slash_penalty_amount");
     mixin ROProperty!("GenesisTimestamp", "genesis_timestamp");
     mixin ROProperty!("MinFee", "min_fee");
 
@@ -142,9 +144,6 @@ public struct ConsensusConfig
 
     /// How frequent the payments to Validators will be in blocks
     public uint payout_period = 144;
-
-    /// The amount of a penalty for slashed validators
-    public Amount slash_penalty_amount = 10_000.coins;
 
     /// The minimum (transaction size adjusted) fee.
     /// Transaction size adjusted fee = tx fee / tx size in bytes.

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1880,9 +1880,6 @@ public struct TestConf
     /// How frequent the payments to Validators will be
     public uint payout_period = 5;
 
-    /// The amount of a penalty for slashed validators
-    Amount slash_penalty_amount = 10_000.coins;
-
     /// The minimum (transaction size adjusted) fee.
     /// Transaction size adjusted fee = tx fee / tx size in bytes.
     public Amount min_fee = Amount(0);
@@ -1949,7 +1946,6 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             quorum_shuffle_interval : test_conf.quorum_shuffle_interval,
             validator_tx_fee_cut : test_conf.validator_tx_fee_cut,
             payout_period : test_conf.payout_period,
-            slash_penalty_amount : test_conf.slash_penalty_amount,
             min_fee : test_conf.min_fee,
         };
 

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -29,7 +29,6 @@ interfaces:
 
 consensus:
   validator_cycle: 20
-  slash_penalty_amount: 10000
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -28,7 +28,6 @@ interfaces:
 
 consensus:
   validator_cycle: 20
-  slash_penalty_amount: 10000
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -28,7 +28,6 @@ interfaces:
 
 consensus:
   validator_cycle: 20
-  slash_penalty_amount: 10000
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -28,7 +28,6 @@ interfaces:
 
 consensus:
   validator_cycle: 20
-  slash_penalty_amount: 10000
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -28,7 +28,6 @@ interfaces:
 
 consensus:
   validator_cycle: 20
-  slash_penalty_amount: 10000
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -28,7 +28,6 @@ interfaces:
 
 consensus:
   validator_cycle: 20
-  slash_penalty_amount: 10000
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -28,7 +28,6 @@ interfaces:
 
 consensus:
   validator_cycle: 20
-  slash_penalty_amount: 10000
 
 ################################################################################
 ##                             Validator configuration                        ##


### PR DESCRIPTION
`genesis_timestamp` needed for https://github.com/bosagora/infrastructure/issues/142
The other entry, I just spotted it while working on this. We are probably overdue for a cleanup, but that's going to wait another day.