### PR TITLE
Docker images: Simplify workflow (remove dup digest output)

### DIFF
--- a/.github/workflows/devel-docker.yml
+++ b/.github/workflows/devel-docker.yml
@@ -32,7 +32,6 @@ jobs:
 
         # This step will checkout the source with all the submodules
       - name: '[Agora] Build and push'
-        id: agore_build
         uses: docker/build-push-action@v2
         with:
           push: ${{ steps.login.outcome == 'success' }}
@@ -41,14 +40,8 @@ jobs:
             AGORA_VERSION=${{ github.sha }}
 
       - name: '[Registry] Build and push'
-        id: registry_build
         uses: docker/build-push-action@v2
         with:
           push: ${{ steps.login.outcome == 'success' }}
           file: ./Dockerfile.NameRegistry
           tags: bpfk/name-registry:devel
-
-      - name: Image digest
-        run: |
-          echo ${{ steps.agora_build.outputs.digest }}
-          echo ${{ steps.registry_build.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
 
         # This step will checkout the source with all the submodules
       - name: '[Agora] Build and push'
-        id: agora_build
         uses: docker/build-push-action@v2
         with:
           # Either 'success' or 'skipped'
@@ -46,14 +45,8 @@ jobs:
             AGORA_VERSION=${{ steps.version.outputs.VERSION }}
 
       - name: '[Registry] Build and push'
-        id: registry_build
         uses: docker/build-push-action@v2
         with:
           push: ${{ steps.login.outcome == 'success' }}
           file: ./Dockerfile.NameRegistry
           tags: bpfk/name-registry:${{ steps.version.outputs.VERSION }}
-
-      - name: Image digest
-        run: |
-          echo ${{ steps.agora_build.outputs.digest }}
-          echo ${{ steps.registry_build.outputs.digest }}


### PR DESCRIPTION
The digest output isn't really useful, as it's already in the logs.
Moreover, the devel-docker.yml workflow had a typo (agore)
meaning only one of the two digest was actually printed.
Removing it as it doesn't seem anyone will be missing it.