### PR TITLE
Implement SigHash support in the execution engine

### DIFF
--- a/source/agora/cli/client/SendTxProcess.d
+++ b/source/agora/cli/client/SendTxProcess.d
@@ -22,6 +22,7 @@ import agora.consensus.data.Transaction;
 import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.script.Lock;
+import agora.script.Signature;
 
 import std.format;
 import std.getopt;
@@ -189,7 +190,7 @@ public int sendTxProcess (string[] args, ref string[] outputs, APIMaker api_make
     Transaction tx = Transaction([Input(Hash.fromString(op.txhash), op.index)],
         [Output(Amount(op.amount), PublicKey.fromString(op.address))]);
 
-    auto signature = key_pair.sign(tx);
+    auto signature = key_pair.sign(tx.getChallenge());
     tx.inputs[0].unlock = genKeyUnlock(signature);
 
     if (op.dump)
@@ -270,12 +271,11 @@ unittest
 
     Transaction tx = Transaction([Input(Hash.fromString(txhash), index)],
         [Output(Amount(amount), PublicKey.fromString(address))]);
-    Hash send_txhash = hashFull(tx);
     auto key_pair = KeyPair.fromSeed(SecretKey.fromString(key));
-    tx.inputs[0].unlock = genKeyUnlock(key_pair.sign(send_txhash[]));
+    tx.inputs[0].unlock = genKeyUnlock(key_pair.sign(tx.getChallenge()));
 
     foreach (ref line; outputs)
         writeln(line);
 
-    assert(node.hasTransactionHash(send_txhash));
+    assert(node.hasTransactionHash(hashFull(tx)));
 }

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -25,6 +25,7 @@ import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.crypto.Schnorr;
 import agora.script.Lock;
+import agora.script.Signature;
 import agora.serialization.Serializer;
 
 import std.algorithm.comparison;
@@ -676,9 +677,8 @@ unittest
     for (int idx = 0; idx < 8; idx++)
     {
         auto tx = Transaction([Input(last_hash, 0)],[Output(Amount(100_000), key_pairs[idx+1].address)]);
-        last_hash = hashFull(tx);
         tx.inputs[0].unlock = genKeyUnlock(
-            key_pairs[idx].sign(last_hash[]));
+            key_pairs[idx].sign(tx.getChallenge()));
         txs ~= tx;
     }
 

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -21,6 +21,7 @@ import agora.consensus.state.UTXOCache;
 import agora.crypto.Hash;
 import agora.script.Engine;
 import agora.script.Lock;
+import agora.script.Signature;
 import agora.crypto.Schnorr;
 
 version (unittest)
@@ -35,7 +36,7 @@ version (unittest)
 version (unittest)
 public Unlock signUnlock (KeyPair key_pair, Transaction tx)
 {
-    return genKeyUnlock(key_pair.sign(tx));
+    return genKeyUnlock(key_pair.sign(tx.getChallenge()));
 }
 
 /*******************************************************************************

--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -35,6 +35,7 @@ import agora.crypto.Key;
 import agora.crypto.Schnorr;
 import agora.script.Engine;
 import agora.script.Lock;
+import agora.script.Signature;
 import agora.serialization.Serializer;
 import agora.utils.Backoff;
 import agora.utils.Log;
@@ -621,7 +622,7 @@ LOuter: while (1)
         {
             auto funding_tx_signed = this.conf.funding_tx.clone();
             funding_tx_signed.inputs[0].unlock
-                = genKeyUnlock(this.kp.sign(this.conf.funding_tx));
+                = genKeyUnlock(this.kp.sign(this.conf.funding_tx.getChallenge()));
 
             log.info("Publishing funding tx..");
             this.txPublisher(funding_tx_signed);
@@ -1917,7 +1918,7 @@ LOuter: while (1)
 
         const nonce_pair_pk = priv_nonce.V + peer_nonce;
         this.pending_close.our_sig = sign(this.kp.secret, this.conf.pair_pk,
-            nonce_pair_pk, priv_nonce.v, this.pending_close.tx);
+            nonce_pair_pk, priv_nonce.v, this.pending_close.tx.getChallenge());
 
         const fail_time = Clock.currTime() + this.flash_conf.max_retry_time;
         Result!Signature sig_res = Result!Signature(ErrorCode.Unknown);

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -1004,7 +1004,6 @@ public abstract class FlashNode : FlashControlAPI
             this.payment_errors.remove(payment_hash);
 
             // get the invoice if it exists and not just the pointer (GC safety)
-            Invoice inv;
             auto invoice = this.invoices.get(payment_hash, Invoice.init);
             this.invoices.remove(payment_hash);
 

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -1401,7 +1401,7 @@ public abstract class ThinFlashNode : FlashNode
 
     ***************************************************************************/
 
-    private void monitorBlockchain ()
+    protected void monitorBlockchain ()
     {
         try
         {

--- a/source/agora/flash/Scripts.d
+++ b/source/agora/flash/Scripts.d
@@ -126,12 +126,12 @@ public Lock createFlashLock (uint age, Hash first_utxo, Point pair_pk,
 
 *******************************************************************************/
 
-public Unlock createUnlockUpdate (Signature sig, in ulong seq_id)
-    @safe nothrow
+public Unlock createUnlockUpdate (Signature sig, in ulong seq_id,
+    SigHash sig_hash = SigHash.NoInput) @safe nothrow
 {
     // remember it's LIFO when popping, TRUE is pushed last
     const seq_bytes = nativeToLittleEndian(seq_id);
-    return Unlock([ubyte(64)] ~ sig.toBlob()[] ~ toPushOpcode(seq_bytes)
+    return Unlock([ubyte(65)] ~ SigPair(sig, sig_hash)[] ~ toPushOpcode(seq_bytes)
         ~ [ubyte(OP.TRUE)]);
 }
 
@@ -148,12 +148,12 @@ public Unlock createUnlockUpdate (Signature sig, in ulong seq_id)
 
 *******************************************************************************/
 
-public Unlock createUnlockSettle (Signature sig, in ulong seq_id)
-    @safe nothrow
+public Unlock createUnlockSettle (Signature sig, in ulong seq_id,
+    SigHash sig_hash = SigHash.NoInput) @safe nothrow
 {
     // remember it's LIFO when popping, FALSE is pushed last
     const seq_bytes = nativeToLittleEndian(seq_id);
-    return Unlock([ubyte(64)] ~ sig.toBlob()[] ~ toPushOpcode(seq_bytes)
+    return Unlock([ubyte(65)] ~ SigPair(sig, sig_hash)[] ~ toPushOpcode(seq_bytes)
         ~ [ubyte(OP.FALSE)]);
 }
 

--- a/source/agora/flash/UpdateSigner.d
+++ b/source/agora/flash/UpdateSigner.d
@@ -33,6 +33,7 @@ import agora.flash.Scripts;
 import agora.flash.Types;
 import agora.script.Engine;
 import agora.script.Lock;
+import agora.script.Signature;
 import agora.serialization.Serializer;
 import agora.utils.Backoff;
 import agora.utils.Log;
@@ -480,7 +481,7 @@ public class UpdateSigner
         if (this.seq_id == 0)
         {
             return sign(this.kp.secret, this.conf.pair_pk, nonce_pair_pk,
-                priv_nonce.update.v, update_tx);
+                priv_nonce.update.v, update_tx.getChallenge());
         }
         else
         {

--- a/source/agora/script/Lock.d
+++ b/source/agora/script/Lock.d
@@ -36,6 +36,7 @@ import agora.crypto.ECC;
 import agora.crypto.Key;
 import agora.crypto.Schnorr: Signature;
 import agora.script.Script;
+import agora.script.Signature;
 import agora.utils.Utility;
 import std.format;
 import std.traits : EnumMembers;
@@ -339,8 +340,8 @@ public Lock genKeyLock (in PublicKey key) pure nothrow @safe
 
 *******************************************************************************/
 
-public Unlock genKeyUnlock (in Signature sig) pure nothrow @safe
+public Unlock genKeyUnlock (in Signature sig, in SigHash sig_hash = SigHash.All) pure nothrow @safe
 {
     // must dupe because it's a value on the stack..
-    return Unlock(sig.toBlob()[].dup);
+    return Unlock(SigPair(sig, sig_hash)[].dup);
 }

--- a/source/agora/script/Script.d
+++ b/source/agora/script/Script.d
@@ -18,6 +18,7 @@ import agora.crypto.ECC;
 import agora.crypto.Hash;
 import agora.crypto.Schnorr: Signature;
 import agora.script.Opcodes;
+import agora.script.Signature;
 import agora.script.Stack;
 
 import std.bitmanip;
@@ -359,6 +360,7 @@ public Script createLockP2PKH (in Hash key_hash) pure nothrow @safe
 
     Params:
         sig = the signature
+        sig_hash = the SigHash type
         pub_key = the public key
 
     Returns:
@@ -367,10 +369,10 @@ public Script createLockP2PKH (in Hash key_hash) pure nothrow @safe
 *******************************************************************************/
 
 version (unittest)
-public Script createUnlockP2PKH (in Signature sig, in Point pub_key)
+public Script createUnlockP2PKH (in Signature sig, in SigHash sig_hash, in Point pub_key)
     pure nothrow @safe
 {
-    return Script([ubyte(64)] ~ sig.toBlob()[] ~ [ubyte(32)] ~ pub_key[]);
+    return Script([ubyte(65)] ~ sig.toBlob()[] ~ [cast(ubyte)sig_hash] ~ [ubyte(32)] ~ pub_key[]);
 }
 
 ///
@@ -387,7 +389,7 @@ unittest
     const key_hash = hashFull(kp.V);
     Script lock_script = createLockP2PKH(key_hash);
     assert(validateScriptSyntax(ScriptType.Lock, lock_script[], 512, result) is null);
-    Script unlock_script = createUnlockP2PKH(sig, kp.V);
+    Script unlock_script = createUnlockP2PKH(sig, SigHash.All, kp.V);
     assert(validateScriptSyntax(ScriptType.Unlock, unlock_script[], 512, result)
         is null);
 }

--- a/source/agora/script/Signature.d
+++ b/source/agora/script/Signature.d
@@ -1,0 +1,164 @@
+/*******************************************************************************
+
+    Contains the signature definitions and the challenge routine.
+
+    Copyright:
+        Copyright (c) 2020 BOS Platform Foundation Korea
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.script.Signature;
+
+import agora.crypto.Schnorr;
+import agora.crypto.Hash;
+import agora.common.Types;
+import agora.consensus.data.Transaction;
+
+import std.range;
+
+/// Used to select the behavior of the signature creation & validation algorithm
+public enum SigHash : ubyte
+{
+    /// default, signs the entire transaction
+    All = 1 << 0,
+}
+
+/// Contains the Signature and its associated SigHash
+public struct SigPair
+{
+align(1):
+    /// The signature (which also signs the sig_hash below)
+    public Signature signature;
+
+    /// Selects behavior of the signature creation & validation algorithm
+    public SigHash sig_hash;
+
+    /***************************************************************************
+
+        todo: unittest
+
+        Returns:
+            The signature + SigHash as a byte array embeddable in a script
+
+    ***************************************************************************/
+
+    public inout(ubyte)[] opSlice () inout pure nothrow @safe /*@nogc*/
+    {
+        return this.signature.toBlob()[] ~ ubyte(this.sig_hash);
+    }
+}
+
+/*******************************************************************************
+
+    Decodes the raw byte representation of a signature to its
+    `Signature` and `SigHash` parts, and validates the `SigHash`
+    to be one of the known flags or accepted combination of flags.
+
+    Params:
+        bytes = contains the <Signature, SigHash> tuple
+        sig_pair = will contain the signature tuple if the Signature was encoded
+                   correctly and the SigHash is one of the known flags or
+                   accepted combination of flags.
+
+    Returns:
+        null if the signature tuple was decoded correctly,
+        otherwise the string explaining the reason why if decoding failed
+
+*******************************************************************************/
+
+public string decodeSignature (const(ubyte)[] bytes,
+    out SigPair sig_pair) pure nothrow @safe @nogc
+{
+    if (bytes.length != SigPair.sizeof)
+        return "Encoded signature tuple is of the wrong size";
+
+    const sig = toSignature(bytes[0 .. Signature.sizeof]);
+    bytes.popFrontN(Signature.sizeof);
+
+    assert(bytes.length == 1);
+    const SigHash sig_hash = cast(SigHash)bytes[0];
+    if (!isValidSigHash(sig_hash))
+        return "Unknown SigHash";
+
+    sig_pair = SigPair(sig, sig_hash);
+    return null;
+}
+
+/*******************************************************************************
+
+    Validates that the given `SigHash` is one of the known flags or one of
+    the accepted combination of flags.
+
+    Params:
+        sig_hash = the `SigHash` to validate
+
+    Returns:
+        true if this is one of the known flags or accepted combination of flags
+
+*******************************************************************************/
+
+private bool isValidSigHash (in SigHash sig_hash) pure nothrow @safe @nogc
+{
+    switch (sig_hash)
+    {
+    case SigHash.All:
+        break;
+
+    default:
+        return false;
+    }
+
+    return true;
+}
+
+///
+unittest
+{
+    assert(!isValidSigHash(cast(SigHash)0));
+    assert(isValidSigHash(SigHash.All));
+}
+
+/*******************************************************************************
+
+    Gets the challenge hash for the provided transaction, input index,
+    and the type of SigHash. This cannot be folded into a `sign` routine
+    because it's also required during signature validation.
+
+    The input index is only used for some types of SigHash (SigHash.NoInput).
+
+    Params:
+        tx = the transaction to sign
+        sig_hash = the `SigHash` to use
+        input_idx = the associated input index we're signing for
+
+    Returns:
+        the challenge as a hash
+
+*******************************************************************************/
+
+public Hash getChallenge (in Transaction tx, in SigHash sig_hash = SigHash.All,
+    in ulong input_idx = 0) nothrow @safe
+{
+    assert(input_idx < tx.inputs.length, "Input index is out of range");
+
+    final switch (sig_hash)
+    {
+    case SigHash.All:
+        return hashMulti(tx, sig_hash);
+    }
+}
+
+///
+unittest
+{
+    import agora.utils.Test;
+    import ocean.core.Test;
+
+    const tx = Transaction([Input(hashFull(1)), Input(hashFull(2))], [], Height(10));
+    assert(getChallenge(tx, SigHash.All, 0) == getChallenge(tx, SigHash.All, 1));
+    assert(getChallenge(tx, SigHash.All, 0) != tx.hashFull());
+}

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -26,6 +26,7 @@ import agora.consensus.validation;
 import agora.crypto.Hash;
 import agora.script.Engine;
 import agora.script.Lock;
+import agora.script.Signature;
 import agora.serialization.Serializer;
 import agora.test.Base;
 
@@ -207,7 +208,7 @@ unittest
     // create a double-spend tx
     txs[0].inputs[0] = txs[1].inputs[0];
     txs[0].outputs[0].value = Amount(100);
-    auto signature = WK.Keys.Genesis.sign(txs[0]);
+    auto signature = WK.Keys.Genesis.sign(txs[0].getChallenge());
     txs[0].inputs[0].unlock = genKeyUnlock(signature);
 
     scope payload_checker = new FeeManager();

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -24,6 +24,7 @@ import agora.consensus.data.Transaction;
 import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.script.Lock;
+import agora.script.Signature;
 import agora.test.Base;
 
 import core.thread;
@@ -90,7 +91,7 @@ unittest
                 last_block = block;
             }
 
-            auto signTx (Transaction tx) @trusted { return prev_key.sign(hashFull(tx)[]); }
+            auto signTx (Transaction tx) @trusted { return prev_key.sign(tx.getChallenge()); }
 
             foreach (block1; blocks)
             {

--- a/source/agora/test/Script.d
+++ b/source/agora/test/Script.d
@@ -22,6 +22,7 @@ import agora.crypto.Schnorr;
 import agora.script.Lock;
 import agora.script.Opcodes;
 import agora.script.Script;
+import agora.script.Signature;
 import agora.test.Base;
 
 import Schnorr = agora.crypto.Schnorr;
@@ -66,8 +67,8 @@ unittest
 
     Unlock keyUnlocker (in Transaction tx, in OutputRef out_ref) @safe nothrow
     {
-        auto sig = WK.Keys.Genesis.sign(tx);
-        return Unlock([ubyte(64)] ~ sig.toBlob()[]);
+        auto pair = SigPair(WK.Keys.Genesis.sign(tx.getChallenge()), SigHash.All);
+        return Unlock([ubyte(65)] ~ pair[].dup);
     }
 
     const block_6 = node_1.getBlocksFrom(6, 1)[0];
@@ -153,8 +154,8 @@ unittest
 
     Unlock keyUnlocker (in Transaction tx, in OutputRef out_ref) @safe nothrow
     {
-        auto sig = WK.Keys.Genesis.sign(tx);
-        return Unlock([ubyte(64)] ~ sig.toBlob()[]);
+        auto pair = SigPair(WK.Keys.Genesis.sign(tx.getChallenge()), SigHash.All);
+        return Unlock([ubyte(65)] ~ pair[].dup);
     }
 
     // the protocol would allow both transactions (unlock time is fine),
@@ -236,8 +237,8 @@ unittest
             .sign(OutputType.Payment, 0,
                 (in Transaction tx, in OutputRef out_ref) @safe nothrow
                 {
-                    auto sig = kp_a.sign(tx);
-                    return Unlock([ubyte(64)] ~ sig.toBlob()[] ~ [ubyte(OP.TRUE)]);
+                    auto pair = SigPair(kp_a.sign(tx.getChallenge()), SigHash.All);
+                    return Unlock([ubyte(65)] ~ pair[] ~ [ubyte(OP.TRUE)]);
                 }))
         .array();
 
@@ -247,8 +248,8 @@ unittest
             .sign(OutputType.Payment, 0,
                 (in Transaction tx, in OutputRef out_ref) @safe nothrow
                 {
-                    auto sig = kp_b.sign(tx);
-                    return Unlock([ubyte(64)] ~ sig.toBlob()[] ~ [ubyte(OP.TRUE)]);
+                    auto pair = SigPair(kp_b.sign(tx.getChallenge()), SigHash.All);
+                    return Unlock([ubyte(65)] ~ pair[] ~ [ubyte(OP.TRUE)]);
                 }))
         .array();
 
@@ -268,8 +269,8 @@ unittest
             .sign(OutputType.Payment, 0,
                 (in Transaction tx, in OutputRef out_ref) @safe nothrow
                 {
-                    auto sig = kp_a.sign(tx);
-                    return Unlock([ubyte(64)] ~ sig.toBlob()[] ~ [ubyte(OP.FALSE)]);
+                    auto pair = SigPair(kp_a.sign(tx.getChallenge()), SigHash.All);
+                    return Unlock([ubyte(65)] ~ pair[] ~ [ubyte(OP.FALSE)]);
                 }))
         .array();
 
@@ -279,8 +280,8 @@ unittest
             .sign(OutputType.Payment, 0,
                 (in Transaction tx, in OutputRef out_ref) @safe nothrow
                 {
-                    auto sig = kp_b.sign(tx);
-                    return Unlock([ubyte(64)] ~ sig.toBlob()[] ~ [ubyte(OP.FALSE)]);
+                    auto pair = SigPair(kp_b.sign(tx.getChallenge()), SigHash.All);
+                    return Unlock([ubyte(65)] ~ pair[] ~ [ubyte(OP.FALSE)]);
                 }))
         .array();
 

--- a/source/agora/utils/TxBuilder.d
+++ b/source/agora/utils/TxBuilder.d
@@ -76,6 +76,7 @@ import agora.crypto.ECC;
 import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.script.Lock;
+import agora.script.Signature;
 /* version (unittest) */ import agora.utils.Test;
 
 import std.algorithm;
@@ -237,7 +238,7 @@ public struct TxBuilder
                 "Address not found in Well-Known keypairs: "
                 ~ out_ref.output.address.toString());
 
-        return genKeyUnlock(ownerKP.sign(tx));
+        return genKeyUnlock(ownerKP.sign(tx.getChallenge()));
     }
 
     /***************************************************************************


### PR DESCRIPTION
SigHash was introduced to allow changing
how a signature from an Input is verified.

This is a strict requirement in order to implement:
- SIGHASH_NOINPUT for Eltoo (BIP118)
- SIGHASH_SINGLE for setting the fees for the final
  settlement transaction in the Eltoo protocol.

The basic payment lock types (LockType.Key / LockType.KeyHash)
expect a <signature, sighash> tuple in the
unlock byte array.

For scripts, the Engine now expects a tuple of <signature, sighash>
on the stack when verifying signatures.

Co-authored-by: Andrej Mitrovic <andrej.mitrovich@gmail.com>