### PR TITLE
dub.json: Reduce exclusion and minor clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 *.exe
 build/
 tracy_build
-source/agora/cli/version/version_build
+scripts/version_get
 source/scpp/cpp_build
 
 # DUB

--- a/dub.json
+++ b/dub.json
@@ -11,7 +11,7 @@
     "stringImportPaths" : [ "build" ],
     "excludedSourceFiles": [ "source/scpp/*.d", "source/scpd/quorum/QuorumIntersectionTests.d" ],
     "preGenerateCommands": [
-        "$DUB --verbose --single source/agora/cli/version/main.d || (sleep 5s && $DUB --verbose --single source/agora/cli/version/main.d)",
+        "$DUB --verbose --single scripts/version_gen.d || (sleep 5s && $DUB --verbose --single scripts/version_gen.d)",
         "$DUB --verbose --single source/scpp/build.d || (sleep 5s && $DUB --verbose --single source/scpp/build.d)"
     ],
     "sourceFiles-posix": [
@@ -76,7 +76,6 @@
                 "source/agora/cli/checkvtable/*",
                 "source/agora/cli/multi/*",
                 "source/agora/cli/vanity/*",
-                "source/agora/cli/version/*",
                 "source/agora/test/*",
                 "source/agora/utils/gc/*"
             ]
@@ -133,7 +132,6 @@
                 "source/agora/cli/checkvtable/*",
                 "source/agora/cli/client/*",
                 "source/agora/cli/vanity/*",
-                "source/agora/cli/version/*",
                 "source/agora/utils/gc/*"
             ]
         },
@@ -148,7 +146,6 @@
                 "source/agora/cli/client/*",
                 "source/agora/cli/multi/*",
                 "source/agora/cli/vanity/*",
-                "source/agora/cli/version/*",
                 "source/agora/utils/gc/*"
             ]
         },
@@ -164,7 +161,6 @@
                 "source/agora/cli/client/*",
                 "source/agora/cli/multi/*",
                 "source/agora/cli/vanity/*",
-                "source/agora/cli/version/*",
                 "source/agora/utils/gc/*"
             ]
         }

--- a/dub.json
+++ b/dub.json
@@ -51,7 +51,7 @@
             "sourceFiles-windows": [
                 "build/TracyClient.obj"
             ],
-            "excludedSourceFiles": ["source/agora/cli/*",]
+            "excludedSourceFiles": [ "source/agora/cli/*" ]
         },
         {
             "name": "client",
@@ -77,7 +77,6 @@
                 "source/agora/cli/multi/*",
                 "source/agora/cli/vanity/*",
                 "source/agora/cli/version/*",
-                "source/agora/registry/*.d",
                 "source/agora/test/*",
                 "source/agora/utils/gc/*"
             ]
@@ -87,7 +86,6 @@
             "targetName": "agora-unittests",
             "excludedSourceFiles": [
                 "source/agora/cli/*/main.d",
-                "source/agora/registry/main.d",
                 "source/agora/utils/gc/*"
             ],
             "sourceFiles-posix": [
@@ -136,8 +134,6 @@
                 "source/agora/cli/client/*",
                 "source/agora/cli/vanity/*",
                 "source/agora/cli/version/*",
-                "source/agora/node/main.d",
-                "source/agora/registry/main.d",
                 "source/agora/utils/gc/*"
             ]
         },
@@ -153,8 +149,6 @@
                 "source/agora/cli/multi/*",
                 "source/agora/cli/vanity/*",
                 "source/agora/cli/version/*",
-                "source/agora/node/main.d",
-                "source/agora/registry/main.d",
                 "source/agora/utils/gc/*"
             ]
         },
@@ -171,8 +165,6 @@
                 "source/agora/cli/multi/*",
                 "source/agora/cli/vanity/*",
                 "source/agora/cli/version/*",
-                "source/agora/node/main.d",
-                "source/agora/registry/main.d",
                 "source/agora/utils/gc/*"
             ]
         }

--- a/scripts/version_gen.d
+++ b/scripts/version_gen.d
@@ -2,7 +2,7 @@
 /+
  dub.json:
  {
-     "name": "version_build"
+     "name": "version_gen"
  }
  +/
 /*******************************************************************************
@@ -23,7 +23,7 @@
 
 *******************************************************************************/
 
-module agora.cli.ver.main;
+module version_gen;
 
 import std.file : exists, mkdirRecurse, readText, write;
 import std.format;
@@ -35,7 +35,7 @@ import std.string;
 import core.stdc.stdlib : exit;
 
 private immutable VersionFileName = "VERSION";
-private immutable RootPath = __FILE_FULL_PATH__.dirName.dirName.dirName.dirName.dirName;
+private immutable RootPath = __FILE_FULL_PATH__.dirName.dirName;
 private immutable VersionFileDir = RootPath.buildPath("build");
 private immutable VersionFilePath = VersionFileDir.buildPath(VersionFileName);
 private immutable EnvVersionName = "AGORA_VERSION";


### PR DESCRIPTION
The exclusion isn't necessary now that we fixed DUB, and the version script should be moved to `scripts`.