### PR TITLE
Test: Flush stdout after destroying the lock

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -262,18 +262,18 @@ private UnitTestResult customModuleUnitTester ()
 
             if (chatty)
             {
+                scope(exit) stdout.flush();
                 auto output = stdout.lockingTextWriter();
                 output.formattedWrite("Unittesting %s", mod.name);
-                stdout.flush();
             }
             auto sw = StopWatch(AutoStart.yes);
             mod.test();
             sw.stop();
             if (chatty)
             {
+                scope(exit) stdout.flush();
                 auto output = stdout.lockingTextWriter();
                 output.formattedWrite(" (took %s)\n", sw.peek());
-                stdout.flush();
             }
 
             atomicOp!"+="(passed, 1);
@@ -281,12 +281,12 @@ private UnitTestResult customModuleUnitTester ()
         }
         catch (Throwable ex)
         {
+            scope (exit) stdout.flush();
             auto output = stdout.lockingTextWriter();
             output.formattedWrite("Module tests failed: %s\n", mod.name);
             output.formattedWrite("%s\n", ex);
             // print logs of the work thread
             CircularAppender!()().print(output);
-            stdout.flush();
         }
         return false;
     }


### PR DESCRIPTION
```
While this works locally, we are not seeing the flush in Github CI,
where it is most important. Currently, the line is only printed
once the timing's newline is printed.
```

Not sure if this will work, or if I need to go with https://github.com/Geod24/localrest/commit/3cceb64faad36084427ffd10db6703ad0b10e0eb or if it's just not possible... Let's see.