### PR TITLE
Unit test:no assert in `combineCandidates`

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1197,8 +1197,10 @@ extern(D):
                 // for all the candidates might take long.
                 version (unittest)
                 if (auto msg = this.ledger.validateConsensusData(data))
-                    assert(0, format!"combineCandidates: Invalid consensus data: %s"(
-                        msg));
+                {
+                    log.error("combineCandidates: Invalid consensus data: {}", msg);
+                    continue;
+                }
 
                 Amount total_adjusted_fee;
                 foreach (const ref tx_hash; data.tx_set)


### PR DESCRIPTION
If there is an invalid `consensusData` in one of the candidates then log
an error and do not include it when combining. As we do not do this
validation when not running in `version (unittest)` this is more like
the production behavior.