### PR TITLE
Fixes issue 2229: Push updated block headers to stoa

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -223,13 +223,16 @@ logging:
     console: false
     file: log/node.log
 
- ################################################################################
+################################################################################
 ##                               Event Handlers                               ##
 ################################################################################
 event_handlers:
   # URLs to push a data when a block is externalized. (path is "/block_externalized")
   block_externalized:
     - http://127.0.0.1:3836/block_externalized
+  # URLs to push a data when a block header is updated. (path is "/block_header_updated")
+  block_header_updated:
+    - http://127.0.0.1:3836/block_header_updated
   # URLs to push a data when a pre-image is updated. (path is "/preimage_received")
   preimage_received:
     - http://127.0.0.1:3836/preimage_received

--- a/source/agora/api/Handlers.d
+++ b/source/agora/api/Handlers.d
@@ -41,6 +41,25 @@ public interface BlockExternalizedHandler
 }
 
 @serializationPolicy!(Base64ArrayPolicy)
+public interface BlockHeaderUpdatedHandler
+{
+// The REST generator requires @safe methods
+@safe:
+
+    /***************************************************************************
+
+        Push an updated block header in JSON format with HTTP POST
+
+        API:
+            See config.event_handlers.block_header_updated_handler_addresses
+
+    ***************************************************************************/
+
+    @path("/")
+    public void pushBlockHeader (const BlockHeader header);
+}
+
+@serializationPolicy!(Base64ArrayPolicy)
 public interface PreImageReceivedHandler
 {
 // The REST generator requires @safe methods

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -279,6 +279,7 @@ public struct AdminConfig
 public enum HandlerType
 {
     block_externalized = "block_externalized",
+    block_header_updated = "block_header_updated",
     preimage_received = "preimage_received",
     transaction_received = "transaction_received"
 }
@@ -1045,7 +1046,7 @@ private immutable(EventHandlerConfig)[] parserEventHandlers (Node* node, in Comm
     immutable(EventHandlerConfig)[] handlers;
     with(HandlerType)
     {
-        only(block_externalized, preimage_received, transaction_received)
+        only(block_externalized, block_header_updated, preimage_received, transaction_received)
             .each!((HandlerType handler_type)
             {
                 if (node !is null)
@@ -1081,6 +1082,8 @@ noexist_event_handlers:
 event_handlers:
   block_externalized:
     - http://127.0.0.1:3836
+  block_header_updated:
+    - http://127.0.0.2:3836
   preimage_received:
     - http://127.0.0.3:3836
   transaction_received:
@@ -1091,6 +1094,7 @@ event_handlers:
         with(HandlerType)
         {
             assert(handlers.filter!(h => h.handler_type == block_externalized).front.handler_addresses == [ `http://127.0.0.1:3836` ]);
+            assert(handlers.filter!(h => h.handler_type == block_header_updated).front.handler_addresses == [ `http://127.0.0.2:3836` ]);
             assert(handlers.filter!(h => h.handler_type == preimage_received).front.handler_addresses == [ `http://127.0.0.3:3836` ]);
             assert(handlers.filter!(h => h.handler_type == transaction_received).front.handler_addresses == [ `http://127.0.0.4:3836` ]);
         }
@@ -1117,6 +1121,7 @@ event_handlers:
                 .front.handler_addresses == [ `http://127.0.0.4:3836`, `http://127.0.0.5:3836` ]);
             assert(handlers.length == 2);
             assert(handlers.count!(h => h.handler_type == preimage_received) == 0);
+            assert(handlers.count!(h => h.handler_type == block_header_updated) == 0);
         }
     }
 }

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -1197,78 +1197,53 @@ public class NetworkManager
 
     /***************************************************************************
 
-        Instantiates a client object implementing `BlockExternalizedHandler`
-
-        In the default implementation, this returns a `BlockExternalizedHandler`
+        Instantiates a client object implementing the `BlockExternalizedHandler`
 
         Params:
             address = The address (IPv4, IPv6, hostname) of target Server
         Returns:
-            A BlockExternalizedHandler to communicate with the server
-            at `address`
+            A Handler to communicate with the server at `address`
 
     ***************************************************************************/
 
-    public BlockExternalizedHandler getBlockExternalizedHandler
-        (Address address)
+    public BlockExternalizedHandler getBlockExternalizedHandler (Address address)
     {
-        import vibe.http.client;
-
-        auto settings = new RestInterfaceSettings;
-        settings.baseURL = URL(address);
-        settings.httpClientSettings = new HTTPClientSettings;
-        settings.httpClientSettings.connectTimeout = this.node_config.timeout;
-        settings.httpClientSettings.readTimeout = this.node_config.timeout;
-        settings.httpClientSettings.proxyURL = this.proxy_url;
-
-        return new RestInterfaceClient!BlockExternalizedHandler(settings);
+        return new RestInterfaceClient!BlockExternalizedHandler(getRestInterfaceSettings(address));
     }
 
     /***************************************************************************
 
-        Instantiates a client object implementing `PreImageReceivedHandler`
-
-        In the default implementation, this returns a `PreImageReceivedHandler`
+        Instantiates a client object implementing the `PreImageReceivedHandler`
 
         Params:
             address = The address (IPv4, IPv6, hostname) of target Server
         Returns:
-            A PreImageReceivedHandler to communicate with the server
-            at `address`
+            A Handler to communicate with the server at `address`
 
     ***************************************************************************/
 
-    public PreImageReceivedHandler getPreimageReceivedHandler
-        (Address address)
+    public PreImageReceivedHandler getPreImageReceivedHandler(Address address)
     {
-        import vibe.http.client;
-
-        auto settings = new RestInterfaceSettings;
-        settings.baseURL = URL(address);
-        settings.httpClientSettings = new HTTPClientSettings;
-        settings.httpClientSettings.connectTimeout = this.node_config.timeout;
-        settings.httpClientSettings.readTimeout = this.node_config.timeout;
-        settings.httpClientSettings.proxyURL = this.proxy_url;
-
-        return new RestInterfaceClient!PreImageReceivedHandler(settings);
+        return new RestInterfaceClient!PreImageReceivedHandler(getRestInterfaceSettings(address));
     }
 
     /***************************************************************************
 
-        Instantiates a client object implementing `TransactionReceivedHandler`
-
-        In the default implementation, this returns a `TransactionReceivedHandler`
+        Instantiates a client object implementing the `TransactionReceivedHandler`
 
         Params:
             address = The address (IPv4, IPv6, hostname) of target Server
         Returns:
-            A TransactionReceivedHandler to communicate with the server
-            at `address`
+            A Handler to communicate with the server at `address`
 
     ***************************************************************************/
 
-    public TransactionReceivedHandler getTransactionReceivedHandler
-        (Address address)
+    public TransactionReceivedHandler getTransactionReceivedHandler (Address address)
+    {
+        return new RestInterfaceClient!TransactionReceivedHandler(getRestInterfaceSettings(address));
+    }
+
+    private RestInterfaceSettings getRestInterfaceSettings (Address address)
     {
         import vibe.http.client;
 
@@ -1278,8 +1253,7 @@ public class NetworkManager
         settings.httpClientSettings.connectTimeout = this.node_config.timeout;
         settings.httpClientSettings.readTimeout = this.node_config.timeout;
         settings.httpClientSettings.proxyURL = this.proxy_url;
-
-        return new RestInterfaceClient!TransactionReceivedHandler(settings);
+        return settings;
     }
 
     /***************************************************************************

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -988,7 +988,7 @@ public class NetworkManager
 
     ***************************************************************************/
 
-    public void getMissingBlockSigs (Ledger ledger) @safe nothrow
+    public BlockHeader[] getMissingBlockSigs (Ledger ledger) @safe nothrow
     {
         import std.algorithm;
         import std.conv;
@@ -999,6 +999,8 @@ public class NetworkManager
         const recent_block_count = 2;
 
         size_t[Height] signed_validators;
+
+        BlockHeader[] headers_updated;
 
         try
         {
@@ -1036,6 +1038,7 @@ public class NetworkManager
                                 try
                                 {
                                     ledger.updateBlockMultiSig(header);
+                                    headers_updated ~= header;
                                 }
                                 catch (Exception e)
                                 {
@@ -1058,6 +1061,7 @@ public class NetworkManager
         {
             log.error("getMissingBlockSigs: Exception thrown : {}", e.msg);
         }
+        return headers_updated;
     }
 
     /// Shut down timers & dump the metadata
@@ -1209,6 +1213,22 @@ public class NetworkManager
     public BlockExternalizedHandler getBlockExternalizedHandler (Address address)
     {
         return new RestInterfaceClient!BlockExternalizedHandler(getRestInterfaceSettings(address));
+    }
+
+    /***************************************************************************
+
+        Instantiates a client object implementing the `BlockHeaderUpdatedHandler`
+
+        Params:
+            address = The address (IPv4, IPv6, hostname) of target Server
+        Returns:
+            A Handler to communicate with the server at `address`
+
+    ***************************************************************************/
+
+    public BlockHeaderUpdatedHandler getBlockHeaderUpdatedHandler (Address address)
+    {
+        return new RestInterfaceClient!BlockHeaderUpdatedHandler(getRestInterfaceSettings(address));
     }
 
     /***************************************************************************

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -266,23 +266,28 @@ public class FullNode : API
                 this.storage, this.enroll_man, this.pool, this.fee_man, this.clock,
                 config.node.block_time_offset_tolerance, &this.onAcceptedBlock);
 
-        // Make `BlockExternalizedHandler` from config
-        foreach (address;
-            config.event_handlers.block_externalized_handler_addresses)
-            this.block_handlers[address] = this.network
-                .getBlockExternalizedHandler(address);
+        // If we have handlers defined in the config
+        if (config.event_handlers.length > 0)
+        {
+            // Make `BlockExternalizedHandler`s from config
+            config.event_handlers.filter!(h => h.handler_type == HandlerType.block_externalized)
+                .map!(handler => handler.handler_addresses).map!(a => a.to!Address)
+                    .each!(address =>
+                        this.block_handlers[address] = this.network.getBlockExternalizedHandler(address));
 
-        // Make `PreImageReceivedHandler` from config
-        foreach (address;
-            config.event_handlers.preimage_updated_handler_addresses)
-            this.preimage_handlers[address] = this.network
-                .getPreimageReceivedHandler(address);
 
-        // Make `TransactionReceivedHandler` from config
-        foreach (address;
-            config.event_handlers.transaction_received_handler_addresses)
-            this.transaction_handlers[address] = this.network
-                .getTransactionReceivedHandler(address);
+            // Make `PreImageReceivedHandler`s from config
+            config.event_handlers.filter!(h => h.handler_type == HandlerType.preimage_received)
+                .map!(handler => handler.handler_addresses).map!(a => a.to!Address)
+                    .each!(address =>
+                        this.preimage_handlers[address] = this.network.getPreImageReceivedHandler(address));
+
+            // Make `TransactionReceivedHandler`s from config
+            config.event_handlers.filter!(h => h.handler_type == HandlerType.transaction_received)
+                .map!(handler => handler.handler_addresses).map!(a => a.to!Address)
+                    .each!(address =>
+                        this.transaction_handlers[address] = this.network.getTransactionReceivedHandler(address));
+        }
 
         Utils.getCollectorRegistry().addCollector(&this.collectAppStats);
         Utils.getCollectorRegistry().addCollector(&this.collectStats);

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -221,6 +221,9 @@ public class FullNode : API
     protected BlockExternalizedHandler[Address] block_handlers;
 
     /// Ditto
+    protected BlockHeaderUpdatedHandler[Address] block_header_handlers;
+
+    /// Ditto
     protected PreImageReceivedHandler[Address] preimage_handlers;
 
     /// Ditto
@@ -275,6 +278,11 @@ public class FullNode : API
                     .each!(address =>
                         this.block_handlers[address] = this.network.getBlockExternalizedHandler(address));
 
+            // Make `BlockHeaderUpdatedHandler`s from config
+            config.event_handlers.filter!(h => h.handler_type == HandlerType.block_header_updated)
+                .map!(handler => handler.handler_addresses).map!(a => a.to!Address)
+                    .each!(address =>
+                        this.block_header_handlers[address] = this.network.getBlockHeaderUpdatedHandler(address));
 
             // Make `PreImageReceivedHandler`s from config
             config.event_handlers.filter!(h => h.handler_type == HandlerType.preimage_received)
@@ -482,7 +490,14 @@ public class FullNode : API
             Height(this.ledger.getBlockHeight() + 1),
             &this.addBlocks);
         this.network.getUnknownTXs(this.ledger);
-        this.network.getMissingBlockSigs(this.ledger);
+        try
+        {
+            this.network.getMissingBlockSigs(this.ledger).each!(h => pushBlockHeader(h));
+        }
+        catch (Exception e)
+        {
+            log.error("Error sending updated block headers:{}", e);
+        }
     }
 
     /***************************************************************************
@@ -1055,6 +1070,39 @@ public class FullNode : API
                 {
                     log.error("Error sending block height #{} to {} :{}",
                         block.header.height, address, e);
+                }
+            });
+        }
+    }
+
+    /***************************************************************************
+
+        Push an updated block header to the `blockheader_handlers` target server
+        list set in config.
+        The blockheader can have signatures from validators added even after the
+        block has been externalized.
+
+        Convert block header data to JSON serialization and send it POST using
+        Rest.
+
+        Params:
+            header = updated block header data
+
+    ***************************************************************************/
+
+    private void pushBlockHeader (const BlockHeader header) @trusted
+    {
+        foreach (address, handler; this.block_header_handlers)
+        {
+            this.taskman.runTask({
+                try
+                {
+                    handler.pushBlockHeader(header);
+                }
+                catch (Exception e)
+                {
+                    log.error("Error sending block header at height #{} to {} :{}",
+                        header.height, address, e);
                 }
             });
         }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1274,6 +1274,13 @@ public class TestNetworkManager : NetworkManager
     }
 
     ///
+    protected final override BlockHeaderUpdatedHandler getBlockHeaderUpdatedHandler
+        (Address address)
+    {
+        assert(0, "Not supported");
+    }
+
+    ///
     protected final override PreImageReceivedHandler getPreImageReceivedHandler
         (Address address)
     {

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1274,7 +1274,7 @@ public class TestNetworkManager : NetworkManager
     }
 
     ///
-    protected final override PreImageReceivedHandler getPreimageReceivedHandler
+    protected final override PreImageReceivedHandler getPreImageReceivedHandler
         (Address address)
     {
         assert(0, "Not supported");


### PR DESCRIPTION
When missing signatures are added during catchup then the updated headers are sent to the configured addresses.