### PR TITLE
Ledger: Use `getValidators` in `getRandomSeed`

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -1061,7 +1061,7 @@ unittest
     assert(man.addValidator(ordered_enrollments[1], WK.Keys[1].address, Height(11),
             &utxo_set.peekUTXO, utxos) is null);
     assert(man.validator_set.countActive(Height(12)) == 2);
-    assert(man.getEnrolledUTXOs(Height(12), keys));
+    assert(man.validator_set.getEnrolledUTXOs(Height(12), keys));
     assert(keys.length == 2);
 
     // set an enrolled height for validator C
@@ -1071,7 +1071,7 @@ unittest
                ordered_enrollments[2], WK.Keys[2].address, Height(12), &utxo_set.peekUTXO, utxos)
            is null);
     assert(man.validator_set.countActive(Height(params.ValidatorCycle + 12)) == 1);
-    assert(man.getEnrolledUTXOs(Height(params.ValidatorCycle + 12), keys));
+    assert(man.validator_set.getEnrolledUTXOs(Height(params.ValidatorCycle + 12), keys));
     assert(keys.length == 1);
     assert(keys[0] == ordered_enrollments[2].utxo_key);
 }

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -530,10 +530,8 @@ public class FullNode : API
         {
             this.recordBlockStats(block);
             ex_validators.each!(ex => this.network.unwhitelist(ex.utxo));
-            Hash[] active_validators;
-            assert(this.enroll_man.getEnrolledUTXOs(block.header.height,
-                active_validators));
-            active_validators.each!(utxo => this.network.whitelist(utxo));
+            this.ledger.getValidators(block.header.height)
+                .each!(validator => this.network.whitelist(validator.utxo));
         }
         // We return if height in ledger is reached for this block to prevent fetching again
         return this.ledger.getBlockHeight() >= block.header.height;

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -346,11 +346,11 @@ public class FullNode : API
 
     private void collectValidatorStats (Collector collector)
     {
-        Hash[] keys;
-        if (this.ledger.enrollment_manager.getEnrolledUTXOs(this.ledger.getBlockHeight() + 1, keys))
-            foreach (const ref key; keys)
-                this.validator_preimages_stats.setMetricTo!"agora_preimages_gauge"(
-                    this.ledger.enrollment_manager.validator_set.getPreimage(key).height, key.toString());
+        auto validators = this.ledger.getValidators(this.ledger.getBlockHeight() + 1);
+
+        foreach (const ref val; validators)
+            this.validator_preimages_stats.setMetricTo!"agora_preimages_gauge"(
+                val.preimage.height, val.address.toString());
 
         foreach (stat; this.validator_preimages_stats.getStats())
             collector.collect(stat.value, stat.label);

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -397,7 +397,10 @@ public class Ledger
         // remove the TXs from the Pool
         block.txs.each!(tx => this.pool.remove(tx));
 
-        this.updateSlashedUTXOSet(block);
+        // Slashing requires the validator set, however there is no slashing
+        // in genesis, and the validator set isn't ready yet.
+        if (block.header.height != 0)
+            this.updateSlashedUTXOSet(block);
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -496,6 +496,14 @@ public class Validator : FullNode, API
             block.header.time_offset > cur_offset - 3 * this.params.BlockInterval.total!"seconds")
             this.checkAndEnroll(block.header.height);
 
+        // FIXME: Add our pre-image to the validator set so that `getValidators`
+        // works as expected. This will need to be fixed in the Ledger in the
+        // future, as `checkRevealPreimage` has some issues, but doing it here
+        // allows us to unify usage of `getValidators`.
+        PreImageInfo self;
+        if (this.ledger.enrollment_manager.getNextPreimage(self, block.header.height))
+            this.ledger.enrollment_manager.addPreimage(self);
+
         // note: may context switch, should be called last after quorums
         // are regenerated above.
         super.onAcceptedBlock(block, validators_changed);

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -46,11 +46,10 @@ private class SameKeyValidator : TestValidatorNode
 
         // Find a UTXO which is not used for the enrollments in Genesis block
         Hash unused_utxo;
-        Hash[] enroll_keys;
-        assert(this.enroll_man.getEnrolledUTXOs(Height(1), enroll_keys));
+        auto validators = this.ledger.getValidators(Height(1));
         foreach (utxo; utxo_hashes)
         {
-            if (!canFind(enroll_keys, utxo))
+            if (!validators.map!(val => val.utxo).canFind(utxo))
             {
                 unused_utxo = utxo;
                 break;


### PR DESCRIPTION
As I am working on removing usages of `getEnrolledUTXOs`, a few things came up:
- We were looking up slashed validators at genesis, getting back `keys.length == 0` and ignoring it;
- We didn't always have our pre-image in the ValidatorSet, which led to self-slashing, and ripple through the code (e.g. #2203 );

Those two bugs are fixed. I also reduced usage of `getEnrolledUTXOs` where it was low risk, and (tests / stats / whitelist) and the last commit is the titular one, which simplifies error handling.