### PR TITLE
Fix "Restart" unittest to not crash 

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1267,8 +1267,8 @@ public class TestNetworkManager : NetworkManager
         auto tid = this.registry.locate(address);
         if (tid != typeof(tid).init)
             return new RemoteAPI!TestAPI(tid, timeout);
-        assert(0, "Trying to access node at address '" ~ address ~
-               "' without first creating it");
+        assert(0, format("Trying to access node at address '%s' from '%s' without first creating it",
+                         address, this.address));
     }
 
     ///

--- a/source/agora/test/Restart.d
+++ b/source/agora/test/Restart.d
@@ -47,6 +47,12 @@ unittest
 
     // Test for https://github.com/bosagora/agora/issues/2344
     network.restart(nodes[$-1]);
+    // Make sure to wait until restart is completed, otherwise the network will
+    // start to shut down before the node has fully started up and this will
+    // trigger the dreaded `assert`
+    // "Trying to access node at address ... without first creating it"
+    network.waitForDiscovery();
+    network.expectHeight(Height(1));
 }
 
 /// Node which has a persistent Ledger (restart always clear the local state)


### PR DESCRIPTION
Pretty self-explanatory. Also added a trivial commit cleaning up a leftover copy-pasted import.