### PR TITLE
ValidatorCleanRestart: Ask for UTXOs instead of assuming unspent

### DIFF
--- a/source/agora/consensus/state/UTXOCache.d
+++ b/source/agora/consensus/state/UTXOCache.d
@@ -94,6 +94,11 @@ abstract class UTXOCache
 
     public abstract size_t length () @safe;
 
+
+    /// Allows iteration on UTXOs
+    public abstract int opApply (
+        scope int delegate (const ref Hash, const ref UTXO) @safe dg) @safe;
+
     /***************************************************************************
 
         Get UTXOs from the UTXO set
@@ -286,6 +291,16 @@ public class TestUTXOSet : UTXOCache
     public override size_t length () @safe
     {
         return this.storage.length;
+    }
+
+    ///
+    public override int opApply (
+        scope int delegate (const ref Hash, const ref UTXO) @safe dg) @safe
+    {
+        foreach (const ref key, const ref value; this.storage)
+            if (auto ret = dg(key, value))
+                return ret;
+        return 0;
     }
 
     /***************************************************************************

--- a/source/agora/consensus/state/UTXOSet.d
+++ b/source/agora/consensus/state/UTXOSet.d
@@ -58,6 +58,13 @@ public class UTXOSet : UTXOCache
         return this.utxo_db.length();
     }
 
+    ///
+    public override int opApply (
+        scope int delegate (const ref Hash, const ref UTXO) @safe dg) @safe
+    {
+        return this.utxo_db.opApply(dg);
+    }
+
     /***************************************************************************
 
         Get UTXOs from the UTXO set

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1434,6 +1434,9 @@ public interface TestAPI : ValidatorAPI
 
     ***************************************************************************/
 
+    public UTXOPair[] getUTXOs (Amount minimum);
+
+    ///
     public UTXOPair[] getUTXOs (PublicKey owner);
 
     /// Ditto
@@ -1602,6 +1605,21 @@ private mixin template TestNodeMixin ()
     public bool hasAcceptedTxHash (Hash tx_hash)
     {
         return !!(tx_hash in this.accepted_txs);
+    }
+
+    ///
+    public override UTXOPair[] getUTXOs (Amount minimum)
+    {
+        UTXOPair[] result;
+        Amount accumulated;
+        foreach (const ref Hash key, const ref UTXO value; this.utxo_set)
+        {
+            result ~= UTXOPair(key, value);
+            accumulated.mustAdd(value.output.value);
+            if (accumulated >= minimum)
+                return result;
+        }
+        throw new Exception("Exhausted UTXO without finding enough coins!");
     }
 
     ///


### PR DESCRIPTION
```
This test was assuming certain UTXOs were unspent, which could backfire
should modifications lead to them being spent.
In order to make the test more resilient, `TestAPI` now exposes a method
to get enough UTXOs to match a certain amount.
This might need some changes in the future, e.g. w.r.t. fees,
but is a much more robust approach.

Additionally, the test was calling `generateBlock`, which had two undesirable effects:
- It would create another transaction, which *could* compete with the frozen one,
  meaning the frozen tx would not be externalized when we expected it to,
  but the `assertSameBlock` will pass.
- In case the frozen tx was rejected for any reason, it will still pass the
  `assertSameBlock` and hide the real error.
```

This has been sitting on my computer for a bit, figured I should submit it for review. Not 100% sure it fixes the bug though, will need to double check.