### PR TITLE
Rename pre-image revelation function to improve tests

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -230,7 +230,7 @@ public class Validator : FullNode, API
         this.clock.startSyncing();
         this.timers ~= this.taskman.setTimer(
             this.config.validator.preimage_reveal_interval,
-            &this.checkRevealPreimage, Periodic.Yes);
+            &this.onPreImageRevealTimer, Periodic.Yes);
 
         if (this.enroll_man.isEnrolled(this.ledger.getBlockHeight() + 1, &this.utxo_set.peekUTXO))
             this.nominator.startNominatingTimer();
@@ -472,7 +472,7 @@ public class Validator : FullNode, API
 
         // FIXME: Add our pre-image to the validator set so that `getValidators`
         // works as expected. This will need to be fixed in the Ledger in the
-        // future, as `checkRevealPreimage` has some issues, but doing it here
+        // future, as `onPreImageRevealTimer` has some issues, but doing it here
         // allows us to unify usage of `getValidators`.
         PreImageInfo self;
         if (this.ledger.enrollment_manager.getNextPreimage(self, block.header.height))
@@ -518,12 +518,13 @@ public class Validator : FullNode, API
 
     /***************************************************************************
 
-        Periodically check for pre-images revelation
+        Periodically called to perform pre-images revelation.
+
         Increase the next reveal height by revelation period if necessary.
 
     ***************************************************************************/
 
-    private void checkRevealPreimage () @safe
+    protected void onPreImageRevealTimer () @safe
     {
         PreImageInfo preimage;
         if (this.enroll_man.getNextPreimage(preimage,

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -53,29 +53,6 @@ private void unexpectBlock (Clients)(Clients clients, Height height)
     }
 }
 
-private class MissingPreImageEM : EnrollmentManager
-{
-    mixin ForwardCtor!();
-
-    /// This does not reveal pre-images intentionally
-    public override bool getNextPreimage (out PreImageInfo preimage,
-        in Height height) @safe
-    {
-        return false;
-    }
-}
-
-private class NoPreImageVN : TestValidatorNode
-{
-    mixin ForwardCtor!();
-
-    protected override EnrollmentManager makeEnrollmentManager ()
-    {
-        return new MissingPreImageEM(this.stateDB, this.cacheDB,
-            this.config.validator.key_pair, params);
-    }
-}
-
 private class BadNominator : TestNominator
 {
     /// Ctor
@@ -127,11 +104,14 @@ unittest
     {
         mixin ForwardCtor!();
 
+        // Always `false`
+        private shared bool neverRevealPreImage;
+
         ///
         public override void createNewNode (Config conf, string file, int line)
         {
             if (this.nodes.length == 0)
-                this.addNewNode!NoPreImageVN(conf, file, line);
+                this.addNewNode!NoPreImageVN(conf, &this.neverRevealPreImage, file, line);
             else
                 super.createNewNode(conf, file, line);
         }
@@ -169,11 +149,14 @@ unittest
     {
         mixin ForwardCtor!();
 
+        // Always `false`
+        private shared bool neverRevealPreImage;
+
         ///
         public override void createNewNode (Config conf, string file, int line)
         {
             if (this.nodes.length == 0)
-                this.addNewNode!NoPreImageVN(conf, file, line);
+                this.addNewNode!NoPreImageVN(conf, &this.neverRevealPreImage, file, line);
             else if (this.nodes.length == 5)
                 this.addNewNode!BadNominatingVN(conf, file, line);
             else

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -38,53 +38,6 @@ import core.thread;
 
 import geod24.Registry;
 
-// This derived `EnrollmentManager` does not reveal any preimages
-// after enrollment.
-private class MissingPreImageEM : EnrollmentManager
-{
-    private shared bool* reveal_preimage;
-
-    ///
-    public this (Parameters!(EnrollmentManager.__ctor) args,
-        shared(bool)* reveal_preimage)
-    {
-        assert(reveal_preimage !is null);
-        this.reveal_preimage = reveal_preimage;
-        super(args);
-    }
-
-    /// This does not reveal pre-images intentionally
-    public override bool getNextPreimage (out PreImageInfo preimage,
-        in Height height) @safe
-    {
-        if (!atomicLoad(*this.reveal_preimage))
-            return false;
-
-        return super.getNextPreimage(preimage, height);
-    }
-}
-
-// This derived TestValidatorNode does not reveal any preimages using the
-// `MissingPreImageEM` class
-private class NoPreImageVN : TestValidatorNode
-{
-    private shared bool* reveal_preimage;
-
-    ///
-    public this (Parameters!(TestValidatorNode.__ctor) args,
-        shared(bool)* reveal_preimage)
-    {
-        this.reveal_preimage = reveal_preimage;
-        super(args);
-    }
-
-    protected override EnrollmentManager makeEnrollmentManager ()
-    {
-        return new MissingPreImageEM(this.stateDB, this.cacheDB,
-            this.config.validator.key_pair, this.params, this.reveal_preimage);
-    }
-}
-
 /// Situation: A misbehaving validator does not reveal its preimages right after
 ///     it's enrolled.
 /// Expectation: The information about the validator is stored in a block.


### PR DESCRIPTION
```
Modifying the behavior of the EnrollmentManager is problematic,
as other parts of the code may depend on it.
For example, the node currently special-case itself in `hasRevealedPreimage`
to work around this. If we want to avoid revealing pre-image,
just override the function that is supposed to reveal them,
not the function that provides them.
```