### PR TITLE
Remove some spurious or misleading log messages

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1181,8 +1181,6 @@ extern(D):
     public override ValueWrapperPtr combineCandidates (uint64_t slot_idx,
         ref const(ValueWrapperPtrSet) candidates)
     {
-        log.info("combineCandidates: {}", slot_idx);
-
         try
         {
             CandidateHolder[] candidate_holders;

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -640,8 +640,8 @@ public class ValidatorSet
             return false;
         }
 
-        // Ignore same height pre-image because validators will gossip them
-        if (prev_preimage.height == preimage.height)
+        // Ignore older height pre-image because validators will gossip them
+        if (prev_preimage.height >= preimage.height)
             return false;
 
         if (auto reason = isInvalidReason(preimage, prev_preimage))


### PR DESCRIPTION
Context: Trying to debug any kind of issue in the network tests makes me hate life.
I took a good look at the logs, to try to make sense of it, but there is a lot of noise in it.
The first step was to not print the `Trace` messages unless configured (#2335).
The most common spurious message is addressed in #2336 although that will require more work, so it is in its own PR.
This PR addresses two common messages we're seeing:
- A simple `combineCandidate` with the slot index / height at which it is called;
   Removing it because it always appear after a "Nominating" message, and it should never have been `Info`;
- We get a lot of "Invalid pre-image data" messages, which are just about the height.
   Since the situation can happen in a normal, functioning system, it shouldn't be logged at `Info` level,
   especially since it's harmless. Ideally we should avoid the flood of network communication, but it's another issue.

For example, look at the following screenshot: 2/3rd of the space is taken by useless messages.
<img width="836" alt="Screen Shot 2021-07-29 at 15 55 40" src="https://user-images.githubusercontent.com/2180215/127445928-674fb251-bdf5-4110-bcec-e324c98c0c46.png">

And this is the `combineCandidate` message:
<img width="834" alt="Screen Shot 2021-07-29 at 15 58 09" src="https://user-images.githubusercontent.com/2180215/127446270-c359de26-8b89-434d-a659-fecbb525e4b2.png">
