### PR TITLE
Change the type of `NodeID` to `ulong`

### DIFF
--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -976,8 +976,7 @@ public SCPQuorumSet toSCPQuorumSet (in QuorumConfig quorum_conf) @safe nothrow
 
     foreach (ref const node; quorum_conf.nodes)
     {
-        auto pub_key = NodeID(node[][0 .. NodeID.sizeof]);
-        quorum.validators.push_back(pub_key);
+        quorum.validators.push_back(node);
     }
 
     foreach (ref const sub_quorum; quorum_conf.quorums)
@@ -1007,7 +1006,7 @@ public QuorumConfig toQuorumConfig (const ref SCPQuorumSet scp_quorum)
     import std.conv;
     import scpd.types.Stellar_types : NodeID;
 
-    Hash[] nodes;
+    ulong[] nodes;
 
     foreach (node; scp_quorum.validators.constIterator)
         nodes ~= node;
@@ -1031,16 +1030,9 @@ unittest
 {
     import agora.crypto.Hash;
 
-    auto quorum = QuorumConfig(2,
-        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
-         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")],
-        [QuorumConfig(2,
-            [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
-             Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")],
-            [QuorumConfig(2,
-                [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
-                 Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd"),
-                 Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")])])]);
+    auto quorum = QuorumConfig(2, [0, 1, 2],
+        [QuorumConfig(2, [0, 2],
+            [QuorumConfig(2, [0, 1, 1])])]);
 
     auto scp_quorum = toSCPQuorumSet(quorum);
     assert(scp_quorum.toQuorumConfig() == quorum);

--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -37,7 +37,7 @@ public struct QuorumConfig
     public uint threshold = 1;
 
     /// List of nodes in this quorum
-    public Hash[] nodes;
+    public ulong[] nodes;
 
     /// List of any sub-quorums
     public QuorumConfig[] quorums;

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -97,7 +97,7 @@ public extern (C++) class Nominator : SCPDriver
     protected ValidatingLedger ledger;
 
     /// The mapping of all known quorum sets
-    private SCPQuorumSetPtr[Hash] known_quorums;
+    private SCPQuorumSetPtr[NodeID] known_quorums;
 
     private alias TimerType = Slot.timerIDs;
     static assert(TimerType.max == 1);
@@ -272,38 +272,30 @@ extern(D):
 
     /***************************************************************************
 
-        Set or update the quorum configuration
-
-        The node additionally takes the list of all other validator's quorum
-        configurations and saves them for later lookup by getQSet().
+        Update our quorum configuration and store the mapping of all quorums
+        for lookup in getQSet().
 
         Params:
-            quorum = the quorum config for this node
-            other_quorums = the quorum config for all other nodes in the network
+            node_id = the node id of this validator
+            quorums = the mapping of all active validators' quorums
 
     ***************************************************************************/
 
-    public void setQuorumConfig (const ref QuorumConfig quorum,
-        const(QuorumConfig)[] other_quorums) nothrow @safe
+    public void setQuorumConfig (ref const(NodeID) node_id,
+        const(QuorumConfig)[NodeID] quorums) nothrow @safe
     {
         assert(!this.is_nominating);
         () @trusted { this.known_quorums.clear(); }();
 
-        // store the list of other node's quorum hashes
-        foreach (qc; other_quorums)
+        foreach (qpair; quorums.byKeyValue)  // opApply2 is not nothrow..
         {
-            auto quorum_set = buildSCPConfig(qc);
+            auto quorum_set = buildSCPConfig(qpair.value);
             auto shared_set = makeSharedSCPQuorumSet(quorum_set);
-            const hash = this.getHashOfQuorum(quorum_set);
-            this.known_quorums[hash] = shared_set;
-        }
+            this.known_quorums[qpair.key] = shared_set;
 
-        // set up our own quorum
-        auto quorum_set = buildSCPConfig(quorum);
-        () @trusted { this.scp.updateLocalQuorumSet(quorum_set); }();
-        auto shared_set = makeSharedSCPQuorumSet(quorum_set);
-        const hash = this.getHashOfQuorum(quorum_set);
-        this.known_quorums[hash] = shared_set;
+            if (qpair.key == node_id)
+                () @trusted { this.scp.updateLocalQuorumSet(quorum_set); }();
+        }
     }
 
     /***************************************************************************
@@ -1053,18 +1045,19 @@ extern(D):
     /***************************************************************************
 
         Params:
-            qSetHash = the hash of the quorum set
+            node_id = the node's id of the quorum set
 
         Returns:
-            the SCPQuorumSet pointer for the provided quorum set hash
+            the SCPQuorumSetPtr for the provided node ID, or null if not found
 
     ***************************************************************************/
 
-    public override SCPQuorumSetPtr getQSet (ref const(StellarHash) qSetHash)
+    public override SCPQuorumSetPtr getQSet (ref const(NodeID) node_id)
     {
-        if (auto scp_quroum = qSetHash in this.known_quorums)
-            return *scp_quroum;
+        if (auto quorum = node_id in this.known_quorums)
+            return *quorum;
 
+        log.error("getQSet SCPQuorumSetPtr.init, id: {}", node_id);
         return SCPQuorumSetPtr.init;
     }
 
@@ -1374,7 +1367,7 @@ private struct SCPStatementHash
 {
     // sanity check in case a new field gets added.
     // todo: use .tupleof tricks for a more reliable field layout change check
-    static assert(SCPNomination.sizeof == 112);
+    static assert(SCPNomination.sizeof == 48);
 
     /// instance pointer
     private const SCPStatement* st;
@@ -1419,7 +1412,6 @@ private struct SCPStatementHash
         const ref SCPStatement._pledges_t._prepare_t prep,
         scope HashDg dg) @safe pure nothrow @nogc
     {
-        hashPart(prep.quorumSetHash[], dg);
         hashPart(prep.ballot, dg);
 
         /// these two can legitimately be null in the protocol
@@ -1452,7 +1444,6 @@ private struct SCPStatementHash
         hashPart(conf.nPrepared, dg);
         hashPart(conf.nCommit, dg);
         hashPart(conf.nH, dg);
-        hashPart(conf.quorumSetHash[], dg);
     }
 
     /***************************************************************************
@@ -1471,7 +1462,6 @@ private struct SCPStatementHash
     {
         hashPart(ext.commit, dg);
         hashPart(ext.nH, dg);
-        hashPart(ext.commitQuorumSetHash[], dg);
     }
 
     /***************************************************************************
@@ -1487,7 +1477,6 @@ private struct SCPStatementHash
     public static void computeHash (const ref SCPNomination nom, scope HashDg dg)
         @safe pure nothrow @nogc
     {
-        hashPart(nom.quorumSetHash[], dg);
         hashPart(nom.votes[], dg);
         hashPart(nom.accepted[], dg);
     }
@@ -1541,38 +1530,38 @@ private struct SCPEnvelopeHash
     auto getStHash () @trusted { return SCPStatementHash(&st); }
 
     assert(getStHash().hashFull() == Hash.fromString(
-        "0x755a41baaba02e099e86224bec897428a1d985efa44aca8408ab17dd7682e272caf527707dfb02b1f665a3860f8f671e6ce651eaf6d6594126fbccac8dfbdac1"));
+        "0xf3f95c2bcdf182f3c4ab3aa22606983c90676d908bcd053110c560cface4b18ff36d4ab359e3a44332c23ff8280385b8bc22d44ee9ab98878ac947c17e61fe75"));
 
     prep.counter++;
     assert(getStHash().hashFull() == Hash.fromString(
-        "0x7dd0d0832ea5132ca96169bb76f958aba7fc131f2a7113a53fa152db8cb342a4cc853a7b69e2b2bffa0510a1d9665f3771d094315610747056923c455de1f523"));
+        "0xcd9c7719642dadd28f3a3fbbbcaca648f8bf35200041f39ed3c3c3ac7d8cc1c589754cff86063998a25c08bcf93ba6ad752df10b8447cfc5b4d43064debca92e"));
 
     prep_prime.counter++;
     assert(getStHash().hashFull() == Hash.fromString(
-        "0x16d39c2a56a3cf75b85c8f2dc4ad1329713ab21515384f65f4b4e1591a9b20771492ebf26595362807c8fc11ef0028d0fa8bcaeed3f25946d4902acc66bcf55e"));
+        "0xd876318b3559b52fe3dbd7fad5ba2756cfdd1729250c02d0b0b6fe2684eee520c9ce37d787027ef2ff3e79fec1ec73dd500b3ce9abdc724caa7bc45e91b26e9a"));
 
     () @trusted { st.pledges.prepare_.prepared = null; }();
     assert(getStHash().hashFull() == Hash.fromString(
-        "0xc49f187ceda67573afab46466b1e6e7207707174a9a0bf850ea79a5e87d76f56d5f0c13b56a73754d4337416d1322e2780420bb426b604c8db16e427d4fb5416"));
+        "0xca227179325dd0aacec18c20f26ee97d40be1fbe505d685cfb20f297bbf62bdc17fd0da45e6464aa37a24139882ed0cb1db0a3f67b9d63e8b70d726c6dacae21"));
 
     () @trusted { st.pledges.prepare_.preparedPrime = null; }();
     assert(getStHash().hashFull() == Hash.fromString(
-        "0x09e54206c86f7b1a6c796b7a6e56e2b30f465d24e223601e246cc19120d817ac867186f6e7c867f2dbaf7022e9eebc5e560de2fa9f2ab2aab2fdd221272caa5c"));
+        "0x85988fb0978100d2fc5da08c1e7cef35ad3ada741b81411d7b33d0d326454ceda82fd65166b2668416b70eb2fdd89bb1eb059b2831f1e576b5a553be210b95e5"));
 
     () @trusted { st.pledges.nominate_ = SCPNomination.init; }();
     st.pledges.type_ = SCPStatementType.SCP_ST_NOMINATE;
     assert(getStHash().hashFull() == Hash.fromString(
-        "0x104cfee4945c44bd75783bdb2c8ed2de55d6e2346d84430282c1710e6474042079b122e9a24a75d2f2b577cf36b7e1eadefc156c5b2562a06c3c8e2b16f02470"));
+        "0x39f437e1ceb4a6c8f70dae0791c29bd1adbf8f9e053137fc7a3ddd7454e51e47546a438f6da2d563c9bb4c38afa0c2af36340ad2d13efc99edee0d25ab815f7f"));
 
     () @trusted { st.pledges.confirm_ = SCPStatement._pledges_t._confirm_t.init; }();
     st.pledges.type_ = SCPStatementType.SCP_ST_CONFIRM;
     assert(getStHash().hashFull() == Hash.fromString(
-        "0x92a0d0bd78e0b74cfd0664bbb1c4542f492991f260d5916bf290c2929790cfc3875179fb3774de8c664af9b3d135e6edb70d48188874723a3a8e884bad37584c"));
+        "0x4e9785c61b6302695b3b8a8ccabdd3ff55b34c9b235cdb54e64c28a5afe2623791f8f33129e0d791ba0ea04161f402a3e9abf54f0269b2f78a3ad0e899037ac7"));
 
     () @trusted { st.pledges.externalize_ = SCPStatement._pledges_t._externalize_t.init; }();
     st.pledges.type_ = SCPStatementType.SCP_ST_EXTERNALIZE;
     assert(getStHash().hashFull() == Hash.fromString(
-        "0x98fec9d03f95de3fb6e5fefe5afb4aed545532cf1ea0440718a17451480ac4740f9b0389e613eefb1c33247d1ddc111343fd0f19ed26124abb5f8d9a9b15ccb9"));
+        "0x8eb8d71b06c7842a5c257a7475522331f04971805ed9b84c036e1c3e232b0e98ceffa015bf146716f28e1f0c20c5d068fca56c5f00431fd44a260cccc342167a"));
 
     SCPEnvelope env;
     auto getEnvHash () @trusted { return SCPEnvelopeHash(&env); }
@@ -1580,24 +1569,24 @@ private struct SCPEnvelopeHash
     // empty envelope
     import std.conv;
     assert(getEnvHash().hashFull() == Hash.fromString(
-        "0x444a77f46f8da37b667c19df725b9ec4fbb9ba67e512dbed8e902fdecde5100a64bbdc90fb3a9e38ef2d52cf1d3a061d48765999d88c6db2c704244a91185705"));
+        "0xea6365d3a07bb5637e7afc1c4110aeaa6018a1bec5e3fa9104366ab46d9a79b83fd3c4a363d9c6dc7bd2266f3dbef79b8c5da06e9c5f16c6925a4070c00069f3"));
 
     // with a statement
     env.statement = st;
     assert(getEnvHash().hashFull() == Hash.fromString(
-        "0x1935453249eaf3d3032633f170e515b06bb8327d3c95606c7cf9724bf592e9db227ef14558c0674c0365baa8a5291aa44a3e7fe6d5860c05585a2aed0e262e52"));
+        "0x98fec9d03f95de3fb6e5fefe5afb4aed545532cf1ea0440718a17451480ac4740f9b0389e613eefb1c33247d1ddc111343fd0f19ed26124abb5f8d9a9b15ccb9"));
 
     // import agora.utils.Test;
     // import std.stdio;
     // writeln(WK.Keys.NODE5.sign(getStHash));
     env.signature = Signature.fromString(
-        "0x969c0879ffedac8d03034a60b59cf9ff8f195052ae5e5fae247823fe349462a0" ~
-        "08f8a0f915d0598cbab106a5bda6ccabe30327f2c4bc980ed817592a9bebb04b")
+        "0x8e506b0d32457a3e6e2c7ba14dec178a53c567430e71dd036301c8246d8a782b" ~
+        "3c4fdf745375bd2fed645433e2a9364b95d6e3931c29ea7fb445bc6ee80867a6")
         .toBlob();
 
     // with a signature
     assert(getEnvHash().hashFull() == Hash.fromString(
-        "0xf97a3cc4ad6420e1c79082627cc90fbc36af71e82500fb3bd40f5857571f8ce9f7e7c9a1e340bf225871bdf818f355362c5387f1775fa88c31228b7789861116"));
+        "0x5c67d7aa06d03a48e2bca081e2eb124afc63908488088271e0da388e76381c4c487cb229cf79839c87728c087077399dba3fe7e435dc71bbbb3de051a6e5a88e"));
 }
 
 // Size assumptions made by this module

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1870,11 +1870,11 @@ public class TestValidatorNode : Validator, TestAPI
             this.ledger.getLastBlock().header.random_seed :
             this.ledger.getBlocksFrom(height).front.header.random_seed;
         QuorumConfig[] quorums;
-        foreach (utxo; utxos)
+        foreach (idx, utxo; utxos)
         {
             UTXO utxo_value;
             this.utxo_set.peekUTXO(utxo, utxo_value);
-            quorums ~= buildQuorumConfig(utxo, utxos,
+            quorums ~= buildQuorumConfig(idx, utxos,
                 this.utxo_set.getUTXOFinder(), rand_seed, this.quorum_params);
         }
         return quorums;

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -36,15 +36,6 @@ import std.range;
 import core.thread;
 import core.time;
 
-immutable A = Hash("0x210f6551d648a4da654da116b100e941e434e4f232b8579439c2ef64b04819bd2782eb3524c7a29c38c347cdf26006bccac54a58a58f103ae7eb5b252eb53b64");
-immutable B = Hash("0x3b44d65edb3361dd91441ab4f449eeda55644026624c4b8ae12ecf0264fa8a228dbf672ef97e2c4f87fb98ad7099e17b7f9ba7dbe8479672066912b1ea24ba77");
-immutable C = Hash("0x7bacc99e9bf827f0fa6dc6a77303d2e6ba6f1591277b896a9305a9e200853986fe9527fd551077a4ac2b511633ada4190a7b82cddaf606171336e1efba87ea8f");
-immutable D = Hash("0x9b2726e79f05abc107b6531486a46c977414e13ed9f3ee994ec14504964f86fcf9464055b891b9c34020feb72535c300ff19e8b5167eb9d202db1a053d746b2c");
-immutable E = Hash("0xab19131ad8974a20881e2cd0798684a06ca0054160735cdf67fe8ee5a0eb4e28e9bf3f4c735f9ed3da958778978c86b409b8d133f30992141f0ac7e01e7f1255");
-immutable F = Hash("0xdb7664caba94c8d4602c10992c13176307e1e05361c150217166ee77fc4af9bf176f31dc61aba61e634dfc0b4c5f729d59e604607f61c9f66b10c6841f972a0a");
-immutable G = Hash("0xf559434f0ef34d45904f91821aa44130ec0d681995f664ac1ec4993450b15adc4fab9ae22e343877bfe96ca317ff4bb538a686f22aa9f43bd49d408c7237a65c");
-immutable H = Hash("0xfe08a45e859d68d3696638189ac2a79178d5d709423175285451b443498b8efd54c9e02103abd3903bbe01813c32429d569acf10d39bb6a1e255bccf5f8e60d6");
-
 /// test preimage changing quorum configs
 unittest
 {
@@ -77,34 +68,24 @@ unittest
         }
     }
 
-    string[Hash] node_to_name = [
-        A : "A", B : "B", C : "C", D : "D", E : "E", F : "F", G : "G", H : "H"];
-
-    string printConvQuorum(in QuorumConfig qc)
-    {
-        return format("%-(%s, %)", qc.nodes.map!(n =>
-            (n in node_to_name) ? node_to_name[n]
-                : format!"Hash not found in node_to_name: %s"(n)));
-    }
-
     enum quorums_1 = [
         // 0
-        QuorumConfig(5, [A, B, C, D, E, F]),
+        QuorumConfig(5, [0, 1, 2, 3, 4, 5]),
 
         // 1
-        QuorumConfig(5, [A, B, C, D, E, F]),
+        QuorumConfig(5, [0, 1, 2, 3, 4, 5]),
 
         // 2
-        QuorumConfig(5, [A, B, C, D, E, F]),
+        QuorumConfig(5, [0, 1, 2, 3, 4, 5]),
 
         // 3
-        QuorumConfig(5, [A, B, C, D, E, F]),
+        QuorumConfig(5, [0, 1, 2, 3, 4, 5]),
 
         // 4
-        QuorumConfig(5, [A, B, C, D, E, F]),
+        QuorumConfig(5, [0, 1, 2, 3, 4, 5]),
 
         // 5
-        QuorumConfig(5, [A, B, C, D, E, F]),
+        QuorumConfig(5, [0, 1, 2, 3, 4, 5]),
 
         QuorumConfig.init,
         QuorumConfig.init,
@@ -115,8 +96,7 @@ unittest
         nodes.enumerate.each!((idx, node) =>
             retryFor(node.getQuorumConfig() == quorums_1[idx], 5.seconds,
                 format("Node %s has quorum config [%s]. Expected quorums_1: [%s]",
-                    idx, printConvQuorum(node.getQuorumConfig()),
-                    printConvQuorum(quorums_1[idx]))));
+                    idx, node.getQuorumConfig(), quorums_1[idx])));
     }
 
     const keys = network.nodes.map!(node => node.getPublicKey().key)
@@ -148,28 +128,28 @@ unittest
 
     enum quorums_2 = [
         // 0
-        QuorumConfig(6, [A, B, C, D, F, G, H]),
+        QuorumConfig(6, [0, 1, 3, 4, 5, 6, 7]),
 
         // 1
-        QuorumConfig(6, [A, B, C, D, E, G, H]),
+        QuorumConfig(6, [0, 1, 2, 3, 5, 6, 7]),
 
         // 2
-        QuorumConfig(6, [A, C, D, E, F, G, H]),
+        QuorumConfig(6, [0, 1, 2, 4, 5, 6, 7]),
 
         // 3
-        QuorumConfig(6, [A, C, D, E, F, G, H]),
+        QuorumConfig(6, [1, 2, 3, 4, 5, 6, 7]),
 
         // 4
-        QuorumConfig(6, [B, C, D, E, F, G, H]),
+        QuorumConfig(6, [0, 1, 3, 4, 5, 6, 7]),
 
         // 5
-        QuorumConfig(6, [A, B, C, E, F, G, H]),
+        QuorumConfig(6, [0, 1, 3, 4, 5, 6, 7]),
 
         // 6
-        QuorumConfig(6, [A, C, D, E, F, G, H]),
+        QuorumConfig(6, [0, 1, 2, 3, 4, 6, 7]),
 
         // 7
-        QuorumConfig(6, [A, B, C, D, F, G, H]),
+        QuorumConfig(6, [1, 2, 3, 4, 5, 6, 7]),
     ];
 
     static assert(quorums_1 != quorums_2);
@@ -179,8 +159,7 @@ unittest
         nodes.enumerate.each!((idx, node) =>
             retryFor(node.getQuorumConfig() == quorums_2[idx], 5.seconds,
                 format("Node %s has quorum config %s. Expected quorums_2: %s",
-                    idx, printConvQuorum(node.getQuorumConfig()),
-                    printConvQuorum(quorums_2[idx]))));
+                    idx, node.getQuorumConfig(), quorums_2[idx])));
     }
 
     // create 19 more blocks with all validators (1 short of end of 2nd cycle)
@@ -198,28 +177,28 @@ unittest
     // which use a different preimage
     enum quorums_3 = [
         // 0
-        QuorumConfig(6, [A, B, C, D, E, G, H]),
+        QuorumConfig(6, [0, 1, 2, 4, 5, 6, 7]),
 
         // 1
-        QuorumConfig(6, [A, B, C, D, F, G, H]),
+        QuorumConfig(6, [0, 1, 3, 4, 5, 6, 7]),
 
         // 2
-        QuorumConfig(6, [B, C, D, E, F, G, H]),
+        QuorumConfig(6, [0, 1, 2, 4, 5, 6, 7]),
 
         // 3
-        QuorumConfig(6, [A, B, C, D, F, G, H]),
+        QuorumConfig(6, [0, 2, 3, 4, 5, 6, 7]),
 
         // 4
-        QuorumConfig(6, [A, B, C, E, F, G, H]),
+        QuorumConfig(6, [1, 2, 3, 4, 5, 6, 7]),
 
         // 5
-        QuorumConfig(6, [A, B, C, D, F, G, H]),
+        QuorumConfig(6, [0, 1, 2, 3, 5, 6, 7]),
 
         // 6
-        QuorumConfig(6, [B, C, D, E, F, G, H]),
+        QuorumConfig(6, [0, 1, 3, 4, 5, 6, 7]),
 
         // 7
-        QuorumConfig(6, [A, B, C, D, F, G, H]),
+        QuorumConfig(6, [0, 1, 2, 3, 4, 6, 7]),
     ];
 
     static assert(quorums_2 != quorums_3);
@@ -229,7 +208,6 @@ unittest
         nodes.enumerate.each!((idx, node) =>
             retryFor(node.getQuorumConfig() == quorums_3[idx], 5.seconds,
                 format("Node %s has quorum config %s. Expected quorums_3: %s",
-                    idx, printConvQuorum(node.getQuorumConfig()),
-                    printConvQuorum(quorums_3[idx]))));
+                    idx, node.getQuorumConfig(), quorums_3[idx])));
     }
 }

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -596,8 +596,6 @@ private struct EnrollmentFmt
 ///
 unittest
 {
-    Hash quorumSetHash;
-
     Hash key = Hash("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f" ~
                     "1b60a8ce26f000000000019d6689c085ae165831e934ff763ae46a2" ~
                     "a6c172b3f1b60a8ce26f");
@@ -650,8 +648,6 @@ unittest
     import agora.common.Set;
     import agora.crypto.Hash;
     import agora.serialization.Serializer;
-
-    Hash quorumSetHash;
 
     Hash key = Hash("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f" ~
                     "1b60a8ce26f000000000019d6689c085ae165831e934ff763ae46a2" ~

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -696,7 +696,7 @@ private struct QuorumConfigFmt
         {
             formattedWrite(sink, "{ thresh: %s, nodes: %s, subqs: %s }",
                 this.data.threshold,
-                this.data.nodes.map!(node => HashFmt(node)),
+                this.data.nodes,
                 this.data.quorums.map!(subq => QuorumConfigFmt(subq)));
         }
         catch (Exception ex)
@@ -709,18 +709,11 @@ private struct QuorumConfigFmt
 ///
 unittest
 {
-    auto quorum = immutable(QuorumConfig)(2,
-        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
-         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")],
-        [immutable(QuorumConfig)(3,
-            [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
-             Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")],
-            [immutable(QuorumConfig)(4,
-                [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
-                 Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd"),
-                 Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")])])]);
+    auto quorum = immutable(QuorumConfig)(2, [0, 1],
+        [immutable(QuorumConfig)(3, [0, 1],
+            [immutable(QuorumConfig)(4, [0, 1, 1])])]);
 
-    static immutable Res1 = `{ thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [{ thresh: 3, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [{ thresh: 4, nodes: [0x11c6...ebf5, 0xdfca...e5fd, 0xdfca...e5fd], subqs: [] }] }] }`;
+    static immutable Res1 = `{ thresh: 2, nodes: [0, 1], subqs: [{ thresh: 3, nodes: [0, 1], subqs: [{ thresh: 4, nodes: [0, 1, 1], subqs: [] }] }] }`;
 
     assert(Res1 == format("%s", prettify(quorum)),
                    format("%s", prettify(quorum)));

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -35,7 +35,7 @@ import agora.utils.PrettyPrinter;
 
 import scpd.Cpp;
 import scpd.types.Stellar_SCP;
-import scpd.types.Stellar_types : StellarHash = Hash;
+import scpd.types.Stellar_types : StellarHash = Hash, NodeID;
 
 import Ocean = ocean.text.convert.Formatter;
 
@@ -92,14 +92,15 @@ public struct SCPBallotFmt
 }
 
 /// SCP Quorum set getter delegate
-private alias GetQSetDg = SCPQuorumSetPtr delegate (
-    ref const(Hash) qSetHash);
+private alias GetQSetDg = SCPQuorumSetPtr delegate (ref const(NodeID));
 
 /// Formatting struct for a quorum Hash => QuorumConfig through the use
 /// of a quorum getter delegate
 private struct QuorumFmt
 {
-    private const(Hash) hash;
+    import std.conv;
+
+    private const(NodeID) node_id;
     private const(GetQSetDg) getQSet;
 
     public void toString (scope void delegate (scope const char[]) @safe sink)
@@ -109,18 +110,24 @@ private struct QuorumFmt
         {
             SCPQuorumSetPtr qset = SCPQuorumSetPtr(CppCtor.Use);
             if (this.getQSet !is null)
-                qset = this.getQSet(this.hash);
+                qset = this.getQSet(this.node_id);
+
+            string node_id;
+            if (this.node_id == ulong.max)
+                node_id = "<unknown>";
+            else
+                node_id = (cast(ulong)this.node_id).to!string;
 
             if (qset.ptr !is null)
             {
                 auto qconf = toQuorumConfig(*qset.ptr);
-                formattedWrite(sink, "{ hash: %s, quorum: %s }",
-                    prettify(this.hash), prettify(qconf));
+                formattedWrite(sink, "{ id: %s, quorum: %s }",
+                     node_id, prettify(qconf));
             }
             else
             {
-                formattedWrite(sink, "{ hash: %s, quorum: <unknown> }",
-                    prettify(this.hash));
+                formattedWrite(sink, "{ id: %s, quorum: <unknown> }",
+                     node_id);
             }
         }
         catch (Exception ex)
@@ -133,6 +140,7 @@ private struct QuorumFmt
 /// Formatting struct for `_prepare_t`
 private struct PrepareFmt
 {
+    private const(NodeID) node_id;
     private const(SCPStatement._pledges_t._prepare_t) prepare;
     private const(GetQSetDg) getQSet;
 
@@ -143,7 +151,7 @@ private struct PrepareFmt
         {
             formattedWrite(sink,
                 "Prepare { qset: %s, ballot: %s, ",
-                QuorumFmt(this.prepare.quorumSetHash, this.getQSet),
+                QuorumFmt(node_id, this.getQSet),
                 SCPBallotFmt(this.prepare.ballot));
 
             if (this.prepare.prepared !is null)
@@ -172,6 +180,7 @@ private struct PrepareFmt
 /// Formatting struct for `_confirm_t`
 private struct ConfirmFmt
 {
+    private const(NodeID) node_id;
     private const(SCPStatement._pledges_t._confirm_t) confirm;
     private const(GetQSetDg) getQSet;
 
@@ -182,7 +191,7 @@ private struct ConfirmFmt
         {
             formattedWrite(sink,
                 "Confirm { qset: %s, ballot: %s, nPrep: %s, nComm: %s, nH: %s }",
-                QuorumFmt(this.confirm.quorumSetHash, this.getQSet),
+                QuorumFmt(this.node_id, this.getQSet),
                 SCPBallotFmt(this.confirm.ballot),
                 this.confirm.nPrepared,
                 this.confirm.nCommit,
@@ -198,6 +207,7 @@ private struct ConfirmFmt
 /// Formatting struct for `_externalize_t`
 private struct ExternalizeFmt
 {
+    private const(NodeID) node_id;
     private const(SCPStatement._pledges_t._externalize_t) externalize;
     private const(GetQSetDg) getQSet;
 
@@ -208,7 +218,7 @@ private struct ExternalizeFmt
         {
             formattedWrite(sink,
                 "Externalize { commitQset: %s, commit: %s, nh: %s }",
-                QuorumFmt(this.externalize.commitQuorumSetHash, this.getQSet),
+                QuorumFmt(this.node_id, this.getQSet),
                 SCPBallotFmt(this.externalize.commit),
                 this.externalize.nH);
         }
@@ -222,6 +232,7 @@ private struct ExternalizeFmt
 /// Formatting struct for `SCPNomination`, deserializes Value types as ConsensusData
 private struct SCPNominationFmt
 {
+    private const(NodeID) node_id;
     private const(SCPNomination) nominate;
     private const(GetQSetDg) getQSet;
 
@@ -232,7 +243,7 @@ private struct SCPNominationFmt
         {
             formattedWrite(sink,
                 "Nominate { qset: %s, ",
-                QuorumFmt(this.nominate.quorumSetHash));
+                QuorumFmt(this.node_id, this.getQSet));
 
             try
             {
@@ -270,6 +281,7 @@ private struct SCPNominationFmt
 /// Formatting struct for `_pledges_t`
 private struct PledgesFmt
 {
+    private const(NodeID) node_id;
     private const(SCPStatement._pledges_t) pledges;
     private const(GetQSetDg) getQSet;
 
@@ -281,16 +293,20 @@ private struct PledgesFmt
             final switch (pledges.type_)
             {
                 case SCPStatementType.SCP_ST_PREPARE:
-                    formattedWrite(sink, "%s", PrepareFmt(this.pledges.prepare_, this.getQSet));
+                    formattedWrite(sink, "%s", PrepareFmt(this.node_id,
+                        this.pledges.prepare_, this.getQSet));
                     break;
                 case SCPStatementType.SCP_ST_CONFIRM:
-                    formattedWrite(sink, "%s", ConfirmFmt(this.pledges.confirm_, this.getQSet));
+                    formattedWrite(sink, "%s", ConfirmFmt(this.node_id,
+                        this.pledges.confirm_, this.getQSet));
                     break;
                 case SCPStatementType.SCP_ST_EXTERNALIZE:
-                    formattedWrite(sink, "%s", ExternalizeFmt(this.pledges.externalize_, this.getQSet));
+                    formattedWrite(sink, "%s", ExternalizeFmt(this.node_id,
+                        this.pledges.externalize_, this.getQSet));
                     break;
                 case SCPStatementType.SCP_ST_NOMINATE:
-                    formattedWrite(sink, "%s", SCPNominationFmt(this.pledges.nominate_, this.getQSet));
+                    formattedWrite(sink, "%s", SCPNominationFmt(this.node_id,
+                        this.pledges.nominate_, this.getQSet));
                     break;
             }
         }
@@ -310,13 +326,21 @@ private struct SCPStatementFmt
     public void toString (scope void delegate (scope const char[]) @safe sink)
         const scope @safe nothrow
     {
+        import std.conv;
+
         try
         {
+            string node_id;
+            if (this.statement.nodeID == ulong.max)
+                node_id = "<unknown>";
+            else
+                node_id = (cast(ulong)this.statement.nodeID).to!string;
+
             formattedWrite(sink,
                 "{ node: %s, slotIndex: %s, pledge: %s }",
-                cast(ulong)this.statement.nodeID,
+                node_id,
                 cast(ulong)this.statement.slotIndex,  // cast: consistent cross-platform output
-                PledgesFmt(this.statement.pledges, getQSet));
+                PledgesFmt(this.statement.nodeID, this.statement.pledges, getQSet));
         }
         catch (Exception ex)
         {
@@ -416,8 +440,6 @@ unittest
     import scpd.types.Stellar_types : NodeID, StellarHash = Hash;
     import scpd.types.Utils;
 
-    Hash quorumSetHash;
-
     Hash key = Hash("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f" ~
                     "1b60a8ce26f000000000019d6689c085ae165831e934ff763ae46a2" ~
                     "a6c172b3f1b60a8ce26f");
@@ -455,9 +477,9 @@ unittest
     auto scp_quorum = toSCPQuorumSet(qc);
     auto qset = makeSharedSCPQuorumSet(scp_quorum);
     auto quorum_hash = hashFull(*qset);
-    SCPQuorumSetPtr[Hash] qmap;
+    SCPQuorumSetPtr[NodeID] qmap;
 
-    SCPQuorumSetPtr getQSet (ref const(Hash) hash)
+    SCPQuorumSetPtr getQSet (ref const(NodeID) hash)
     {
         if (auto qset = hash in qmap)
             return *qset;
@@ -471,7 +493,6 @@ unittest
     /** SCP PREPARE */
     env.statement.pledges.type_ = SCPStatementType.SCP_ST_PREPARE;
     env.statement.pledges.prepare_ = SCPStatement._pledges_t._prepare_t.init; // must initialize
-    env.statement.pledges.prepare_.quorumSetHash = quorum_hash;
     env.statement.pledges.prepare_.ballot = ballot;
     env.statement.pledges.prepare_.nC = 100;
     env.statement.pledges.prepare_.nH = 200;
@@ -480,30 +501,30 @@ unittest
     env.signature = typeof(env.signature).init;
 
     // missing signature
-    static immutable MissingSig = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { hash: 0x5774...9db2, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...0000 }`;
+    static immutable MissingSig = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { id: 0, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...0000 }`;
 
     testAssert(MissingSig, scpPrettify(&env));
 
     env.signature = sig.toBlob();
 
     // null quorum (hash not found)
-    static immutable PrepareRes1 = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { hash: 0x5774...9db2, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable PrepareRes1 = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { id: 0, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // with quorum mapping
-    static immutable PrepareRes2 = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable PrepareRes2 = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { id: 0, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // 'prep' pointer is set
-    static immutable PrepareRes3 = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable PrepareRes3 = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { id: 0, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // 'preparedPrime' pointer is set
-    static immutable PrepareRes4 = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prepPrime: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable PrepareRes4 = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { id: 0, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prepPrime: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     testAssert(PrepareRes1, scpPrettify(&env));
     testAssert(PrepareRes1, scpPrettify(&env, null));
     testAssert(PrepareRes1, scpPrettify(&env, &getQSet));
 
     // add the quorum hash mapping, it should change the output
-    qmap[quorum_hash] = qset;
+    qmap[env.statement.nodeID] = qset;
     testAssert(PrepareRes2, scpPrettify(&env, &getQSet));
 
     // set 'prepared' pointer
@@ -523,30 +544,31 @@ unittest
     env.statement.pledges.confirm_.nH = 200;
 
     // confirm without a known hash
-    static immutable ConfirmRes1 = `{ statement: { node: 0, slotIndex: 0, pledge: Confirm { qset: { hash: 0x0000...0000, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable ConfirmRes1 = `{ statement: { node: <unknown>, slotIndex: 0, pledge: Confirm { qset: { id: <unknown>, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // confirm with a known hash
-    static immutable ConfirmRes2 = `{ statement: { node: 0, slotIndex: 0, pledge: Confirm { qset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable ConfirmRes2 = `{ statement: { node: 0, slotIndex: 0, pledge: Confirm { qset: { id: 0, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // un-deserializable value
-    static immutable ConfirmRes3 = `{ statement: { node: 0, slotIndex: 0, pledge: Confirm { qset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 0, value: <un-deserializable> }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
-    // unknown hash
+    static immutable ConfirmRes3 = `{ statement: { node: 0, slotIndex: 0, pledge: Confirm { qset: { id: 0, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 0, value: <un-deserializable> }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    // unknown id
+    env.statement.nodeID = ulong.max;
     testAssert(ConfirmRes1, scpPrettify(&env, &getQSet));
 
-    // known hash
-    env.statement.pledges.confirm_.quorumSetHash = quorum_hash;
+    // known id
+    env.statement.nodeID = NodeID(0);
     testAssert(ConfirmRes2, scpPrettify(&env, &getQSet));
 
     // un-deserializable value
     env.statement.pledges.confirm_.ballot = SCPBallot.init;
     testAssert(ConfirmRes3, scpPrettify(&env, &getQSet));
 
-    // unknown hash
-    static immutable ExtRes1 = `{ statement: { node: 0, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x0000...0000, quorum: <unknown> }, commit: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nh: 100 } }, sig: 0x0000...be78 }`;
-    // known hash
-    static immutable ExtRes2 = `{ statement: { node: 0, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, commit: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nh: 100 } }, sig: 0x0000...be78 }`;
+    // unknown id
+    static immutable ExtRes1 = `{ statement: { node: <unknown>, slotIndex: 0, pledge: Externalize { commitQset: { id: <unknown>, quorum: <unknown> }, commit: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nh: 100 } }, sig: 0x0000...be78 }`;
+    // known id
+    static immutable ExtRes2 = `{ statement: { node: 0, slotIndex: 0, pledge: Externalize { commitQset: { id: 0, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, commit: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nh: 100 } }, sig: 0x0000...be78 }`;
     // un-deserializable value
-    static immutable ExtRes3 = `{ statement: { node: 0, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, commit: { counter: 0, value: <un-deserializable> }, nh: 100 } }, sig: 0x0000...be78 }`;
+    static immutable ExtRes3 = `{ statement: { node: 0, slotIndex: 0, pledge: Externalize { commitQset: { id: 0, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, commit: { counter: 0, value: <un-deserializable> }, nh: 100 } }, sig: 0x0000...be78 }`;
 
     /** SCP EXTERNALIZE */
     env.statement.pledges.type_ = SCPStatementType.SCP_ST_EXTERNALIZE;
@@ -554,21 +576,22 @@ unittest
     env.statement.pledges.externalize_.commit = ballot;
     env.statement.pledges.externalize_.nH = 100;
 
-    // unknown hash
+    // unknown id
+    env.statement.nodeID = ulong.max;
     testAssert(ExtRes1, scpPrettify(&env, &getQSet));
 
-    // known hash
-    env.statement.pledges.externalize_.commitQuorumSetHash = quorum_hash;
+    // known id
+    env.statement.nodeID = NodeID(0);
     testAssert(ExtRes2, scpPrettify(&env, &getQSet));
 
     // un-deserializable value
     env.statement.pledges.externalize_.commit = SCPBallot.init;
     testAssert(ExtRes3, scpPrettify(&env, &getQSet));
 
-    // unknown hash
-    static immutable NomRes1 = `{ statement: { node: 0, slotIndex: 0, pledge: Nominate { qset: { hash: 0x0000...0000, quorum: <unknown> }, votes: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }], accepted: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }] } }, sig: 0x0000...be78 }`;
-    // known hash
-    static immutable NomRes2 = `{ statement: { node: 0, slotIndex: 0, pledge: Nominate { qset: { hash: 0x5774...9db2, quorum: <unknown> }, votes: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }], accepted: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }] } }, sig: 0x0000...be78 }`;
+    // unknown id
+    static immutable NomRes1 = `{ statement: { node: <unknown>, slotIndex: 0, pledge: Nominate { qset: { id: <unknown>, quorum: <unknown> }, votes: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }], accepted: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }] } }, sig: 0x0000...be78 }`;
+    // known id
+    static immutable NomRes2 = `{ statement: { node: 0, slotIndex: 0, pledge: Nominate { qset: { id: 0, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, votes: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }], accepted: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }] } }, sig: 0x0000...be78 }`;
 
     /** SCP NOMINATE */
     env.statement.pledges.type_ = SCPStatementType.SCP_ST_NOMINATE;
@@ -581,10 +604,11 @@ unittest
     env.statement.pledges.nominate_.accepted.push_back(value);
     env.statement.pledges.nominate_.accepted.push_back(value);
 
-    // unknown hash
+    // unknown id
+    env.statement.nodeID = ulong.max;
     testAssert(NomRes1, scpPrettify(&env, &getQSet));
 
-    // known hash
-    env.statement.pledges.nominate_.quorumSetHash = quorum_hash;
+    // known id
+    env.statement.nodeID = NodeID(0);
     testAssert(NomRes2, scpPrettify(&env, &getQSet));
 }

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -314,7 +314,7 @@ private struct SCPStatementFmt
         {
             formattedWrite(sink,
                 "{ node: %s, slotIndex: %s, pledge: %s }",
-                prettify(Hash(this.statement.nodeID[])),
+                cast(ulong)this.statement.nodeID,
                 cast(ulong)this.statement.slotIndex,  // cast: consistent cross-platform output
                 PledgesFmt(this.statement.pledges, getQSet));
         }
@@ -450,9 +450,7 @@ unittest
     auto pair = WK.Keys.NODE2;
     auto pair_utxo_key = Hash("0x321efeea33f06eceefcc2ff8a646eac3e7d0d3de52820485b7004105dec3211f3631981a9c436afcd2dfdb264c5546c04855825080b2f6173b67f74c8df321a3");
 
-    auto qc = QuorumConfig(2,
-        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
-         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")]);
+    auto qc = QuorumConfig(2, [0, 1]);
 
     auto scp_quorum = toSCPQuorumSet(qc);
     auto qset = makeSharedSCPQuorumSet(scp_quorum);
@@ -468,7 +466,7 @@ unittest
     }
 
     SCPEnvelope env;
-    env.statement.nodeID = NodeID(pair_utxo_key[][0 .. NodeID.sizeof]);
+    env.statement.nodeID = NodeID(0);
 
     /** SCP PREPARE */
     env.statement.pledges.type_ = SCPStatementType.SCP_ST_PREPARE;
@@ -482,23 +480,23 @@ unittest
     env.signature = typeof(env.signature).init;
 
     // missing signature
-    static immutable MissingSig = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Prepare { qset: { hash: 0x2b20...4596, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...0000 }`;
+    static immutable MissingSig = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { hash: 0x5774...9db2, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...0000 }`;
 
     testAssert(MissingSig, scpPrettify(&env));
 
     env.signature = sig.toBlob();
 
     // null quorum (hash not found)
-    static immutable PrepareRes1 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Prepare { qset: { hash: 0x2b20...4596, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable PrepareRes1 = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { hash: 0x5774...9db2, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // with quorum mapping
-    static immutable PrepareRes2 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Prepare { qset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable PrepareRes2 = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: <null>, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // 'prep' pointer is set
-    static immutable PrepareRes3 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Prepare { qset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable PrepareRes3 = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prepPrime: <null>, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // 'preparedPrime' pointer is set
-    static immutable PrepareRes4 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Prepare { qset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prepPrime: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable PrepareRes4 = `{ statement: { node: 0, slotIndex: 0, pledge: Prepare { qset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prep: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, prepPrime: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nc: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     testAssert(PrepareRes1, scpPrettify(&env));
     testAssert(PrepareRes1, scpPrettify(&env, null));
@@ -525,13 +523,13 @@ unittest
     env.statement.pledges.confirm_.nH = 200;
 
     // confirm without a known hash
-    static immutable ConfirmRes1 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Confirm { qset: { hash: 0x0000...0000, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable ConfirmRes1 = `{ statement: { node: 0, slotIndex: 0, pledge: Confirm { qset: { hash: 0x0000...0000, quorum: <unknown> }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // confirm with a known hash
-    static immutable ConfirmRes2 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Confirm { qset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable ConfirmRes2 = `{ statement: { node: 0, slotIndex: 0, pledge: Confirm { qset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
 
     // un-deserializable value
-    static immutable ConfirmRes3 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Confirm { qset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, ballot: { counter: 0, value: <un-deserializable> }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
+    static immutable ConfirmRes3 = `{ statement: { node: 0, slotIndex: 0, pledge: Confirm { qset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, ballot: { counter: 0, value: <un-deserializable> }, nPrep: 42, nComm: 100, nH: 200 } }, sig: 0x0000...be78 }`;
     // unknown hash
     testAssert(ConfirmRes1, scpPrettify(&env, &getQSet));
 
@@ -544,11 +542,11 @@ unittest
     testAssert(ConfirmRes3, scpPrettify(&env, &getQSet));
 
     // unknown hash
-    static immutable ExtRes1 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x0000...0000, quorum: <unknown> }, commit: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nh: 100 } }, sig: 0x0000...be78 }`;
+    static immutable ExtRes1 = `{ statement: { node: 0, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x0000...0000, quorum: <unknown> }, commit: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nh: 100 } }, sig: 0x0000...be78 }`;
     // known hash
-    static immutable ExtRes2 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, commit: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nh: 100 } }, sig: 0x0000...be78 }`;
+    static immutable ExtRes2 = `{ statement: { node: 0, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, commit: { counter: 42, value: { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 } }, nh: 100 } }, sig: 0x0000...be78 }`;
     // un-deserializable value
-    static immutable ExtRes3 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x2b20...4596, quorum: { thresh: 2, nodes: [0x11c6...ebf5, 0xdfca...e5fd], subqs: [] } }, commit: { counter: 0, value: <un-deserializable> }, nh: 100 } }, sig: 0x0000...be78 }`;
+    static immutable ExtRes3 = `{ statement: { node: 0, slotIndex: 0, pledge: Externalize { commitQset: { hash: 0x5774...9db2, quorum: { thresh: 2, nodes: [0, 1], subqs: [] } }, commit: { counter: 0, value: <un-deserializable> }, nh: 100 } }, sig: 0x0000...be78 }`;
 
     /** SCP EXTERNALIZE */
     env.statement.pledges.type_ = SCPStatementType.SCP_ST_EXTERNALIZE;
@@ -568,9 +566,9 @@ unittest
     testAssert(ExtRes3, scpPrettify(&env, &getQSet));
 
     // unknown hash
-    static immutable NomRes1 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Nominate { qset: { hash: 0x0000...0000, quorum: <unknown> }, votes: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }], accepted: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }] } }, sig: 0x0000...be78 }`;
+    static immutable NomRes1 = `{ statement: { node: 0, slotIndex: 0, pledge: Nominate { qset: { hash: 0x0000...0000, quorum: <unknown> }, votes: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }], accepted: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }] } }, sig: 0x0000...be78 }`;
     // known hash
-    static immutable NomRes2 = `{ statement: { node: 0x321e...21a3, slotIndex: 0, pledge: Nominate { qset: { hash: 0x2b20...4596, quorum: <unknown> }, votes: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }], accepted: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }] } }, sig: 0x0000...be78 }`;
+    static immutable NomRes2 = `{ statement: { node: 0, slotIndex: 0, pledge: Nominate { qset: { hash: 0x5774...9db2, quorum: <unknown> }, votes: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }], accepted: [{ tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }, { tx_set: [0xeb5e...4551], enrolls: [{ utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }, { utxo: 0x0000...e26f, seed: 0x4a5e...a33b, cycles: 1008, sig: 0x0000...be78 }], missing_validators: [0, 2, 4], time_offset: 42 }] } }, sig: 0x0000...be78 }`;
 
     /** SCP NOMINATE */
     env.statement.pledges.type_ = SCPStatementType.SCP_ST_NOMINATE;

--- a/source/scpd/Cpp.d
+++ b/source/scpd/Cpp.d
@@ -32,6 +32,7 @@ import agora.serialization.Serializer;
 import core.stdcpp.string;
 import core.stdcpp.xutility;
 import std.meta;
+import std.traits;
 
 import vibe.data.json;
 
@@ -441,7 +442,6 @@ extern(C++, (StdNamespace)) extern(C++, class) struct vector (T, Alloc = allocat
         static QT fromBinary (QT) (scope DeserializeDg data,
             in DeserializerOptions opts) @safe
         {
-            import std.traits;
             import scpd.types.Utils;
 
             // Note: Unqual necessary because we can't construct an
@@ -454,6 +454,16 @@ extern(C++, (StdNamespace)) extern(C++, class) struct vector (T, Alloc = allocat
                 ret.push_back(entry);
             }
             return () @trusted { return cast(QT) ret; }();
+        }
+
+        static if (isBasicType!T)
+        {
+            /// Overload for basic types to not require a `const ref`
+            public void push_back (T value) @trusted pure nothrow @nogc
+            {
+                import Utils = scpd.types.Utils;
+                Utils.push_back(this, value);
+            }
         }
 
         public void push_back (ref T value) @trusted pure nothrow @nogc

--- a/source/scpd/quorum/QuorumIntersectionChecker.d
+++ b/source/scpd/quorum/QuorumIntersectionChecker.d
@@ -19,6 +19,20 @@ import scpd.Cpp;
 import scpd.quorum.QuorumTracker;
 import scpd.types.Stellar_types;
 
+// Quorum intersection checker implementation
+// This method was originally implemented in C++ but 
+// since the changes to `NodeID` had to be moved to D.
+extern (C++, "_GLOBAL__N_1") {
+    extern class QuorumIntersectionCheckerImpl {
+        std_string nodeName (const NodeID node) const
+        {
+            import std.conv;
+            auto slice = node.to!string;
+            return sliceToStdString(slice.ptr, slice.length);
+        }
+    }
+}
+
 extern (C++, `stellar`):
 
 /// Ditto

--- a/source/scpd/scp/BallotProtocol.d
+++ b/source/scpd/scp/BallotProtocol.d
@@ -127,12 +127,6 @@ extern(C++, class) public struct BallotProtocol
     void* getJsonQuorumInfo(ref const(NodeID)  id, bool summary,
         bool fullKeys = false);
 
-    // returns the hash of the QuorumSet that should be downloaded
-    // with the statement.
-    // note: the companion hash for an EXTERNALIZE statement does
-    // not match the hash of the QSet, but the hash of commitQuorumSetHash
-    static Hash getCompanionQuorumSetHashFromStatement(const ref SCPStatement st);
-
     // helper function to retrieve b for PREPARE, P for CONFIRM or
     // c for EXTERNALIZE messages
     static SCPBallot getWorkingBallot(const ref SCPStatement st);

--- a/source/scpd/scp/LocalNode.d
+++ b/source/scpd/scp/LocalNode.d
@@ -123,4 +123,4 @@ extern(C++, class) public struct LocalNode
                                     const ref vector!NodeID nodeSet);
 }
 
-static assert(LocalNode.sizeof == 280);
+static assert(LocalNode.sizeof == 224);

--- a/source/scpd/scp/SCP.d
+++ b/source/scpd/scp/SCP.d
@@ -90,6 +90,9 @@ nothrow:
     // Local nodeID getter
     ref const(NodeID) getLocalNodeID();
 
+    // Change nodeID
+    void changeNodeID(ref const(NodeID) id);
+
     // returns the local node descriptor
     //std::shared_ptr<LocalNode> getLocalNode();
     shared_ptr!LocalNode getLocalNode();

--- a/source/scpd/scp/SCPDriver.d
+++ b/source/scpd/scp/SCPDriver.d
@@ -80,9 +80,8 @@ nothrow:
     // ValueWrapperPtr factory
     ValueWrapperPtr wrapValue(ref const(Value) value);
 
-    // Delegates the retrieval of the quorum set designated by `qSetHash` to
-    // the user of SCP.
-    abstract SCPQuorumSetPtr getQSet(ref const(Hash) qSetHash);
+    // Delegates the retrieval of the quorum set associated with this node ID
+    abstract SCPQuorumSetPtr getQSet(ref const(NodeID) nodeID);
 
     // Users of the SCP library should inherit from SCPDriver and implement the
     // virtual methods which are called by the SCP implementation to

--- a/source/scpd/scp/SCPDriver.d
+++ b/source/scpd/scp/SCPDriver.d
@@ -20,6 +20,8 @@ import scpd.types.Stellar_types;
 import scpd.types.XDRBase;
 
 import core.stdc.inttypes;
+import core.stdcpp.string;
+import std.conv;
 
 extern(C++, `stellar`):
 
@@ -140,7 +142,7 @@ nothrow:
     {
         try
         {
-            auto slice = Hash(pk).toString();
+            string slice = pk.to!string;
             return sliceToStdString(slice.ptr, slice.length);
         }
         catch (Exception exc)
@@ -155,7 +157,7 @@ nothrow:
     {
         try
         {
-            auto slice = Hash(pk).toString();
+            string slice = pk.to!string;
             return sliceToStdString(slice.ptr, slice.length);
         }
         catch (Exception exc)

--- a/source/scpd/scp/Utils.d
+++ b/source/scpd/scp/Utils.d
@@ -21,5 +21,5 @@ import scpd.types.Stellar_types;
 extern (C++):
 
 /// SCP constructor wrapper
-SCP* createSCP (SCPDriver driver, ref const(NodeID) nodeID, bool isValidator,
+SCP* createSCP (SCPDriver driver, NodeID nodeID, bool isValidator,
     ref const(SCPQuorumSet) qSetLocal);

--- a/source/scpd/tests/GlueTypes.d
+++ b/source/scpd/tests/GlueTypes.d
@@ -43,7 +43,6 @@ alias TypesWithLayout = AliasSeq!
     SCPQuorumSet,
 
     /// scpd.types.Stellar_types
-    Hash,
 );
 
 /// For these types we cannot do layout checks as we require
@@ -55,7 +54,6 @@ alias TypesNoLayout = AliasSeq!
     Value,
     SCPStatementType,
     NodeID,
-    Signature,
 
     /// scpd.types.XDRBase
     xvector!Value,

--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -46,12 +46,11 @@ enum SCPStatementType : int32_t {
 }
 
 struct SCPNomination {
-    Hash quorumSetHash;
     xvector!(Value) votes;
     xvector!(Value) accepted;
 }
 
-static assert(SCPNomination.sizeof == 112);
+static assert(SCPNomination.sizeof == 48);
 
 struct SCPStatement {
 
@@ -65,7 +64,6 @@ struct SCPStatement {
 
     static struct _pledges_t {
         static struct _prepare_t {
-            Hash quorumSetHash;
             SCPBallot ballot;
             pointer!(SCPBallot) prepared;
             pointer!(SCPBallot) preparedPrime;
@@ -73,7 +71,7 @@ struct SCPStatement {
             uint32_t nH;
         }
 
-        static assert(_prepare_t.sizeof == 120);
+        static assert(_prepare_t.sizeof == 56);
 
         static struct _confirm_t {
             SCPBallot ballot;
@@ -81,18 +79,16 @@ struct SCPStatement {
             uint32_t nPrepared;
             uint32_t nCommit;
             uint32_t nH;
-            Hash quorumSetHash;
         }
 
-        static assert(_confirm_t.sizeof == 144);
+        static assert(_confirm_t.sizeof == 80);
 
         static struct _externalize_t {
             SCPBallot commit;
             uint32_t nH;
-            Hash commitQuorumSetHash;
         }
 
-        static assert(_externalize_t.sizeof == 104);
+        static assert(_externalize_t.sizeof == 40);
 
         //using _xdr_case_type = xdr::xdr_traits<SCPStatementType>::case_type;
         //private:
@@ -308,7 +304,7 @@ struct SCPStatement {
     _pledges_t pledges;
 }
 
-static assert(SCPStatement.sizeof == 168);
+static assert(SCPStatement.sizeof == 104);
 static assert(Signature.sizeof == 64);
 
 struct SCPEnvelope {
@@ -316,7 +312,7 @@ struct SCPEnvelope {
   Signature signature;
 }
 
-static assert(SCPEnvelope.sizeof == 232);
+static assert(SCPEnvelope.sizeof == 168);
 
 struct SCPQuorumSet {
     import agora.crypto.Hash;

--- a/source/scpd/types/Stellar_SCP.d
+++ b/source/scpd/types/Stellar_SCP.d
@@ -308,7 +308,7 @@ struct SCPStatement {
     _pledges_t pledges;
 }
 
-static assert(SCPStatement.sizeof == 224);
+static assert(SCPStatement.sizeof == 168);
 static assert(Signature.sizeof == 64);
 
 struct SCPEnvelope {
@@ -316,7 +316,7 @@ struct SCPEnvelope {
   Signature signature;
 }
 
-static assert(SCPEnvelope.sizeof == 288);
+static assert(SCPEnvelope.sizeof == 232);
 
 struct SCPQuorumSet {
     import agora.crypto.Hash;
@@ -347,39 +347,27 @@ struct SCPQuorumSet {
     import agora.crypto.Key;
     import std.conv;
 
-    const qc1 = toSCPQuorumSet(QuorumConfig(2,
-        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
-         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")]));
+    const qc1 = toSCPQuorumSet(QuorumConfig(2, [0, 1]));
 
     assert(qc1.hashFull() == Hash.fromString(
-        "0x2b202a92d7e32a7aa839ad17df498a8db0efa445b2cc1c73e32763db49e64162d43d766eb08d04d13ecb5eab1e012781e28a90375658a2f75f1cc02198904596"));
+        "0x57744ff3b19f006505cb69a617f99314119dbfa7bff94eb59b058b7088076ae8f4631085db5dca56c0b97d208e8276801a7602453f0fa57ec0ce2dfe25669db2"));
 
-    const qc2 = toSCPQuorumSet(QuorumConfig(3,
-        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
-         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")]));
+    const qc2 = toSCPQuorumSet(QuorumConfig(3, [0, 1]));
 
     assert(qc2.hashFull() == Hash.fromString(
-        "0x2380963ec547f302eeb9b4ec95ad12bd986c587e4e0148b91fca421620404f250c3eadfae7b4de2807b8e8c25b1ca81aa3b856014b4d9c3b5b2060be8924a1b3"));
+        "0xdccacd796d28677dd3690c5dea888262c40c8d904e452eed3d56f99154fd209303ed4a270a81a51ed4224375889d86d1a441c914a2ec5ece78313a12a60aca72"));
 
-    const qc3 = toSCPQuorumSet(QuorumConfig(2,
-        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
-         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")],
-             [QuorumConfig(2,
-                [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
-                 Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")])]));
+    const qc3 = toSCPQuorumSet(QuorumConfig(2, [0, 1],
+             [QuorumConfig(2, [0, 1])]));
 
     assert(qc3.hashFull() == Hash.fromString(
-        "0x36de5a8b9263cb1b08dc4fbc329b0bac645a33c7c22be3c452e4db91c346b3f80b0acce1b047b8e63c1918adccae5958000501f786d68ec29d240bf74335e9b4"));
+        "0xac26280aaea44f23c11fb6dc14eda3c83e5642288049244edb9bb0331a99f7e5f5e614e07e6d5b1009cc80e7895181f1eb0f0ad299cbb5fffe2d7994e970f6ee"));
 
-    const qc4 = toSCPQuorumSet(QuorumConfig(2,
-        [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
-         Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")],
-             [QuorumConfig(3,
-                [Hash("0x11c6b0395c8e1716978c41958eab84e869755c09f7131b3bbdc882a647cb3f2c46c450607c6da71d34d1eab28fbfdf14376b444ef46ed1d0a7d2237ab430ebf5"),
-                 Hash("0xdfcada320948a86f6027daf7e5a964a36103ea0e662abaa692212392a280b7c211e56beb2bf83fbc53459603c6750e00cdc194c773f9941dc43b07c6f639e5fd")])]));
+    const qc4 = toSCPQuorumSet(QuorumConfig(2, [0, 1],
+             [QuorumConfig(3, [0, 1])]));
 
     assert(qc4.hashFull() == Hash.fromString(
-        "0x0b7d0c118e89ce2a5f9c7c9c3ece531389c76242f99209d769359b3b0f3b8b54eec74ef8b1b820f2a8ecf9a68b252be9cc76931ce88d1b5795970e268891b95b"));
+        "0xeaafeb7634d31143b235b8d1e45d57deda854d3a8cca6af0e78379d5cdb2e547e15e67d8d2da01510f4de45b7d650b418da4051d34ca1d2760a7be2772ac66d0"));
 }
 static assert(SCPQuorumSet.sizeof == 56);
 

--- a/source/scpd/types/Stellar_types.d
+++ b/source/scpd/types/Stellar_types.d
@@ -34,7 +34,7 @@ alias uint512 = opaque_array!64;
 
 
 alias Hash      = uint512;
-alias NodeID    = uint512;
+alias NodeID    = uint64_t;
 alias Signature = uint512;
 
 unittest
@@ -44,6 +44,5 @@ unittest
     static import agora.crypto.Schnorr;
 
     static assert(agora.crypto.Hash.Hash.sizeof == Hash.sizeof);
-    static assert(agora.crypto.Hash.Hash.sizeof == NodeID.sizeof);
     static assert(agora.crypto.Schnorr.Signature.sizeof == Signature.sizeof);
 }

--- a/source/scpp/extra/DLayoutChecks.cpp
+++ b/source/scpp/extra/DLayoutChecks.cpp
@@ -63,7 +63,6 @@ FieldInfo cppFieldInfo ( SCPBallot &object, const char *field_name )
 
 FieldInfo cppFieldInfo ( SCPNomination &object, const char *field_name )
 {
-    HANDLE(quorumSetHash)
     HANDLE(votes)
     HANDLE(accepted)
     return FieldInfo(-1, -1);  // assert on the D side for better error messages
@@ -71,7 +70,6 @@ FieldInfo cppFieldInfo ( SCPNomination &object, const char *field_name )
 
 FieldInfo cppFieldInfo ( SCPStatement::_pledges_t::_prepare_t &object, const char *field_name )
 {
-    HANDLE(quorumSetHash)
     HANDLE(ballot)
     HANDLE(prepared)
     HANDLE(preparedPrime)
@@ -87,7 +85,6 @@ FieldInfo cppFieldInfo ( SCPStatement::_pledges_t::_confirm_t &object, const cha
     HANDLE(nPrepared)
     HANDLE(nCommit)
     HANDLE(nH)
-    HANDLE(quorumSetHash)
     return FieldInfo(-1, -1);  // assert on the D side for better error messages
 }
 
@@ -95,7 +92,6 @@ FieldInfo cppFieldInfo ( SCPStatement::_pledges_t::_externalize_t &object, const
 {
     HANDLE(commit)
     HANDLE(nH)
-    HANDLE(commitQuorumSetHash)
     return FieldInfo(-1, -1);  // assert on the D side for better error messages
 }
 

--- a/source/scpp/extra/DSCPUtils.cpp
+++ b/source/scpp/extra/DSCPUtils.cpp
@@ -9,7 +9,7 @@
 using namespace xdr;
 using namespace stellar;
 
-SCP* createSCP(SCPDriver* driver, NodeID const& nodeID, bool isValidator, SCPQuorumSet const& qSetLocal)
+SCP* createSCP(SCPDriver* driver, NodeID nodeID, bool isValidator, SCPQuorumSet const& qSetLocal)
 {
     return new stellar::SCP(*driver, nodeID, isValidator, qSetLocal);
 }

--- a/source/scpp/src/quorum/QuorumIntersectionCheckerImpl.cpp
+++ b/source/scpp/src/quorum/QuorumIntersectionCheckerImpl.cpp
@@ -691,11 +691,15 @@ QuorumIntersectionCheckerImpl::buildSCCs()
     mStats.mNumSCCs = mTSC.mSCCs.size();
 }
 
+// The definition of the function moved to the file,
+// source/scpd/quorum/QuorumIntersectionChecker.d
+/*
 std::string
 QuorumIntersectionCheckerImpl::nodeName(size_t node) const
 {
     return stellar::KeyUtils::toShortString(mBitNumPubKeys.at(node));
 }
+*/
 
 bool
 QuorumIntersectionCheckerImpl::networkEnjoysQuorumIntersection() const

--- a/source/scpp/src/quorum/QuorumIntersectionCheckerImpl.h
+++ b/source/scpp/src/quorum/QuorumIntersectionCheckerImpl.h
@@ -531,7 +531,7 @@ class QuorumIntersectionCheckerImpl : public stellar::QuorumIntersectionChecker
     bool isMinimalQuorum(BitSet const& nodes) const;
     void noteFoundDisjointQuorums(BitSet const& nodes,
                                   BitSet const& disj) const;
-    std::string nodeName(size_t node) const;
+    std::string nodeName(const stellar::NodeID node) const;
 
     friend class MinQuorumEnumerator;
 

--- a/source/scpp/src/scp/BallotProtocol.h
+++ b/source/scpp/src/scp/BallotProtocol.h
@@ -125,12 +125,6 @@ private:
     Json::Value getJsonQuorumInfo(NodeID const& id, bool summary,
                                   bool fullKeys = false);
 
-    // returns the hash of the QuorumSet that should be downloaded
-    // with the statement.
-    // note: the companion hash for an EXTERNALIZE statement does
-    // not match the hash of the QSet, but the hash of commitQuorumSetHash
-    static Hash getCompanionQuorumSetHashFromStatement(SCPStatement const& st);
-
     // helper function to retrieve b for PREPARE, P for CONFIRM or
     // c for EXTERNALIZE messages
     static SCPBallot getWorkingBallot(SCPStatement const& st);

--- a/source/scpp/src/scp/LocalNode.cpp
+++ b/source/scpp/src/scp/LocalNode.cpp
@@ -412,6 +412,12 @@ LocalNode::getNodeID()
     return mNodeID;
 }
 
+void
+LocalNode::changeNodeID(NodeID const& nodeID)
+{
+    mNodeID = nodeID;
+}
+
 bool
 LocalNode::isValidator()
 {

--- a/source/scpp/src/scp/LocalNode.h
+++ b/source/scpp/src/scp/LocalNode.h
@@ -20,7 +20,7 @@ namespace stellar
 class LocalNode
 {
   protected:
-    const NodeID mNodeID;
+    NodeID mNodeID;
     const bool mIsValidator;
     SCPQuorumSet mQSet;
     Hash mQSetHash;
@@ -36,6 +36,8 @@ class LocalNode
               SCPDriver& driver);
 
     NodeID const& getNodeID();
+
+    void changeNodeID(NodeID const& nodeID);
 
     void updateQuorumSet(SCPQuorumSet const& qSet);
 

--- a/source/scpp/src/scp/NominationProtocol.cpp
+++ b/source/scpp/src/scp/NominationProtocol.cpp
@@ -148,8 +148,6 @@ NominationProtocol::emitNomination()
     st.pledges.type(SCP_ST_NOMINATE);
     auto& nom = st.pledges.nominate();
 
-    nom.quorumSetHash = mSlot.getLocalNode()->getQuorumSetHash();
-
     for (auto const& v : mVotes)
     {
         nom.votes.emplace_back(v->getValue());

--- a/source/scpp/src/scp/SCP.cpp
+++ b/source/scpp/src/scp/SCP.cpp
@@ -70,6 +70,12 @@ SCP::getLocalNodeID()
 }
 
 void
+SCP::changeNodeID(NodeID const& id)
+{
+    mLocalNode->changeNodeID(id);
+}
+
+void
 SCP::purgeSlots(uint64 maxSlotIndex)
 {
     auto it = mKnownSlots.begin();

--- a/source/scpp/src/scp/SCP.cpp
+++ b/source/scpp/src/scp/SCP.cpp
@@ -350,8 +350,6 @@ SCP::envToStr(SCPStatement const& st, bool fullKeys) const
 {
     std::ostringstream oss;
 
-    Hash const& qSetHash = Slot::getCompanionQuorumSetHashFromStatement(st);
-
     std::string nodeId = mDriver.toStrKey(st.nodeID, fullKeys);
 
     oss << "{ENV@" << nodeId << " | "
@@ -362,7 +360,6 @@ SCP::envToStr(SCPStatement const& st, bool fullKeys) const
     {
         auto const& p = st.pledges.prepare();
         oss << " | PREPARE"
-            << " | D: " << hexAbbrev(qSetHash)
             << " | b: " << ballotToStr(p.ballot)
             << " | p: " << ballotToStr(p.prepared)
             << " | p': " << ballotToStr(p.preparedPrime) << " | c.n: " << p.nC
@@ -373,7 +370,6 @@ SCP::envToStr(SCPStatement const& st, bool fullKeys) const
     {
         auto const& c = st.pledges.confirm();
         oss << " | CONFIRM"
-            << " | D: " << hexAbbrev(qSetHash)
             << " | b: " << ballotToStr(c.ballot) << " | p.n: " << c.nPrepared
             << " | c.n: " << c.nCommit << " | h.n: " << c.nH;
     }
@@ -382,15 +378,13 @@ SCP::envToStr(SCPStatement const& st, bool fullKeys) const
     {
         auto const& ex = st.pledges.externalize();
         oss << " | EXTERNALIZE"
-            << " | c: " << ballotToStr(ex.commit) << " | h.n: " << ex.nH
-            << " | (lastD): " << hexAbbrev(qSetHash);
+            << " | c: " << ballotToStr(ex.commit) << " | h.n: " << ex.nH;
     }
     break;
     case SCPStatementType::SCP_ST_NOMINATE:
     {
         auto const& nom = st.pledges.nominate();
-        oss << " | NOMINATE"
-            << " | D: " << hexAbbrev(qSetHash) << " | X: {";
+        oss << " | NOMINATE";
         bool first = true;
         for (auto const& v : nom.votes)
         {

--- a/source/scpp/src/scp/SCP.h
+++ b/source/scpp/src/scp/SCP.h
@@ -65,6 +65,10 @@ class SCP
     // Local nodeID getter
     NodeID const& getLocalNodeID();
 
+
+    // Change nodeID
+    void changeNodeID(NodeID const& id);
+
     // returns the local node descriptor
     std::shared_ptr<LocalNode> getLocalNode();
 

--- a/source/scpp/src/scp/SCPDriver.h
+++ b/source/scpp/src/scp/SCPDriver.h
@@ -79,17 +79,15 @@ class SCPDriver
     // ValueWrapperPtr factory
     virtual ValueWrapperPtr wrapValue(Value const& value);
 
-    // Retrieves a quorum set from its hash
+    // Retrieves the quorum set configuration for the given node ID
     //
-    // All SCP statement (see `SCPNomination` and `SCPStatement`) include
-    // a quorum set hash.
-    // SCP does not define how quorum sets are exchanged between nodes,
-    // hence their retrieval is delegated to the user of SCP.
-    // The return value is not cached by SCP, as quorum sets are transient.
+    // Note: In our modified version of SCP we do not include quorum set hashes
+    // in SCP protocol messages as the quorums are implicitly known by the
+    // system for all active validator nodes.
     //
     // `nullptr` is a valid return value which cause the statement to be
     // considered invalid.
-    virtual SCPQuorumSetPtr getQSet(Hash const& qSetHash) = 0;
+    virtual SCPQuorumSetPtr getQSet(NodeID const& nodeID) = 0;
 
     // Users of the SCP library should inherit from SCPDriver and implement the
     // virtual methods which are called by the SCP implementation to

--- a/source/scpp/src/scp/Slot.cpp
+++ b/source/scpp/src/scp/Slot.cpp
@@ -228,30 +228,6 @@ Slot::createEnvelope(SCPStatement const& statement)
     return envelope;
 }
 
-Hash
-Slot::getCompanionQuorumSetHashFromStatement(SCPStatement const& st)
-{
-    Hash h;
-    switch (st.pledges.type())
-    {
-    case SCP_ST_PREPARE:
-        h = st.pledges.prepare().quorumSetHash;
-        break;
-    case SCP_ST_CONFIRM:
-        h = st.pledges.confirm().quorumSetHash;
-        break;
-    case SCP_ST_EXTERNALIZE:
-        h = st.pledges.externalize().commitQuorumSetHash;
-        break;
-    case SCP_ST_NOMINATE:
-        h = st.pledges.nominate().quorumSetHash;
-        break;
-    default:
-        dbgAbort();
-    }
-    return h;
-}
-
 std::vector<Value>
 Slot::getStatementValues(SCPStatement const& st)
 {
@@ -284,24 +260,7 @@ Slot::getQuorumSetFromStatement(SCPStatement const& st)
     }
     else
     {
-        Hash h;
-        if (t == SCP_ST_PREPARE)
-        {
-            h = st.pledges.prepare().quorumSetHash;
-        }
-        else if (t == SCP_ST_CONFIRM)
-        {
-            h = st.pledges.confirm().quorumSetHash;
-        }
-        else if (t == SCP_ST_NOMINATE)
-        {
-            h = st.pledges.nominate().quorumSetHash;
-        }
-        else
-        {
-            dbgAbort();
-        }
-        res = getSCPDriver().getQSet(h);
+        res = getSCPDriver().getQSet(st.nodeID);
     }
     return res;
 }
@@ -310,7 +269,7 @@ Json::Value
 Slot::getJsonInfo(bool fullKeys)
 {
     Json::Value ret;
-    std::map<Hash, SCPQuorumSetPtr> qSetsUsed;
+    std::map<NodeID, SCPQuorumSetPtr> qSetsUsed;
 
     int count = 0;
     for (auto const& item : mStatementsHistory)
@@ -320,19 +279,11 @@ Slot::getJsonInfo(bool fullKeys)
         v.append(mSCP.envToStr(item.mStatement, fullKeys));
         v.append(item.mValidated);
 
-        Hash const& qSetHash =
-            getCompanionQuorumSetHashFromStatement(item.mStatement);
-        auto qSet = getSCPDriver().getQSet(qSetHash);
+        auto qSet = getSCPDriver().getQSet(item.mStatement.nodeID);
         if (qSet)
         {
-            qSetsUsed.insert(std::make_pair(qSetHash, qSet));
+            qSetsUsed.insert(std::make_pair(item.mStatement.nodeID, qSet));
         }
-    }
-
-    auto& qSets = ret["quorum_sets"];
-    for (auto const& q : qSetsUsed)
-    {
-        qSets[hexAbbrev(q.first)] = getLocalNode()->toJson(*q.second, fullKeys);
     }
 
     ret["validated"] = mFullyValidated;

--- a/source/scpp/src/scp/Slot.h
+++ b/source/scpp/src/scp/Slot.h
@@ -157,12 +157,6 @@ class Slot : public std::enable_shared_from_this<Slot>
     Json::Value getJsonQuorumInfo(NodeID const& id, bool summary,
                                   bool fullKeys = false);
 
-    // returns the hash of the QuorumSet that should be downloaded
-    // with the statement.
-    // note: the companion hash for an EXTERNALIZE statement does
-    // not match the hash of the QSet, but the hash of commitQuorumSetHash
-    static Hash getCompanionQuorumSetHashFromStatement(SCPStatement const& st);
-
     // returns the values associated with the statement
     static std::vector<Value> getStatementValues(SCPStatement const& st);
 

--- a/source/scpp/src/xdr/Agora-types.h
+++ b/source/scpp/src/xdr/Agora-types.h
@@ -19,6 +19,6 @@ namespace stellar
 
     // Logical types used by SCP / Agora
     using Hash =      uint512;
-    using NodeID =    uint512; // Currently hash of `utxo` staked for validator
+    using NodeID =    uint64;   // Currently index of `utxo` staked for validator
     using Signature = uint512; // `(R,s)`, could be reduced to `(s)`
 }

--- a/source/scpp/src/xdr/Stellar-SCP.h
+++ b/source/scpp/src/xdr/Stellar-SCP.h
@@ -89,32 +89,24 @@ template<> struct xdr_traits<::stellar::SCPStatementType>
 } namespace stellar {
 
 struct SCPNomination {
-  Hash quorumSetHash{};
   xdr::xvector<Value> votes{};
   xdr::xvector<Value> accepted{};
 
   SCPNomination() = default;
-  template<typename _quorumSetHash_T,
-           typename _votes_T,
+  template<typename _votes_T,
            typename _accepted_T,
            typename = typename
-           std::enable_if<std::is_constructible<Hash, _quorumSetHash_T>::value
-                          && std::is_constructible<xdr::xvector<Value>, _votes_T>::value
+           std::enable_if<std::is_constructible<xdr::xvector<Value>, _votes_T>::value
                           && std::is_constructible<xdr::xvector<Value>, _accepted_T>::value
                          >::type>
-  explicit SCPNomination(_quorumSetHash_T &&_quorumSetHash,
-                         _votes_T &&_votes,
+  explicit SCPNomination(_votes_T &&_votes,
                          _accepted_T &&_accepted)
-    : quorumSetHash(std::forward<_quorumSetHash_T>(_quorumSetHash)),
-      votes(std::forward<_votes_T>(_votes)),
+    : votes(std::forward<_votes_T>(_votes)),
       accepted(std::forward<_accepted_T>(_accepted)) {}
 };
 } namespace xdr {
 template<> struct xdr_traits<::stellar::SCPNomination>
   : xdr_struct_base<field_ptr<::stellar::SCPNomination,
-                              decltype(::stellar::SCPNomination::quorumSetHash),
-                              &::stellar::SCPNomination::quorumSetHash>,
-                    field_ptr<::stellar::SCPNomination,
                               decltype(::stellar::SCPNomination::votes),
                               &::stellar::SCPNomination::votes>,
                     field_ptr<::stellar::SCPNomination,
@@ -122,13 +114,11 @@ template<> struct xdr_traits<::stellar::SCPNomination>
                               &::stellar::SCPNomination::accepted>> {
   template<typename Archive> static void
   save(Archive &ar, const ::stellar::SCPNomination &obj) {
-    archive(ar, obj.quorumSetHash, "quorumSetHash");
     archive(ar, obj.votes, "votes");
     archive(ar, obj.accepted, "accepted");
   }
   template<typename Archive> static void
   load(Archive &ar, ::stellar::SCPNomination &obj) {
-    archive(ar, obj.quorumSetHash, "quorumSetHash");
     archive(ar, obj.votes, "votes");
     archive(ar, obj.accepted, "accepted");
     xdr::validate(obj);
@@ -139,7 +129,6 @@ template<> struct xdr_traits<::stellar::SCPNomination>
 struct SCPStatement {
   struct _pledges_t {
     struct _prepare_t {
-      Hash quorumSetHash{};
       SCPBallot ballot{};
       xdr::pointer<SCPBallot> prepared{};
       xdr::pointer<SCPBallot> preparedPrime{};
@@ -147,28 +136,24 @@ struct SCPStatement {
       uint32 nH{};
 
       _prepare_t() = default;
-      template<typename _quorumSetHash_T,
-               typename _ballot_T,
+      template<typename _ballot_T,
                typename _prepared_T,
                typename _preparedPrime_T,
                typename _nC_T,
                typename _nH_T,
                typename = typename
-               std::enable_if<std::is_constructible<Hash, _quorumSetHash_T>::value
-                              && std::is_constructible<SCPBallot, _ballot_T>::value
+               std::enable_if<std::is_constructible<SCPBallot, _ballot_T>::value
                               && std::is_constructible<xdr::pointer<SCPBallot>, _prepared_T>::value
                               && std::is_constructible<xdr::pointer<SCPBallot>, _preparedPrime_T>::value
                               && std::is_constructible<uint32, _nC_T>::value
                               && std::is_constructible<uint32, _nH_T>::value
                              >::type>
-      explicit _prepare_t(_quorumSetHash_T &&_quorumSetHash,
-                          _ballot_T &&_ballot,
+      explicit _prepare_t(_ballot_T &&_ballot,
                           _prepared_T &&_prepared,
                           _preparedPrime_T &&_preparedPrime,
                           _nC_T &&_nC,
                           _nH_T &&_nH)
-        : quorumSetHash(std::forward<_quorumSetHash_T>(_quorumSetHash)),
-          ballot(std::forward<_ballot_T>(_ballot)),
+        : ballot(std::forward<_ballot_T>(_ballot)),
           prepared(std::forward<_prepared_T>(_prepared)),
           preparedPrime(std::forward<_preparedPrime_T>(_preparedPrime)),
           nC(std::forward<_nC_T>(_nC)),
@@ -180,7 +165,6 @@ struct SCPStatement {
       uint32 nPrepared{};
       uint32 nCommit{};
       uint32 nH{};
-      Hash quorumSetHash{};
 
       _confirm_t() = default;
       template<typename _ballot_T,
@@ -188,48 +172,39 @@ struct SCPStatement {
                typename _nPrepared_T,
                typename _nCommit_T,
                typename _nH_T,
-               typename _quorumSetHash_T,
                typename = typename
                std::enable_if<std::is_constructible<SCPBallot, _ballot_T>::value
                               && std::is_constructible<uint256, _value_sig_T>::value
                               && std::is_constructible<uint32, _nPrepared_T>::value
                               && std::is_constructible<uint32, _nCommit_T>::value
                               && std::is_constructible<uint32, _nH_T>::value
-                              && std::is_constructible<Hash, _quorumSetHash_T>::value
                              >::type>
       explicit _confirm_t(_ballot_T &&_ballot,
                           _value_sig_T &&_value_sig,
                           _nPrepared_T &&_nPrepared,
                           _nCommit_T &&_nCommit,
-                          _nH_T &&_nH,
-                          _quorumSetHash_T &&_quorumSetHash)
+                          _nH_T &&_nH)
         : ballot(std::forward<_ballot_T>(_ballot)),
           value_sig(std::forward<_value_sig_T>(_value_sig)),
           nPrepared(std::forward<_nPrepared_T>(_nPrepared)),
           nCommit(std::forward<_nCommit_T>(_nCommit)),
-          nH(std::forward<_nH_T>(_nH)),
-          quorumSetHash(std::forward<_quorumSetHash_T>(_quorumSetHash)) {}
+          nH(std::forward<_nH_T>(_nH)) {}
     };
     struct _externalize_t {
       SCPBallot commit{};
       uint32 nH{};
-      Hash commitQuorumSetHash{};
 
       _externalize_t() = default;
       template<typename _commit_T,
                typename _nH_T,
-               typename _commitQuorumSetHash_T,
                typename = typename
                std::enable_if<std::is_constructible<SCPBallot, _commit_T>::value
                               && std::is_constructible<uint32, _nH_T>::value
-                              && std::is_constructible<Hash, _commitQuorumSetHash_T>::value
                              >::type>
       explicit _externalize_t(_commit_T &&_commit,
-                              _nH_T &&_nH,
-                              _commitQuorumSetHash_T &&_commitQuorumSetHash)
+                              _nH_T &&_nH)
         : commit(std::forward<_commit_T>(_commit)),
-          nH(std::forward<_nH_T>(_nH)),
-          commitQuorumSetHash(std::forward<_commitQuorumSetHash_T>(_commitQuorumSetHash)) {}
+          nH(std::forward<_nH_T>(_nH)) {}
     };
 
     using _xdr_case_type = xdr::xdr_traits<SCPStatementType>::case_type;
@@ -401,9 +376,6 @@ struct SCPStatement {
 } namespace xdr {
 template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_prepare_t>
   : xdr_struct_base<field_ptr<::stellar::SCPStatement::_pledges_t::_prepare_t,
-                              decltype(::stellar::SCPStatement::_pledges_t::_prepare_t::quorumSetHash),
-                              &::stellar::SCPStatement::_pledges_t::_prepare_t::quorumSetHash>,
-                    field_ptr<::stellar::SCPStatement::_pledges_t::_prepare_t,
                               decltype(::stellar::SCPStatement::_pledges_t::_prepare_t::ballot),
                               &::stellar::SCPStatement::_pledges_t::_prepare_t::ballot>,
                     field_ptr<::stellar::SCPStatement::_pledges_t::_prepare_t,
@@ -420,7 +392,6 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_prepare_t>
                               &::stellar::SCPStatement::_pledges_t::_prepare_t::nH>> {
   template<typename Archive> static void
   save(Archive &ar, const ::stellar::SCPStatement::_pledges_t::_prepare_t &obj) {
-    archive(ar, obj.quorumSetHash, "quorumSetHash");
     archive(ar, obj.ballot, "ballot");
     archive(ar, obj.prepared, "prepared");
     archive(ar, obj.preparedPrime, "preparedPrime");
@@ -429,7 +400,6 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_prepare_t>
   }
   template<typename Archive> static void
   load(Archive &ar, ::stellar::SCPStatement::_pledges_t::_prepare_t &obj) {
-    archive(ar, obj.quorumSetHash, "quorumSetHash");
     archive(ar, obj.ballot, "ballot");
     archive(ar, obj.prepared, "prepared");
     archive(ar, obj.preparedPrime, "preparedPrime");
@@ -453,10 +423,7 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_confirm_t>
                               &::stellar::SCPStatement::_pledges_t::_confirm_t::nCommit>,
                     field_ptr<::stellar::SCPStatement::_pledges_t::_confirm_t,
                               decltype(::stellar::SCPStatement::_pledges_t::_confirm_t::nH),
-                              &::stellar::SCPStatement::_pledges_t::_confirm_t::nH>,
-                    field_ptr<::stellar::SCPStatement::_pledges_t::_confirm_t,
-                              decltype(::stellar::SCPStatement::_pledges_t::_confirm_t::quorumSetHash),
-                              &::stellar::SCPStatement::_pledges_t::_confirm_t::quorumSetHash>> {
+                              &::stellar::SCPStatement::_pledges_t::_confirm_t::nH>> {
   template<typename Archive> static void
   save(Archive &ar, const ::stellar::SCPStatement::_pledges_t::_confirm_t &obj) {
     archive(ar, obj.ballot, "ballot");
@@ -464,7 +431,6 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_confirm_t>
     archive(ar, obj.nPrepared, "nPrepared");
     archive(ar, obj.nCommit, "nCommit");
     archive(ar, obj.nH, "nH");
-    archive(ar, obj.quorumSetHash, "quorumSetHash");
   }
   template<typename Archive> static void
   load(Archive &ar, ::stellar::SCPStatement::_pledges_t::_confirm_t &obj) {
@@ -473,7 +439,6 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_confirm_t>
     archive(ar, obj.nPrepared, "nPrepared");
     archive(ar, obj.nCommit, "nCommit");
     archive(ar, obj.nH, "nH");
-    archive(ar, obj.quorumSetHash, "quorumSetHash");
     xdr::validate(obj);
   }
 };
@@ -483,21 +448,16 @@ template<> struct xdr_traits<::stellar::SCPStatement::_pledges_t::_externalize_t
                               &::stellar::SCPStatement::_pledges_t::_externalize_t::commit>,
                     field_ptr<::stellar::SCPStatement::_pledges_t::_externalize_t,
                               decltype(::stellar::SCPStatement::_pledges_t::_externalize_t::nH),
-                              &::stellar::SCPStatement::_pledges_t::_externalize_t::nH>,
-                    field_ptr<::stellar::SCPStatement::_pledges_t::_externalize_t,
-                              decltype(::stellar::SCPStatement::_pledges_t::_externalize_t::commitQuorumSetHash),
-                              &::stellar::SCPStatement::_pledges_t::_externalize_t::commitQuorumSetHash>> {
+                              &::stellar::SCPStatement::_pledges_t::_externalize_t::nH>> {
   template<typename Archive> static void
   save(Archive &ar, const ::stellar::SCPStatement::_pledges_t::_externalize_t &obj) {
     archive(ar, obj.commit, "commit");
     archive(ar, obj.nH, "nH");
-    archive(ar, obj.commitQuorumSetHash, "commitQuorumSetHash");
   }
   template<typename Archive> static void
   load(Archive &ar, ::stellar::SCPStatement::_pledges_t::_externalize_t &obj) {
     archive(ar, obj.commit, "commit");
     archive(ar, obj.nH, "nH");
-    archive(ar, obj.commitQuorumSetHash, "commitQuorumSetHash");
     xdr::validate(obj);
   }
 };

--- a/source/scpp/src/xdr/Stellar-SCP.x
+++ b/source/scpp/src/xdr/Stellar-SCP.x
@@ -25,7 +25,6 @@ enum SCPStatementType
 
 struct SCPNomination
 {
-    Hash quorumSetHash; // D
     Value votes<>;      // X
     Value accepted<>;   // Y
 };
@@ -40,7 +39,6 @@ struct SCPStatement
     case SCP_ST_PREPARE:
         struct
         {
-            Hash quorumSetHash;       // D
             SCPBallot ballot;         // b
             SCPBallot* prepared;      // p
             SCPBallot* preparedPrime; // p'
@@ -55,14 +53,12 @@ struct SCPStatement
             uint32 nPrepared;   // p.n
             uint32 nCommit;     // c.n
             uint32 nH;          // h.n
-            Hash quorumSetHash; // D
         } confirm;
     case SCP_ST_EXTERNALIZE:
         struct
         {
             SCPBallot commit;         // c
             uint32 nH;                // h.n
-            Hash commitQuorumSetHash; // D used before EXTERNALIZE
         } externalize;
     case SCP_ST_NOMINATE:
         SCPNomination nominate;


### PR DESCRIPTION
This contains the code changing the type of `NodeID` to `ulong` and removing quorum hashes from SCP protocol messages.

Fixes #1191, #982