### PR TITLE
Bug fix for setting `validators` `BitMask`

### DIFF
--- a/source/agora/common/BitMask.d
+++ b/source/agora/common/BitMask.d
@@ -77,12 +77,11 @@ public struct BitMask
         this.bytes[] = bytes;
     }
 
-    // set the bits that are set in given BitMask
-    public auto opOpAssign (string op : "|") (in BitMask add)
+    // copy bits set from given BitMask bytes
+    public void copyFrom (in BitMask rhs)
     {
-        assert(this.length == add.length, "BitMask assignment must be for same bit length");
-        this.bytes[] |= add.bytes[];
-        return this;
+        assert(this.length == rhs.length);
+        this.bytes[] = rhs.bytes;
     }
 
     /// return the indices of bits set
@@ -156,6 +155,16 @@ unittest
     assert(bitmask[1]);
 }
 
+unittest
+{
+    auto bitmask = BitMask.fromString("01011");
+    const bitmask2 = bitmask;
+    assert(bitmask2 == bitmask);
+    // Now update to new BitMask value
+    bitmask = BitMask.fromString("10001");
+    assert(bitmask == BitMask.fromString("10001"));
+}
+
 /// More set than unset
 unittest
 {
@@ -171,8 +180,8 @@ unittest
     auto bitmask = BitMask.fromString("111011111");
     assert(bitmask.length == 9);
     assert(bitmask.toString == "111011111");
-    auto bitmask_copy = BitMask(9);
-    bitmask_copy |= bitmask;
+    auto bitmask_copy = BitMask.fromString("001011101");
+    bitmask_copy = bitmask;
     assert(!bitmask_copy[3]);
     only(0,1,2,4,5).each!(i => assert(bitmask_copy[i]));
 }

--- a/source/agora/node/BlockStorage.d
+++ b/source/agora/node/BlockStorage.d
@@ -971,7 +971,7 @@ public class MemBlockStorage : IBlockStorage
             throw new Exception("Number of validators doesn't match while updating signatures");
 
         block.header.signature = sig;
-        block.header.validators |= validators;
+        block.header.validators.copyFrom(validators);
 
         this.blocks[height.value] = serializeFull(block);
     }

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -304,7 +304,7 @@ public class Validator : FullNode, API
             return false;
 
         auto signed_validators = BitMask(block.header.validators.count);
-        signed_validators |= block.header.validators;
+        signed_validators.copyFrom(block.header.validators);
 
         auto node_validator_index = this.nominator.enroll_man
             .getIndexOfValidator(block.header.height, this.config.validator.key_pair.address);


### PR DESCRIPTION
We were using the `|=` operator to do a bitwise `OR` of the original
`BitMask` and the new `BitMask` setting. This was causing problems
during signature catchup as we were updating the signature to match the
incoming combined signatures but then setting the signed bits from both
the local and remote `BitMasks`.
I tried to use `opAssign` but then had problems in code that does not
assign the `validators` `BitMask` during construction, for example
`data.Block.makeNewBlock` assigns the `BlockHeader` fields after default
`ctor` is called. To require only constructing `BlockHeader` with
validators BitMask included is an undesirable restriction.
Another possible solution would be to set the `length` and handle the
allocation of the `ubytes` during the `opAssign` when the `length` is
zero, but it doesn't feel right to be doing this outside of the `struct`
`ctors`.
So the chosen solution is to have a function named `copyFrom` which
updates an existing `BitMask` with the values from the provided
`BitMask`.