### PR TITLE
Nominator: Fix null check and shutdown of inactive validator

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -237,7 +237,7 @@ extern(D):
             // TODO: We should apply the situation where this validator has
             // enrolled with another UTXO after its previous enrollment expired.
             auto self_enroll = this.enroll_man.getEnrollmentKey();
-            if (this.scp == null && self_enroll != Hash.init)
+            if (this.scp is null && self_enroll != Hash.init)
             {
                 auto node_id = NodeID(self_enroll[][0 .. NodeID.sizeof]);
                 const IsValidator = true;
@@ -348,7 +348,7 @@ extern(D):
     {
         this.is_nominating = false;
         () @trusted {
-            if (this.scp != null)
+            if (this.scp !is null)
                 this.scp.stopNomination(height);
         }();
 
@@ -687,7 +687,7 @@ extern(D):
 
         () @trusted
         {
-            if (this.scp.empty())
+            if (this.scp is null || this.scp.empty())
                 return;
 
             envelopes = this.scp.getExternalizingState(this.scp.getHighSlotIndex());

--- a/source/agora/test/Restart.d
+++ b/source/agora/test/Restart.d
@@ -27,7 +27,7 @@ import geod24.Registry;
 /// A test that stops and restarts a node
 unittest
 {
-    TestConf conf = TestConf.init;
+    TestConf conf = { outsider_validators: 1 };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();
@@ -42,10 +42,13 @@ unittest
     network.expectHeight(Height(1));
 
     // Now shut down & restart one node
-    auto restartMe = nodes[$-1];
+    auto restartMe = nodes[0];
     network.restart(restartMe);
     network.waitForDiscovery();
     network.expectHeight(Height(1));
+
+    // Test for https://github.com/bosagora/agora/issues/2344
+    network.restart(nodes[$-1]);
 }
 
 /// Node which has a persistent Ledger (restart always clear the local state)


### PR DESCRIPTION
If a validator is not enrolled, it does not create an SCP object.
This would lead to a crash with SEGV on shutdown as 'storeLatestEnvelope'
would call 'empty' on a 'null' SCP object.

Fixes #2344 