### PR TITLE
Reduce reliance on the EnrollmentManager's `getExpiringValidators` and `addPreimage`

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -531,52 +531,6 @@ public class EnrollmentManager
 
     /***************************************************************************
 
-        Add a pre-image information to a validator data
-
-        Params:
-            preimage = the pre-image information to add
-
-        Returns:
-            true if the pre-image information has been added to the validator
-
-    ***************************************************************************/
-
-    public bool addPreimage (in PreImageInfo preimage) @safe nothrow
-    {
-        return this.validator_set.addPreimage(preimage);
-    }
-
-    /***************************************************************************
-
-        Add pre-images for enrolled validators
-
-        Params:
-            preimages = the pre-images to add
-
-        Returns:
-            true if preimages was added successfully
-
-    ***************************************************************************/
-
-    public bool addPreimages (in PreImageInfo[] preimages) @safe nothrow
-    {
-        foreach (image; preimages)
-        {
-            auto stored_image =
-                this.validator_set.getPreimage(image.utxo);
-            if (stored_image == PreImageInfo.init ||
-                stored_image.height >= image.height)
-                continue;
-
-            if (!this.validator_set.addPreimage(image))
-                return false;
-        }
-
-        return true;
-    }
-
-    /***************************************************************************
-
         Get the pre-image hash for this validator
 
         Params:
@@ -1209,7 +1163,7 @@ unittest
             height : Height(params.ValidatorCycle),
             hash : cache[$ - params.ValidatorCycle - 1] };
 
-        assert(man.addPreimage(preimage));
+        assert(man.validator_set.addPreimage(preimage));
     }
 }
 
@@ -1312,7 +1266,7 @@ unittest
 
     PreImageInfo preimage;
     assert(man.getNextPreimage(preimage, Height(params.ValidatorCycle / 2)));
-    assert(man.addPreimage(preimage));
+    assert(man.validator_set.addPreimage(preimage));
     assert(findEnrollment(genesis_enroll.utxo_key, state));
     assert(state.preimage.hash == preimage.hash);
     assert(state.preimage.height == preimage.height);

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -751,27 +751,6 @@ public class EnrollmentManager
 
     /***************************************************************************
 
-        Query Validators that have just finished their cycle
-
-        Params:
-            height = requested height
-            ex_validators = Array to save the ExpiringValidators
-
-        Returns:
-            `PublicKey`s and enrollment heights of `Validator`s whose enrollment
-            cycle have just ended
-
-    ***************************************************************************/
-
-    public ExpiringValidator[] getExpiringValidators (in Height height,
-        ref ExpiringValidator[] ex_validators)
-        @trusted nothrow
-    {
-        return this.validator_set.getExpiringValidators(height, ex_validators);
-    }
-
-    /***************************************************************************
-
         Query stakes of active Validators
 
         Params:

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -256,6 +256,23 @@ public class Ledger
 
     /***************************************************************************
 
+        Add a pre-image information to a validator data
+
+        Params:
+            preimage = the pre-image information to add
+
+        Returns:
+            true if the pre-image information has been added to the validator
+
+    ***************************************************************************/
+
+    public bool addPreimage (in PreImageInfo preimage) @safe nothrow
+    {
+        return this.enroll_man.validator_set.addPreimage(preimage);
+    }
+
+    /***************************************************************************
+
         Add a block to the ledger.
 
         If the block fails verification, it is not added to the ledger.
@@ -1254,17 +1271,17 @@ public class Ledger
         {
             auto validators = this.getValidators(height);
 
-            void addPreimages (in PublicKey public_key, in PreImageInfo preimage_info)
+            void addPreimageLog (in PublicKey public_key, in PreImageInfo preimage_info)
             {
                 log.info("Adding test preimages for height {} for validator {}: {}", height, public_key, preimage_info);
-                this.enroll_man.addPreimages([ preimage_info ]);
+                this.addPreimage(preimage_info);
             }
             validators.enumerate.each!((idx, val)
             {
                 if (skip_indexes.length && skip_indexes.canFind(idx))
                     log.info("Skip add preimage for validator idx {} at height {} as requested by test", idx, height);
                 else
-                    addPreimages(val.address, PreImageInfo(val.preimage.utxo,
+                    addPreimageLog(val.address, PreImageInfo(val.preimage.utxo,
                         getWellKnownPreimages(WK.Keys[val.address])[height], height));
             });
         } catch (Exception e)

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -1001,7 +1001,7 @@ public class NetworkManager
                 break;
 
             foreach (const ref preimage_info; peer.client.getPreimagesForEnrollKeys(enroll_keys))
-                if (ledger.enrollment_manager.addPreimage(preimage_info))
+                if (ledger.addPreimage(preimage_info))
                     enroll_keys.remove(preimage_info.utxo);
         }
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -532,7 +532,7 @@ public class FullNode : API
             // A) We already have a duplicate preimage
             // B) The preimage is for a newer enrollment which is in one of the
             //    `blocks` which we haven't read from yet
-            this.ledger.enrollment_manager.addPreimages(preimages);
+            preimages.each!(pi => this.ledger.addPreimage(pi));
             // A block might have been externalized in the meantime,
             // so just skip older heights
             if (block.header.height <= this.ledger.getBlockHeight())
@@ -1037,7 +1037,7 @@ public class FullNode : API
         this.recordReq("receive_preimage");
         log.trace("Received Preimage: {}", prettify(preimage));
 
-        if (this.enroll_man.addPreimage(preimage))
+        if (this.ledger.addPreimage(preimage))
         {
             log.info("Accepted preimage: {}", prettify(preimage));
             this.network.peers.each!(p => p.client.sendPreimage(preimage));

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -99,7 +99,7 @@ public class Validator : FullNode, API
         // does not call `onAcceptedBlock`.
         PreImageInfo self;
         if (this.ledger.enrollment_manager.getNextPreimage(self, this.ledger.getBlockHeight()))
-            this.ledger.enrollment_manager.addPreimage(self);
+            this.ledger.addPreimage(self);
 
         // currently we are not saving preimage info,
         // we only have the commitment in the genesis block
@@ -502,7 +502,7 @@ public class Validator : FullNode, API
         // allows us to unify usage of `getValidators`.
         PreImageInfo self;
         if (this.ledger.enrollment_manager.getNextPreimage(self, block.header.height))
-            this.ledger.enrollment_manager.addPreimage(self);
+            this.ledger.addPreimage(self);
 
         // note: may context switch, should be called last after quorums
         // are regenerated above.
@@ -556,7 +556,7 @@ public class Validator : FullNode, API
         if (this.enroll_man.getNextPreimage(preimage,
             this.ledger.getBlockHeight()))
         {
-            this.enroll_man.addPreimage(preimage);
+            this.ledger.addPreimage(preimage);
             this.network.peers.each!(p => p.client.sendPreimage(preimage));
             this.pushPreImage(preimage);
         }


### PR DESCRIPTION
See each commit for details.