### PR TITLE
Unit tests: Ensure non-empty blocks when expected

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1069,9 +1069,13 @@ public class TestAPIManager
             else
             {
                 // Send transaction to the first client
-                spendables.takeExactly(1)
-                    .map!(txb => txb.sign())
-                    .each!(tx => first_client.putTransaction(tx));
+                auto tx = spendables.takeExactly(1).map!(txb => txb.sign()).front;
+                first_client.putTransaction(tx);
+                // Wait for tx gossipping before setting time for block
+                client_idxs.each!(idx =>
+                    retryFor(this.clients[idx].hasTransactionHash(tx.hashFull()),
+                        4.seconds, format!"[%s:%s] Client #%s did not receive tx in expected time for height %s"
+                            (file, line, idx, target_height)));
                 break;
             }
         }

--- a/source/agora/test/Simple.d
+++ b/source/agora/test/Simple.d
@@ -50,6 +50,11 @@ unittest
     {
         network.generateBlocks(h);
         network.assertSameBlocks(h, last_height + 1);
+        // Make sure the blocks are not empty
+        uint blocks = (h - last_height - 1).to!uint;
+        node_1.getBlocksFrom(last_height + 1, blocks)
+            .each!(block => assert(block.txs.count > 0,
+                format!"No txs in block %s"(block.header.height)));
         last_height = h;
     });
 }


### PR DESCRIPTION
AddBlocks has a parameter to determine if we want empty blocks or not.
Sometimes we still ended up with empty blocks though. 
This corrects that and updates the `Simple` unit test to check all blocks ave a tx.