### PR TITLE
Fix 2294: Always provide block height stats

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -376,8 +376,6 @@ public class FullNode : API
         this.block_stats.increaseMetricBy!"agora_block_txs_total"(
             block.txs.length);
         this.block_stats.increaseMetricBy!"agora_block_externalized_total"(1);
-        this.block_stats.setMetricTo!"agora_block_height_counter"(
-            block.header.height.value);
     }
 
     /// Convenience function to increase an endpoint stats

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -313,7 +313,6 @@ public class FullNode : API
 
     mixin DefineCollectorForStats!("app_stats", "collectAppStats");
     mixin DefineCollectorForStats!("endpoint_request_stats", "collectStats");
-    mixin DefineCollectorForStats!("block_stats", "collectBlockStats");
 
     /***************************************************************************
 
@@ -345,6 +344,21 @@ public class FullNode : API
 
     /***************************************************************************
 
+        Collect block stats
+
+        Params:
+            collector = the Collector to collect the stats into
+
+    ***************************************************************************/
+
+    private void collectBlockStats (Collector collector)
+    {
+        this.block_stats.agora_block_height_counter = this.ledger.getBlockHeight();
+        collector.collect(this.block_stats);
+    }
+
+    /***************************************************************************
+
         Collect all validator & preimage stats into the collector
 
         Params:
@@ -368,14 +382,10 @@ public class FullNode : API
     private void recordBlockStats (in Block block) @safe
     {
         const new_count = this.ledger.enrollment_manager.validator_set.countActive(block.header.height + 1);
-        this.block_stats.setMetricTo!"agora_block_height_counter"(
-            block.header.height.value);
-        this.block_stats.setMetricTo!"agora_block_enrollments_gauge"(new_count);
-        this.block_stats.increaseMetricBy!"agora_block_txs_amount_total"(
-            getUnspentAmount(block.txs));
-        this.block_stats.increaseMetricBy!"agora_block_txs_total"(
-            block.txs.length);
-        this.block_stats.increaseMetricBy!"agora_block_externalized_total"(1);
+        this.block_stats.agora_block_enrollments_gauge = new_count;
+        this.block_stats.agora_block_txs_amount_total += getUnspentAmount(block.txs);
+        this.block_stats.agora_block_txs_total += block.txs.length;
+        this.block_stats.agora_block_externalized_total += 1;
     }
 
     /// Convenience function to increase an endpoint stats

--- a/source/agora/stats/Block.d
+++ b/source/agora/stats/Block.d
@@ -16,7 +16,7 @@ module agora.stats.Block;
 import agora.stats.Stats;
 
 ///
-public struct BlockStatsValue
+public struct BlockStats
 {
     public ulong agora_block_height_counter;
     public ulong agora_block_externalized_total;
@@ -24,6 +24,3 @@ public struct BlockStatsValue
     public ulong agora_block_txs_total;
     public ulong agora_block_txs_amount_total;
 }
-
-///
-public alias BlockStats = Stats!(BlockStatsValue, NoLabel);


### PR DESCRIPTION
```
Our stats are backed by an AA / map because it is useful to have some stats
not showing by default (e.g. when we log status code).
However, in the case of block stats, we always want to return them,
so we can simplify the code and call 'collect' with the struct directly.
```