### PR TITLE
Improve logging configuration in network integration tests

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -83,7 +83,9 @@ import core.thread;
 /* The following imports are frequently needed in tests */
 
 public import agora.common.Types;
- // Contains utilities for testing, e.g. `retryFor`
+/// Allows to easily configure the loggers
+public import agora.utils.Log : LogLevel;
+// Contains utilities for testing, e.g. `retryFor`
 public import agora.utils.Test;
 // `core.time` provides duration-related utilities, used e.g. for `retryFor`
 public import core.time;
@@ -1971,6 +1973,31 @@ public struct TestConf
         /// Transaction size adjusted fee = tx fee / tx size in bytes.
         min_fee: Amount(0),
     };
+
+    /***
+        Base values for the `logging` section
+
+        By default, the nodes will log at the default log level, which is either
+        the value of the `dloglevel` environment variable,
+        or `Info` if the variable is not set.
+
+        Any setting provided here will override this default value and
+        propagate to child loggers. For example, if the unittest binary is called
+        with `dloglevel=Error`, and the following is used, the nodes will
+        only log messages at `Error` level or above, except for the SCP log
+        messages which will be at `Trace` level:
+        ---
+        TestConf conf = {
+            logging: [
+                {
+                    name: "SCP",
+                    level: LogLevel.Trace,
+                },
+            ],
+        };
+        ---
+    */
+    public immutable(LoggerConfig)[] logging;
 }
 
 /*******************************************************************************
@@ -2087,6 +2114,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             consensus: makeConsensusConfig(),
             validator : validator,
             network : makeNetworkConfig(idx, addresses),
+            logging: test_conf.logging,
         };
 
         return conf;
@@ -2102,6 +2130,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             interfaces: [ makeInterfaceConfig(self_address) ],
             consensus: makeConsensusConfig(),
             network : makeNetworkConfig(idx, addresses),
+            logging: test_conf.logging,
         };
 
         return conf;

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -412,9 +412,6 @@ public class FlashNodeFactory (FlashListenerType = FlashListener)
 
     public void printLogs (string file = __FILE__, int line = __LINE__)
     {
-        if (no_logs)
-            return;
-
         synchronized  // make sure logging output is not interleaved
         {
             writeln("---------------------------- START OF LOGS ----------------------------");


### PR DESCRIPTION
This allows to do two things:
- Set the default `LogLevel` for the whole process via environment variable;
- Override, for any logger, the configuration of any logger via `TestConf`;

The usage with `SCP` doesn't actually work now, but that seems to be an issue with the SCP logging.
Tested various combination `dloglevel` and override and it works like a charm.