### PR TITLE
TxBuilder: Reduce number of parameters to 'sign'

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -2005,7 +2005,8 @@ unittest
     txs = txs.enumerate()
         .map!(en => TxBuilder(en.value)
               .deduct(data_fee)
-              .sign(OutputType.Payment, data))
+              .payload(data)
+              .sign())
               .array;
     txs.each!(tx => assert(ledger.acceptTransaction(tx)));
     ledger.forceCreateBlock();

--- a/source/agora/test/LockHeight.d
+++ b/source/agora/test/LockHeight.d
@@ -38,10 +38,12 @@ unittest
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     const Height UnlockHeight_2 = Height(2);
-    auto unlock_2_txs = txs.map!(tx => TxBuilder(tx).sign(OutputType.Payment, null, UnlockHeight_2)).array();
+    auto unlock_2_txs = txs.map!(
+        tx => TxBuilder(tx).lock(UnlockHeight_2).sign(OutputType.Payment)).array();
 
     const Height UnlockHeight_3 = Height(3);
-    auto unlock_3_txs = txs.map!(tx => TxBuilder(tx).sign(OutputType.Payment, null, UnlockHeight_3)).array();
+    auto unlock_3_txs = txs.map!(
+        tx => TxBuilder(tx).lock(UnlockHeight_3).sign(OutputType.Payment)).array();
 
     assert(unlock_2_txs != unlock_3_txs);
 

--- a/source/agora/test/Script.d
+++ b/source/agora/test/Script.d
@@ -74,13 +74,11 @@ unittest
 
     const lock_height_2 = Height(2);
     auto unlock_height_2 = block_6.spendable()
-        .map!(txb => txb.sign(OutputType.Payment, null, lock_height_2, 0,
-            &keyUnlocker));
+        .map!(txb => txb.lock(lock_height_2).sign(OutputType.Payment, 0, &keyUnlocker));
 
     const lock_height_3 = Height(3);
     auto unlock_height_3 = block_6.spendable()
-        .map!(txb => txb.sign(OutputType.Payment, null, lock_height_3, 0,
-            &keyUnlocker)).array;
+        .map!(txb => txb.lock(lock_height_3).sign(OutputType.Payment, 0, &keyUnlocker)).array;
 
     // txs with unlock height 2 should be rejected by the lock script
     unlock_height_2.each!(tx => nodes.each!(node => node.putTransaction(tx)));
@@ -164,13 +162,13 @@ unittest
     const uint UnlockAge_2 = 2;
     auto age_2_txs = iota(cast(uint)txs[3].outputs.length)
         .map!(idx => TxBuilder(txs[3], idx)
-            .sign(OutputType.Payment, null, Height(0), UnlockAge_2, &keyUnlocker))
+            .sign(OutputType.Payment, UnlockAge_2, &keyUnlocker))
         .array();
 
     const uint UnlockAge_3 = 3;
     auto age_3_txs = iota(cast(uint)txs[3].outputs.length)
         .map!(idx => TxBuilder(txs[3], idx)
-            .sign(OutputType.Payment, null, Height(0), UnlockAge_3, &keyUnlocker))
+            .sign(OutputType.Payment, UnlockAge_3, &keyUnlocker))
         .array();
 
     age_2_txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));
@@ -235,7 +233,7 @@ unittest
     // using IF branch
     auto true_a_txs = iota(cast(uint)txs[3].outputs.length)
         .map!(idx => TxBuilder(txs[3], idx)
-            .sign(OutputType.Payment, null, Height(0), 0,
+            .sign(OutputType.Payment, 0,
                 (in Transaction tx, in OutputRef out_ref) @safe nothrow
                 {
                     auto sig = kp_a.sign(tx);
@@ -246,7 +244,7 @@ unittest
     // ditto, but different key-pair
     auto true_b_txs = iota(cast(uint)txs[3].outputs.length)
         .map!(idx => TxBuilder(txs[3], idx)
-            .sign(OutputType.Payment, null, Height(0), 0,
+            .sign(OutputType.Payment, 0,
                 (in Transaction tx, in OutputRef out_ref) @safe nothrow
                 {
                     auto sig = kp_b.sign(tx);
@@ -267,7 +265,7 @@ unittest
     // using ELSE branch
     auto false_a_txs = iota(cast(uint)txs[4].outputs.length)
         .map!(idx => TxBuilder(txs[4], idx)
-            .sign(OutputType.Payment, null, Height(0), 0,
+            .sign(OutputType.Payment, 0,
                 (in Transaction tx, in OutputRef out_ref) @safe nothrow
                 {
                     auto sig = kp_a.sign(tx);
@@ -278,7 +276,7 @@ unittest
     // ditto, but different key-pair
     auto false_b_txs = iota(cast(uint)txs[4].outputs.length)
         .map!(idx => TxBuilder(txs[4], idx)
-            .sign(OutputType.Payment, null, Height(0), 0,
+            .sign(OutputType.Payment, 0,
                 (in Transaction tx, in OutputRef out_ref) @safe nothrow
                 {
                     auto sig = kp_b.sign(tx);

--- a/source/agora/test/UnlockAge.d
+++ b/source/agora/test/UnlockAge.d
@@ -50,7 +50,7 @@ unittest
     auto txs_1 = split_up[1].map!(txb => txb.sign()).array;
     auto txs_2 = split_up[2].map!(txb => txb.sign()).array;
     const uint UnlockAge_3 = 3;
-    auto age_3_txs = split_up[3].map!(txb => txb.sign(OutputType.Payment, null, Height(0), UnlockAge_3)).array();
+    auto age_3_txs = split_up[3].map!(txb => txb.sign(OutputType.Payment, UnlockAge_3)).array();
 
     age_3_txs.each!(tx => node_1.putTransaction(tx));  // rejected, wrong age
     txs_0.each!(tx => node_1.putTransaction(tx));      // accepted

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -558,7 +558,7 @@ Outputs (1): boa1xzgenes5...gm67(61,000,000)<Payment>
     }
 
     const Block second_block = makeNewBlock(GenesisBlock,
-        genesisSpendable().take(2).map!(txb => txb.sign(OutputType.Payment, null, Height(0), 0, &unlocker)), 0, Hash.init, genesis_validator_keys.length);
+        genesisSpendable().take(2).map!(txb => txb.sign(OutputType.Payment, 0, &unlocker)), 0, Hash.init, genesis_validator_keys.length);
 
     auto validators = BitField!ubyte(2);
     validators[1] = true;


### PR DESCRIPTION
It's not uncommon for users to pass their own unlocker to TxBuilder.
This proves difficult as we add more parameters to sign.
But those parameters can just be made function calls that set the value,
reducing the overhead for users.