### PR TITLE
Trivial: Remove single-use EM.removeAllValidators

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -786,17 +786,6 @@ public class EnrollmentManager
 
     /***************************************************************************
 
-        Remove all validators from the validator set
-
-    ***************************************************************************/
-
-    public void removeAllValidators () @trusted
-    {
-        this.validator_set.removeAll();
-    }
-
-    /***************************************************************************
-
         Returns: A delegate to query past Enrollments
 
     ***************************************************************************/

--- a/source/agora/node/Ledger.d
+++ b/source/agora/node/Ledger.d
@@ -174,7 +174,7 @@ public class Ledger
             || this.enroll_man.validator_set.countActive(this.last_block.header.height + 1) == 0)
         {
             this.utxo_set.clear();
-            this.enroll_man.removeAllValidators();
+            this.enroll_man.validator_set.removeAll();
 
             // Calling `addValidatedBlock` will reset this value
             const HighestHeight = this.last_block.header.height;


### PR DESCRIPTION
There is no use for this function but to replay the entire blockchain,
so just inline the call inside the Ledger.