### PR TITLE
Fixes issue2251: Only sign block after SCP externalize

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1991,8 +1991,10 @@ public struct TestConf
     /// Out of 100
     public ubyte validator_tx_fee_cut = 70;
 
-    /// How frequent the payments to Validators will be
-    public uint payout_period = 5;
+    /// How frequent the payments to Validators will be. If too low then tests
+    /// which assert all blocks are the same will sometimes fail if the catchup
+    /// is after height goes beyond a payment block.
+    public uint payout_period = ConsensusConfig.init.payout_period;
 
     /// The minimum (transaction size adjusted) fee.
     /// Transaction size adjusted fee = tx fee / tx size in bytes.

--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -22,7 +22,8 @@ import agora.common.Amount;
 unittest
 {
     TestConf conf = {
-        quorum_threshold : 100
+        quorum_threshold : 100,
+        payout_period : 5
     };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
@@ -80,7 +81,8 @@ unittest
     import core.thread;
 
     TestConf conf = {
-        quorum_threshold : 100
+        quorum_threshold : 100,
+        payout_period : 5
     };
 
     static class LocalAPIManager : TestAPIManager
@@ -142,7 +144,8 @@ unittest
     import core.thread;
 
     TestConf conf = {
-        quorum_threshold : 80
+        quorum_threshold : 80,
+        payout_period : 5
     };
 
     static class LocalAPIManager : TestAPIManager

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -567,8 +567,7 @@ private class FlashListener : TestFlashListenerAPI
 unittest
 {
     TestConf conf = {
-        quorum_threshold : 100,
-        payout_period : 100
+        quorum_threshold : 100
     };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
@@ -671,8 +670,7 @@ unittest
 unittest
 {
     TestConf conf = {
-        quorum_threshold : 100,
-        payout_period : 100
+        quorum_threshold : 100
     };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
@@ -801,8 +799,7 @@ unittest
     }
 
     TestConf conf = {
-        quorum_threshold : 100,
-        payout_period : 100
+        quorum_threshold : 100
     };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
@@ -911,8 +908,7 @@ unittest
 unittest
 {
     TestConf conf = {
-        quorum_threshold : 100,
-        payout_period : 100
+        quorum_threshold : 100
     };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
@@ -1063,8 +1059,7 @@ unittest
 unittest
 {
     TestConf conf = {
-        quorum_threshold : 100,
-        payout_period : 100
+        quorum_threshold : 100
     };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
@@ -1237,8 +1232,7 @@ unittest
 unittest
 {
     TestConf conf = {
-        quorum_threshold : 100,
-        payout_period : 100
+        quorum_threshold : 100
     };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
@@ -1468,8 +1462,7 @@ unittest
     }
 
     TestConf conf = {
-        quorum_threshold : 100,
-        payout_period : 100
+        quorum_threshold : 100
     };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
@@ -1553,8 +1546,7 @@ unittest
 unittest
 {
     TestConf conf = {
-        quorum_threshold : 100,
-        payout_period : 100
+        quorum_threshold : 100
     };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
@@ -1646,8 +1638,7 @@ unittest
 unittest
 {
     TestConf conf = {
-        quorum_threshold : 100,
-        payout_period : 100
+        quorum_threshold : 100
     };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
@@ -1859,8 +1850,7 @@ unittest
     }
 
     TestConf conf = {
-        quorum_threshold : 100,
-        payout_period : 100
+        quorum_threshold : 100
     };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
@@ -1975,8 +1965,7 @@ unittest
     }
 
     TestConf conf = {
-        quorum_threshold : 100,
-        payout_period : 100
+        quorum_threshold : 100
     };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();

--- a/source/agora/test/ManyBlocks.d
+++ b/source/agora/test/ManyBlocks.d
@@ -25,7 +25,7 @@ import agora.test.Base;
 /// Simple test
 unittest
 {
-    TestConf conf = { quorum_threshold : 100, payout_period : 200 };
+    TestConf conf = { quorum_threshold : 100 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -28,10 +28,7 @@ void manyValidators (size_t validators)
     import core.time : seconds;
     import agora.crypto.Key;
 
-    TestConf conf = {
-        outsider_validators : validators - GenesisValidators,
-        // Prevent missing signatures due to only catching up from last payment block
-        payout_period : 200  };
+    TestConf conf = { outsider_validators : validators - GenesisValidators };
 
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();


### PR DESCRIPTION
When the SCP balloting completes and the single event EXTERNALIZE is triggered then we can sign the block and gossip the signature to other nodes. This is to prevent leaking our private key by signing multiple blocks due to more than one COMMIT ballot.

First two commits have been put in seperate PR https://github.com/bosagora/agora/pull/2302