### PR TITLE
Only instantiate the Ledger once in Validator

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -89,8 +89,8 @@ public class Validator : FullNode, API
         this.quorum_params = QuorumParams(this.params.MaxQuorumNodes,
             this.params.QuorumThreshold);
 
-        auto vledger = this.makeLedger();
-        this.ledger = vledger;
+        auto vledger = cast(ValidatingLedger) this.ledger;
+        assert(vledger !is null);
         this.nominator = this.makeNominator(
             this.clock, this.network, vledger, this.enroll_man, this.taskman);
         this.nominator.onInvalidNomination = &this.invalidNominationHandler;


### PR DESCRIPTION
We were instantiating it twice, which could be problematic,
and is definitely wasteful. We know we have a ValidatingLedger
so a simple dynamic cast will do.