### PR TITLE
Talos: Fix Ban duration regression

### DIFF
--- a/talos/src/components/items/controls/itemsSliderWrapper.js
+++ b/talos/src/components/items/controls/itemsSliderWrapper.js
@@ -101,7 +101,7 @@ class ItemsSliderWrapper extends Component {
 
   getIndexItemsByValue(value) {
     const { items } = this.props
-    var nextIndex = items.lastIndexOf(value);
+    var nextIndex = items.map(it => it.value).lastIndexOf(value);
     return nextIndex >= 0 ? nextIndex : 0;
   }
 


### PR DESCRIPTION
A previous commit (5121d92d274e1d197cfcbafbe31cc034db0e0ad6)
inadvertently dropped the mapping while fixing a warning,
leading to the component not (visually) working anymore.