### PR TITLE
Fix #2338 - Fix SCP logging and allow TRACE / DEBUG log

### DIFF
--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -456,7 +456,7 @@ public class AgoraLayout : Appender.Layout
 
 ***************************************************************************/
 
-private extern(C++) void writeDLog (const(char)* logger, int level,
+private extern(C++, "agora") void writeDLog (const(char)* logger, int level,
     const(char)* msg) nothrow
 {
     try

--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -491,3 +491,13 @@ private extern(C++, "agora") void writeDLog (const(char)* logger, int level,
         assert(0);
     }
 }
+
+/// Used by C++ code to check whether a log level is enabled
+/// and avoid needlessly formatting messages
+private extern(C++, "agora") int getLogLevel (const(char)* logger)
+{
+    import std.string;
+    auto log = Log.lookup(fromStringz(logger));
+    assert(log !is null);
+    return log.level();
+}

--- a/source/scpd/Cpp.d
+++ b/source/scpd/Cpp.d
@@ -47,6 +47,7 @@ extern(C++) {
     void copyCtorCPPObject(T) (T* ptr, inout(T)* rhs);
     void copyCtorCPPObject(T) (immutable(T)* ptr, inout(T)* rhs);
     int getCPPSizeof(T) ();
+    std_string sliceToStdString (const(char)* ptr, size_t length);
 }
 
 private mixin template CPPBindingMixin (T, bool Copyable = true, bool DefaultConstructable = false)

--- a/source/scpd/scp/SCPDriver.d
+++ b/source/scpd/scp/SCPDriver.d
@@ -124,7 +124,10 @@ nothrow:
     {
         import agora.crypto.Hash;
         try
-            return std_string(v.hashFull().toString());
+        {
+            auto slice = v.hashFull().toString();
+            return sliceToStdString(slice.ptr, slice.length);
+        }
         catch (Exception exc)
         {
             scope (failure) assert(0);
@@ -136,7 +139,10 @@ nothrow:
     std_string toStrKey(ref const(NodeID) pk, bool fullKey = true) const
     {
         try
-            return std_string(Hash(pk).toString());
+        {
+            auto slice = Hash(pk).toString();
+            return sliceToStdString(slice.ptr, slice.length);
+        }
         catch (Exception exc)
         {
             scope (failure) assert(0);
@@ -147,9 +153,11 @@ nothrow:
     // `toShortString` converts to the common name of a key if found
     std_string toShortString(ref const(NodeID) pk) const
     {
-        import agora.crypto.Key : PublicKey;
         try
-            return std_string(Hash(pk).toString());
+        {
+            auto slice = Hash(pk).toString();
+            return sliceToStdString(slice.ptr, slice.length);
+        }
         catch (Exception exc)
         {
             scope (failure) assert(0);

--- a/source/scpp/extra/DUtils.cpp
+++ b/source/scpp/extra/DUtils.cpp
@@ -18,6 +18,11 @@
 using namespace xdr;
 using namespace stellar;
 
+std::string sliceToStdString (char const* ptr, size_t length)
+{
+    return std::string(ptr, length);
+}
+
 std::set<unsigned int>* makeTestSet()
 {
     std::set<unsigned int>* set = new std::set<unsigned int>({1, 2, 3, 4, 5});

--- a/source/scpp/src/util/Logging.cpp
+++ b/source/scpp/src/util/Logging.cpp
@@ -19,9 +19,6 @@ DLogger::DLogger(int level, std::string const& loggerName)
 
 DLogger::~DLogger()
 {
-    if (mLevel == TRACE && !Logging::logTrace("SCP"))
-        return;
-
     agora::writeDLog(mLoggerName.c_str(), mLevel, mOutStream.str().c_str());
 }
 }

--- a/source/scpp/src/util/Logging.cpp
+++ b/source/scpp/src/util/Logging.cpp
@@ -22,6 +22,6 @@ DLogger::~DLogger()
     if (mLevel == TRACE && !Logging::logTrace("SCP"))
         return;
 
-    writeDLog(mLoggerName.c_str(), mLevel, mOutStream.str().c_str());
+    agora::writeDLog(mLoggerName.c_str(), mLevel, mOutStream.str().c_str());
 }
 }

--- a/source/scpp/src/util/Logging.h
+++ b/source/scpp/src/util/Logging.h
@@ -19,6 +19,7 @@
 namespace agora {
     // Exposed in `agora.utils.Log`
     void writeDLog(const char* logger, int level, const char* msg);
+    int getLogLevel (const char* logger);
 };
 
 namespace stellar
@@ -29,8 +30,14 @@ class Logging
     static void init();
     static void setFmt(std::string const& peerID, bool timestamps = true);
     static void setLoggingToFile(std::string const& filename);
-    static bool logDebug(std::string const& partition) { return false; }
-    static bool logTrace(std::string const& partition) { return false; }
+    static bool logDebug(std::string const& partition)
+    {
+        return agora::getLogLevel(partition.c_str()) <= DEBUG;
+    }
+    static bool logTrace(std::string const& partition)
+    {
+        return agora::getLogLevel(partition.c_str()) <= TRACE;
+    }
     static void rotate();
 };
 

--- a/source/scpp/src/util/Logging.h
+++ b/source/scpp/src/util/Logging.h
@@ -16,8 +16,10 @@
 #define FATAL 4
 #define CLOG(LEVEL, MOD) stellar::DLogger(LEVEL, MOD)
 
-// Logging function to D code
-void writeDLog(const char* logger, int level, const char* msg);
+namespace agora {
+    // Exposed in `agora.utils.Log`
+    void writeDLog(const char* logger, int level, const char* msg);
+};
 
 namespace stellar
 {


### PR DESCRIPTION
There were a few issues with SCP logging which made issues hard to debug.
The following should be a little easier to follow:

<img width="843" alt="Screen Shot 2021-07-30 at 19 42 52" src="https://user-images.githubusercontent.com/2180215/127641803-9cf73895-9df0-4e44-be8d-726e8e01a8a6.png">
