### PR TITLE
`LocalTransaction` unit test update

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -137,7 +137,7 @@ public extern (C++) class Nominator : SCPDriver
         @safe onInvalidNomination;
 
     /// Delegate called when a block is to be externalized
-    public extern (D) bool delegate (const ref Block) @safe acceptBlock;
+    public extern (D) string delegate (const ref Block) @safe acceptBlock;
 
     /// Nomination start time
     protected TimePoint nomination_start_time;
@@ -175,7 +175,7 @@ extern(D):
         Clock clock, NetworkManager network, ValidatingLedger ledger,
         EnrollmentManager enroll_man, ITaskManager taskman, ManagedDatabase cacheDB,
         Duration nomination_interval,
-        bool delegate (const ref Block) @safe externalize)
+        string delegate (const ref Block) @safe externalize)
     {
         assert(externalize !is null);
 
@@ -1014,11 +1014,10 @@ extern(D):
         // which applies when a block is externalize (for example if the quorum
         // config changes or the list of validators change,
         // new network connections might need to be established).
-        if (!this.acceptBlock(signed_block))
+        if (auto fail_msg = this.acceptBlock(signed_block))
         {
-            auto msg = this.ledger.validateBlock(signed_block);
-            log.error("Block was not accepted by node {}: {}", this.kp.address, msg);
-            assert(0, "Block was not accepted: " ~ msg);
+            log.error("Block was not accepted by node {}: {}", this.kp.address, fail_msg);
+            assert(0, "Block was not accepted: " ~ fail_msg);
         }
     }
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -265,11 +265,7 @@ public class FullNode : API
         const ulong StackMaxTotalSize = 16_384;
         const ulong StackMaxItemSize = 512;
         this.engine = new Engine(StackMaxTotalSize, StackMaxItemSize);
-        if (!config.validator.enabled)
-            this.ledger = new Ledger(params, this.engine, this.utxo_set,
-                this.storage, this.enroll_man, this.pool, this.fee_man, this.clock,
-                config.node.block_time_offset_tolerance, &this.onAcceptedBlock);
-
+        this.ledger = this.makeLedger();
         // If we have handlers defined in the config
         if (config.event_handlers.length > 0)
         {
@@ -854,6 +850,25 @@ public class FullNode : API
     {
         return new EnrollmentManager(this.stateDB, this.cacheDB,
             this.config.validator.key_pair, this.params);
+    }
+
+    /***************************************************************************
+
+        Returns an instance of a Ledger to be used for a `Fullnode`.
+
+        It is overridden in `Validator` and also Test-suites can inject
+        different behaviour to enable testing.
+
+        Returns:
+            An instance of a `Ledger`
+
+    ***************************************************************************/
+
+    protected Ledger makeLedger ()
+    {
+        return new Ledger(params, this.engine, this.utxo_set, this.storage,
+            this.enroll_man, this.pool, this.fee_man, this.clock,
+            config.node.block_time_offset_tolerance, &this.onAcceptedBlock);
     }
 
     /*+*************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -293,7 +293,7 @@ public class Validator : FullNode, API
 
     ***************************************************************************/
 
-    protected override bool acceptBlock (const ref Block block) @trusted
+    protected override string acceptBlock (const ref Block block) @trusted
     {
         import agora.common.BitMask;
         import agora.crypto.Schnorr;
@@ -301,8 +301,8 @@ public class Validator : FullNode, API
         import std.range;
         import std.format;
 
-        if (!super.acceptBlock(block))
-            return false;
+        if (auto fail_msg = super.acceptBlock(block))
+            return fail_msg;
 
         auto signed_validators = BitMask(block.header.validators.count);
         signed_validators.copyFrom(block.header.validators);
@@ -315,7 +315,8 @@ public class Validator : FullNode, API
         {
             log.trace("This validator {} was not active at height {}",
                 this.config.validator.key_pair.address, block.header.height);
-            return true;
+            return format!"Validator %s was not active at height %s"
+                (this.config.validator.key_pair.address, block.header.height);
         }
 
         auto sig = this.nominator.createBlockSignature(block);
@@ -339,7 +340,7 @@ public class Validator : FullNode, API
                 multiSigCombine([ block.header.signature, sig ]), signed_validators);
             this.ledger.updateBlockMultiSig(signed_block.header);
         }
-        return true;
+        return null;
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -88,12 +88,8 @@ public class Validator : FullNode, API
         this.quorum_params = QuorumParams(this.params.MaxQuorumNodes,
             this.params.QuorumThreshold);
 
-        auto vledger = new ValidatingLedger(this.params, this.engine,
-            this.utxo_set, this.storage, this.enroll_man, this.pool,
-            this.fee_man, this.clock, config.node.block_time_offset_tolerance,
-            &this.onAcceptedBlock);
+        auto vledger = this.makeLedger();
         this.ledger = vledger;
-
         this.nominator = this.makeNominator(
             this.clock, this.network, vledger, this.enroll_man, this.taskman);
         this.nominator.onInvalidNomination = &this.invalidNominationHandler;
@@ -411,6 +407,25 @@ public class Validator : FullNode, API
             this.params, this.config.validator.key_pair, clock, network, ledger,
             enroll_man, taskman, this.cacheDB,
             this.config.validator.nomination_interval, &this.acceptBlock);
+    }
+
+    /***************************************************************************
+
+        Returns an instance of a `ValidatingLedger`.
+
+        Test-suites can inject different behaviour to enable testing.
+
+        Returns:
+            An instance of a `ValidatingLedger`
+
+    ***************************************************************************/
+
+    protected override ValidatingLedger makeLedger ()
+    {
+        return new ValidatingLedger(this.params, this.engine,
+            this.utxo_set, this.storage, this.enroll_man, this.pool,
+            this.fee_man, this.clock, config.node.block_time_offset_tolerance,
+            &this.onAcceptedBlock);
     }
 
     /***************************************************************************

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -99,7 +99,7 @@ unittest
 // catch up to the network.
 unittest
 {
-    static class PickyLedger : Ledger
+    static class PickyLedger : ValidatingLedger
     {
         mixin ForwardCtor!();
 
@@ -113,12 +113,14 @@ unittest
 
     static class PickyValidator : TestValidatorNode
     {
-        public this (Parameters!(typeof(super).__ctor) args)
+        mixin ForwardCtor!();
+
+        protected override ValidatingLedger makeLedger ()
         {
-            super(args);
-            this.ledger = new PickyLedger(params, this.engine, this.utxo_set, this.storage,
-                this.enroll_man, this.pool, this.fee_man, this.clock,
-                this.config.node.block_time_offset_tolerance, &this.onAcceptedBlock);
+            return new PickyLedger(this.params, this.engine,
+                this.utxo_set, this.storage, this.enroll_man, this.pool,
+                this.fee_man, this.clock, config.node.block_time_offset_tolerance,
+                &this.onAcceptedBlock);
         }
 
         public override void putTransaction (Transaction tx) @safe


### PR DESCRIPTION
First commit is just to log the reason for not accepting a block without recalling `validateBlock` and hoping for the same reason.
In test failures often the message was blank because it did not fail on the second validate. As it causes an `Assert(0)` it is very important to include the reason in the log as the node will be stopped.

Second commit:-
There were a couple of issues with the second unit test in this file.
1) `PickyLedger` should be a `ValidatingLedger`.
2) `PickyValidator` node had a `validatingLedger` constructed in the `Validator` class. 
Then the ledger of the `PickyValidator` was set to a constructed `PickyLedger`. 
On some occasions the original ledger was being used when the intention was to use the `PickyLedger`.
This was fixed by using dependency injection. This also makes the `Fullnode` ledger use DI to remove an undesirable check if it is a `Validator` within it's construction.