### PR TITLE
SCP: Remove usage of PublicKey

### DIFF
--- a/source/scpd/tests/GlueTypes.d
+++ b/source/scpd/tests/GlueTypes.d
@@ -54,12 +54,12 @@ alias TypesNoLayout = AliasSeq!
     /// scpd.types.Stellar_SCP
     Value,
     SCPStatementType,
-    PublicKey,
+    NodeID,
     Signature,
 
     /// scpd.types.XDRBase
     xvector!Value,
-    xvector!PublicKey,
+    xvector!NodeID,
     xvector!SCPQuorumSet,
 
     LocalNode,

--- a/source/scpd/types/Stellar_types.d
+++ b/source/scpd/types/Stellar_types.d
@@ -29,9 +29,21 @@ extern(C++, `stellar`):
 // we can just swap it, and get a much more D-friendly interface.
 
 // todo: replace with BitBlob and use pragma(mangle) to force it to link
-alias Hash = opaque_array!64;
 alias uint256 = opaque_array!32;
 alias uint512 = opaque_array!64;
-alias PublicKey = uint256;
-alias Signature = opaque_array!64;
-alias NodeID = PublicKey;
+
+
+alias Hash      = uint512;
+alias NodeID    = uint256;
+alias Signature = uint512;
+
+unittest
+{
+    static import agora.crypto.Hash;
+    static import agora.crypto.Key;
+    static import agora.crypto.Schnorr;
+
+    static assert(agora.crypto.Hash.Hash.sizeof == Hash.sizeof);
+    static assert(agora.crypto.Key.PublicKey.sizeof == NodeID.sizeof);
+    static assert(agora.crypto.Schnorr.Signature.sizeof == Signature.sizeof);
+}

--- a/source/scpp/extra/DSizeChecks.cpp
+++ b/source/scpp/extra/DSizeChecks.cpp
@@ -44,8 +44,8 @@ CPPSIZEOF(SCPQuorumSet)
 
 /// scpd.types.Stellar_types
 CPPSIZEOF(Hash)
-CPPSIZEOF(PublicKey)
-// Signature is removed because it is the same as Hash.
+CPPSIZEOF(NodeID)
+// Signature and hash are both aliases to uint512
 static_assert(std::is_same<Signature, Hash>::value, "Signature and Hash must be the same type");
 CPPSIZEOF(ByteSlice)
 
@@ -55,7 +55,7 @@ CPPSIZEOF(ByteSlice)
 /// scpd.types.XDRBase
 CPPSIZEOF(xarray<std::uint8_t COMMA 4>)
 CPPSIZEOF(xvector<Value>)
-CPPSIZEOF(xvector<PublicKey>)
+CPPSIZEOF(xvector<NodeID>)
 CPPSIZEOF(xvector<SCPQuorumSet>)
 
 CPPSIZEOF(LocalNode)

--- a/source/scpp/extra/DUtils.cpp
+++ b/source/scpp/extra/DUtils.cpp
@@ -41,7 +41,7 @@ opaque_vec<> XDRToOpaque(const stellar::SCPStatement& param)
 #define PUSHBACKINST2(T, VT) template void push_back<T, VT>(VT&, T&);
 #define PUSHBACKINST3(T, V) template void push_back<T, V<T>>(V<T>&, T&);
 
-PUSHBACKINST2(const PublicKey, xvector<PublicKey>)
+PUSHBACKINST2(const NodeID, xvector<NodeID>)
 PUSHBACKINST3(xvector<unsigned char>, std::vector)
 PUSHBACKINST3(unsigned char, std::vector)
 
@@ -66,9 +66,9 @@ opaque_vec<> duplicate_value (void const *value_)
     return dup;
 }
 
-PUSHBACKINST1(PublicKey)
+PUSHBACKINST1(NodeID)
 PUSHBACKINST1(SCPQuorumSet)
-PUSHBACKINST3(PublicKey, std::vector)
+PUSHBACKINST3(NodeID, std::vector)
 PUSHBACKINST3(SCPEnvelope, std::vector)
 PUSHBACKINST3(SCPQuorumSet, std::vector)
 
@@ -77,7 +77,7 @@ CPPSETFOREACHINST(int)
 CPPSETFOREACHINST(Value)
 CPPSETFOREACHINST(ValueWrapperPtr)
 CPPSETFOREACHINST(SCPBallot)
-CPPSETFOREACHINST(PublicKey)
+CPPSETFOREACHINST(NodeID)
 CPPSETFOREACHINST(unsigned int)
 
 #define CPPSETEMPTYINST(T) template bool cpp_set_empty<T>(const void*);
@@ -85,7 +85,7 @@ CPPSETEMPTYINST(int)
 CPPSETEMPTYINST(Value)
 CPPSETEMPTYINST(ValueWrapperPtr)
 CPPSETEMPTYINST(SCPBallot)
-CPPSETEMPTYINST(PublicKey)
+CPPSETEMPTYINST(NodeID)
 CPPSETEMPTYINST(unsigned int)
 
 #define CPPUNORDEREDMAPASSIGNINST(K, V) template void cpp_unordered_map_assign<K, V>(void*, const K&, const V&);
@@ -138,7 +138,7 @@ CPPOBJECTINST(std::shared_ptr<SCPEnvelopeWrapper>);
 
 CPPOBJECTINST(std::set<int>);
 CPPOBJECTINST(std::set<Value>);
-CPPOBJECTINST(std::set<PublicKey>);
+CPPOBJECTINST(std::set<NodeID>);
 CPPOBJECTINST(std::set<SCPBallot>);
 CPPOBJECTINST(std::set<unsigned int>);
 
@@ -158,16 +158,16 @@ CPPUNORDEREDMAPINST(int, int, 1)
 #define CPPMAPINST(K, V, id)   typedef std::map<K, V> map_type_##id;  \
                                 CPPOBJECTINST(map_type_##id);
 CPPMAPINST(int, int, 0)
-CPPMAPINST(PublicKey, SCPEnvelope, 1)
+CPPMAPINST(NodeID, SCPEnvelope, 1)
 CPPMAPINST(uint64_t, std::shared_ptr<Slot>, 2)
-CPPMAPINST(stellar::PublicKey, std::shared_ptr<SCPEnvelopeWrapper>, 3)
+CPPMAPINST(stellar::NodeID, std::shared_ptr<SCPEnvelopeWrapper>, 3)
 
 #define CPPUNORDEREDMAPRANDHASHINST(K, V, id)   typedef std::unordered_map<K, V, stellar::RandHasher<K, std::hash<K > > > rand_map_type_##id;  \
                                 CPPOBJECTINST(rand_map_type_##id);
 
 
 CPPUNORDEREDMAPRANDHASHINST(int, int, 0);
-CPPUNORDEREDMAPRANDHASHINST(stellar::PublicKey, stellar::QuorumTracker::NodeInfo, 1);
+CPPUNORDEREDMAPRANDHASHINST(stellar::NodeID, stellar::QuorumTracker::NodeInfo, 1);
 
 // typedef std::set<ValueWrapperPtr, WrappedValuePtrComparator*> ValueWrapperPtrSet2;
 

--- a/source/scpp/src/scp/LocalNode.h
+++ b/source/scpp/src/scp/LocalNode.h
@@ -96,7 +96,7 @@ class LocalNode
         NodeID const* excluded = nullptr);
 
     static Json::Value toJson(SCPQuorumSet const& qSet,
-                              std::function<std::string(PublicKey const&)> r);
+                              std::function<std::string(NodeID const&)> r);
 
     Json::Value toJson(SCPQuorumSet const& qSet, bool fullKeys) const;
     std::string to_string(SCPQuorumSet const& qSet) const;

--- a/source/scpp/src/xdr/Agora-types.h
+++ b/source/scpp/src/xdr/Agora-types.h
@@ -5,16 +5,20 @@
 
 #include <xdrpp/types.h>
 
-namespace stellar {
+namespace stellar
+{
+    // Base types used in Stellar and Agora alike
+    using uint32 = std::uint32_t;
+    using int32  = std::int32_t;
+    using uint64 = std::uint64_t;
+    using int64  = std::int64_t;
 
-using Hash = xdr::opaque_array<64>;
-using uint256 = xdr::opaque_array<32>;
-using uint512 = xdr::opaque_array<64>;
-using uint32 = std::uint32_t;
-using int32 = std::int32_t;
-using uint64 = std::uint64_t;
-using int64 = std::int64_t;
+    // Opaque value types (BitBlob!{32,64} on the Agora side, ABI compatible)
+    using uint256 = xdr::opaque_array<32>;
+    using uint512 = xdr::opaque_array<64>;
 
-using PublicKey = uint256;
-using Signature = xdr::opaque_array<64>;
+    // Logical types used by SCP / Agora
+    using Hash =      uint512;
+    using NodeID =    uint256; // Currently a `PublicKey`
+    using Signature = uint512; // `(R,s)`, could be reduced to `(s)`
 }

--- a/source/scpp/src/xdr/Stellar-SCP.h
+++ b/source/scpp/src/xdr/Stellar-SCP.h
@@ -10,8 +10,6 @@
 #include "xdr/Stellar-types.h"
 
 namespace stellar {
-
-using NodeID = PublicKey;
 using Value = xdr::opaque_vec<>;
 
 struct SCPBallot {


### PR DESCRIPTION
```
This finally removes the last usages of 'PublicKey',
ensuring that only 'NodeID' is used through the code base.
```

@linked0 : Realized I missed a few occurrences, this should be the last of it.