### PR TITLE
Instead of using hash values when signing VoterCard, use VoterCard.

### DIFF
--- a/source/agora/node/admin/AdminInterface.d
+++ b/source/agora/node/admin/AdminInterface.d
@@ -159,7 +159,7 @@ public class AdminInterface : NodeControlAPI
         );
 
         login_info.voter_card.signature =
-            this.key_pair.sign(hashFull(login_info.voter_card)[]);
+            this.key_pair.sign(login_info.voter_card);
 
         contentType = "image/svg+xml";
         vary = "Accept-Encoding";


### PR DESCRIPTION
Now, there is no need to deliver hash values separately because the hash value is created internally in the process of signing.