### PR TITLE
Remove sleep from NetworkManager unit test

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1965,10 +1965,11 @@ public struct TestConf
         max_listeners: size_t.max,
 
         // Catchup needs to happens much more frequently than in production
-        block_catchup_interval: 2.seconds,
+        block_catchup_interval: 1.seconds,
 
         // The default is much longer, but in unittests latency is negligible
-        retry_delay: 500.msecs,
+        retry_delay: 300.msecs,
+        timeout: 300.msecs,
         max_retries: 10,
 
         // Always set to true, cannot be overriden, but also set here for clarity

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -71,7 +71,7 @@ unittest
 
     // reject inbound requests
     const DropRequests = true;
-    nodes[1 .. $].each!(node => node.sleep(100.msecs, DropRequests));
+    nodes[1 .. $].each!(node => node.deafen(100.msecs, DropRequests));
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
 

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -178,13 +178,6 @@ unittest
     node_bad.clearFilter();
     node_validators.each!(node => node.clearFilter());
 
-    // The testing time decreases compared to the last code because setting
-    // seeds to the `PreImageCycle`s make it unnecessary to generate kind of
-    // large number seeds. So we have to add some preparation time to this
-    // network test like this.
-    // TODO: We should find why this is needed and remove this waiting time.
-    Thread.sleep(10.seconds);
-
     // node test will accept its blocks from node_validator,
     // as the blocks in node_bad do not pass validation
     network.assertSameBlocks(iota(GenesisValidators + 1), Height(2));


### PR DESCRIPTION
Using an updated NodeConfig for unit tests seems to make the sleep of 10 seconds no longer needed.