### PR TITLE
Use C++17 everywhere

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -22,7 +22,7 @@
     ],
 
     "versions": [ "_GLIBCXX_USE_CXX98_ABI" ],
-    "dflags": [ "-extern-std=c++14", "-preview=in", "-revert=dtorfields" ],
+    "dflags": [ "-extern-std=c++17", "-preview=in", "-revert=dtorfields" ],
     "lflags-posix": [ "-lstdc++", "-lsqlite3" ],
     "lflags-windows": [  "sqlite3.lib", "/nodefaultlib:msvcetd.lib" ],
     "lflags-linux": [ "--export-dynamic" ],

--- a/scripts/build_tracy.d
+++ b/scripts/build_tracy.d
@@ -35,7 +35,7 @@ version (Windows)
 {
     immutable ObjExt = `.obj`;
     immutable CppCmd = [
-        `cl`, `/std:c++14`, `/DEBUG`, `/c`, `/D "TRACY_ENABLE"`,
+        `cl`, `/std:c++17`, `/DEBUG`, `/c`, `/D "TRACY_ENABLE"`,
         `/D "TRACY_ON_DEMAND"`,`/Fo"` ~ OutputFile ~ `"`, TracySourcePath,
     ];
 }
@@ -43,7 +43,7 @@ else
 {
     immutable ObjExt = `.o`;
     immutable CppCmd = [
-        `clang++`, `-std=c++14`, `-g`, `-c`, `-DTRACY_ENABLE`,
+        `clang++`, `-std=c++17`, `-g`, `-c`, `-DTRACY_ENABLE`,
         `-DTRACY_ON_DEMAND`, `-fPIC`, `-o`, OutputFile, TracySourcePath,
     ];
 }

--- a/source/scpp/build.d
+++ b/source/scpp/build.d
@@ -111,7 +111,7 @@ else version (Windows)
         "/Zc:forScope",
         "/RTC1",
         "/Gd",
-        "/std:c++14",
+        "/std:c++17",
         "/FC",
         "/EHsc",
         "/c"


### PR DESCRIPTION
A previous commit switched the SCP build from C++14 to C++17,
but forgot a few important places.