### PR TITLE
Fixes Issue2099: add check for minimum fees and enforce in unit tests

### DIFF
--- a/source/agora/consensus/Fee.d
+++ b/source/agora/consensus/Fee.d
@@ -244,6 +244,12 @@ public class FeeManager
 
     public string check (in Transaction tx, Amount tx_fee) nothrow @safe
     {
+        Amount minimumFee = params.MinFee;
+        if (!minimumFee.mul(tx.sizeInBytes()))
+            return "Fee: Transaction size overflows fee cap";
+        if (tx_fee < minimumFee)
+            return "Transaction: Fee is less than adjusted minimum fee";
+
         if (tx.payload.length == 0)
             return null;
 
@@ -254,12 +260,6 @@ public class FeeManager
             this.params.TxPayloadFeeFactor);
         if (tx_fee < required_fee)
             return "Transaction: There is not enough data fee";
-
-        Amount minimumFee = params.MinFee;
-        if (!minimumFee.mul(tx.sizeInBytes()))
-            return "Fee: Transaction size overflows fee cap";
-        if (tx_fee < minimumFee)
-            return "Transaction: Fee is less than adjusted minimum fee";
 
         return null;
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1998,10 +1998,6 @@ public struct TestConf
 
         // `validator_cycle` is set to 20 to match the genesis block
         // Do not set it dynamically, it will be overridden
-
-        /// The minimum (transaction size adjusted) fee.
-        /// Transaction size adjusted fee = tx fee / tx size in bytes.
-        min_fee: Amount(0),
     };
 
     /***

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -602,12 +602,22 @@ private class FlashListener : TestFlashListenerAPI
     }
 }
 
+version (unittest)
+{
+    TestConf flashTestConf ()
+    {
+        TestConf conf;
+        conf.consensus.quorum_threshold = 100;
+        conf.consensus.min_fee = Amount(0); // TODO: remove this line when fees are handled
+        return conf;
+    }
+}
+
 /// Test unilateral non-collaborative close (funding + update* + settle)
 //version (none)
 unittest
 {
-    TestConf conf;
-    conf.consensus.quorum_threshold = 100;
+    auto conf = flashTestConf();
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -707,8 +717,7 @@ unittest
 //version (none)
 unittest
 {
-    TestConf conf;
-    conf.consensus.quorum_threshold = 100;
+    auto conf = flashTestConf();
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -834,8 +843,7 @@ unittest
         }
     }
 
-    TestConf conf;
-    conf.consensus.quorum_threshold = 100;
+    auto conf = flashTestConf();
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -936,8 +944,7 @@ unittest
 //version (none)
 unittest
 {
-    TestConf conf;
-    conf.consensus.quorum_threshold = 100;
+    auto conf = flashTestConf();
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1086,8 +1093,7 @@ unittest
 /// Test path probing
 unittest
 {
-    TestConf conf;
-    conf.consensus.quorum_threshold = 100;
+    auto conf = flashTestConf();
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1258,8 +1264,7 @@ unittest
 /// Test path probing
 unittest
 {
-    TestConf conf;
-    conf.consensus.quorum_threshold = 100;
+    auto conf = flashTestConf();
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1487,8 +1492,7 @@ unittest
         }
     }
 
-    TestConf conf;
-    conf.consensus.quorum_threshold = 100;
+    auto conf = flashTestConf();
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1570,8 +1574,7 @@ unittest
 //version (none)
 unittest
 {
-    TestConf conf;
-    conf.consensus.quorum_threshold = 100;
+    auto conf = flashTestConf();
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1661,8 +1664,7 @@ unittest
 /// test various error cases
 unittest
 {
-    TestConf conf;
-    conf.consensus.quorum_threshold = 100;
+    auto conf = flashTestConf();
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1877,8 +1879,7 @@ unittest
         }
     }
 
-    TestConf conf;
-    conf.consensus.quorum_threshold = 100;
+    auto conf = flashTestConf();
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -1991,8 +1992,7 @@ unittest
         }
     }
 
-    TestConf conf;
-    conf.consensus.quorum_threshold = 100;
+    auto conf = flashTestConf();
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();
@@ -2060,8 +2060,7 @@ unittest
 //version (none)
 unittest
 {
-    TestConf conf;
-    conf.consensus.quorum_threshold = 100;
+    auto conf = flashTestConf();
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope (exit) network.shutdown();


### PR DESCRIPTION
Firstly this fixes the bug where fees were not checked unless the transaction had a `Data Payload`.
Then it removes the zero fee rate `Amount` that was set in the `Base.d` `TestConf` so that tests did not fail if fees were too low for the size of the transaction.