### PR TITLE
Tests: Remove unused TestNominator

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -490,23 +490,6 @@ public class TestBanManager : BanManager
     public override void dump () { }
 }
 
-/// Nominator with custom rules for when blocks should be nominated
-public extern (C++) class TestNominator : Nominator
-{
-extern(D):
-    /// test start time
-    protected ulong test_start_time;
-
-    ///
-    public this (Parameters!(Nominator.__ctor) args,
-        ulong test_start_time)
-    {
-        super(args);
-        this.test_start_time = test_start_time;
-    }
-
-}
-
 /// We use a pair of (key, client) rather than a hashmap client[key],
 /// since we want to know the order of the nodes which were configured
 /// in the makeTestNetwork() call.
@@ -1542,9 +1525,6 @@ private mixin template TestNodeMixin ()
     /// pointer to the unittests-adjusted clock time
     protected shared(TimePoint)* cur_time;
 
-    /// test start time
-    protected ulong test_start_time;
-
     /// All txs which were at one point accepted into the tx pool
     protected Set!Hash accepted_txs;
 
@@ -1750,7 +1730,6 @@ public class TestFullNode : FullNode, TestAPI
         this.nregistry = nreg;
         this.blocks = blocks;
         this.cur_time = cur_time;
-        this.test_start_time = *cur_time;
         super(config);
     }
 
@@ -1814,7 +1793,6 @@ public class TestValidatorNode : Validator, TestAPI
         this.nregistry = nreg;
         this.blocks = blocks;
         this.cur_time = cur_time;
-        this.test_start_time = *cur_time;
 
         // This is normally done by `agora.node.Runner`
         // By default all output is written to the appender
@@ -1842,16 +1820,6 @@ public class TestValidatorNode : Validator, TestAPI
     public override QuorumConfig getQuorumConfig ()
     {
         return this.qc;
-    }
-
-    /// Returns an instance of a TestNominator with customizable behavior
-    protected override TestNominator makeNominator (
-        Parameters!(Validator.makeNominator) args)
-    {
-        return new TestNominator(
-            this.params, this.config.validator.key_pair, args,
-            this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.test_start_time);
     }
 
     /// Provides a unittest-adjusted clock source for the node

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -63,7 +63,7 @@ struct EnvelopeTypeCounts
     size_t externalize_count;
 }
 
-private extern(C++) class ByzantineNominator : TestNominator
+private extern(C++) class ByzantineNominator : Nominator
 {
     private ByzantineReason reason;
 
@@ -96,17 +96,17 @@ class ByzantineNode (ByzantineReason reason) : TestValidatorNode
 {
     mixin ForwardCtor!();
 
-    protected override TestNominator makeNominator (
+    protected override ByzantineNominator makeNominator (
         Parameters!(TestValidatorNode.makeNominator) args)
     {
         return new ByzantineNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.test_start_time, reason);
+            &this.acceptBlock, reason);
     }
 }
 
-private class SpyNominator : TestNominator
+private class SpyNominator : Nominator
 {
     private shared(EnvelopeTypeCounts)* envelope_type_counts;
 
@@ -156,14 +156,13 @@ private class SpyingValidator : TestValidatorNode
     }
 
     ///
-    protected override TestNominator makeNominator (
+    protected override SpyNominator makeNominator (
         Parameters!(TestValidatorNode.makeNominator) args)
     {
         return new SpyNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.test_start_time,
-            this.envelope_type_counts);
+            &this.acceptBlock, this.envelope_type_counts);
     }
 }
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -142,12 +142,12 @@ unittest
     import geod24.Registry;
     import core.atomic;
 
-    static class BadNominator : TestNominator
+    static class BadNominator : Nominator
     {
         private shared(size_t)* runCount;
 
         /// Ctor
-        public this (Parameters!(TestNominator.__ctor) args, shared(size_t)* countPtr)
+        public this (Parameters!(Nominator.__ctor) args, shared(size_t)* countPtr)
         {
             super(args);
             this.runCount = countPtr;
@@ -182,14 +182,13 @@ unittest
         }
 
         ///
-        protected override TestNominator makeNominator (
+        protected override BadNominator makeNominator (
             Parameters!(TestValidatorNode.makeNominator) args)
         {
             return new BadNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock, this.test_start_time,
-                this.runCount);
+                &this.acceptBlock, this.runCount);
         }
     }
 

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -21,6 +21,7 @@ import agora.common.Config;
 import agora.common.Task;
 import agora.common.Types;
 import agora.consensus.data.Block;
+import agora.consensus.protocol.Nominator;
 import agora.crypto.ECC;
 import agora.crypto.Schnorr;
 import agora.test.Base;
@@ -53,11 +54,11 @@ private enum ByzantineReason
     BadSignature
 }
 
-private extern(C++) class BadBlockSigningNominator : TestNominator
+private extern(C++) class BadBlockSigningNominator : Nominator
 {
     private ByzantineReason reason;
 
-    extern(D) this (Parameters!(TestNominator.__ctor) args, ByzantineReason reason)
+    extern(D) this (Parameters!(Nominator.__ctor) args, ByzantineReason reason)
     {
         super(args);
         this.reason = reason;
@@ -106,7 +107,7 @@ private class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new BadBlockSigningNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.test_start_time, reason);
+            &this.acceptBlock, reason);
     }
 }
 

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -21,6 +21,7 @@ import agora.consensus.data.Enrollment;
 import agora.consensus.data.PreImageInfo;
 import agora.consensus.EnrollmentManager;
 import agora.consensus.protocol.Data;
+import agora.consensus.protocol.Nominator;
 import agora.serialization.Serializer;
 import agora.test.Base;
 import agora.utils.Test;
@@ -53,13 +54,11 @@ private void unexpectBlock (Clients)(Clients clients, Height height)
     }
 }
 
-private class BadNominator : TestNominator
+private class BadNominator : Nominator
 {
+extern(D):
     /// Ctor
-    public this (Parameters!(TestNominator.__ctor) args)
-    {
-        super(args);
-    }
+    mixin ForwardCtor!();
 
 extern (C++):
 
@@ -85,13 +84,13 @@ private class BadNominatingVN : TestValidatorNode
     mixin ForwardCtor!();
 
     ///
-    protected override TestNominator makeNominator (
+    protected override BadNominator makeNominator (
         Parameters!(TestValidatorNode.makeNominator) args)
     {
         return new BadNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.test_start_time);
+            &this.acceptBlock);
     }
 }
 

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -42,7 +42,7 @@ import scpd.types.Stellar_SCP;
 /// ditto
 unittest
 {
-    extern (C++) static class CustomNominator : TestNominator
+    extern (C++) static class CustomNominator : Nominator
     {
         // To see how many voting rounds are needed to reach consensus
         public __gshared int round_number;
@@ -75,7 +75,7 @@ unittest
             return new CustomNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock, this.test_start_time);
+                &this.acceptBlock);
         }
     }
 

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -22,6 +22,7 @@ import agora.common.Config;
 import agora.common.Types;
 import agora.consensus.data.Block;
 import agora.consensus.data.ValidatorBlockSig;
+import agora.consensus.protocol.Nominator;
 import agora.crypto.Schnorr: Signature;
 import agora.test.Base;
 import agora.utils.Log;
@@ -36,11 +37,10 @@ import core.thread;
 mixin AddLogger!();
 
 
-private extern(C++) class DoesNotExternalizeBlockNominator : TestNominator
+private extern(C++) class DoesNotExternalizeBlockNominator : Nominator
 {
-    extern(D) this (Parameters!(TestNominator.__ctor) args)
-    {
-        super(args);
+    extern(D) {
+        mixin ForwardCtor!();
     }
 
     public override void valueExternalized (uint64_t slot_idx, ref const(Value) value) nothrow
@@ -72,13 +72,13 @@ private class TestNode () : TestValidatorNode
 {
     mixin ForwardCtor!();
 
-    protected override TestNominator makeNominator (
+    protected override DoesNotExternalizeBlockNominator makeNominator (
         Parameters!(TestValidatorNode.makeNominator) args)
     {
         return new DoesNotExternalizeBlockNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.test_start_time);
+            &this.acceptBlock);
     }
 }
 

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -41,7 +41,7 @@ unittest
 {
     __gshared bool Checked = false;
 
-    static class ReNominator : TestNominator
+    static class ReNominator : Nominator
     {
         /// Ctor
         mixin ForwardCtor!();
@@ -83,7 +83,7 @@ unittest
             return new ReNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock, this.test_start_time);
+                &this.acceptBlock);
         }
     }
 

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -25,6 +25,7 @@ import agora.consensus.data.Transaction;
 import agora.consensus.data.Block;
 import agora.consensus.EnrollmentManager;
 import agora.consensus.PreImage;
+import agora.consensus.protocol.Nominator;
 import agora.crypto.Hash;
 import agora.node.Ledger;
 import geod24.Registry;
@@ -163,7 +164,7 @@ unittest
 // create another enrollment request for the next block
 unittest
 {
-    static class SocialDistancingNominator : TestNominator
+    static class SocialDistancingNominator : Nominator
     {
         mixin ForwardCtor!();
 
@@ -181,13 +182,13 @@ unittest
         mixin ForwardCtor!();
 
         ///
-        protected override TestNominator makeNominator (
+        protected override SocialDistancingNominator makeNominator (
             Parameters!(TestValidatorNode.makeNominator) args)
         {
             return new SocialDistancingNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock, this.test_start_time);
+                &this.acceptBlock);
         }
 
     }


### PR DESCRIPTION
This is a relic from the times before stateDB and cacheDB were introduced,
but it is not used anymore and can be removed, along with 'test_start_time'.