### PR TITLE
Adding test configuration options and fine tuning for reduced `ci` run times

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2013,7 +2013,7 @@ public struct TestConf
     public Duration preimage_catchup_interval = 100.seconds;
 
     /// How often the validator should check for preimages to reveal
-    public Duration preimage_reveal_interval = 1.seconds;
+    public Duration preimage_reveal_interval = 200.msecs;
 
     /// How often the validator should check if it is time for nomination
     public Duration nomination_interval = 100.msecs;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2012,6 +2012,9 @@ public struct TestConf
     /// Matches the eponymous field in the `validator` section.
     public Duration preimage_catchup_interval = 100.seconds;
 
+    /// How often the validator should check for preimages to reveal
+    public Duration preimage_reveal_interval = 1.seconds;
+
     /// max failed requests before a node is banned
     /// Matches the eponymous field in the `banman` section.
     public size_t max_failed_requests = 100;
@@ -2174,7 +2177,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             addresses_to_register : [self_address],
             registry_address : "name.registry",
             recurring_enrollment : test_conf.recurring_enrollment,
-            preimage_reveal_interval : 1.seconds,  // check revealing frequently
+            preimage_reveal_interval : test_conf.preimage_reveal_interval,
             nomination_interval: 100.msecs,
             preimage_catchup_interval: test_conf.preimage_catchup_interval,
             cycle_seed : cycle_seed,

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2015,6 +2015,9 @@ public struct TestConf
     /// How often the validator should check for preimages to reveal
     public Duration preimage_reveal_interval = 1.seconds;
 
+    /// How often the validator should check if it is time for nomination
+    public Duration nomination_interval = 100.msecs;
+
     /// max failed requests before a node is banned
     /// Matches the eponymous field in the `banman` section.
     public size_t max_failed_requests = 100;
@@ -2178,7 +2181,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             registry_address : "name.registry",
             recurring_enrollment : test_conf.recurring_enrollment,
             preimage_reveal_interval : test_conf.preimage_reveal_interval,
-            nomination_interval: 100.msecs,
+            nomination_interval: test_conf.nomination_interval,
             preimage_catchup_interval: test_conf.preimage_catchup_interval,
             cycle_seed : cycle_seed,
             cycle_seed_height : cycle_seed_height,

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2033,7 +2033,7 @@ public struct TestConf
         max_listeners: size_t.max,
 
         // Catchup needs to happens much more frequently than in production
-        block_catchup_interval: 1.seconds,
+        block_catchup_interval: 500.msecs,
 
         // The default is much longer, but in unittests latency is negligible
         retry_delay: 300.msecs,

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -58,6 +58,8 @@ unittest
     }
 
     TestConf conf;
+    // This test relies on getUnknownTXs which is called when block catchup is performed.
+    conf.node.block_catchup_interval = 100.msecs;
     conf.consensus.quorum_threshold = 100;
     auto network = makeTestNetwork!NoGossipAPIManager(conf);
     network.start();

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -134,6 +134,8 @@ unittest
     }
 
     TestConf conf = { full_nodes : 2 };
+    // We want a more frequent block catchup for this test
+    conf.node.block_catchup_interval = 200.msecs;
     auto network = makeTestNetwork!BadAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -116,6 +116,8 @@ version(none) unittest
 unittest
 {
     TestConf conf = { full_nodes: 1 };
+    conf.nomination_interval = 500.msecs;
+    conf.node.block_catchup_interval = 1.seconds;
     conf.consensus.quorum_threshold = 75;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();


### PR DESCRIPTION
Adding a couple of configuration settings to the TestConf struct to help reducing test run time.
Experimenting in this branch also with reduced values for some test configuration values.