### PR TITLE
Test: Use NodeConfig directly instead of copying members

### DIFF
--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -28,10 +28,10 @@ unittest
     TestConf conf =
     {
         full_nodes : 1,
-        retry_delay : 10.msecs,
-        max_retries : 10,
-        max_failed_requests : 32
+        max_failed_requests : 32,
     };
+    conf.node.retry_delay = 10.msecs;
+    conf.node.max_retries = 10;
 
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();

--- a/source/agora/test/BlockTimeConsensus.d
+++ b/source/agora/test/BlockTimeConsensus.d
@@ -23,7 +23,8 @@ import agora.test.Base;
 ///
 unittest
 {
-    TestConf conf = { block_interval_sec : 2 };
+    TestConf conf;
+    conf.node.block_interval_sec = 2;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.setTimeFor(Height(0));
     network.start();
@@ -45,7 +46,7 @@ unittest
         network.setTimeFor(height);
         network.assertSameBlocks(height);
         auto time_offset = nodes[0].getBlocksFrom(height, 1)[0].header.time_offset;
-        assert(time_offset == conf.block_interval_sec * height);
+        assert(time_offset == conf.node.block_interval_sec * height);
     }
 
     // Check for adding blocks 1 to 4

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -58,7 +58,8 @@ unittest
 unittest
 {
     // node #7 is the outsider, so total foreign nodes may be 6
-    TestConf conf = { max_listeners : 6, full_nodes : 1 };
+    TestConf conf = { full_nodes : 1 };
+    conf.node.max_listeners = 6;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -94,9 +94,9 @@ unittest
     }
 
     TestConf conf = {
-        timeout : 5.seconds,
-        quorum_threshold : 51
+        quorum_threshold : 51,
     };
+    conf.node.timeout = 5.seconds;
 
     auto network = makeTestNetwork!CustomAPIManager(conf);
     network.start();
@@ -107,13 +107,13 @@ unittest
     auto validator = network.clients[0];
 
     // Make four of six validators stop responding for a while
-    nodes.drop(1).take(4).each!(node => node.ctrl.sleep(conf.timeout, true));
+    nodes.drop(1).take(4).each!(node => node.ctrl.sleep(conf.node.timeout, true));
 
     // Block 1 with multiple consensus rounds
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
     txs.each!(tx => validator.putTransaction(tx));
 
-    network.expectHeightAndPreImg(Height(1), network.blocks[0].header, conf.timeout + 5.seconds);
+    network.expectHeightAndPreImg(Height(1), network.blocks[0].header, conf.node.timeout + 5.seconds);
     assert(CustomNominator.round_number >= 2,
         format("The validator's round number is %s. Expected: above %s",
             CustomNominator.round_number, 2));

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -25,7 +25,7 @@ import core.thread;
 /// test retrying requests after failure
 unittest
 {
-    TestConf conf = TestConf.init;
+    TestConf conf;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();
@@ -79,6 +79,6 @@ unittest
 
     // node 1 will keep trying to send transactions up to
     // max_retries * (retry_delay + timeout) seconds (see Base.d),
-    const delay = conf.max_retries * (conf.retry_delay + conf.timeout);
+    const delay = conf.node.max_retries * (conf.node.retry_delay + conf.node.timeout);
     network.expectHeight(Height(1), delay);
 }

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -24,10 +24,8 @@ import agora.crypto.Key;
 ///
 unittest
 {
-    TestConf conf =
-    {
-        retry_delay : 100.msecs,
-    };
+    TestConf conf;
+    conf.node.retry_delay = 100.msecs;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();
@@ -49,8 +47,8 @@ unittest
     {
         topology : NetworkTopology.MinimallyConnected,
         full_nodes : 4,
-        min_listeners : 9,
     };
+    conf.node.min_listeners = 9;
     auto network = makeTestNetwork!TestAPIManager(conf);
 
     network.start();
@@ -72,8 +70,8 @@ unittest
     TestConf conf =
     {
         topology : NetworkTopology.MinimallyConnected,
-        min_listeners : 1
     };
+    conf.node.min_listeners = 1;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -52,7 +52,8 @@ unittest
     TestConf conf = {
         recurring_enrollment : false,
         outsider_validators : 2,
-        max_listeners : 7 };
+    };
+    conf.node.max_listeners = 7;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/QuorumShuffle.d
+++ b/source/agora/test/QuorumShuffle.d
@@ -15,6 +15,7 @@ module agora.test.QuorumShuffle;
 
 version (unittest):
 
+import agora.common.Types;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
 import agora.consensus.data.Transaction;
@@ -24,17 +25,17 @@ import agora.utils.Log;
 import agora.utils.PrettyPrinter;
 
 mixin AddLogger!();
+
 /// With a validator cycle of 20 and shuffle cycle of 6 we should expect
 /// quorums being shuffled at these block heights:
 /// 6, 12, 18, 20 (enrollment change), 26 (next shuffle cycle)
 unittest
 {
-    import agora.common.Types;
     TestConf conf = {
-        max_listeners : 7,
         max_quorum_nodes : 4,  // makes it easier to test shuffle cycling
         quorum_shuffle_interval : 6,
     };
+    conf.node.max_listeners = 7;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/RestoreSlashingInfo.d
+++ b/source/agora/test/RestoreSlashingInfo.d
@@ -31,10 +31,10 @@ import agora.utils.PrettyPrinter;
 unittest
 {
     TestConf conf = {
-        timeout : 10.seconds,
         outsider_validators : 3,
         recurring_enrollment : false
     };
+    conf.node.timeout = 10.seconds;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/TimeBlockInterval.d
+++ b/source/agora/test/TimeBlockInterval.d
@@ -26,7 +26,8 @@ import std.algorithm;
 ///
 unittest
 {
-    TestConf conf = { block_interval_sec : 10 };
+    TestConf conf;
+    conf.node.block_interval_sec = 10;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();
@@ -43,5 +44,5 @@ unittest
             en.value.each!(tx => node_1.putTransaction(tx));
             network.expectHeightAndPreImg(Height(en.index + 1));
         });
-    assert(node_1.getNetworkTime() >= startTime + (4 * conf.block_interval_sec));
+    assert(node_1.getNetworkTime() >= startTime + (4 * conf.node.block_interval_sec));
 }

--- a/source/agora/test/TimeDrift.d
+++ b/source/agora/test/TimeDrift.d
@@ -27,7 +27,8 @@ import std.range;
 ///
 unittest
 {
-    TestConf conf = { block_interval_sec : 1, max_quorum_nodes : 5, quorum_threshold : 100 };
+    TestConf conf = { max_quorum_nodes : 5, quorum_threshold : 100 };
+    conf.node.block_interval_sec = 1;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();
@@ -71,7 +72,7 @@ unittest
     // calculated clock offset:  [+0, +0, +0, +0, +0, +1]
 
     // set the time to `height` * `block_interval_sec` for 5/6 nodes
-    assert(conf.block_interval_sec == 1);
+    assert(conf.node.block_interval_sec == 1);
     network.setTimeFor(network.nodes.take(5), Height(1));
     [ 1,  1,  1,  1,  1, 0].enumerate.each!((idx, height) =>
         checkNodeLocalTime(idx, height));

--- a/source/agora/test/Timeout.d
+++ b/source/agora/test/Timeout.d
@@ -22,10 +22,13 @@ import agora.test.Base;
 ///
 unittest
 {
-    TestConf conf = { retry_delay : 1.msecs,
-        max_retries : 2,
-        timeout : 500.msecs,
-        max_failed_requests : 1000 };  // never ban
+    TestConf conf = {
+        max_failed_requests : 1000, // never ban
+    };
+    conf.node.max_retries = 2;
+    conf.node.retry_delay = 1.msecs;
+    conf.node.timeout = 500.msecs;
+
     auto network = makeTestNetwork!TestAPIManager(conf);
     auto nodes = network.clients;
 


### PR DESCRIPTION
```
As we added more elements into NodeConfig, they were also added to TestConf.
The duplication was obvious, and the resolution is to simply embed a NodeConfig
in TestConf as the template used for each nodes.
```

We could probably extend this in the future, but `NodeConfig` was the worst offender.