### PR TITLE
NoPreImageVN: Don't rely on the caller setting the parameter

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2291,9 +2291,10 @@ public class NoPreImageVN : TestValidatorNode
     /// GET: /preimages_for_enroll_keys
     public override PreImageInfo[] getPreimagesForEnrollKeys (Set!Hash enroll_keys = Set!Hash.init) @safe nothrow
     {
-        if (!atomicLoad(*this.reveal_preimage))
-            enroll_keys.remove(this.enroll_man.getEnrollmentKey());
-
-        return super.getPreimagesForEnrollKeys(enroll_keys);
+        const self = this.enroll_man.getEnrollmentKey();
+        const reveal = atomicLoad(*this.reveal_preimage);
+        return super.getPreimagesForEnrollKeys(enroll_keys)
+            .filter!(pi => reveal || pi.utxo != self)
+            .array();
     }
 }


### PR DESCRIPTION
In case the caller does not set the enroll_keys parameter,
we will reveal our own pre-image regardless of the boolean.