### PR TITLE
Force set HTTP methods for some admin interface method

### DIFF
--- a/source/agora/api/Admin.d
+++ b/source/agora/api/Admin.d
@@ -14,6 +14,7 @@
 module agora.api.Admin;
 
 import vibe.data.serialization;
+import vibe.http.common;
 import vibe.web.rest;
 
 import ocean.util.log.ILogger;
@@ -59,6 +60,7 @@ public interface NodeControlAPI
 
     ***************************************************************************/
 
+    @method(HTTPMethod.GET)
     public string loginQR (@viaHeader("Content-Type") out string contentType,
                            @viaHeader("Vary") out string vary);
 
@@ -71,6 +73,7 @@ public interface NodeControlAPI
 
     ***************************************************************************/
 
+    @method(HTTPMethod.GET)
     public string encryptionKeyQR (string app, ulong height,
                                    @viaHeader("Content-Type") out string contentType,
                                    @viaHeader("Vary") out string vary);


### PR DESCRIPTION
It was previously serviced by GET.
Vibe recognized it as a POST HTTP interface method.

REST route: POST /admin/login_qr ["Content-Type", "Vary"]
REST route: POST /admin/encryption_key_qr ["app", "height", "Content-Type", "Vary"]