### PR TITLE
Introduce a module to throw an exception with a formatted message

### DIFF
--- a/source/agora/common/Amount.d
+++ b/source/agora/common/Amount.d
@@ -27,6 +27,8 @@
 
 module agora.common.Amount;
 
+import agora.common.Ensure;
+
 import std.format;
 
 /// Defines a monetary type used in the blockchain
@@ -90,12 +92,11 @@ public struct Amount
     }
 
     /// Support for Vibe.d deserialization
-    public static Amount fromString (scope const(char)[] str) pure @safe
+    public static Amount fromString (scope const(char)[] str) @safe
     {
         import std.conv : to;
         immutable ul = str.to!ulong;
-        if (!Amount.isInRange(ul))
-            throw new Exception("Invalid input value to Amount");
+        ensure(Amount.isInRange(ul), "Invalid input value to Amount: {}", str);
         return Amount(ul, true);
     }
 
@@ -104,8 +105,7 @@ public struct Amount
     public ref Amount opOpAssign (string op : "+") (in Amount other) return
         @safe
     {
-        if (!this.add(other))
-            throw new Exception(format("Amount %d cannot be added to %d", other, this));
+        ensure(this.add(other), "Amount {} cannot be added to {}", other, this);
         return this;
     }
 
@@ -114,8 +114,7 @@ public struct Amount
     public ref Amount opOpAssign (string op : "-") (in Amount other) return
         @safe
     {
-        if (!this.sub(other))
-            throw new Exception(format("Amount %d cannot be subtracted to %d", other, this));
+        ensure(this.sub(other), "Amount {} cannot be subtracted from {}", other, this);
         return this;
     }
 
@@ -124,8 +123,7 @@ public struct Amount
         @safe
     {
         Amount copy = this;
-        if (!copy.add(other))
-            throw new Exception(format("Amount %d cannot be added to %d", other, this));
+        ensure(copy.add(other), "Amount {} cannot be added to {}", other, this);
         return copy;
     }
 
@@ -134,8 +132,7 @@ public struct Amount
         @safe
     {
         Amount copy = this;
-        if (!copy.sub(other))
-            throw new Exception(format("Amount %d cannot be subtracted to %d", other, this));
+        ensure(copy.sub(other), "Amount {} cannot be subtracted from {}", other, this);
         return copy;
     }
 
@@ -466,7 +463,7 @@ nothrow pure @nogc @safe unittest
     assert(val == Amount.UnitPerCoin);
 }
 
-pure @safe unittest
+@safe unittest
 {
     import std.exception;
     assert(Amount.fromString(`5000000000000000`) == Amount.MaxUnitSupply);

--- a/source/agora/common/Ensure.d
+++ b/source/agora/common/Ensure.d
@@ -1,0 +1,60 @@
+/*******************************************************************************
+
+     Throw a statically allocated exception with formatting capacility.
+
+     The function in this module are not `@nogc` / `pure` but they do not
+     allocate if the formatting does not allocate.
+     A static buffer is used by the Exception, so the output length is limited.
+     Do not try to print a full block, for example.
+
+    Copyright:
+        Copyright (c) 2019-2021 BOSAGORA Foundation
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.common.Ensure;
+
+import ocean.text.convert.Formatter;
+
+/// Module ctor to initialize the thread-local instance
+static this ()
+{
+    instance = new FormattedException();
+}
+
+/// The underlying instance
+private FormattedException instance;
+
+/// An exception which doesn't allocate but allows formatting a message
+private final class FormattedException : Exception
+{
+    /// Internal buffer, should be enough for most messages
+    private char[2048] buffer;
+    /// Used size
+    private size_t end;
+
+    private this () @safe pure nothrow @nogc
+    {
+        super("An Exception occured");
+    }
+
+    public override const(char)[] message () const return
+        @safe pure nothrow @nogc
+    {
+        return this.buffer[0 .. this.end];
+    }
+}
+
+public void ensure (Args...) (bool exp, string fmt, lazy Args args)
+{
+    if (!exp)
+    {
+        auto res = instance.buffer.snformat(fmt, args);
+        instance.end = res.length;
+        throw instance;
+    }
+}

--- a/source/agora/crypto/Key.d
+++ b/source/agora/crypto/Key.d
@@ -13,6 +13,7 @@
 
 module agora.crypto.Key;
 
+import agora.common.Ensure;
 import agora.common.Types;
 import agora.crypto.Bech32;
 import agora.crypto.Crc16;
@@ -185,9 +186,9 @@ public struct PublicKey
     public static PublicKey fromString (scope const(char)[] str) @trusted
     {
         auto dec = decodeBech32(str);
-        enforce(dec.hrp == HumanReadablePart);
-        enforce(dec.data.length == VersionWidth + PublicKey.sizeof);
-        enforce(dec.data[0] == VersionByte.AccountID);
+        ensure(dec.hrp == HumanReadablePart, "PublicKey HRP should be {}", HumanReadablePart);
+        ensure(dec.data.length == VersionWidth + PublicKey.sizeof, "PublicKey binary size mismatch");
+        ensure(dec.data[0] == VersionByte.AccountID, "Account byte mismatch");
         return PublicKey(typeof(this.data)(dec.data[VersionWidth .. $]));
     }
 
@@ -345,9 +346,10 @@ public struct SecretKey
     public static SecretKey fromString (scope const(char)[] str)
     {
         const bin = Base32.decode(str);
-        enforce(bin.length == VersionWidth + SecretKey.sizeof + ChecksumWidth);
-        enforce(bin[0] == VersionByte.Seed);
-        enforce(validate(bin[0 .. $ - ChecksumWidth], bin[$ - ChecksumWidth .. $]));
+        ensure(bin.length == VersionWidth + SecretKey.sizeof + ChecksumWidth, "SecretKey binary size mismatch");
+        ensure(bin[0] == VersionByte.Seed, "SecretKey binary marker mismatch");
+        ensure(validate(bin[0 .. $ - ChecksumWidth], bin[$ - ChecksumWidth .. $]),
+               "SecretKey did not pass checksum validation");
         return SecretKey(typeof(this.data)(bin[VersionWidth .. $ - ChecksumWidth]));
     }
 

--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -22,6 +22,7 @@ import agora.flash.Types;
 import agora.flash.UpdateSigner;
 
 import agora.common.Amount;
+import agora.common.Ensure;
 import agora.common.ManagedDatabase;
 import agora.common.Set;
 import agora.common.Task;
@@ -328,10 +329,9 @@ public class Channel
 
         scope DeserializeDg dg = (size) @safe
         {
-            if (size > data.length)
-                throw new Exception(
-                    format("Requested %d bytes but only %d bytes available",
-                        size, data.length));
+            ensure(size <= data.length,
+                   "Requested {} bytes but only {} bytes available",
+                   size, data.length);
 
             auto res = data[0 .. size];
             data = data[size .. $];
@@ -540,10 +540,9 @@ public class Channel
             // this would mean some of the metadata on disk is missing (flash registry)
             // FIXME: add retry mechanism for loading this channel until peer is found,
             // and force unilateral closure after a given timeout.
-            if (this.peer is null)
-                throw new Exception(format(
-                    "Cannot find address of flash node in registry for the key %s",
-                    this.peer_pk));
+            ensure(this.peer !is null,
+                    "Cannot find address of flash node in registry for the key {}",
+                    this.peer_pk);
         }
 
         // check on start-up once in case this is a preloaded channel

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -15,6 +15,7 @@ module agora.flash.Node;
 
 import agora.api.FullNode : FullNodeAPI = API;
 import agora.common.Amount;
+import agora.common.Ensure;
 import agora.common.ManagedDatabase;
 import agora.common.Set;
 import agora.common.Task;
@@ -324,8 +325,9 @@ public abstract class FlashNode : FlashControlAPI
         catch (Exception exc)
         {
             () @trusted {
+                auto msg = exc.message();
                 printf("Error happened while dumping this node's state: %.*s\n",
-                       cast(int) exc.msg.length, exc.msg.ptr);
+                       cast(int) msg.length, msg.ptr);
 
                 scope (failure) assert(0);
                 writeln("========================================");
@@ -486,10 +488,9 @@ public abstract class FlashNode : FlashControlAPI
 
         scope DeserializeDg dg = (size) @safe
         {
-            if (size > data.length)
-                throw new Exception(
-                    format("Requested %d bytes but only %d bytes available",
-                        size, data.length));
+            ensure(size <= data.length,
+                    "Requested {} bytes but only {} bytes available",
+                    size, data.length);
 
             auto res = data[0 .. size];
             data = data[size .. $];

--- a/source/agora/flash/UpdateSigner.d
+++ b/source/agora/flash/UpdateSigner.d
@@ -17,6 +17,7 @@
 
 module agora.flash.UpdateSigner;
 
+import agora.common.Ensure;
 import agora.common.ManagedDatabase;
 import agora.common.Task;
 import agora.common.Types;
@@ -121,10 +122,9 @@ public class UpdateSigner
 
         scope DeserializeDg dg = (size) @safe
         {
-            if (size > data.length)
-                throw new Exception(
-                    format("Requested %d bytes but only %d bytes available",
-                        size, data.length));
+            ensure(size <= data.length,
+                    "Requested {} bytes but only {} bytes available",
+                    size, data.length);
 
             auto res = data[0 .. size];
             data = data[size .. $];

--- a/source/agora/registry/Server.d
+++ b/source/agora/registry/Server.d
@@ -13,6 +13,7 @@
 
 module agora.registry.Server;
 
+import agora.common.Ensure;
 import agora.common.Types;
 import agora.crypto.Hash;
 import agora.crypto.Key;
@@ -85,13 +86,13 @@ public final class NameRegistry: NameRegistryAPI
     public override void putValidator (RegistryPayload registry_payload)
     {
         // verify signature
-        if (!registry_payload.verifySignature(registry_payload.data.public_key))
-            throw new Exception("incorrect signature");
+        ensure(registry_payload.verifySignature(registry_payload.data.public_key),
+                "Incorrect signature for payload");
 
         // check if we received stale data
         if (auto previous = registry_payload.data.public_key in registry_map)
-            if (previous.data.seq > registry_payload.data.seq)
-                throw new Exception("registry already has a more up-to-date version of the data");
+            ensure(previous.data.seq <= registry_payload.data.seq,
+                "registry already has a more up-to-date version of the data");
 
         // register data
         log.info("Registering network addresses: {} for public key: {}", registry_payload.data.addresses,

--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -15,6 +15,7 @@ module scpd.types.Stellar_SCP;
 
 import vibe.data.json;
 
+import agora.common.Ensure;
 import agora.serialization.Serializer;
 
 import scpd.Cpp;
@@ -178,7 +179,7 @@ struct SCPStatement {
                 ret.nominate_ = (*obj).deserializeJson!SCPNomination();
             }
             else
-                throw new Exception("Unrecognized envelope type");
+                ensure(false, "Unrecognized envelope type");
             return ret;
         }
 


### PR DESCRIPTION
It's common to need to format a string while throwing an exception.
But there are two downsides to this:
- The code is more verbose, as an import of `std.format` is needed,
  and the call becomes `throw new Exception(format("...", args))`;
- Creating the `Exception` itself allocates with the GC;
- The formatting allocates too;

For this reason, the `enforce` method provided by `agora.common.Enforce`
is statically allocated when the thread starts, and has a buffer for
allocation. This ensures that we will not allocate (even if the code
is not annotated as `@nogc`) and thus we can avoid triggerring GC
collections on throwing Exceptions.