### PR TITLE
Add attributes to TxBuilder.deduct

### DIFF
--- a/source/agora/utils/TxBuilder.d
+++ b/source/agora/utils/TxBuilder.d
@@ -459,7 +459,7 @@ public struct TxBuilder
 
     ***************************************************************************/
 
-    public ref typeof(this) deduct (Amount amount)
+    public ref typeof(this) deduct (Amount amount) @safe nothrow
         return
     {
         if (!this.leftover.value.sub(amount))


### PR DESCRIPTION
The attributes are needed in order to call the function from faucet methods.
It is used when trying to deduct fees.