### PR TITLE
Nominator: Return the correct enum value for MaybeValid values

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -902,6 +902,9 @@ extern(D):
 
         if (auto fail_reason = this.ledger.validateConsensusData(data, this.initial_missing_validators))
         {
+            if (fail_reason == Ledger.InvalidConsensusDataReason.MayBeValid)
+                return ValidationLevel.kMaybeValidValue;
+
             log.error("validateValue(): Validation failed: {}. Data: {}",
                 fail_reason, data.prettify);
             return ValidationLevel.kInvalidValue;


### PR DESCRIPTION
```
This error message floods the log, because it is logged at Error level.
It is currently only returned if there are unknown txs (nominated txs we don't know about).
In this case, the node shouldn't outright reject the nomination,
but return the associated SCP value (`kMaybeValid`).
```