### PR TITLE
Add the genesis timestamp to the stats

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -240,6 +240,10 @@ public class FullNode : API
 
     public this (Config config)
     {
+        // Not at global scope because it would conflict with our `Clock` type
+        import std.datetime.systime : SysTime, unixTimeToStdTime;
+        import std.datetime.timezone: UTC;
+
         this.config = config;
         this.log = this.makeLogger();
         this.params = FullNode.makeConsensusParams(config);
@@ -295,6 +299,7 @@ public class FullNode : API
             __TIMESTAMP__, __VERSION__.to!string,
             config.validator.enabled
                 ? config.validator.key_pair.address.toString() : null,
+            SysTime(unixTimeToStdTime(this.params.GenesisTimestamp), UTC()).toISOString(),
         );
     }
 

--- a/source/agora/stats/App.d
+++ b/source/agora/stats/App.d
@@ -37,6 +37,8 @@ public struct ApplicationStatsLabels
     public string frontend_version;
     /// Expose this node's public key, if any
     public string public_key;
+    /// The genesis timestamp used (useful for TestNet)
+    public string genesis_timestamp;
 }
 
 /// Dummy stats with a single variable


### PR DESCRIPTION
We are moving towards setting the genesis timestamp dynamically
(on TestNet deploy), and hence we should add it to the stats
to make monitoring easier.