### PR TITLE
Make Network test `manyValidators` more reliable

### DIFF
--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -21,7 +21,6 @@
 module agora.node.Ledger;
 
 import agora.common.Amount;
-import agora.common.BitMask;
 import agora.common.Config;
 import agora.common.ManagedDatabase;
 import agora.common.Set;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -714,18 +714,15 @@ public class TestAPIManager
     ***************************************************************************/
 
     public void waitForPreimages (const(Enrollment)[] enrolls, Height height,
-        Duration timeout = 10.seconds,
-        string file = __FILE__, int line = __LINE__)
+        Duration timeout = 10.seconds)
     {
-        this.waitForPreimages(iota(GenesisValidators), enrolls, height,
-            timeout, file, line);
+        this.waitForPreimages(iota(GenesisValidators), enrolls, height, timeout);
     }
 
     /// Ditto
     public void waitForPreimages (Idxs)(Idxs clients_idxs,
         const(Enrollment)[] enrolls, Height height,
-        Duration timeout = 10.seconds,
-        string file = __FILE__, int line = __LINE__)
+        Duration timeout = 10.seconds)
     {
         static assert (isInputRange!Idxs);
         import std.algorithm.searching : any;

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -28,7 +28,10 @@ void manyValidators (size_t validators)
     import core.time : seconds;
     import agora.crypto.Key;
 
-    TestConf conf = { outsider_validators : validators - GenesisValidators };
+    TestConf conf = {
+        outsider_validators : validators - GenesisValidators,
+        // Prevent missing signatures due to only catching up from last payment block
+        payout_period : 200  };
 
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -94,7 +94,8 @@ private class NodeManager (): TestAPIManager
         if (this.nodes.length < 1)  // Use first node as test node
         {
             assert(conf.validator.enabled);
-            log.trace("Create node {} as cathup test node", this.nodes.length);
+            log.trace("Create node #{} ({}) as catchup test node",
+                this.nodes.length, conf.validator.key_pair.address);
             this.addNewNode!(TestNode!())(conf, file, line);
         }
         else


### PR DESCRIPTION
This has a fix for the flaky `ManyValidators` test plus a few trivial changes that were in PR [2270](https://github.com/bosagora/agora/pull/2270). 
As more changes are required in the other PR I think it is worth getting these merged first.