### PR TITLE
Change PreImageInfo.adjust to be Height-based

### DIFF
--- a/source/agora/common/BitMask.d
+++ b/source/agora/common/BitMask.d
@@ -56,7 +56,7 @@ public struct BitMask
     private size_t length;
 
     /// return the count of active validators
-    public size_t count() const @nogc
+    public size_t count () const scope @nogc
     {
         return this.length;
     }

--- a/source/agora/consensus/data/PreImageInfo.d
+++ b/source/agora/consensus/data/PreImageInfo.d
@@ -36,30 +36,29 @@ public struct PreImageInfo
 
     /***************************************************************************
 
-        Reduce the height and adjust `hash` accordingly
+        Compute the preimage at `target`
 
-        This method hashes `this.hash` `value` times, and offset `this.height`
-        by the same amount.
+        This method returns `this.hash` after hashing it
+        `height - this.height` times.
 
         Params:
-          value = The amount to offset the pre-image by.
-                  Must be lesser or equal to `this.height`.
+          target = The target height.
+                   Must be lesser or equal to `this.height`.
 
         Returns:
-          A reference to itself for easy chaining.
+          The resulting hash.
 
     ***************************************************************************/
 
-    public ref PreImageInfo adjust (size_t value) return @safe nothrow @nogc
+    public Hash opIndex (Height target) const scope @safe pure nothrow @nogc
     {
-        assert(this.height >= value);
-        while (value > 0)
+        assert(this.height >= target);
+        Hash result = this.hash;
+        for (size_t count = this.height - target; count > 0; --count)
         {
-            this.hash = this.hash.hashFull();
-            this.height -= 1;
-            --value;
+            result = result.hashFull();
         }
-        return this;
+        return result;
     }
 }
 

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -598,7 +598,7 @@ public class ValidatorSet
 
                 auto pi = PreImageInfo(enroll_key, preimage, preimage_height);
                 assert(preimage_height >= height); // The query should ensure this
-                return pi.adjust(preimage_height - height);
+                return PreImageInfo(pi.utxo, pi[height], height);
             }
             else
             {

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -92,8 +92,7 @@ public string isInvalidReason (in Enrollment enrollment,
         PreImageInfo enroll_preimage = PreImageInfo(
                 enrollment.utxo_key, enrollment.commitment, height);
         // Now we can check the preimages are consistent
-        auto distance = height - enroll_state.preimage.height;
-        if (enroll_preimage.adjust(distance).hash != enroll_state.preimage.hash)
+        if (enroll_preimage[enroll_state.preimage.height] != enroll_state.preimage.hash)
             return "The seed has an invalid hash value";
     }
 

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -978,7 +978,7 @@ public class Ledger
         // Ideally, the following should never happen, as we would catch this
         // before we reach this point, but this safety checks ensures we don't
         // generate a wrong random seed (we would otherwise hash in `Hash.init`
-        // or trigger an assertion failure in `PreImageInfo.adjust`).
+        // or trigger an assertion failure in `PreImageInfo.opIndex`).
         bool missing = false;
         foreach (entry; signing.save.filter!(en => en.value.preimage.height < height))
         {
@@ -995,7 +995,7 @@ public class Ledger
             .enumerate.filter!(en => !missing_validators.canFind(en.index))
             // We made sure in the previous `foreach` that `height >= pi.height`
             // Note that map is needed for`reduce` to be able to deduce the seed type
-            .map!(en => en.value.preimage.adjust(en.value.preimage.height - height).hash)
+            .map!(en => en.value.preimage[height])
             // Generate the final value
             .reduce!((a , b) => hashMulti(a, b));
     }


### PR DESCRIPTION
```
The old distance-based adjustment dates back from a previous iteration,
which used distance from the last preimage instead of an absolute (height) value.
We can simplify it by using the Height directly, and changing it to
opIndex, following what PreImageCache does.
```

Also included a trivial but unrelated commit to save CI time.