### PR TITLE
Fix #2197 - Mismatch between registry query and response

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -679,7 +679,7 @@ public class NetworkManager
 
                         if (!payload.verifySignature(key))
                         {
-                            log.warn("RegistryPayload signature is incorrect for {}", key);
+                            log.error("RegistryPayload signature is incorrect for {}: {}", key, payload);
                             return false;
                         }
                         foreach (addr; payload.data.addresses)

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -668,16 +668,25 @@ public class NetworkManager
 
                 taskman.runTask
                 ({
+                    // https://github.com/bosagora/agora/issues/2197
+                    const ckey = key;
                     retry!
                     ({
-                        auto payload = this.registry_client.getValidator(key);
+                        auto payload = this.registry_client.getValidator(ckey);
                         if (payload == RegistryPayload.init)
                         {
                             log.warn("Could not find mapping in registry for key {}", key);
                             return false;
                         }
 
-                        if (!payload.verifySignature(key))
+                        if (payload.data.public_key != ckey)
+                        {
+                            log.error("Registry answered with the wrong key: {} => {}",
+                                      ckey, payload);
+                            return false;
+                        }
+
+                        if (!payload.verifySignature(ckey))
                         {
                             log.error("RegistryPayload signature is incorrect for {}: {}", key, payload);
                             return false;


### PR DESCRIPTION
Work around a D bug by copying the value type on the stack.
Since `runTask` context switch immediately we're fine, however if we were to `schedule` it'd be problematic because we would still have race conditions.