### PR TITLE
Adding tls and basic auth to admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,7 @@ docs/
 source/scpp/extra/DVMChecks.cpp
 
 # Agora log directory when Agora is started up with config.example.yml
-log/ 
+log/
+
+# Agora single node data and log directory
+.single

--- a/devel/config-single.yaml
+++ b/devel/config-single.yaml
@@ -35,10 +35,12 @@ admin:
   enabled: true
   address: 0.0.0.0
   port:    2827
+  username: admin
+  pwd: s3cr3t
 
 # The node will self-ban but this section needs at least one entry
 network:
-  - http://127.0.0.1:2826/
+  - https://127.0.0.1:2826/
 
 logging:
   root:

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -161,6 +161,8 @@ admin:
   enabled: true      # `false` by default
   address: 127.0.0.1 # Private
   port:    2827      # 0xB0B
+  username: admin
+  pwd: someSecret
 
 ################################################################################
 ##                               Node discovery                               ##

--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -281,6 +281,12 @@ public struct AdminConfig
 
     /// Bind port
     public ushort port = 0xB0B;
+
+    /// Username
+    public string username;
+
+    /// Password
+    public string pwd;
 }
 
 public enum HandlerType
@@ -504,6 +510,8 @@ private Config parseConfigImpl (in CommandLine cmdln, Node root)
     {
         conf.admin.address = get!(string, "admin", "address")(cmdln, admin);
         conf.admin.port    = get!(ushort, "admin", "port")(cmdln, admin);
+        conf.admin.username = get!(string, "admin", "username")(cmdln, admin);
+        conf.admin.pwd = get!(string, "admin", "pwd")(cmdln, admin);
     }
     return conf;
 }


### PR DESCRIPTION
This adds basic auth where username and password must match those given in the config file of the server. It also enables tls if the cert and key pem files are stored on the server. 