### PR TITLE
Part of Issue2099: Only create Coinbase tx every payoutPeriod

### DIFF
--- a/source/agora/consensus/Fee.d
+++ b/source/agora/consensus/Fee.d
@@ -377,6 +377,8 @@ public class FeeManager
         const validator_fees = this.getValidatorFees(tot_fee, tot_data_fee,
             stakes);
 
+        const commons_fees = this.getCommonsBudgetFee(tot_fee, tot_data_fee, stakes);
+
         foreach (idx, stake; stakes)
         {
             this.accumulated_fees.update(stake.output.address,
@@ -391,6 +393,16 @@ public class FeeManager
                 "REPLACE INTO accumulated_fees (fee, public_key) VALUES (?,?)",
                 this.accumulated_fees[stake.output.address], stake.output.address);
         }
+        this.accumulated_fees.update(this.params.CommonsBudgetAddress,
+                { return commons_fees; },
+                (ref Amount so_far) {
+                    so_far += commons_fees;
+                    return so_far;
+                }
+            );
+        this.db.execute(
+                "REPLACE INTO accumulated_fees (fee, public_key) VALUES (?,?)",
+                this.accumulated_fees[this.params.CommonsBudgetAddress], this.params.CommonsBudgetAddress);
     }
 
     /***************************************************************************

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -334,8 +334,10 @@ public class Ledger
                 expected_height, &this.fee_man.check)) !is null ||
             !this.pool.add(tx))
         {
-            log.info("Rejected tx. Reason: {}. Tx: {}",
-                reason !is null ? reason : "double-spend/coinbase", tx);
+            log.info("Rejected tx. Reason: {}. Tx: {}, txHash: {}",
+                reason !is null ? reason
+                    : tx.isCoinbase ? "Coinbase transaction" : "double-spend",
+                tx, tx.hashFull());
             return false;
         }
         // If we were looking for this TX, stop

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -311,8 +311,7 @@ public class Ledger
         Called when a new transaction is received.
 
         If the transaction is accepted it will be added to
-        the transaction pool. If there are enough valid transactions
-        in the pool, a block will be created.
+        the transaction pool.
 
         If the transaction is invalid, it's rejected and false is returned.
 

--- a/source/agora/consensus/validation/Transaction.d
+++ b/source/agora/consensus/validation/Transaction.d
@@ -86,7 +86,8 @@ public string isInvalidReason (
             return "Transaction: Output(s) overflow or underflow";
 
         // disallow 0 amount
-        if (output.value == Amount(0))
+        // TODO: remove Coinbase check when fees are calculated in TxBuilder
+        if (output.type != OutputType.Coinbase && output.value == Amount(0))
             return "Transaction: Value of output is 0";
 
         // Each freeze output of a transaction must have at least `Amount.MinFreezeAmount`.

--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -54,14 +54,15 @@ unittest
         blocks ~= node_1.getBlocksFrom(new_height, 1);
 
         auto cb_txs = blocks[$-1].txs.filter!(tx => tx.isCoinbase).array;
-        assert(cb_txs.length == 1);
-        auto cb_outs = cb_txs[0].outputs;
-
         // Regular block
         if (blocks[$-1].header.height % conf.consensus.payout_period)
-            assert(cb_outs.length == 1);
+            assert(cb_txs.length == 0);
         else // Payout block
+        {
+            assert(cb_txs.length == 1);
+            auto cb_outs = cb_txs[0].outputs;
             assert(cb_outs.length == 1 + blocks[0].header.enrollments.length);
+        }
     }
 
     // create GenesisValidatorCycle - 1 blocks
@@ -197,14 +198,15 @@ unittest
         blocks ~= valid_nodes.front.getBlocksFrom(new_height, 1);
 
         auto cb_txs = blocks[$-1].txs.filter!(tx => tx.isCoinbase).array;
-        assert(cb_txs.length == 1);
-        auto cb_outs = cb_txs[0].outputs;
-
         // Regular block
         if (blocks[$-1].header.height % conf.consensus.payout_period)
-            assert(cb_outs.length == 1);
+            assert(cb_txs.length == 0);
         else // Payout block
+        {
+            assert(cb_txs.length == 1);
+            auto cb_outs = cb_txs[0].outputs;
             assert(cb_outs.length == 1 + blocks[0].header.enrollments.length);
+        }
     }
 
     // create GenesisValidatorCycle - 1 blocks
@@ -213,7 +215,7 @@ unittest
         createAndExpectNewBlock(Height(block_idx));
     }
 
-    // Node with the different config should not accept any blocks
+    // Node with the different config should not accept payout block
     auto bad_node = nodes[0];
-    assert(bad_node.getBlockHeight() == Height(0));
+    assert(bad_node.getBlockHeight() == Height(conf.consensus.payout_period - 1));
 }

--- a/source/agora/test/TransactionReplacement.d
+++ b/source/agora/test/TransactionReplacement.d
@@ -73,6 +73,6 @@ unittest
     const block = node1.getBlock(Height(1));
 
     // verify that the transaction with fee 13000 is the only one included in the block
-    assert(block.txs.length == 2); // Coinbase + our transaction
+    assert(block.txs.length == 1); // our transaction
     assert(block.txs.filter!(tx => tx.isPayment).front() == txs[4]);
 }


### PR DESCRIPTION
Extracted this change to a separate PR as it is quite a big change and needs some tests to be fixed.
The `tx fees` for the validators and the Commons Budget will be accumulated until the payout block. 
In the payout block a single `Coinbase tx` has outputs to all non slashed validators and the Commons Budget.