### PR TITLE
Improve time it takes for missing pre-image fetching during nomination.

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -1213,10 +1213,12 @@ public class Ledger
             .filter!(kv => kv.value.preimage.height < height)
             .map!(kv => cast(uint) kv.index).array();
 
-        // trying to retrieve preimages that - based on the consensus data -
-        // was shared with other nodes
-        foreach (const validator_ind; setDifference(missing_validators_lower_bound, missing_validators))
-            this.enrolls_keys_for_unknown_preimages.put(validators[validator_ind].utxo());
+        // populate the lookup set which will be used retrieve preimages that are missing
+        () @trusted {
+            this.enrolls_keys_for_unknown_preimages.clear();
+        }();
+        missing_validators_lower_bound.each!(i =>
+            this.enrolls_keys_for_unknown_preimages.put(validators[i].utxo()));
 
         // NodeA will check the candidate from NodeB in the following way:
         //

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1964,7 +1964,7 @@ public struct TestConf
     /// How often the validator should try to catchup for the preimages for the
     /// next block
     /// Matches the eponymous field in the `validator` section.
-    public Duration preimage_catchup_interval = 100.seconds;
+    public Duration preimage_catchup_interval = 5.seconds;
 
     /// max failed requests before a node is banned
     /// Matches the eponymous field in the `banman` section.

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -134,6 +134,8 @@ unittest
     }
 
     TestConf conf = { full_nodes : 2 };
+    // We want a more frequent block catchup for this test
+    conf.node.block_catchup_interval = 200.msecs;
     auto network = makeTestNetwork!BadAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/PreimageSharing.d
+++ b/source/agora/test/PreimageSharing.d
@@ -20,29 +20,26 @@ import agora.consensus.data.PreImageInfo;
 import agora.utils.Test;
 import agora.test.Base;
 
-/// doesn't reveal any preimages, except during nomination or when
-/// reveal_preimage is set to true
-public class NoPreImageExceptNominationVN : NoPreImageVN
+/// doesn't reveal any preimages, except during nomination
+public class NoPreImageExceptNominationVN : TestValidatorNode
 {
     ///
     mixin ForwardCtor!();
 
-    /// GET: /preimages_for_enroll_keys
-    public override PreImageInfo[] getPreimagesForEnrollKeys (Set!Hash enroll_keys = Set!Hash.init) @safe nothrow
+    protected override void onPreImageRevealTimer ()
     {
-        return TestValidatorNode.getPreimagesForEnrollKeys(enroll_keys);
+        // Will not reveal preimages
     }
 }
 
 unittest
 {
-    TestConf conf = {
-        preimage_catchup_interval : 1.seconds,
-    };
+    TestConf conf;
+    conf.preimage_catchup_interval = 100.msecs;
     conf.consensus.quorum_threshold = 100;
 
     // set up nodes
-    auto network = makeTestNetwork!(LazyAPIManager!NoPreImageExceptNominationVN)(conf);
+    auto network = makeTestNetwork!(TestNetwork!(NoPreImageExceptNominationVN))(conf);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();


### PR DESCRIPTION
I think it is more reliable to try and fetch any missing pre-images during nomination and not just those that other nodes have indicated by their consensus data.