### PR TITLE
Changed JSON serialization for QR admin methods

### DIFF
--- a/source/agora/api/Admin.d
+++ b/source/agora/api/Admin.d
@@ -13,6 +13,8 @@
 
 module agora.api.Admin;
 
+import agora.utils.Utility;
+
 import vibe.data.serialization;
 import vibe.http.common;
 import vibe.web.rest;
@@ -61,6 +63,9 @@ public interface NodeControlAPI
     ***************************************************************************/
 
     @method(HTTPMethod.GET)
+    @resultSerializer!(RawStringSerializer.serialize,
+                       RawStringSerializer.deserialize,
+                       "image/svg+xml")()
     public string loginQR (@viaHeader("Content-Type") out string contentType,
                            @viaHeader("Vary") out string vary);
 
@@ -74,6 +79,9 @@ public interface NodeControlAPI
     ***************************************************************************/
 
     @method(HTTPMethod.GET)
+    @resultSerializer!(RawStringSerializer.serialize,
+                       RawStringSerializer.deserialize,
+                       "image/svg+xml")()
     public string encryptionKeyQR (string app, ulong height,
                                    @viaHeader("Content-Type") out string contentType,
                                    @viaHeader("Vary") out string vary);

--- a/source/agora/utils/Utility.d
+++ b/source/agora/utils/Utility.d
@@ -227,3 +227,47 @@ public struct UbyteHexString
         });
     }
 }
+
+/// Utility class to implement vibe.d ResultSerializer.serialize and
+/// ResultSerializer.deserialize templates
+public class RawStringSerializer
+{
+    /***************************************************************************
+
+        Serialize the string as it is without any modifications
+        like JSON escaping
+
+        Params:
+            Policy = serialization policy type
+            InputT = input data type (string)
+            OutputRangeT = output range type
+            output_range = output range to serialize the string into
+            input_string = string to serialize
+
+    ***************************************************************************/
+
+    public static void serialize (alias Policy, InputT, OutputRangeT)(OutputRangeT output_range, InputT input_string)
+    {
+        import std.string;
+        output_range.put(input_string.representation);
+    }
+
+    /***************************************************************************
+
+        Deserialize the string that was previouly serialized by
+        raw_string_serialize
+
+        Params:
+            Policy = serialization policy type
+            ReturnT = return type (string)
+            InputRangeT = input range type
+            input_range = input range
+
+    ***************************************************************************/
+
+    public static ReturnT deserialize (alias Policy, ReturnT, InputRangeT)(InputRangeT input_range)
+    {
+        import std.string;
+        return std.string.toUTF8(input_range);
+    }
+}


### PR DESCRIPTION
QR admin methods return a svg image and the return value should not be serialized with
JSON serializer as that serializer would escape " and other characters.

The new serializer just returns the svg image as it is.