### PR TITLE
Amount: Introduce operator overloads

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1196,7 +1196,7 @@ extern(D):
                         continue; // most likely a CoinBase Transaction
                     else if (errormsg)
                         assert(0);
-                    total_adjusted_fee.mustAdd(adjusted_fee);
+                    total_adjusted_fee += adjusted_fee;
                 }
 
                 CandidateHolder candidate_holder =

--- a/source/agora/flash/Network.d
+++ b/source/agora/flash/Network.d
@@ -212,7 +212,8 @@ public class Network
                     auto chan_fee = min_fee_hop[1];
 
                     auto total_fee = fees[min_pk];
-                    total_fee.mustAdd(chan_fee);
+                    if (!total_fee.add(chan_fee))
+                        assert(0);
                     if (total_fee < fees[peer_pk])
                     {
                         fees[peer_pk] = total_fee;

--- a/source/agora/node/TransactionRelayer.d
+++ b/source/agora/node/TransactionRelayer.d
@@ -399,7 +399,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
 
         auto genesis_tx = GenesisBlock.txs.filter!(tx => tx.isPayment).front;
         Amount amount = genesis_tx.outputs[gen_out_ind].value;
-        amount.mustSub(fee);
+        amount -= fee;
         Transaction tx = Transaction(
                 [Input(genesis_tx.hashFull(), gen_out_ind)],
             [Output(amount, WK.Keys.AA.address)]);

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1677,7 +1677,7 @@ private mixin template TestNodeMixin ()
         foreach (const ref Hash key, const ref UTXO value; this.utxo_set)
         {
             result ~= UTXOPair(key, value);
-            accumulated.mustAdd(value.output.value);
+            accumulated += value.output.value;
             if (accumulated >= minimum)
                 return result;
         }

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -248,7 +248,7 @@ unittest
     // 2) A very large frozen amount (60.999k)
     Amount freezeAmount = network.blocks[0].frozens.front.outputs[0].value;
     // Must be under Amount.MinFreezeAmount so that the refund isn't frozen
-    freezeAmount.mustSub(1_000.coins);
+    freezeAmount -= 1_000.coins;
     auto tx = network.blocks[0].spendable
         .map!(txb => txb
               .draw(freezeAmount, WK.Keys.AA.address.only).sign(OutputType.Freeze)

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -98,7 +98,7 @@ unittest
     auto penalty = nodes[0].getUTXOs(WK.Keys.CommonsBudget.address);
     assert(penalty.length == 1);
     auto total = refund[0].utxo.output.value;
-    total.mustAdd(penalty[0].utxo.output.value);
+    total += penalty[0].utxo.output.value;
     // Check that the two amounts add up to the original stake
     // TODO: Check for 40k, not just the total.
     assert(total == original_stake);

--- a/source/agora/test/TransactionReplacement.d
+++ b/source/agora/test/TransactionReplacement.d
@@ -45,12 +45,7 @@ unittest
 
     // create double spend transactions with fees 10000, 10100 .. 13000
     auto txs = [Amount(10000), Amount(10100), Amount(10200), Amount(11000), Amount(13000)]
-        .map!((amount)
-            {
-                auto output_amount = Amount(input_tx_amount);
-                output_amount.mustSub(amount);
-                return output_amount;
-            })
+        .map!((amount) => input_tx_amount - amount)
         .map!(output_amount => TxBuilder(input_tx, 0).draw(output_amount, [output_addr])
         .deductRemaining().sign()).array();
 


### PR DESCRIPTION
Fixes #1824 in the process.
Some usages of `mustSub` / `mustAdd` were replaced by `if` / `assert(0)` as this is just a refactoring.
The `assert` should be eliminated in the future.

This should also be useful for improving fee calculation.