### PR TITLE
Add fuzzer to integration test network

### DIFF
--- a/ci/system_integration_test.d
+++ b/ci/system_integration_test.d
@@ -26,7 +26,8 @@ immutable BuildImg = [ "docker", "build", "--build-arg", `DUB_OPTIONS=-b cov`,
                        "-t", "agora", RootPath, ];
 immutable TestContainer = [ "docker", "run", "agora", "--help", ];
 immutable DockerCompose = [ "docker-compose", "-f", ComposeFile, "--env-file", EnvFile ];
-immutable DockerComposeUp = DockerCompose ~ [ "up", "--abort-on-container-exit", ];
+immutable DockerComposeUp = DockerCompose ~ [ "up", "--abort-on-container-exit",
+    "--scale", "fuzzer=0",];
 immutable DockerComposeDown = DockerCompose ~ [ "down", "-t", "30", ];
 immutable DockerComposeLogs = DockerCompose ~ [ "logs", "-t", ];
 immutable RunIntegrationTests = [ "dub", "--root", IntegrationPath, "--",

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+cd ${FUZZER_WORK_DIR}
+# compile spec
+dotnet ${RESTLER_BIN_DIR}/Restler.dll compile --api_spec ${SPEC_DIR}/spec.yaml
+
+dotnet ${RESTLER_BIN_DIR}/Restler.dll fuzz --grammar_file "Compile/grammar.py" --dictionary_file "Compile/dict.json" \
+    --settings ${FUZZER_SETTINGS} --time_budget 1 --target_ip ${FUZZ_TARGET_IP} --target_port ${FUZZ_TARGET_PORT} \
+    --host ${FUZZ_TARGET_HOST}

--- a/tests/system/docker-compose.yml
+++ b/tests/system/docker-compose.yml
@@ -94,3 +94,14 @@ services:
       - node-7
     volumes:
       - "./node/faucet/config.yaml:/root/faucet/config.yaml"
+
+  # fuzzer
+  fuzzer:
+    image: "mcr.microsoft.com/restlerfuzzer/restler:v8.0.0"
+    env_file: fuzzer_environment.sh
+    volumes:
+      - "./fuzzer_workspace:/root/fuzzer_workspace"
+      - "./fuzzer_settings.json:/root/fuzzer_settings.json"
+      - "../../source/agora/api/spec.yaml:/root/spec.yaml"
+      - "../../scripts/fuzz.sh:/root/fuzz.sh"
+    command: /root/fuzz.sh

--- a/tests/system/fuzzer_environment.sh
+++ b/tests/system/fuzzer_environment.sh
@@ -1,0 +1,7 @@
+RESTLER_BIN_DIR=/RESTler/restler
+SPEC_DIR=/root
+FUZZ_TARGET_IP=node-2
+FUZZ_TARGET_HOST=node-2
+FUZZ_TARGET_PORT=2826
+FUZZER_WORK_DIR=/root/fuzzer_workspace
+FUZZER_SETTINGS=/root/fuzzer_settings.json

--- a/tests/system/fuzzer_settings.json
+++ b/tests/system/fuzzer_settings.json
@@ -1,0 +1,3 @@
+{
+    "disable_cert_validation": true
+}


### PR DESCRIPTION
A simple `docker-compose up` will start both the network and the fuzzer.
I have run this for a while and already fixed two crashes it triggered.

So this closes #2232 