### PR TITLE
Add onchain fees to funding and closing TX

### DIFF
--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -96,8 +96,6 @@ public string isInvalidReason (
             return reason;
     }
 
-    const tx_hash = hashFull(tx);
-
     string isInvalidInput (in Input input, ref UTXO utxo_value,
         ref Amount sum_unspent)
     {

--- a/source/agora/flash/ErrorCode.d
+++ b/source/agora/flash/ErrorCode.d
@@ -117,4 +117,7 @@ public enum ErrorCode : ushort
     /// Either funding UTXO does not belong to the given PublicKey or does not
     /// have enough funds
     RejectedFundingUTXO,
+
+    /// Too much fee request for closing TX
+    RejectedClosingFee,
 }

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -1119,7 +1119,11 @@ public abstract class FlashNode : FlashControlAPI
 
         // create funding, don't sign it yet as we'll share it first
         auto funding_tx = createFundingTx(funding_utxo, funding_utxo_hash,
-            capacity, pair_pk);
+            capacity, pair_pk, this.listener.getEstimatedTxFee());
+
+        if (funding_tx == Transaction.init)
+            return Result!Hash(ErrorCode.RejectedFundingUTXO,
+                format("The provided UTXO does not have requested funds for TX fees"));
 
         const funding_tx_hash = hashFull(funding_tx);
         const Hash chan_id = funding_tx_hash;

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -1072,7 +1072,7 @@ public abstract class FlashNode : FlashControlAPI
     {
         if (auto chans = reg_pk in this.channels)
             if (auto channel = chan_id in *chans)
-                return channel.beginCollaborativeClose();
+                return channel.beginCollaborativeClose(this.listener.getEstimatedTxFee());
 
         return Result!bool(ErrorCode.InvalidChannelID, "Channel ID not found");
     }

--- a/source/agora/flash/Scripts.d
+++ b/source/agora/flash/Scripts.d
@@ -174,7 +174,7 @@ public Unlock createUnlockSettle (Signature sig, in ulong seq_id)
 
 *******************************************************************************/
 
-public Transaction createFundingTx (in UTXO utxo, in Hash utxo_hash, 
+public Transaction createFundingTx (in UTXO utxo, in Hash utxo_hash,
     in Amount capacity, in Point pair_pk, Amount fee) @safe nothrow
 {
     auto inputs = [Input(utxo_hash)];

--- a/source/agora/flash/api/FlashListenerAPI.d
+++ b/source/agora/flash/api/FlashListenerAPI.d
@@ -119,13 +119,10 @@ public interface FlashListenerAPI
 
     /***************************************************************************
 
-        Params:
-            size_bytes = TX size in bytes
-
         Returns:
-            Appropriate amount of fees
+            Appropriate amount of fees per byte
 
     ***************************************************************************/
 
-    public Amount getEstimatedTxFee (uint size_bytes);
+    public Amount getEstimatedTxFee ();
 }

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -556,9 +556,9 @@ private class FlashListener : TestFlashListenerAPI
         assert(0);
     }
 
-    public Amount getEstimatedTxFee (uint size_bytes)
+    public Amount getEstimatedTxFee ()
     {
-        assert(0);
+        return Amount(1);
     }
 }
 

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -1735,6 +1735,11 @@ unittest
         utxo, utxo_hash, Amount.MaxUnitSupply, Settle_10_Blocks, bob_pair.V);
     assert(res.error == ErrorCode.RejectedFundingUTXO);
 
+    // error on not enough funds on funding UTXO for TX fees
+    res = alice.openNewChannel(alice_pubkey,
+        utxo, utxo_hash, utxo.output.value, Settle_10_Blocks, bob_pair.V);
+    assert(res.error == ErrorCode.RejectedFundingUTXO);
+
     // error on not own funding UTXO
     res = bob.openNewChannel(bob_pubkey,
         utxo, utxo_hash, Amount(10_000), 1000, alice_pair.V);

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -1414,7 +1414,7 @@ unittest
     auto close_tx = bob.getClosingTx(bob_pubkey, bob_charlie_chan_id_2);
     assert(close_tx.outputs.length == 2);
     assert(close_tx.outputs.count!(o => o.value == Amount(8000)) == 1); // No fees
-    assert(close_tx.outputs.count!(o => o.value == Amount(2000)) == 1);
+    assert(close_tx.outputs.count!(o => o.value == Amount(2000 - close_tx.sizeInBytes)) == 1);
     network.expectTxExternalization(close_tx);
     factory.listener.waitUntilChannelState(bob_charlie_chan_id_2,
         ChannelState.Closed);
@@ -1426,7 +1426,7 @@ unittest
     close_tx = alice.getClosingTx(alice_pubkey, alice_bob_chan_id);
     assert(close_tx.outputs.length == 2);
     assert(close_tx.outputs.count!(o => o.value == Amount(7990)) == 1); // Fees
-    assert(close_tx.outputs.count!(o => o.value == Amount(2010)) == 1);
+    assert(close_tx.outputs.count!(o => o.value == Amount(2010 - close_tx.sizeInBytes)) == 1);
     network.expectTxExternalization(close_tx);
     factory.listener.waitUntilChannelState(alice_bob_chan_id,
         ChannelState.Closed);


### PR DESCRIPTION
As these are collaborative, they can use the channel funds for onchain fees.

Any fees associated with a non-collaborative closing attempt should be handled differently and paid by the peer that is attempting to close the channel.