### PR TITLE
Stats: Change agora_preimages_gauge to a counter

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -361,7 +361,7 @@ public class FullNode : API
         auto validators = this.ledger.getValidators(this.ledger.getBlockHeight() + 1);
 
         foreach (const ref val; validators)
-            this.validator_preimages_stats.setMetricTo!"agora_preimages_gauge"(
+            this.validator_preimages_stats.setMetricTo!"agora_preimages_counter"(
                 val.preimage.height, val.address.toString());
 
         foreach (stat; this.validator_preimages_stats.getStats())

--- a/source/agora/stats/Validator.d
+++ b/source/agora/stats/Validator.d
@@ -16,7 +16,6 @@ module agora.stats.Validator;
 import agora.stats.Stats;
 
 ///
-///
 public struct ValidatorCountStatsValue
 {
     public ulong agora_validators_gauge;
@@ -31,7 +30,7 @@ public struct ValidatorPreimagesStatsLabel
 ///
 public struct ValidatorPreimagesStatsValue
 {
-    public ulong agora_preimages_gauge;
+    public ulong agora_preimages_counter;
 }
 
 ///


### PR DESCRIPTION
We were previously using a gauge, as the value could go up and down,
since it was a distance from the enrollment.
Nowadays, the value is absolute (it's height), hence we should use a counter.