### PR TITLE
Fixes issue 2299: Skip adding our signature when catching up

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -539,8 +539,7 @@ public class FullNode : API
 
     /***************************************************************************
 
-        Function that is overriden in Validator to enable block signing during
-            periodic catchup.
+        Add block to ledger and remove expired validators from network whitelist
 
         Params:
             block = block to be added to the Ledger

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -292,7 +292,6 @@ public class Validator : FullNode, API
     protected override string acceptBlock (const ref Block block) @trusted
     {
         import agora.common.BitMask;
-        import agora.crypto.Schnorr;
         import std.algorithm;
         import std.range;
         import std.format;
@@ -327,14 +326,9 @@ public class Validator : FullNode, API
         }
         else
         {
-            signed_validators[node_validator_index] = true;
-            this.network.gossipBlockSignature(ValidatorBlockSig(block.header.height,
-                this.config.validator.key_pair.address, sig.s));
-            log.trace("Periodic Catchup: ADD to block signature R: {} and s: {}",
-                sig.R, sig.s.toString(PrintMode.Clear));
-            const signed_block = block.updateSignature(
-                multiSigCombine([ block.header.signature, sig ]), signed_validators);
-            this.ledger.updateBlockMultiSig(signed_block.header);
+            log.warn("This node's signature is not in the block signature. " ~
+                "However, we will not sign in case we signed a different block " ~
+                "at this height and could reveal our private key.");
         }
         return null;
     }


### PR DESCRIPTION
We should only sign a single block at a certain height to prevent leaking our private key. It is very difficult for us to know when adding blocks given to us by other nodes if we have in fact already signed a different block at this height.