### PR TITLE
Use average fees of TXs in pool as acceptance criteria

### DIFF
--- a/doc/Database.md
+++ b/doc/Database.md
@@ -72,6 +72,7 @@ Stores the pending transaction. Should be made readable.
 |------------|----------|-------------|-------------|-------------------|
 | key        | TEXT     | Hash        | PRIMARY KEY | Transaction hash  |
 | val        | BLOB     | Transaction | NOT NULL    | Binary-serialized |
+| fee        | INTEGER  | Amount      | NOT NULL    | fee rate          |
 
 ### `enrollment_pool` table
 

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -64,6 +64,9 @@ node:
   # The percentage by which the double spend transaction's fee should be
   # increased in order to be added to the transaction pool
   double_spent_threshold_pct: 20
+  # The minimum percentage of average fee in the pool which the incoming
+  # transaction should include
+  min_fee_pct: 80
 
 # Each entry in this array is an interface Agora will listen to, allowing to
 # expose the same node on more than one network interface or with different

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -339,7 +339,8 @@ public class Ledger
 
     ***************************************************************************/
 
-    public bool acceptTransaction (in Transaction tx) @safe
+    public bool acceptTransaction (in Transaction tx,
+        in ubyte double_spent_threshold_pct = 0) @safe
     {
         const Height expected_height = this.getBlockHeight() + 1;
         string reason;
@@ -362,11 +363,11 @@ public class Ledger
             if (!reason)
                 reason = tx.isCoinbase ? "Coinbase transaction" : "double-spend";
             log.info("Rejected tx. Reason: {}. Tx: {}, txHash: {}",
-                reason, tx, tx.hashFull());
+                reason, tx, tx_hash);
             return false;
         }
         // If we were looking for this TX, stop
-        this.unknown_txs.remove(tx.hashFull());
+        this.unknown_txs.remove(tx_hash);
         return true;
     }
 

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -206,6 +206,10 @@ public struct NodeConfig
     // increased in order to be added to the transaction pool
     public ubyte double_spent_threshold_pct = 20;
 
+    // The minimum percentage of average fee in the pool which the incoming
+    // transaction should include
+    public ushort min_fee_pct = 80;
+
     /// The maximum number of transactions relayed in every batch.
     /// Value 0 means no limit.
     public @Optional uint relay_tx_max_num;

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -954,7 +954,8 @@ public class FullNode : API
         this.recordReq("transaction");
         this.tx_stats.increaseMetricBy!"agora_transactions_received_total"(1);
 
-        if (!this.ledger.acceptTransaction(tx, config.node.double_spent_threshold_pct))
+        if (!this.ledger.acceptTransaction(tx, config.node.double_spent_threshold_pct,
+            config.node.min_fee_pct))
         {
             this.tx_stats.increaseMetricBy!"agora_transactions_rejected_total"(1);
             return;

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -952,19 +952,15 @@ public class FullNode : API
     public override void postTransaction (in Transaction tx) @safe
     {
         this.recordReq("transaction");
-        auto tx_hash = hashFull(tx);
-        if (this.pool.hasTransactionHash(tx_hash) ||
-            !ledger.isAcceptableDoubleSpent(tx, config.node.double_spent_threshold_pct))
-            return;
-
         this.tx_stats.increaseMetricBy!"agora_transactions_received_total"(1);
-        if (!this.ledger.acceptTransaction(tx))
+
+        if (!this.ledger.acceptTransaction(tx, config.node.double_spent_threshold_pct))
         {
             this.tx_stats.increaseMetricBy!"agora_transactions_rejected_total"(1);
             return;
         }
 
-        log.info("Accepted transaction: {} ({})", prettify(tx), tx_hash);
+        log.info("Accepted transaction: {} ({})", prettify(tx), hashFull(tx));
         this.tx_stats.increaseMetricBy!"agora_transactions_accepted_total"(1);
         this.transaction_relayer.addTransaction(tx);
         this.pushTransaction(tx);

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -954,9 +954,11 @@ public class FullNode : API
         this.recordReq("transaction");
         this.tx_stats.increaseMetricBy!"agora_transactions_received_total"(1);
 
-        if (!this.ledger.acceptTransaction(tx, config.node.double_spent_threshold_pct,
+        if (auto reason = this.ledger.acceptTransaction(tx, config.node.double_spent_threshold_pct,
             config.node.min_fee_pct))
         {
+            log.info("Rejected tx. Reason: {}. Tx: {}, txHash: {}",
+                reason, tx, hashFull(tx));
             this.tx_stats.increaseMetricBy!"agora_transactions_rejected_total"(1);
             return;
         }

--- a/source/agora/node/TransactionRelayer.d
+++ b/source/agora/node/TransactionRelayer.d
@@ -447,7 +447,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
         assert(transaction_relayer.addTransactionImp(tx4) is null);
 
         // adding tx1 .. tx4 to the transaction pool
-        [tx1, tx2, tx3, tx4].each!(tx => transaction_relayer.pool.add(tx));
+        [tx1, tx2, tx3, tx4].each!(tx => transaction_relayer.pool.add(tx, 0.coins));
 
         assert(transaction_relayer.tx_hashes.length == 4);
         assert(transaction_relayer.txs.length == 4);

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -88,12 +88,12 @@ unittest
     {
         mixin ForwardCtor!();
 
-        public override bool acceptTransaction (in Transaction tx,
+        public override string acceptTransaction (in Transaction tx,
             in ubyte double_spent_threshold_pct = 0, in ushort min_fee_pct = 0) @safe
         {
             // Dont accept any incoming TX
             log.info("Picky node ignoring TX {}", tx);
-            return false;
+            return "Nah";
         }
     }
 

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -88,7 +88,8 @@ unittest
     {
         mixin ForwardCtor!();
 
-        public override bool acceptTransaction (in Transaction tx) @safe
+        public override bool acceptTransaction (in Transaction tx,
+            in ubyte double_spent_threshold_pct = 0) @safe
         {
             // Dont accept any incoming TX
             log.info("Picky node ignoring TX {}", tx);

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -89,7 +89,7 @@ unittest
         mixin ForwardCtor!();
 
         public override bool acceptTransaction (in Transaction tx,
-            in ubyte double_spent_threshold_pct = 0) @safe
+            in ubyte double_spent_threshold_pct = 0, in ushort min_fee_pct = 0) @safe
         {
             // Dont accept any incoming TX
             log.info("Picky node ignoring TX {}", tx);


### PR DESCRIPTION
This will allow to protect against TX flood attacks.
    
With double_spent_threshold_pct and max_fee_undercut_pct, for an
attacker to flood more and more transactions to the network they would
have to pay increasingly more fees.

With double_spent_threshold_pct of %20, an attacker would have to pay almost 80M times
more than the average TX in the pool to be able to create 100 double-spent TXs.

With this, we can keep our pool size unlimited, but make it unpractical to use it as a
DoS vector.

Fixes #1959