### PR TITLE
Fix `ensure` to actually write the error message + trivial fixes

### DIFF
--- a/source/agora/common/Ensure.d
+++ b/source/agora/common/Ensure.d
@@ -49,12 +49,15 @@ private final class FormattedException : Exception
     }
 }
 
-public void ensure (Args...) (bool exp, string fmt, lazy Args args)
+public void ensure (Args...) (bool exp, string fmt, lazy Args args,
+    string file = __FILE__, typeof(__LINE__) line = __LINE__)
 {
     if (!exp)
     {
         auto res = instance.buffer.snformat(fmt, args);
         instance.end = res.length;
+        instance.file = file;
+        instance.line = line;
         throw instance;
     }
 }

--- a/source/agora/common/Ensure.d
+++ b/source/agora/common/Ensure.d
@@ -42,10 +42,60 @@ private final class FormattedException : Exception
         super("An Exception occured");
     }
 
+    /// Overrides `Throwable.message`
     public override const(char)[] message () const return
         @safe pure nothrow @nogc
     {
         return this.buffer[0 .. this.end];
+    }
+
+    /***************************************************************************
+
+        Overrides `Throwable.toString` sink overload
+
+        Unfortunately, `Throwable.toString` does not call `message`,
+        instead calling `msg` directly, which means our overload of `message`
+        does not help. We need to overload this method and replicate the logic
+        in the original code (see `object.d` in druntime for the original).
+
+        Params:
+          sink = The sink to send the piece-meal string to
+
+    ***************************************************************************/
+
+    public override void toString (scope void delegate(in char[]) sink) const scope
+    {
+        import core.internal.string : unsignedToTempString;
+
+        char[20] buffer = void;
+
+        sink(typeid(this).name);
+        sink("@"); sink(file);
+        sink("("); sink(unsignedToTempString(line, buffer)); sink(")");
+
+        if (this.end > 0)
+        {
+            // Aside from a couple stylistic changes,
+            // this is the only line that differs from `Throwable.toString`
+            sink(": "); sink(this.message());
+        }
+        // `Throwable.info` might be `null`, e.g. in a finalizer,
+        // but will probably never be for us.
+        if (this.info)
+        {
+            try
+            {
+                sink("\n----------------");
+                foreach (t; info)
+                {
+                    sink("\n"); sink(t);
+                }
+            }
+            catch (Throwable)
+            {
+                // ignore more errors
+            }
+        }
     }
 }
 

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -245,7 +245,8 @@ public class Ledger
     public ValidatorInfo[] getValidators (in Height height) scope @safe
     {
         auto result = this.enroll_man.validator_set.getValidators(height);
-        ensure(result.length > 0, "Ledger.getValidators didn't find any validator");
+        ensure(result.length > 0,
+               "Ledger.getValidators didn't find any validator at height {}", height);
         return result;
     }
 

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -491,7 +491,6 @@ public class Ledger
 
     protected void updateValidatorSet (in Block block) @safe
     {
-
         PublicKey pubkey = this.enroll_man.getEnrollmentPublicKey();
         UTXO[Hash] utxos = this.utxo_set.getUTXOs(pubkey);
         foreach (idx, ref enrollment; block.header.enrollments)

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -138,7 +138,7 @@ public extern (C++) class Nominator : SCPDriver
         @safe onInvalidNomination;
 
     /// Delegate called when a block is to be externalized
-    public extern (D) string delegate (const ref Block) @safe acceptBlock;
+    public extern (D) string delegate (in Block) @safe acceptBlock;
 
     /// Nomination start time
     protected TimePoint nomination_start_time;
@@ -179,7 +179,7 @@ extern(D):
         Clock clock, NetworkManager network, ValidatingLedger ledger,
         EnrollmentManager enroll_man, ITaskManager taskman, ManagedDatabase cacheDB,
         Duration nomination_interval,
-        string delegate (const ref Block) @safe externalize)
+        string delegate (in Block) @safe externalize)
     {
         assert(externalize !is null);
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -556,7 +556,7 @@ public class FullNode : API
 
     ***************************************************************************/
 
-    protected string acceptBlock (const ref Block block) @trusted
+    protected string acceptBlock (in Block block) @trusted
     {
         ExpiringValidator[] ex_validators;
         this.enroll_man.getExpiringValidators(block.header.height, ex_validators);

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -289,7 +289,7 @@ public class Validator : FullNode, API
 
     ***************************************************************************/
 
-    protected override string acceptBlock (const ref Block block) @trusted
+    protected override string acceptBlock (in Block block) @trusted
     {
         import agora.common.BitMask;
         import std.algorithm;


### PR DESCRIPTION
Better reviewed commit-by-commit.
The first 6 are pretty trivial and not worth the CI time. The last two are fixing `ensure` to work as one would expect, that is, report the correct file/line and actually write the message.
Note that the stack trace will still point to `ensure` itself but it will be transparent otherwise.