### PR TITLE
Fix #2381: Allow the Ledger to return an empty validator set

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -233,19 +233,23 @@ public class Ledger
           height = Height at which to query the validator set.
                    Accurate results are only guaranteed for
                    `height <= this.getBlockHeight() + 1`.
+          empty = Whether to allow an empty return value.
+                  By default, this function will throw if there is no validators
+                  at `height`. If `true` is passed, it will not.
 
         Throws:
-          If no validators are present at height `height`.
+          If no validators are present at height `height` and `empty` is `false`.
 
         Returns:
             A list of validators that are active at `height`
 
     ***************************************************************************/
 
-    public ValidatorInfo[] getValidators (in Height height) scope @safe
+    public ValidatorInfo[] getValidators (in Height height, bool empty = false)
+        scope @safe
     {
         auto result = this.enroll_man.validator_set.getValidators(height);
-        ensure(result.length > 0,
+        ensure(empty || result.length > 0,
                "Ledger.getValidators didn't find any validator at height {}", height);
         return result;
     }

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -1290,7 +1290,7 @@ public class FullNode : API
         this.recordReq("validators");
         if (height == 0)
             return null;
-        return this.ledger.getValidators(Height(height));
+        return this.ledger.getValidators(Height(height), true);
     }
 
     ///


### PR DESCRIPTION
In some scenarios, one might want to look up validators in the future.
In that case, they would call GET /validators with an arbitrarily high
height value, which might cause an exception internally.