### PR TITLE
Prevent private key extraction from block signatures

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -946,7 +946,7 @@ public class Ledger
             }
             assert(validator.preimage.height >= block.header.height);
             const hash = validator.preimage[block.header.height];
-            Point R = CR + Scalar(hash).toPoint();
+            Point R = CR * Scalar(hash);
             sum_K = sum_K + K;
             sum_R = sum_R + R;
         }

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -121,7 +121,7 @@ public struct BlockHeader
         // rc = r used in signing the commitment
         const Scalar rc = Scalar(hashMulti(secret_key, "consensus.signature.noise", offset));
         const Scalar reduced_preimage = Scalar(preimage);
-        const Scalar r = rc + reduced_preimage; // make it unique for block height
+        const Scalar r = rc * reduced_preimage; // make it unique for block height
         const Point R = r.toPoint();
         return sign(secret_key, R, r, challenge);
     }
@@ -849,7 +849,7 @@ unittest
     assert(v.isValid(), "v is not a valid Scalar!");
     Point V = v.toPoint();
     const Scalar rc = Scalar(hashMulti(v, "consensus.signature.noise", 0));
-    const Scalar r = rc + Scalar(preimage);
+    const Scalar r = rc * Scalar(preimage);
     const Point R = r.toPoint();
 
     // Two messages

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -878,7 +878,7 @@ extern(D):
         // Fetch the R from enrollment commitment for signing validator
         const CR = this.enroll_man.getCommitmentNonce(validator.address, block_sig.height);
         // Determine the R of signature (R, s)
-        Point R = CR + Scalar(validator.preimage[block_sig.height]).toPoint();
+        Point R = CR * Scalar(validator.preimage[block_sig.height]);
         // Compose the signature (R, s)
         const sig = Signature(R, block_sig.signature);
         // Check this signature is valid for this block and signing validator

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -72,13 +72,13 @@ private extern(C++) class BadBlockSigningNominator : Nominator
         {
             case ByzantineReason.BadCommitmentR:
                 const Scalar rc = Scalar.random(); // This is normally the enrollment commitment
-                const Scalar r = rc + Scalar(preimage);
+                const Scalar r = rc * Scalar(preimage);
                 const Point R = r.toPoint();
                 return sign(this.kp.secret, R, r, challenge);
             case ByzantineReason.BadSignature:
                 const Scalar rc = Scalar(hashMulti(WK.Keys.NODE2.secret,
                     "consensus.signature.noise", 0));
-                const Scalar r = rc + Scalar(preimage);
+                const Scalar r = rc * Scalar(preimage);
                 const Point R = r.toPoint();
                 // Sign with random in place of validator secret key
                 const wrong_scalar_v = Scalar.random();


### PR DESCRIPTION
The noise for the signature was being created by adding the preimage to
enrollment commitment secret. This was flawed as with two signatures the
private key could be extracted. The solution is to multiple the scaler
preimage by the secret enrollment commitment to generate the signature
noise.