### PR TITLE
TransactionPool: Try to remove() non-existing TXs

### DIFF
--- a/source/agora/node/TransactionPool.d
+++ b/source/agora/node/TransactionPool.d
@@ -170,8 +170,6 @@ public class TransactionPool
     public void remove (in Transaction tx, bool rm_double_spent = true) @trusted
     {
         auto tx_hash = tx.hashFull();
-        if (!this.hasTransactionHash(tx_hash))
-            return;
 
         this.db.execute("DELETE FROM tx_pool WHERE key = ?", tx_hash);
 
@@ -196,9 +194,6 @@ public class TransactionPool
     /// Ditto
     public void remove (in Hash tx_hash, bool rm_double_spent = true) @trusted
     {
-        if (!this.hasTransactionHash(tx_hash))
-            return;
-
         auto results = this.db.execute("SELECT val FROM tx_pool " ~
             "WHERE key = ?", tx_hash);
         if (!results.empty)


### PR DESCRIPTION
Code path will correctly handle the case where the requested TX is
not in the pool anyway. So no need to query the database only to
check for existence of the TX.

Additionally, in the case where we don't have an externalized TX
in our pool but have TXs that spend the same inputs we should still
continue to remove those double-spent TXs as if we had the original TX
in the pool.