### PR TITLE
Change `NodeID` as a `Hash` of `UTXO`

### DIFF
--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -956,7 +956,7 @@ public SCPQuorumSet toSCPQuorumSet (in QuorumConfig quorum_conf) @safe nothrow
 
     foreach (ref const node; quorum_conf.nodes)
     {
-        auto pub_key = NodeID(node.data[][0 .. NodeID.sizeof]);
+        auto pub_key = NodeID(node[][0 .. NodeID.sizeof]);
         quorum.validators.push_back(pub_key);
     }
 
@@ -985,12 +985,12 @@ public QuorumConfig toQuorumConfig (const ref SCPQuorumSet scp_quorum)
     @safe nothrow
 {
     import std.conv;
-    import scpd.types.Stellar_types : Hash, NodeID;
+    import scpd.types.Stellar_types : NodeID;
 
-    PublicKey[] nodes;
+    Hash[] nodes;
 
     foreach (node; scp_quorum.validators.constIterator)
-        nodes ~= PublicKey(node[]);
+        nodes ~= node;
 
     QuorumConfig[] quorums;
     foreach (ref sub_quorum; scp_quorum.innerSets.constIterator)
@@ -1009,16 +1009,18 @@ public QuorumConfig toQuorumConfig (const ref SCPQuorumSet scp_quorum)
 ///
 unittest
 {
+    import agora.crypto.Hash;
+
     auto quorum = QuorumConfig(2,
-        [PublicKey.fromString("boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecsszs3fs7r"),
-         PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2")],
+        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
+         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")],
         [QuorumConfig(2,
-            [PublicKey.fromString("boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecsszs3fs7r"),
-             PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2")],
+            [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
+             Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")],
             [QuorumConfig(2,
-                [PublicKey.fromString("boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecsszs3fs7r"),
-                 PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2"),
-                 PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2")])])]);
+                [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
+                 Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd"),
+                 Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")])])]);
 
     auto scp_quorum = toSCPQuorumSet(quorum);
     assert(scp_quorum.toQuorumConfig() == quorum);

--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -37,7 +37,7 @@ public struct QuorumConfig
     public uint threshold = 1;
 
     /// List of nodes in this quorum
-    public PublicKey[] nodes;
+    public Hash[] nodes;
 
     /// List of any sub-quorums
     public QuorumConfig[] quorums;

--- a/source/agora/consensus/Quorum.d
+++ b/source/agora/consensus/Quorum.d
@@ -74,9 +74,8 @@ public struct QuorumParams
 
 *******************************************************************************/
 
-public QuorumConfig buildQuorumConfig (in PublicKey key,
-    in Hash[] utxo_keys, scope UTXOFinder finder, in Hash rand_seed,
-    const ref QuorumParams params)
+public QuorumConfig buildQuorumConfig (in Hash key, in Hash[] utxo_keys,
+    scope UTXOFinder finder, in Hash rand_seed, const ref QuorumParams params)
     @safe nothrow
 {
     // special-case: only 1 validator is active
@@ -109,7 +108,7 @@ public QuorumConfig buildQuorumConfig (in PublicKey key,
         if (added[idx])  // skip duplicate
             continue;
 
-        quorum.nodes ~= stakes[idx].key;
+        quorum.nodes ~= stakes[idx].utxo_key;
         added[idx] = true;  // mark used
     }
 
@@ -123,80 +122,88 @@ public QuorumConfig buildQuorumConfig (in PublicKey key,
 unittest
 {
     auto keys = getKeys(1);
+    PublicKey[Hash] utxo_to_key;
     auto quorums = buildTestQuorums(Amount.MinFreezeAmount.only, keys,
-        hashFull(1), QuorumParams.init, 0);
+        hashFull(1), QuorumParams.init, 0, utxo_to_key);
     verifyQuorumsSanity(quorums);
     verifyQuorumsIntersect(quorums);
-    assert(countNodeInclusions(quorums, keys) == [1]);
+    assert(countNodeInclusions(quorums, keys, utxo_to_key) == [1]);
 }
 
 // 2 nodes
 unittest
 {
     auto keys = getKeys(2);
+    PublicKey[Hash] utxo_to_key;
     auto quorums = buildTestQuorums(Amount.MinFreezeAmount.repeat(2), keys,
-        hashFull(1), QuorumParams.init, 1);
+        hashFull(1), QuorumParams.init, 1, utxo_to_key);
     verifyQuorumsSanity(quorums);
     verifyQuorumsIntersect(quorums);
-    assert(countNodeInclusions(quorums, keys) == [2, 2]);
+    assert(countNodeInclusions(quorums, keys, utxo_to_key) == [2, 2]);
 }
 
 // 3 nodes with equal stakes
 unittest
 {
     auto keys = getKeys(3);
+    PublicKey[Hash] utxo_to_key;
     auto quorums = buildTestQuorums(Amount.MinFreezeAmount.repeat(3), keys,
-        hashFull(1), QuorumParams.init, 2);
+        hashFull(1), QuorumParams.init, 2, utxo_to_key);
     verifyQuorumsSanity(quorums);
     verifyQuorumsIntersect(quorums);
-    assert(countNodeInclusions(quorums, keys) == [3, 3, 3]);
+    assert(countNodeInclusions(quorums, keys, utxo_to_key) == [3, 3, 3]);
 }
 
 // 4 nodes with equal stakes
 unittest
 {
     auto keys = getKeys(4);
+    PublicKey[Hash] utxo_to_key;
     auto quorums = buildTestQuorums(Amount.MinFreezeAmount.repeat(4), keys,
-        hashFull(1), QuorumParams.init, 3);
+        hashFull(1), QuorumParams.init, 3, utxo_to_key);
     verifyQuorumsSanity(quorums);
     verifyQuorumsIntersect(quorums);
-    assert(countNodeInclusions(quorums, keys) == [4, 4, 4, 4]);
+    assert(countNodeInclusions(quorums, keys, utxo_to_key) == [4, 4, 4, 4]);
 }
 
 // 8 nodes with equal stakes
 unittest
 {
     auto keys = getKeys(8);
+    PublicKey[Hash] utxo_to_key;
     auto quorums_1 = buildTestQuorums(Amount.MinFreezeAmount.repeat(8), keys,
-        hashFull(1), QuorumParams.init, 4);
+        hashFull(1), QuorumParams.init, 4, utxo_to_key);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
-    assert(countNodeInclusions(quorums_1, keys) == [6, 5, 8, 8, 7, 8, 8, 6]);
+    assert(countNodeInclusions(quorums_1, keys, utxo_to_key) == [7, 6, 8, 8, 7, 8, 7, 5]);
 
+    PublicKey[Hash] utxo_to_key_2;
     auto quorums_2 = buildTestQuorums(Amount.MinFreezeAmount.repeat(8), keys,
-        hashFull(2), QuorumParams.init, 5);
+        hashFull(2), QuorumParams.init, 5, utxo_to_key_2);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
-    assert(countNodeInclusions(quorums_2, keys) == [7, 8, 7, 7, 8, 7, 7, 5]);
+    assert(countNodeInclusions(quorums_2, keys, utxo_to_key_2) == [8, 7, 8, 5, 6, 8, 7, 7]);
 }
 
 // 16 nodes with equal stakes
 unittest
 {
     auto keys = getKeys(16);
+    PublicKey[Hash] utxo_to_key;
     auto quorums_1 = buildTestQuorums(Amount.MinFreezeAmount.repeat(16), keys,
-        hashFull(1), QuorumParams.init, 6);
+        hashFull(1), QuorumParams.init, 6, utxo_to_key);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
-    assert(countNodeInclusions(quorums_1, keys) ==
-        [5, 8, 5, 9, 8, 7, 5, 7, 6, 8, 9, 7, 6, 7, 11, 4]);
+    assert(countNodeInclusions(quorums_1, keys, utxo_to_key) ==
+        [6, 8, 10, 8, 6, 10, 6, 10, 7, 6, 9, 4, 6, 5, 6, 5]);
 
+    PublicKey[Hash] utxo_to_key_2;
     auto quorums_2 = buildTestQuorums(Amount.MinFreezeAmount.repeat(16), keys,
-        hashFull(2), QuorumParams.init, 7);
+        hashFull(2), QuorumParams.init, 7, utxo_to_key_2);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
-    assert(countNodeInclusions(quorums_2, keys) ==
-        [5, 5, 4, 6, 4, 8, 7, 11, 7, 9, 10, 10, 7, 6, 6, 7]);
+    assert(countNodeInclusions(quorums_2, keys, utxo_to_key_2) ==
+        [5, 9, 4, 8, 9, 8, 9, 7, 5, 5, 7, 7, 9, 8, 5, 7]);
 }
 
 // 16 nodes with linearly ascending stakes
@@ -205,19 +212,21 @@ unittest
     auto amounts = iota(16)
         .map!(idx => Amount(400000000000uL + (100000000000uL * idx)));
     auto keys = getKeys(16);
+    PublicKey[Hash] utxo_to_key;
     auto quorums_1 = buildTestQuorums(amounts, keys, hashFull(1),
-        QuorumParams.init, 8);
+        QuorumParams.init, 8, utxo_to_key);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
-    assert(countNodeInclusions(quorums_1, keys) ==
-        [4, 3, 9, 4, 6, 6, 8, 5, 3, 8, 9, 10, 8, 9, 9, 11]);
+    assert(countNodeInclusions(quorums_1, keys, utxo_to_key) ==
+        [2, 1, 6, 7, 5, 4, 9, 6, 7, 7, 10, 13, 8, 11, 7, 9]);
 
+    PublicKey[Hash] utxo_to_key_2;
     auto quorums_2 = buildTestQuorums(amounts, keys, hashFull(2),
-        QuorumParams.init, 9);
+        QuorumParams.init, 9, utxo_to_key_2);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
-    assert(countNodeInclusions(quorums_2, keys) ==
-        [4, 2, 7, 8, 8, 5, 5, 5, 9, 7, 9, 8, 8, 8, 10, 9]);
+    assert(countNodeInclusions(quorums_2, keys, utxo_to_key_2) ==
+        [3, 3, 4, 4, 3, 6, 11, 3, 8, 8, 9, 8, 9, 10, 11, 12]);
 }
 
 // 16 nodes where two nodes own 66% of the stake
@@ -226,19 +235,21 @@ unittest
     auto keys = getKeys(16);
     auto amounts = Amount(400000000000uL).repeat(16).array;
     amounts[0] = amounts[$ - 1] = Amount(400000000000uL * 14);
+    PublicKey[Hash] utxo_to_key;
     auto quorums_1 = buildTestQuorums(amounts, keys, hashFull(1),
-        QuorumParams.init, 10);
+        QuorumParams.init, 10, utxo_to_key);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
-    assert(countNodeInclusions(quorums_1, keys) ==
-        [16, 4, 6, 5, 9, 6, 7, 6, 5, 5, 6, 6, 6, 5, 5, 15]);
+    assert(countNodeInclusions(quorums_1, keys, utxo_to_key) ==
+        [16, 5, 7, 9, 4, 8, 7, 5, 5, 7, 6, 6, 4, 4, 4, 15]);
 
+    PublicKey[Hash] utxo_to_key_2;
     auto quorums_2 = buildTestQuorums(amounts, keys, hashFull(2),
-        QuorumParams.init, 11);
+        QuorumParams.init, 11, utxo_to_key_2);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
-    assert(countNodeInclusions(quorums_2, keys) ==
-        [16, 8, 3, 4, 6, 2, 9, 5, 4, 7, 5, 7, 9, 9, 2, 16]);
+    assert(countNodeInclusions(quorums_2, keys, utxo_to_key_2) ==
+        [16, 6, 4, 7, 6, 7, 4, 4, 6, 10, 6, 6, 7, 5, 3, 15]);
 }
 
 // 32 nodes where two nodes own 66% of the stake
@@ -247,25 +258,27 @@ unittest
     auto keys = getKeys(32);
     auto amounts = Amount(400000000000uL).repeat(32).array;
     amounts[0] = amounts[$ - 1] = Amount(400000000000uL * 30);
+    PublicKey[Hash] utxo_to_key;
     auto quorums_1 = buildTestQuorums(amounts, keys, hashFull(1),
-        QuorumParams.init, 12);
+        QuorumParams.init, 12, utxo_to_key);
     verifyQuorumsSanity(quorums_1);
     // verified to work but disabled because it runs slow with a
     // non-max threshold (~20 seconds)
     //verifyQuorumsIntersect(quorums_1);
-    assert(countNodeInclusions(quorums_1, keys) ==
-        [31, 7, 9, 5, 5, 4, 4, 7, 6, 6, 5, 7, 6, 5, 6, 4, 7, 5, 6, 6, 7, 1, 6,
-         2, 6, 5, 5, 6, 8, 4, 2, 31]);
+    assert(countNodeInclusions(quorums_1, keys, utxo_to_key) ==
+        [32, 4, 3, 5, 5, 6, 7, 5, 5, 7, 8, 6, 3, 5, 5, 3, 8, 4, 4, 5, 5, 4, 8,
+         5, 7, 8, 4, 6, 5, 5, 5, 32]);
 
+    PublicKey[Hash] utxo_to_key_2;
     auto quorums_2 = buildTestQuorums(amounts, keys, hashFull(2),
-        QuorumParams.init, 13);
+        QuorumParams.init, 13, utxo_to_key_2);
     verifyQuorumsSanity(quorums_2);
     // verified to work but disabled because it runs slow with a
     // non-max threshold (~20 seconds)
     //verifyQuorumsIntersect(quorums_2);
-    assert(countNodeInclusions(quorums_2, keys) ==
-        [31, 7, 4, 9, 6, 5, 8, 3, 4, 6, 6, 8, 3, 3, 7, 7, 8, 4, 4, 7, 5, 5, 6,
-         6, 2, 6, 5, 2, 6, 6, 3, 32]);
+    assert(countNodeInclusions(quorums_2, keys, utxo_to_key_2) ==
+        [32, 3, 4, 4, 6, 4, 2, 5, 6, 6, 6, 3, 6, 5, 6, 5, 9, 4, 9, 9, 10, 4, 5,
+         10, 6, 3, 9, 4, 2, 3, 2, 32]);
 }
 
 // 64 nodes where two nodes own 66% of the stake
@@ -274,27 +287,29 @@ unittest
     auto keys = getKeys(64);
     auto amounts = Amount(400000000000uL).repeat(64).array;
     amounts[0] = amounts[$ - 1] = Amount(400000000000uL * 62);
+    PublicKey[Hash] utxo_to_key;
     auto quorums_1 = buildTestQuorums(amounts, keys, hashFull(1),
-        QuorumParams.init, 14);
+        QuorumParams.init, 14, utxo_to_key);
     verifyQuorumsSanity(quorums_1);
     // verified to work but disabled because it runs slow with a
     // non-max threshold (~20 minutes)
     //verifyQuorumsIntersect(quorums_1);
-    assert(countNodeInclusions(quorums_1, keys) ==
-        [62, 5, 2, 5, 5, 3, 6, 7, 4, 7, 5, 5, 8, 2, 2, 5, 7, 7, 4, 4, 5, 5,
-         3, 10, 3, 8, 2, 6, 6, 7, 4, 4, 4, 7, 8, 6, 7, 4, 5, 6, 4, 7, 7, 9,
-         6, 7, 5, 5, 6, 2, 7, 4, 6, 6, 3, 6, 6, 4, 5, 5, 5, 3, 3, 62]);
+    assert(countNodeInclusions(quorums_1, keys, utxo_to_key) ==
+        [63, 6, 6, 4, 5, 5, 6, 2, 7, 2, 9, 4, 3, 3, 12, 4, 2, 3, 5, 6, 5, 4, 3,
+         7, 4, 3, 7, 3, 3, 3, 4, 7, 6, 5, 6, 7, 7, 6, 10, 4, 2, 5, 7, 5, 4, 6,
+         6, 9, 5, 5, 5, 7, 5, 8, 7, 6, 5, 4, 3, 4, 5, 7, 4, 63]);
 
+    PublicKey[Hash] utxo_to_key_2;
     auto quorums_2 = buildTestQuorums(amounts, keys, hashFull(2),
-        QuorumParams.init, 15);
+        QuorumParams.init, 15, utxo_to_key_2);
     verifyQuorumsSanity(quorums_2);
     // verified to work but disabled because it runs slow with a
     // non-max threshold (~20 minutes)
     //verifyQuorumsIntersect(quorums_2);
-    assert(countNodeInclusions(quorums_2, keys) ==
-        [64, 7, 4, 3, 1, 4, 1, 7, 5, 3, 4, 7, 5, 5, 10, 3, 6, 4, 5, 6, 2, 5, 4,
-         7, 5, 5, 8, 6, 6, 3, 7, 10, 4, 8, 7, 6, 4, 3, 4, 4, 6, 6, 3, 6, 7, 4,
-         8, 3, 7, 7, 2, 10, 5, 7, 6, 4, 4, 4, 3, 8, 6, 3, 6, 61]);
+    assert(countNodeInclusions(quorums_2, keys, utxo_to_key_2) ==
+        [62, 8, 4, 7, 8, 4, 5, 6, 5, 2, 3, 6, 4, 6, 3, 8, 3, 8, 5, 5, 7, 3, 5, 2,
+         3, 1, 3, 7, 5, 6, 7, 3, 5, 7, 6, 8, 2, 8, 8, 7, 3, 5, 7, 3, 4, 9, 2, 3,
+         8, 2, 8, 5, 8, 5, 6, 9, 6, 2, 2, 4, 7, 7, 6, 62]);
 }
 
 // 128 nodes where two nodes own 66% of the stake
@@ -303,31 +318,33 @@ unittest
     auto keys = getKeys(128);
     auto amounts = Amount(400000000000uL).repeat(128).array;
     amounts[0] = amounts[$ - 1] = Amount(400000000000uL * 126);
+    PublicKey[Hash] utxo_to_key;
     auto quorums_1 = buildTestQuorums(amounts, keys, hashFull(1),
-        QuorumParams.init, 16);
+        QuorumParams.init, 16, utxo_to_key);
     verifyQuorumsSanity(quorums_1);
     // not verified to work.
     //verifyQuorumsIntersect(quorums_1);
-    assert(countNodeInclusions(quorums_1, keys) ==
-        [125, 7, 7, 9, 2, 8, 6, 4, 5, 4, 4, 3, 6, 3, 3, 3, 2, 6, 3, 3, 2, 3, 2,
-         8, 4, 5, 6, 5, 7, 5, 3, 8, 4, 3, 8, 6, 3, 5, 7, 5, 4, 3, 2, 4, 3, 5, 8,
-         3, 11, 3, 6, 6, 9, 4, 7, 8, 7, 4, 8, 7, 8, 5, 3, 4, 3, 5, 8, 6, 6, 3,
-         3, 4, 3, 4, 5, 1, 6, 3, 3, 6, 6, 6, 4, 5, 7, 4, 5, 9, 5, 7, 10, 7, 5,
-         2, 7, 3, 10, 5, 8, 4, 5, 5, 5, 4, 4, 3, 8, 5, 3, 7, 2, 9, 4, 8, 7, 6,
-         8, 5, 8, 4, 5, 3, 4, 3, 5, 8, 2, 124]);
+    assert(countNodeInclusions(quorums_1, keys, utxo_to_key) ==
+        [125, 5, 4, 3, 6, 5, 4, 6, 3, 5, 3, 2, 4, 4, 4, 3, 4, 3, 5, 5, 11, 7, 9,
+         4, 4, 3, 4, 5, 4, 6, 3, 8, 3, 6, 7, 4, 9, 4, 5, 6, 5, 6, 6, 2, 4, 3,
+         8, 6, 4, 4, 5, 9, 10, 8, 4, 6, 3, 4, 6, 4, 7, 7, 6, 2, 5, 7, 5, 6, 7,
+         3, 5, 4, 7, 5, 7, 5, 2, 7, 3, 5, 5, 4, 4, 11, 4, 7, 5, 7, 10, 3, 4, 3,
+         5, 4, 8, 7, 5, 3, 4, 4, 3, 2, 2, 5, 5, 4, 7, 3, 4, 7, 6, 8, 5, 3, 4, 6,
+         6, 4, 7, 8, 6, 8, 4, 6, 4, 4, 6, 125]);
 
+    PublicKey[Hash] utxo_to_key_2;
     auto quorums_2 = buildTestQuorums(amounts, keys, hashFull(2),
-        QuorumParams.init, 17);
+        QuorumParams.init, 17, utxo_to_key_2);
     verifyQuorumsSanity(quorums_2);
     // not verified to work.
     //verifyQuorumsIntersect(quorums_2);
-    assert(countNodeInclusions(quorums_2, keys) ==
-        [122, 4, 8, 4, 10, 6, 3, 5, 5, 6, 7, 4, 6, 4, 4, 4, 3, 5, 6, 3, 4, 2,
-         8, 6, 3, 3, 3, 5, 5, 8, 6, 3, 4, 7, 6, 8, 3, 4, 4, 4, 5, 6, 3, 4, 7,
-         4, 7, 5, 2, 7, 3, 7, 5, 7, 3, 2, 5, 6, 5, 4, 7, 6, 2, 2, 4, 5, 6, 6,
-         11, 5, 3, 3, 5, 5, 6, 7, 3, 7, 3, 2, 4, 7, 6, 7, 5, 7, 2, 10, 6, 6,
-         6, 8, 6, 4, 7, 6, 5, 5, 5, 3, 3, 4, 5, 10, 4, 8, 2, 7, 3, 8, 9, 4, 3,
-         4, 10, 4, 4, 6, 5, 7, 6, 4, 5, 5, 3, 5, 6, 127]);
+    assert(countNodeInclusions(quorums_2, keys, utxo_to_key_2) ==
+        [120, 8, 3, 7, 8, 4, 7, 3, 7, 4, 3, 4, 5, 5, 2, 4, 10, 4, 4, 5, 4, 3, 7,
+         5, 5, 5, 6, 6, 2, 5, 7, 8, 7, 3, 5, 3, 8, 3, 3, 3, 4, 5, 8, 4, 6, 3,
+         7, 6, 5, 6, 4, 7, 2, 4, 5, 6, 3, 5, 3, 4, 3, 5, 3, 9, 8, 11, 7, 3, 6,
+         5, 3, 9, 5, 7, 3, 6, 3, 5, 4, 8, 5, 7, 3, 5, 4, 6, 8, 5, 3, 5, 7, 5,
+         7, 8, 1, 7, 4, 3, 7, 3, 3, 5, 4, 5, 3, 6, 5, 8, 5, 3, 7, 8, 1, 7, 9,
+         7, 7, 7, 5, 4, 6, 4, 4, 6, 3, 6, 5, 125]);
 }
 
 // using various different quorum parameter configurations
@@ -335,33 +352,36 @@ unittest
 {
     QuorumParams qp_1 = { MaxQuorumNodes : 4, QuorumThreshold : 80 };
     auto keys = getKeys(10);
+    PublicKey[Hash] utxo_to_key;
     auto quorums_1 = buildTestQuorums(Amount.MinFreezeAmount.repeat(10), keys,
-        hashFull(1), qp_1, 18);
+        hashFull(1), qp_1, 18, utxo_to_key);
     verifyQuorumsSanity(quorums_1);
     verifyQuorumsIntersect(quorums_1);
     quorums_1.byValue.each!(qc => assert(qc.nodes.length <= 4));
     quorums_1.byValue.each!(qc => assert(qc.threshold == 4));
-    assert(countNodeInclusions(quorums_1, keys) ==
-        [3, 4, 5, 5, 3, 2, 6, 4, 2, 6]);
+    assert(countNodeInclusions(quorums_1, keys, utxo_to_key) ==
+        [5, 6, 6, 3, 2, 4, 3, 4, 3, 4]);
 
     QuorumParams qp_2 = { MaxQuorumNodes : 8, QuorumThreshold : 80 };
+    PublicKey[Hash] utxo_to_key_2;
     auto quorums_2 = buildTestQuorums(Amount.MinFreezeAmount.repeat(10), keys,
-        hashFull(1), qp_2, 19);
+        hashFull(1), qp_2, 19, utxo_to_key_2);
     verifyQuorumsSanity(quorums_2);
     verifyQuorumsIntersect(quorums_2);
     quorums_2.byValue.each!(qc => assert(qc.nodes.length <= 8));
     quorums_2.byValue.each!(qc => assert(qc.threshold == 7));
-    assert(countNodeInclusions(quorums_2, keys) ==
-        [6, 9, 9, 7, 6, 9, 10, 8, 8, 8]);
+    assert(countNodeInclusions(quorums_2, keys, utxo_to_key_2) ==
+        [7, 9, 8, 9, 7, 6, 7, 9, 9, 9]);
 
     QuorumParams qp_3 = { MaxQuorumNodes : 8, QuorumThreshold : 60 };
+    PublicKey[Hash] utxo_to_key_3;
     auto quorums_3 = buildTestQuorums(Amount.MinFreezeAmount.repeat(10), keys,
-        hashFull(1), qp_3, 20);
+        hashFull(1), qp_3, 20, utxo_to_key_3);
     verifyQuorumsSanity(quorums_3);
     verifyQuorumsIntersect(quorums_3);
     quorums_3.byValue.each!(qc => assert(qc.nodes.length <= 8));
     quorums_3.byValue.each!(qc => assert(qc.threshold == 5));
-    assert(countNodeInclusions(quorums_3, keys),
+    assert(countNodeInclusions(quorums_3, keys, utxo_to_key_3),
         [9, 7, 6, 9, 8, 7, 10, 9, 5, 10]);
 }
 
@@ -406,7 +426,7 @@ unittest
     used to initialize the RNG generator.
 
     Params
-        key = the public key of a node
+        key = the UTXO key for enrollment of a node
         rand_seed = the random seed
 
     Returns:
@@ -414,7 +434,7 @@ unittest
 
 *******************************************************************************/
 
-private auto getGenerator (const ref PublicKey key, in Hash rand_seed)
+private auto getGenerator (const ref Hash key, in Hash rand_seed)
     @safe nothrow
 {
     Mt19937_64 gen;
@@ -423,11 +443,14 @@ private auto getGenerator (const ref PublicKey key, in Hash rand_seed)
     return gen;
 }
 
-/// The pair of (key, stake) for each node
+/// The pair of (key, utxo_key, stake) for each node
 private struct NodeStake
 {
     /// the node key
     private PublicKey key;
+
+    /// the UTXO key for enrollment
+    private Hash utxo_key;
 
     /// the node stake
     private Amount amount;
@@ -438,7 +461,7 @@ private struct NodeStake
     Build a list of NodeStake's in descending stake order
 
     Params
-        filter = the node's own key should be filtered here
+        filter = the UTXO of the node's enrollment should be filtered here
         utxo_keys = the list of enrollments' UTXO keys
         finder = delegate to find the public key & stake of each UTXO key
 
@@ -447,7 +470,7 @@ private struct NodeStake
 
 *******************************************************************************/
 
-private NodeStake[] buildStakesDescending (const ref PublicKey filter,
+private NodeStake[] buildStakesDescending (const ref Hash filter,
     in Hash[] utxo_keys, scope UTXOFinder finder) @safe nothrow
 {
     static NodeStake[] stakes;
@@ -459,8 +482,8 @@ private NodeStake[] buildStakesDescending (const ref PublicKey filter,
         UTXO value;
         assert(finder(utxo_key, value), "UTXO for validator not found!");
 
-        if (value.output.address != filter)
-            stakes ~= NodeStake(value.output.address, value.output.value);
+        if (utxo_key != filter)
+            stakes ~= NodeStake(value.output.address, utxo_key, value.output.value);
     }
 
     stakes.sort!((a, b) => a.amount > b.amount);
@@ -479,13 +502,14 @@ private NodeStake[] buildStakesDescending (const ref PublicKey filter,
 *******************************************************************************/
 
 version (unittest)
-private QuorumConfig[PublicKey] buildTestQuorums (Range)(Range amounts,
+private QuorumConfig[Hash] buildTestQuorums (Range)(Range amounts,
     const(PublicKey)[] keys, const auto ref Hash rand_seed,
-    const auto ref QuorumParams params, int id)
+    const auto ref QuorumParams params, int id, out PublicKey[Hash] utxo_to_key)
 {
     assert(amounts.length == keys.length);
-    QuorumConfig[PublicKey] quorums;
+    QuorumConfig[Hash] quorums;
     TestUTXOSet storage = new TestUTXOSet;
+    Hash[PublicKey] key_to_utxo;
     foreach (idx, const ref amount; amounts.save.enumerate)
     {
         Transaction tx = Transaction([ Output(amount, keys[idx], OutputType.Freeze) ]);
@@ -494,19 +518,21 @@ private QuorumConfig[PublicKey] buildTestQuorums (Range)(Range amounts,
         Hash txhash = hashMulti(id, idx, amount);
         foreach (size_t out_idx, ref output_; tx.outputs)
         {
-            Hash h = UTXO.getHash(txhash, out_idx);
             UTXO v = {
                 output: output_
             };
             storage[txhash] = v;
+            key_to_utxo[keys[idx]] = txhash;
+            utxo_to_key[txhash] = keys[idx];
         }
     }
+
 
     Hash[] utxos = storage.keys;
     foreach (idx, _; amounts.enumerate)
     {
-        quorums[keys[idx]] = buildQuorumConfig(
-            keys[idx], utxos, &storage.peekUTXO, rand_seed, params);
+        quorums[key_to_utxo[keys[idx]]] = buildQuorumConfig(
+            key_to_utxo[keys[idx]], utxos, &storage.peekUTXO, rand_seed, params);
     }
 
     return quorums;
@@ -530,12 +556,13 @@ private QuorumConfig[PublicKey] buildTestQuorums (Range)(Range amounts,
 *******************************************************************************/
 
 version (unittest)
-private size_t[] countNodeInclusions (QuorumConfig[PublicKey] quorums,
-    in PublicKey[] keys)
+private size_t[] countNodeInclusions (QuorumConfig[Hash] quorums,
+    in PublicKey[] keys, ref PublicKey[Hash] utxo_to_key)
 {
     size_t[const(PublicKey)] counts;
+
     foreach (_, const ref qc; quorums)
-        qc.nodes.each!(node => counts[node]++);
+        qc.nodes.each!(node => counts[utxo_to_key[node]]++);
 
     size_t[] results;
     foreach (key; keys)
@@ -563,7 +590,7 @@ private size_t[] countNodeInclusions (QuorumConfig[PublicKey] quorums,
 *******************************************************************************/
 
 version (unittest)
-private void verifyQuorumsSanity (in QuorumConfig[PublicKey] quorums)
+private void verifyQuorumsSanity (in QuorumConfig[Hash] quorums)
 {
     import scpd.scp.QuorumSetUtils;
 
@@ -595,12 +622,12 @@ private void verifyQuorumsSanity (in QuorumConfig[PublicKey] quorums)
 
 version (unittest):
 version (Windows)
-private void verifyQuorumsIntersect (QuorumConfig[PublicKey] quorums)
+private void verifyQuorumsIntersect (QuorumConfig[Hash] quorums)
 {
     // @bug@: Need to fix linking issues with QuorumIntersectionChecker.create()
 }
 else
-private void verifyQuorumsIntersect (QuorumConfig[PublicKey] quorums)
+private void verifyQuorumsIntersect (QuorumConfig[Hash] quorums)
 {
     import scpd.quorum.QuorumIntersectionChecker;
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -181,14 +181,11 @@ extern(D):
         this.network = network;
         this.empty_value = ConsensusData.init.serializeFull().toVec();
         this.kp = key_pair;
-        auto node_id = NodeID(key_pair.address.data[][0 .. NodeID.sizeof]);
-        const IsValidator = true;
-        const no_quorum = SCPQuorumSet.init;  // will be configured by setQuorumConfig()
-        this.scp = createSCP(this, node_id, IsValidator, no_quorum);
         this.taskman = taskman;
         this.ledger = ledger;
         this.enroll_man = enroll_man;
         this.scp_envelope_store = new SCPEnvelopeStore(cacheDB);
+        this.createSCPObject();
         this.restoreSCPState();
         this.nomination_interval = nomination_interval;
         this.acceptBlock = externalize;
@@ -210,6 +207,40 @@ extern(D):
             auto env = this.queued_envelopes.front;
             this.queued_envelopes.removeFront();
             this.handleSCPEnvelope(env);
+        }
+    }
+
+    /***************************************************************************
+
+        Create Stellar SCP object
+
+        A validator creates SCP object with the UTXO for enrollment. This
+        checks that the UTXO key for enrollment exists and new SCP should be
+        created because of new enrollment of this node.
+
+    ***************************************************************************/
+
+    public void createSCPObject () nothrow @safe
+    {
+        try
+        {
+            // TODO: We should apply the situation where this validator has
+            // enrolled with another UTXO after its previous enrollment expired.
+            auto self_enroll = this.enroll_man.getEnrollmentKey();
+            if (this.scp == null && self_enroll != Hash.init)
+            {
+                auto node_id = NodeID(this.kp.address.data[][0 .. NodeID.sizeof]);
+                const IsValidator = true;
+                const no_quorum = SCPQuorumSet.init;  // will be configured by setQuorumConfig()
+                () @trusted {
+                    this.scp = createSCP(this, node_id, IsValidator, no_quorum);
+                }();
+            }
+        }
+        catch (Exception e)
+        {
+            log.fatal("createSCPObject: Exception thrown: {}", e);
+            assert(0);
         }
     }
 
@@ -306,7 +337,10 @@ extern(D):
     public void stopNominationRound (Height height) @safe nothrow
     {
         this.is_nominating = false;
-        () @trusted { this.scp.stopNomination(height); }();
+        () @trusted {
+            if (this.scp != null)
+                this.scp.stopNomination(height);
+        }();
 
         foreach (timer; this.active_timers)
         {

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -1466,6 +1466,24 @@ public class ValidatingLedger : Ledger
         return this.fee_man.getAdjustedTXFee(tx, &this.utxo_set.peekUTXO, tot_fee);
     }
 
+    /***************************************************************************
+
+        Get an UTXO, no double-spend protection.
+
+        Params:
+            hash = the hash of the UTXO (`hashMulti(tx_hash, index)`)
+            value = the UTXO
+
+        Returns:
+            true if the UTXO was found
+
+    ***************************************************************************/
+
+    public bool peekUTXO (in Hash utxo, out UTXO value) nothrow @safe
+    {
+        return this.utxo_set.peekUTXO(utxo, value);
+    }
+
     version (unittest):
 
     private bool externalize (ConsensusData data,

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -196,12 +196,12 @@ public class Validator : FullNode, API
             // In the fast path, this is called immediately after a block has been
             // externalized, so we can simply use the Ledger. Otherwise we need
             // to run from storage.
+            auto self_enroll = this.enroll_man.getEnrollmentKey();
             const rand_seed = this.ledger.getBlockHeight() == height ?
                 this.ledger.getLastBlock().header.random_seed :
                 this.ledger.getBlocksFrom(height).front.header.random_seed;
-            qc = buildQuorumConfig(this.config.validator.key_pair.address,
-                utxos, this.utxo_set.getUTXOFinder(), rand_seed,
-                this.quorum_params);
+            qc = buildQuorumConfig(self_enroll, utxos, this.utxo_set.getUTXOFinder(),
+                rand_seed, this.quorum_params);
 
             other_qcs.length = 0;
             () @trusted { assumeSafeAppend(other_qcs); }();
@@ -209,9 +209,7 @@ public class Validator : FullNode, API
             foreach (utxo; utxos.filter!(
                 utxo => utxo != filter_utxo))  // skip our own
             {
-                UTXO utxo_value;
-                assert(this.utxo_set.peekUTXO(utxo, utxo_value));
-                other_qcs ~= buildQuorumConfig(utxo_value.output.address, utxos,
+                other_qcs ~= buildQuorumConfig(utxo, utxos,
                     this.utxo_set.getUTXOFinder(), rand_seed, this.quorum_params);
             }
         }

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -156,6 +156,9 @@ public class Validator : FullNode, API
             assert(0);
         }
 
+        // We create new SCP object if the enrollment key is changed.
+        this.nominator.createSCPObject();
+
         static QuorumConfig[] other_qcs;
         this.rebuildQuorumConfig(this.qc, other_qcs, this_utxo, utxo_keys, height);
         this.nominator.setQuorumConfig(this.qc, other_qcs);

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1804,9 +1804,13 @@ public class TestValidatorNode : Validator, TestAPI
             this.ledger.getLastBlock().header.random_seed :
             this.ledger.getBlocksFrom(height).front.header.random_seed;
         QuorumConfig[] quorums;
-        foreach (pub_key; pub_keys)
-            quorums ~= buildQuorumConfig(pub_key, utxos,
+        foreach (utxo; utxos)
+        {
+            UTXO utxo_value;
+            this.utxo_set.peekUTXO(utxo, utxo_value);
+            quorums ~= buildQuorumConfig(utxo, utxos,
                 this.utxo_set.getUTXOFinder(), rand_seed, this.quorum_params);
+        }
         return quorums;
     }
 }

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -36,6 +36,15 @@ import std.range;
 import core.thread;
 import core.time;
 
+immutable A = Hash("0x210f6551d648a4da654da116b100e941e434e4f232b8579439c2ef64b04819bd2782eb3524c7a29c38c347cdf26006bccac54a58a58f103ae7eb5b252eb53b64");
+immutable B = Hash("0x3b44d65edb3361dd91441ab4f449eeda55644026624c4b8ae12ecf0264fa8a228dbf672ef97e2c4f87fb98ad7099e17b7f9ba7dbe8479672066912b1ea24ba77");
+immutable C = Hash("0x7bacc99e9bf827f0fa6dc6a77303d2e6ba6f1591277b896a9305a9e200853986fe9527fd551077a4ac2b511633ada4190a7b82cddaf606171336e1efba87ea8f");
+immutable D = Hash("0x9b2726e79f05abc107b6531486a46c977414e13ed9f3ee994ec14504964f86fcf9464055b891b9c34020feb72535c300ff19e8b5167eb9d202db1a053d746b2c");
+immutable E = Hash("0xab19131ad8974a20881e2cd0798684a06ca0054160735cdf67fe8ee5a0eb4e28e9bf3f4c735f9ed3da958778978c86b409b8d133f30992141f0ac7e01e7f1255");
+immutable F = Hash("0xdb7664caba94c8d4602c10992c13176307e1e05361c150217166ee77fc4af9bf176f31dc61aba61e634dfc0b4c5f729d59e604607f61c9f66b10c6841f972a0a");
+immutable G = Hash("0x63528cf40508daceee7cbf9692d83f6e0822c3062c11126122afeb9f75429ba7fa3aeb97240c6d2d9f72398aa7cbeba3addec9b1d78789f72d37a7edd805d890");
+immutable H = Hash("0xe26c5c215dd2f3c7db89dfc7879afb0cb8711e3c8dede9143b44f9b3406c168f0e41d3954ea110ef32e2c090c9ca49482da53ac85cd8a366b2db7d1b0b59215c");
+
 /// test preimage changing quorum configs
 unittest
 {
@@ -67,60 +76,32 @@ unittest
         }
     }
 
+    string[Hash] node_to_name = [
+        A : "A", B : "B", C : "C", D : "D", E : "E", F : "F", G : "G", H : "H"];
+
+    string printConvQuorum(in QuorumConfig qc)
+    {
+        return format("%-(%s, %)", qc.nodes.map!(n => node_to_name[n]));
+    }
+
     enum quorums_1 = [
         // 0
-        QuorumConfig(5, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.NODE4.address]),
+        QuorumConfig(5, [A, B, C, D, E, F]),
 
         // 1
-        QuorumConfig(5, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.NODE4.address]),
+        QuorumConfig(5, [A, B, C, D, E, F]),
 
         // 2
-        QuorumConfig(5, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.NODE4.address]),
+        QuorumConfig(5, [A, B, C, D, E, F]),
 
         // 3
-        QuorumConfig(5, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.NODE4.address]),
+        QuorumConfig(5, [A, B, C, D, E, F]),
 
         // 4
-        QuorumConfig(5, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.NODE4.address]),
+        QuorumConfig(5, [A, B, C, D, E, F]),
 
         // 5
-        QuorumConfig(5, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.NODE4.address]),
+        QuorumConfig(5, [A, B, C, D, E, F]),
 
         QuorumConfig.init,
         QuorumConfig.init,
@@ -130,8 +111,9 @@ unittest
         scope (failure) printQuorums();
         nodes.enumerate.each!((idx, node) =>
             retryFor(node.getQuorumConfig() == quorums_1[idx], 5.seconds,
-                format("Node %s has quorum config %s. Expected quorums_1: %s",
-                    idx, node.getQuorumConfig().prettify, quorums_1[idx].prettify)));
+                format("Node %s has quorum config [%s]. Expected quorums_1: [%s]",
+                    idx, printConvQuorum(node.getQuorumConfig()),
+                    printConvQuorum(quorums_1[idx]))));
     }
 
     const keys = network.nodes.map!(node => node.getPublicKey().key)
@@ -163,92 +145,28 @@ unittest
 
     enum quorums_2 = [
         // 0
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
+        QuorumConfig(6, [A, B, G, C, E, F, H]),
 
         // 1
-        QuorumConfig(6, [
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
+        QuorumConfig(6, [A, B, G, C, E, F, H]),
 
         // 2
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
+        QuorumConfig(6, [A, B, G, C, D, E, H]),
 
         // 3
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
+        QuorumConfig(6, [A, G, C, D, E, F, H]),
 
         // 4
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-        ]),
+        QuorumConfig(6, [A, B, G, C, E, F, H]),
 
         // 5
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
+        QuorumConfig(6, [A, G, C, D, E, F, H]),
 
         // 6
-        QuorumConfig(6, [
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
+        QuorumConfig(6, [A, B, G, C, D, F, H]),
 
         // 7
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-        ]),
+        QuorumConfig(6, [B, G, C, D, E, F, H]),
     ];
 
     static assert(quorums_1 != quorums_2);
@@ -258,7 +176,8 @@ unittest
         nodes.enumerate.each!((idx, node) =>
             retryFor(node.getQuorumConfig() == quorums_2[idx], 5.seconds,
                 format("Node %s has quorum config %s. Expected quorums_2: %s",
-                    idx, node.getQuorumConfig(), quorums_2[idx])));
+                    idx, printConvQuorum(node.getQuorumConfig()),
+                    printConvQuorum(quorums_2[idx]))));
     }
 
     // create 19 more blocks with all validators (1 short of end of 2nd cycle)
@@ -276,92 +195,28 @@ unittest
     // which use a different preimage
     enum quorums_3 = [
         // 0
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
+        QuorumConfig(6, [A, G, C, D, E, F, H]),
 
         // 1
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
+        QuorumConfig(6, [A, B, G, C, D, E, H]),
 
         // 2
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-        ]),
+        QuorumConfig(6, [A, G, C, D, E, F, H]),
 
         // 3
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
+        QuorumConfig(6, [B, G, C, D, E, F, H]),
 
         // 4
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
+        QuorumConfig(6, [A, B, G, C, E, F, H]),
 
         // 5
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.NODE2.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
+        QuorumConfig(6, [A, B, G, C, E, F, H]),
 
         // 6
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
+        QuorumConfig(6, [A, B, G, C, E, F, H]),
 
         // 7
-        QuorumConfig(6, [
-            WK.Keys.NODE7.address,
-            WK.Keys.NODE5.address,
-            WK.Keys.NODE6.address,
-            WK.Keys.C.address,
-            WK.Keys.NODE3.address,
-            WK.Keys.A.address,
-            WK.Keys.NODE4.address,
-        ]),
+        QuorumConfig(6, [A, B, G, C, D, E, H]),
     ];
 
     static assert(quorums_2 != quorums_3);
@@ -371,6 +226,7 @@ unittest
         nodes.enumerate.each!((idx, node) =>
             retryFor(node.getQuorumConfig() == quorums_3[idx], 5.seconds,
                 format("Node %s has quorum config %s. Expected quorums_3: %s",
-                    idx, node.getQuorumConfig(), quorums_3[idx])));
+                    idx, printConvQuorum(node.getQuorumConfig()),
+                    printConvQuorum(quorums_3[idx]))));
     }
 }

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -696,7 +696,7 @@ private struct QuorumConfigFmt
         {
             formattedWrite(sink, "{ thresh: %s, nodes: %s, subqs: %s }",
                 this.data.threshold,
-                this.data.nodes.map!(node => PubKeyFmt(node)),
+                this.data.nodes.map!(node => HashFmt(node)),
                 this.data.quorums.map!(subq => QuorumConfigFmt(subq)));
         }
         catch (Exception ex)
@@ -710,17 +710,17 @@ private struct QuorumConfigFmt
 unittest
 {
     auto quorum = immutable(QuorumConfig)(2,
-        [PublicKey.fromString("boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecsszs3fs7r"),
-         PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2")],
+        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
+         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")],
         [immutable(QuorumConfig)(3,
-            [PublicKey.fromString("boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecsszs3fs7r"),
-             PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2")],
+            [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
+             Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")],
             [immutable(QuorumConfig)(4,
-                [PublicKey.fromString("boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecsszs3fs7r"),
-                 PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2"),
-                 PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2")])])]);
+                [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
+                 Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd"),
+                 Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")])])]);
 
-    static immutable Res1 = `{ thresh: 2, nodes: [boa1xp9rtxss...fs7r, boa1xpc2ugml...p0w2], subqs: [{ thresh: 3, nodes: [boa1xp9rtxss...fs7r, boa1xpc2ugml...p0w2], subqs: [{ thresh: 4, nodes: [boa1xp9rtxss...fs7r, boa1xpc2ugml...p0w2, boa1xpc2ugml...p0w2], subqs: [] }] }] }`;
+    static immutable Res1 = `{ thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [{ thresh: 3, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [{ thresh: 4, nodes: [0x11c6...ebf5, 0xdfca...e5fd, 0xdfca...e5fd], subqs: [] }] }] }`;
 
     assert(Res1 == format("%s", prettify(quorum)),
                    format("%s", prettify(quorum)));

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -314,7 +314,7 @@ private struct SCPStatementFmt
         {
             formattedWrite(sink,
                 "{ node: %s, slotIndex: %s, pledge: %s }",
-                prettify(PublicKey(this.statement.nodeID[])),
+                prettify(Hash(this.statement.nodeID[])),
                 cast(ulong)this.statement.slotIndex,  // cast: consistent cross-platform output
                 PledgesFmt(this.statement.pledges, getQSet));
         }
@@ -448,10 +448,11 @@ unittest
     ballot.value = cd.serializeFull[].toVec();
 
     auto pair = WK.Keys.NODE2;
+    auto pair_utxo_key = Hash("0x321efeea33f06eceefcc2ff8a646eac3e7d0d3de52820485b7004105dec3211f3631981a9c436afcd2dfdb264c5546c04855825080b2f6173b67f74c8df321a3");
 
     auto qc = QuorumConfig(2,
-        [PublicKey.fromString("boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecsszs3fs7r"),
-         PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2")]);
+        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
+         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")]);
 
     auto scp_quorum = toSCPQuorumSet(qc);
     auto qset = makeSharedSCPQuorumSet(scp_quorum);
@@ -467,7 +468,7 @@ unittest
     }
 
     SCPEnvelope env;
-    env.statement.nodeID = NodeID(pair.address[][0 .. NodeID.sizeof]);
+    env.statement.nodeID = NodeID(pair_utxo_key[][0 .. NodeID.sizeof]);
 
     /** SCP PREPARE */
     env.statement.pledges.type_ = SCPStatementType.SCP_ST_PREPARE;
@@ -481,23 +482,23 @@ unittest
     env.signature = typeof(env.signature).init;
 
     // missing signature
-    static immutable MissingSig = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Prepare { qset: { hash: 0xc048...6205, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...0000 }`;
+    static immutable MissingSig = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Prepare { qset: { hash: 0x2b20...4596, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...0000 }`;
 
     testAssert(MissingSig, scpPrettify(&env));
 
     env.signature = sig.toBlob();
 
     // null quorum (hash not found)
-    static immutable PrepareRes1 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Prepare { qset: { hash: 0xc048...6205, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable PrepareRes1 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Prepare { qset: { hash: 0x2b20...4596, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // with quorum mapping
-    static immutable PrepareRes2 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Prepare { qset: { hash: 0xc048...6205, quorum: { thresh: 2, nodes: [boa1xp9rtxss...fs7r, boa1xpc2ugml...p0w2], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable PrepareRes2 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Prepare { qset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // 'prep' pointer is set
-    static immutable PrepareRes3 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Prepare { qset: { hash: 0xc048...6205, quorum: { thresh: 2, nodes: [boa1xp9rtxss...fs7r, boa1xpc2ugml...p0w2], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable PrepareRes3 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Prepare { qset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // 'preparedPrime' pointer is set
-    static immutable PrepareRes4 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Prepare { qset: { hash: 0xc048...6205, quorum: { thresh: 2, nodes: [boa1xp9rtxss...fs7r, boa1xpc2ugml...p0w2], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prepPrime: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable PrepareRes4 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Prepare { qset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prepPrime: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     testAssert(PrepareRes1, scpPrettify(&env));
     testAssert(PrepareRes1, scpPrettify(&env, null));
@@ -524,13 +525,13 @@ unittest
     env.statement.pledges.confirm_.nH = 200;
 
     // confirm without a known hash
-    static immutable ConfirmRes1 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Confirm { qset: { hash: 0x0000...0000, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable ConfirmRes1 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Confirm { qset: { hash: 0x0000...0000, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // confirm with a known hash
-    static immutable ConfirmRes2 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Confirm { qset: { hash: 0xc048...6205, quorum: { thresh: 2, nodes: [boa1xp9rtxss...fs7r, boa1xpc2ugml...p0w2], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable ConfirmRes2 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Confirm { qset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // un-deserializable value
-    static immutable ConfirmRes3 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Confirm { qset: { hash: 0xc048...6205, quorum: { thresh: 2, nodes: [boa1xp9rtxss...fs7r, boa1xpc2ugml...p0w2], subqs: [] } }, ballot: { counter: 0, value: <un-deserializable> }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable ConfirmRes3 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Confirm { qset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, ballot: { counter: 0, value: <un-deserializable> }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
     // unknown hash
     testAssert(ConfirmRes1, scpPrettify(&env, &getQSet));
 
@@ -543,11 +544,11 @@ unittest
     testAssert(ConfirmRes3, scpPrettify(&env, &getQSet));
 
     // unknown hash
-    static immutable ExtRes1 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x0000...0000, quorum: <unknown> }, commit: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nh: 100 } }, sig: 0x0000...be78 }`;
+    static immutable ExtRes1 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x0000...0000, quorum: <unknown> }, commit: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nh: 100 } }, sig: 0x0000...be78 }`;
     // known hash
-    static immutable ExtRes2 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0xc048...6205, quorum: { thresh: 2, nodes: [boa1xp9rtxss...fs7r, boa1xpc2ugml...p0w2], subqs: [] } }, commit: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nh: 100 } }, sig: 0x0000...be78 }`;
+    static immutable ExtRes2 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, commit: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nh: 100 } }, sig: 0x0000...be78 }`;
     // un-deserializable value
-    static immutable ExtRes3 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0xc048...6205, quorum: { thresh: 2, nodes: [boa1xp9rtxss...fs7r, boa1xpc2ugml...p0w2], subqs: [] } }, commit: { counter: 0, value: <un-deserializable> }, nh: 100 } }, sig: 0x0000...be78 }`;
+    static immutable ExtRes3 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, commit: { counter: 0, value: <un-deserializable> }, nh: 100 } }, sig: 0x0000...be78 }`;
 
     /** SCP EXTERNALIZE */
     env.statement.pledges.type_ = SCPStatementType.SCP_ST_EXTERNALIZE;
@@ -567,9 +568,9 @@ unittest
     testAssert(ExtRes3, scpPrettify(&env, &getQSet));
 
     // unknown hash
-    static immutable NomRes1 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Nominate { qset: { hash: 0x0000...0000, quorum: <unknown> }, votes: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }], accepted: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }] } }, sig: 0x0000...be78 }`;
+    static immutable NomRes1 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Nominate { qset: { hash: 0x0000...0000, quorum: <unknown> }, votes: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }], accepted: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }] } }, sig: 0x0000...be78 }`;
     // known hash
-    static immutable NomRes2 = `{ statement: { node: boa1xzval2a3...gsh2, slotIndex: 0, pledge: Nominate { qset: { hash: 0xc048...6205, quorum: <unknown> }, votes: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }], accepted: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }] } }, sig: 0x0000...be78 }`;
+    static immutable NomRes2 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Nominate { qset: { hash: 0x2b20...4596, quorum: <unknown> }, votes: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }], accepted: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }] } }, sig: 0x0000...be78 }`;
 
     /** SCP NOMINATE */
     env.statement.pledges.type_ = SCPStatementType.SCP_ST_NOMINATE;

--- a/source/scpd/scp/LocalNode.d
+++ b/source/scpd/scp/LocalNode.d
@@ -123,4 +123,4 @@ extern(C++, class) public struct LocalNode
                                     const ref vector!NodeID nodeSet);
 }
 
-static assert(LocalNode.sizeof == 248);
+static assert(LocalNode.sizeof == 280);

--- a/source/scpd/scp/SCPDriver.d
+++ b/source/scpd/scp/SCPDriver.d
@@ -135,9 +135,8 @@ nothrow:
     // `toStrKey` returns StrKey encoded string representation
     std_string toStrKey(ref const(NodeID) pk, bool fullKey = true) const
     {
-        import agora.crypto.Key : PublicKey;
         try
-            return std_string(PublicKey(pk[]).toString());
+            return std_string(Hash(pk).toString());
         catch (Exception exc)
         {
             scope (failure) assert(0);
@@ -150,7 +149,7 @@ nothrow:
     {
         import agora.crypto.Key : PublicKey;
         try
-            return std_string(PublicKey(pk[]).toString());
+            return std_string(Hash(pk).toString());
         catch (Exception exc)
         {
             scope (failure) assert(0);

--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -307,7 +307,7 @@ struct SCPStatement {
     _pledges_t pledges;
 }
 
-static assert(SCPStatement.sizeof == 192);
+static assert(SCPStatement.sizeof == 224);
 static assert(Signature.sizeof == 64);
 
 struct SCPEnvelope {
@@ -315,7 +315,7 @@ struct SCPEnvelope {
   Signature signature;
 }
 
-static assert(SCPEnvelope.sizeof == 256);
+static assert(SCPEnvelope.sizeof == 288);
 
 struct SCPQuorumSet {
     import agora.crypto.Hash;
@@ -347,38 +347,38 @@ struct SCPQuorumSet {
     import std.conv;
 
     const qc1 = toSCPQuorumSet(QuorumConfig(2,
-        [PublicKey.fromString("boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecsszs3fs7r"),
-         PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2")]));
+        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
+         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")]));
 
     assert(qc1.hashFull() == Hash.fromString(
-        "0xc04848f147308156eebf4b9ecab13500f3d54ad0ef494b99f5a1c40b9f4625d13b7afd1a9d3a88ceaba16fea6730e63cc493f40632263d86c3afcaacfd0a6205"));
+        "0x2b202a92d7e32a7aa839ad17df498a8db0efa445b2cc1c73e32763db49e64162d43d766eb08d04d13ecb5eab1e012781e28a90375658a2f75f1cc02198904596"));
 
     const qc2 = toSCPQuorumSet(QuorumConfig(3,
-        [PublicKey.fromString("boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecsszs3fs7r"),
-         PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2")]));
+        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
+         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")]));
 
     assert(qc2.hashFull() == Hash.fromString(
-        "0x203c5f249c25bc28ac8b482fe458c047a995491a5ed861f34c5b3feefc390778b5d69b697c512b6ead2b6c791f64e1910241bf33de7fc4a2a4ef1d479165a635"));
+        "0x2380963ec547f302eeb9b4ec95ad12bd986c587e4e0148b91fca421620404f250c3eadfae7b4de2807b8e8c25b1ca81aa3b856014b4d9c3b5b2060be8924a1b3"));
 
     const qc3 = toSCPQuorumSet(QuorumConfig(2,
-        [PublicKey.fromString("boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecsszs3fs7r"),
-         PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2")],
+        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
+         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")],
              [QuorumConfig(2,
-            [PublicKey.fromString("boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecsszs3fs7r"),
-             PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2")])]));
+                [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
+                 Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")])]));
 
     assert(qc3.hashFull() == Hash.fromString(
-        "0x5a12d796400f9d2f8a4e7b988ad56d2c820dd34ac52e7332800304bd686feeb2c91474c0e3fecf08136c1c14f038281209e6cc0583951336cfbeb3daa34981d3"));
+        "0x36de5a8b9263cb1b08dc4fbc329b0bac645a33c7c22be3c452e4db91c346b3f80b0acce1b047b8e63c1918adccae5958000501f786d68ec29d240bf74335e9b4"));
 
     const qc4 = toSCPQuorumSet(QuorumConfig(2,
-        [PublicKey.fromString("boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecsszs3fs7r"),
-         PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2")],
+        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
+         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")],
              [QuorumConfig(3,
-            [PublicKey.fromString("boa1xp9rtxssrry6zqc4yt40h5h3al6enaywnvxfsp0ng8jt0ywyecsszs3fs7r"),
-             PublicKey.fromString("boa1xpc2ugmlve2ttuq6sjl4fznrggf2l5hksk2h2nsakexn690zxg4gss4p0w2")])]));
+                [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
+                 Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")])]));
 
     assert(qc4.hashFull() == Hash.fromString(
-        "0x0f7ab32ff495d99e34730bce47a9bf18025cb5e677b2aa28f8f391ff80d844e53854410eae1f1da53fdae7af873a9ca020fc37b0b680ea3fdbb6882d60af1b10"));
+        "0x0b7d0c118e89ce2a5f9c7c9c3ece531389c76242f99209d769359b3b0f3b8b54eec74ef8b1b820f2a8ecf9a68b252be9cc76931ce88d1b5795970e268891b95b"));
 }
 static assert(SCPQuorumSet.sizeof == 56);
 

--- a/source/scpd/types/Stellar_types.d
+++ b/source/scpd/types/Stellar_types.d
@@ -34,7 +34,7 @@ alias uint512 = opaque_array!64;
 
 
 alias Hash      = uint512;
-alias NodeID    = uint256;
+alias NodeID    = uint512;
 alias Signature = uint512;
 
 unittest
@@ -44,6 +44,6 @@ unittest
     static import agora.crypto.Schnorr;
 
     static assert(agora.crypto.Hash.Hash.sizeof == Hash.sizeof);
-    static assert(agora.crypto.Key.PublicKey.sizeof == NodeID.sizeof);
+    static assert(agora.crypto.Hash.Hash.sizeof == NodeID.sizeof);
     static assert(agora.crypto.Schnorr.Signature.sizeof == Signature.sizeof);
 }

--- a/source/scpp/extra/DSizeChecks.cpp
+++ b/source/scpp/extra/DSizeChecks.cpp
@@ -43,7 +43,6 @@ CPPSIZEOF(SCPEnvelope)
 CPPSIZEOF(SCPQuorumSet)
 
 /// scpd.types.Stellar_types
-CPPSIZEOF(Hash)
 CPPSIZEOF(NodeID)
 // Signature and hash are both aliases to uint512
 static_assert(std::is_same<Signature, Hash>::value, "Signature and Hash must be the same type");

--- a/source/scpp/src/xdr/Agora-types.h
+++ b/source/scpp/src/xdr/Agora-types.h
@@ -19,6 +19,6 @@ namespace stellar
 
     // Logical types used by SCP / Agora
     using Hash =      uint512;
-    using NodeID =    uint256; // Currently a `PublicKey`
+    using NodeID =    uint512; // Currently hash of `utxo` staked for validator
     using Signature = uint512; // `(R,s)`, could be reduced to `(s)`
 }


### PR DESCRIPTION
We use the Hash of `UTXO` for `NodeID` instead of `PublicKey` because a user could run multiple `Validator`s so we should provide a way to identify each validator although all the validators come from the same `PublicKey`.

Fixes #1309 

There are two checkpoints.
1. If we should create a new `SCP` object when a new enrollment is used, is it needed to delete the old SCP?
2. Some `QuorumConfig`s is not shuffled in the unit test of `agora.test.QuorumPreimage`, which is needed to check.
