### PR TITLE
Move `handshake` (aka `getPublicKey`) endpoint to FullNode

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -22,6 +22,7 @@ import agora.consensus.data.Enrollment;
 import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.Transaction;
 import agora.consensus.data.ValidatorInfo;
+import agora.crypto.Key;
 
 import vibe.data.serialization;
 import vibe.http.common;
@@ -42,6 +43,19 @@ public struct NodeInfo
 
     /// Partial or full view of the addresses of the node's quorum (based on is_complete)
     public Set!string addresses;
+}
+
+/// Identity of a Validator node
+public struct Identity
+{
+    /// Public Key of the node
+    PublicKey key;
+
+    /// UTXO that is used as collateral
+    Hash utxo;
+
+    /// MAC
+    ubyte[] mac;
 }
 
 /*******************************************************************************
@@ -71,6 +85,24 @@ public interface API
 {
 // The REST generator requires @safe methods
 @safe:
+
+    /***************************************************************************
+
+        Endpoint used by other FullNodes or Validator to establish a long
+        connection to this node.
+
+        Note that this is done in the FullNode API, as a node doesn't know if
+        another node is a full node or validator just from the address (but can
+        expect a validator, e.g. when contacting a registry-provided address).
+
+        Params:
+          peer = `PublicKey` of the node initiating the connection.
+                 This is used for establishing a shared secret and doesn't
+                 need to be an enrolled key.
+
+    ***************************************************************************/
+
+    public Identity handshake (PublicKey peer);
 
     /***************************************************************************
 

--- a/source/agora/api/Validator.d
+++ b/source/agora/api/Validator.d
@@ -57,19 +57,6 @@ import vibe.web.rest;
 ///
 public import agora.api.FullNode;
 
-/// Identity of a Validator node
-public struct Identity
-{
-    /// Public Key of the node
-    PublicKey key;
-
-    /// UTXO that is used as collateral
-    Hash utxo;
-
-    /// MAC
-    ubyte[] mac;
-}
-
 /*******************************************************************************
 
     Define the API a validator exposes to other validators

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -260,6 +260,12 @@ public class NetworkClient
             key);
     }
 
+    ///
+    public Identity handshake (PublicKey key) @trusted
+    {
+        return this.attemptRequest!(API.handshake, Throw.Yes)(this.api, key);
+    }
+
     /***************************************************************************
 
         Register the node's address to listen for gossiping messages.

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -181,11 +181,10 @@ public class NetworkManager
                     import agora.flash.OnionPacket : generateSharedSecret;
                     import libsodium.crypto_auth;
 
-                    // LocalRest will return PublicKey.init,
-                    // vibe.d will throw HTTPStatusException with status == 404
                     const ephemeral_kp = KeyPair.random();
-                    auto id = client.getPublicKey(ephemeral_kp.address);
+                    auto id = client.handshake(ephemeral_kp.address);
 
+                    // No identity, either a full node or not enrolled
                     if (id.key == PublicKey.init)
                         break;
 
@@ -208,13 +207,6 @@ public class NetworkManager
                 }
                 catch (Exception ex)
                 {
-                    if (auto http = cast(HTTPStatusException)ex)
-                    {
-                        // 404 => API not implemented, it's a FullNode
-                        if (http.status == 404)
-                            break;
-                    }
-
                     if (!this.onFailedRequest(this.address))
                         return;
 

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -68,9 +68,6 @@ public class NetworkManager
     /// Node information
     public static struct NodeConnInfo
     {
-        /// Is this node a Validator
-        bool is_validator;
-
         /// Hash of the output used as collateral, only set if the node is a Validator
         Hash utxo;
 
@@ -79,6 +76,12 @@ public class NetworkManager
 
         /// Client
         NetworkClient client;
+
+        ///
+        public bool isValidator () const scope @safe pure nothrow @nogc
+        {
+            return this.key != PublicKey.init;
+        }
     }
 
     /***************************************************************************
@@ -238,7 +241,6 @@ public class NetworkManager
                 log.info("Found new FullNode: {}", address);
 
             NodeConnInfo node = {
-                is_validator : is_validator,
                 key : key,
                 utxo: utxo,
                 client : client
@@ -469,7 +471,7 @@ public class NetworkManager
         this.connected_peers.put(node.client.address);
         this.peers.insertBack(node);
 
-        if (node.is_validator)
+        if (node.isValidator())
         {
             this.required_peers.remove(node.utxo);
             this.connected_validator_keys.put(node.utxo);
@@ -867,7 +869,7 @@ public class NetworkManager
 
     public auto validators () return @safe nothrow pure
     {
-        return this.peers[].filter!(p => p.is_validator);
+        return this.peers[].filter!(p => p.isValidator());
     }
 
     /***************************************************************************

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -392,9 +392,6 @@ public class NetworkManager
     /// Easy lookup of currently connected peers
     protected Set!Address connected_peers;
 
-    /// Keeps track of Validator keys we're already connected to
-    private Set!Hash connected_validator_keys;
-
     /// All known addresses so far (used for getNodeInfo())
     protected Set!Address known_addresses;
 
@@ -472,10 +469,7 @@ public class NetworkManager
         this.peers.insertBack(node);
 
         if (node.isValidator())
-        {
             this.required_peers.remove(node.utxo);
-            this.connected_validator_keys.put(node.utxo);
-        }
 
         this.discovery_task.add(node.client);
         this.metadata.peers.put(node.client.address);
@@ -655,7 +649,7 @@ public class NetworkManager
         foreach (peer; required_peer_utxos.byKeyValue)
         {
             this.quorum_set_keys.put(peer.key);
-            if (peer.key !in this.connected_validator_keys)
+            if (!this.peers[].map!(ni => ni.utxo).canFind(peer.key))
                 this.required_peers.put(peer.key);
         }
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -839,6 +839,12 @@ public class FullNode : API
     * the business code.                                                       *
     ***************************************************************************/
 
+    ///
+    public override Identity handshake (PublicKey peer)
+    {
+        return Identity.init;
+    }
+
     /***************************************************************************
 
         Register the given address as a listener for gossip / consensus messages.

--- a/source/agora/node/TransactionRelayer.d
+++ b/source/agora/node/TransactionRelayer.d
@@ -219,7 +219,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
     /// Sends an array of transactions ordered by fee to known network clients.
     public void relayTransactions () @safe nothrow
     {
-        if ((*this.clients)[].canFind!(client => client.is_validator))
+        if ((*this.clients)[].canFind!(client => client.isValidator()))
             this.getRelayTransactions().each!(tx => (*this.clients).each!(node_info => node_info.client.sendTransaction(tx)));
     }
 

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -251,6 +251,12 @@ public class Validator : FullNode, API
         this.network.discover(this.required_peer_utxos);
     }
 
+    ///
+    public override Identity handshake (PublicKey peer)
+    {
+        return this.getPublicKey(peer);
+    }
+
     /// GET /public_key
     public override Identity getPublicKey (PublicKey key = PublicKey.init) nothrow @safe
     {


### PR DESCRIPTION
One should never rely on `Exception` for control flow, but we were doing just that when establishing a connection.
As explained in the commit message, the assumptions that led to `getPublicKey` being used the way it is turned out to be wrong:
```
When 'getPublicKey' was first introduced, it was under the assumption that
a node would be either a FullNode or a Validator.
However, this had a major oversight: while a FullNode will never promote
to a Validator internally, from the outside, a node could switch between
a FullNode and a Validator (because an unenrolled Validator is no different
from a FullNode). This led to a few complications in the NetworkManager
and related code, including this hack with HTTPStatusException.
This is now partially fixed by moving the 'handshake' endpoint to FullNode.
```