### PR TITLE
Fix #2305 - Use UTXO rather than PublicKey in slot_sigs

### DIFF
--- a/source/agora/common/BitMask.d
+++ b/source/agora/common/BitMask.d
@@ -113,7 +113,7 @@ public struct BitMask
     public auto opIndexAssign(bool set, size_t bit_index) @nogc
     {
         if (bit_index >= this.length)
-                assert(0, "Attempt to set index beyond length of bitmask");
+            assert(0, "Attempt to set index beyond length of bitmask");
         const size_t byte_index = (bit_index) / 8;
         if (set)
             this.bytes[byte_index] |= mask(bit_index);

--- a/source/agora/consensus/data/ValidatorBlockSig.d
+++ b/source/agora/consensus/data/ValidatorBlockSig.d
@@ -64,40 +64,41 @@ public struct ValidatorBlockSig
     /// The block height of this signature
     public Height height;
 
-    /// The public key of the validator
-    public PublicKey public_key;
+    /// The stake of the validator
+    public Hash utxo;
 
     /// The block signature as s of Signature (R, s) for the validator
     public SigScalar signature;
 
-    public this (Height height, PublicKey public_key, SigScalar signature) @safe @nogc nothrow
+    public this (Height height, Hash utxo, SigScalar signature) @safe @nogc nothrow
     {
         this.height = height;
-        this.public_key = public_key;
+        this.utxo = utxo;
         this.signature = signature;
     }
 
-    public this (Height height, PublicKey public_key, Scalar signature) @safe @nogc nothrow
+    public this (Height height, Hash utxo, Scalar signature) @safe @nogc nothrow
     {
-        this(height, public_key, SigScalar(signature));
+        this(height, utxo, SigScalar(signature));
     }
 }
 
 unittest
 {
+    import agora.crypto.Hash;
     import agora.serialization.Serializer;
 
     testSymmetry!ValidatorBlockSig();
 
     Height height = Height(100);
-    PublicKey public_key = PublicKey.fromString(`boa1xrra39xpg5q9zwhsq6u7pw508z2let6dj8r5lr4q0d0nff240fvd27yme3h`);
+    Hash hash = "Hello world".hashFull();
     Scalar signature = Scalar("0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778");
-    ValidatorBlockSig sig = ValidatorBlockSig(height, public_key, signature);
+    ValidatorBlockSig sig = ValidatorBlockSig(height, hash, signature);
     testSymmetry(sig);
 
     import vibe.data.json;
     assert(sig.serializeToJsonString() == "{\"height\":\"100\"," ~
-        "\"public_key\":\"boa1xrra39xpg5q9zwhsq6u7pw508z2let6dj8r5lr4q0d0nff240fvd27yme3h\"," ~
-        "\"signature\":\"0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778\"}",
-        sig.serializeToJsonString());
+        "\"utxo\":\"0xee438b9928cd623262b040b3b2b1522235b8a92269d1a724cd53c25" ~
+           "d1042ec86b2d178cef755014a5892706e689cd82e00de9f1225e87dcc0600b2c8b2be9931\"," ~
+        "\"signature\":\"0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778\"}");
 }

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -1221,7 +1221,7 @@ public class NetworkManager
     public void gossipBlockSignature (ValidatorBlockSig block_sig) nothrow
     {
         log.trace("Gossip block signature {} for height #{} node {}",
-            block_sig.signature, block_sig.height , block_sig.public_key);
+            block_sig.signature, block_sig.height , block_sig.utxo);
         this.validators().each!(v => v.client.sendBlockSignature(block_sig));
     }
 

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -314,6 +314,7 @@ public class Validator : FullNode, API
                 (this.config.validator.key_pair.address, block.header.height);
         }
 
+        const this_utxo = this.enroll_man.getEnrollmentKey();
         auto sig = this.nominator.createBlockSignature(block);
         assert(node_validator_index < block.header.validators.count,
             format!"The validator index %s is invalid"(node_validator_index));
@@ -321,8 +322,8 @@ public class Validator : FullNode, API
         {
             log.trace("This node's signature is already in the block signature");
             // Gossip this signature as it may have been only shared via ballot signing
-            this.network.gossipBlockSignature(ValidatorBlockSig(block.header.height,
-                this.config.validator.key_pair.address, sig.s));
+            this.network.gossipBlockSignature(
+                ValidatorBlockSig(block.header.height, this_utxo, sig.s));
         }
         else
         {


### PR DESCRIPTION
This was raised during review, and the fix is rather simple.
While doing so, I identified a bug, where a restart will lead to some AA being empty, and thanks to the new checks in the BitMask, it got caught.