### PR TITLE
Test: Take Logger configuration into account

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1815,6 +1815,16 @@ public class TestValidatorNode : Validator, TestAPI
         this.blocks = blocks;
         this.cur_time = cur_time;
         this.test_start_time = *cur_time;
+
+        // This is normally done by `agora.node.Runner`
+        // By default all output is written to the appender
+        Log.root.level(Log.root.Level.Info, true);
+        foreach (const ref settings; config.logging)
+        {
+            auto log = settings.name ? Log.lookup(settings.name) : Log.root;
+            log.level(settings.level, settings.propagate);
+        }
+
         super(config);
     }
 


### PR DESCRIPTION
```
When a test fail, the logs printed to stdout are extremely verbose,
as they include all the trace calls.
This is not the case for the main thread,
which only prints the Error level,
or what we see in production, which uses Info by default.
The reason we were seeing everything is that the configuration
is done in agora.node.Runner, which is not used in unittests.
By slightly duplicating code, we now only print Info level by default,
and an API manager can use a custom log level to get a more verbose output.
We can also, in the future, add a field to configure the default log level
in TestConf, allowing to tailor the logs to a given test.
```