### PR TITLE
Fix bug with signature catchup

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -1000,7 +1000,6 @@ public class NetworkManager
         try
         {
             auto start_height = ledger.getLastPaymentBlock();
-            log.trace("Catchup signatures since block height {}", start_height);
             auto headers = ledger.getBlocksFrom(start_height).map!(block => block.header);
             size_t[Height] enrolled_validators = headers.map!(header =>
                 tuple(header.height, header.validators.count)).assocArray;
@@ -1023,6 +1022,7 @@ public class NetworkManager
                 auto missing_heights = heightsMissingSigs();
                 if (!missing_heights.empty)
                 {
+                    log.trace("getMissingBlockSigs: detected missing signatures at heights {}", missing_heights);
                     foreach (peer; this.peers[])
                     {
                         foreach (header; peer.client.getBlockHeaders(missing_heights))

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -1167,7 +1167,7 @@ public class FullNode : API
         BlockHeader[] headers;
         if (!heights.empty)
         {
-            foreach (block; this.ledger.getBlocksFrom(Height(heights[].front)))
+            foreach (block; this.ledger.getBlocksFrom(Height(heights[].minElement)))
             {
                 if (block.header.height in heights)
                     headers ~= block.header;


### PR DESCRIPTION
As we use a `set` for the headers which are missing we should use the
min value from the `set` not the first element for the call to
`getBlocksFrom`.