### PR TITLE
`LocalTransaction` test: sort transactions when nominating

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -1480,11 +1480,10 @@ public class ValidatingLedger : Ledger
 
             if (result.length >= max_txs)
             {
-                result.sort();
-                return result;
+                break;
             }
         }
-
+        result.sort();
         const pre_cb_len = result.length;
         // Dont append a CB TX to an empty TX set
         if (pre_cb_len > 0)

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -231,7 +231,7 @@ extern(D):
 
         A validator creates SCP object with the UTXO for enrollment. This
         checks that the UTXO key for enrollment exists and new SCP should be
-        created because of new enrollment of this node. If there is an 
+        created because of new enrollment of this node. If there is an
         existing SCP object, this just change the node id for the SCP object.
 
         Params:


### PR DESCRIPTION
This test still sometimes fails when waiting for the block to be externalized. 
The transactions should be sorted when nominating.