### PR TITLE
Catch up with missing preimages regardless of nomination status

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -115,9 +115,6 @@ public class Ledger
     /// but less than current time + block_time_offset_tolerance
     public Duration block_time_offset_tolerance;
 
-    /// Enrollment keys for unknown preimages for the next height
-    private Set!Hash enrolls_keys_for_unknown_preimages;
-
     /***************************************************************************
 
         Constructor
@@ -1172,20 +1169,6 @@ public class Ledger
 
     /***************************************************************************
 
-        Get the enrollment keys for unknown preimages
-
-        Returns:
-            the enrollment keys for unknown preimages
-
-    ***************************************************************************/
-
-    public Set!Hash getEnrollKeysForUnknownPreimages () @safe nothrow
-    {
-        return this.enrolls_keys_for_unknown_preimages;
-    }
-
-    /***************************************************************************
-
         Check if information for pre-images and slashed validators is valid
 
         Params:
@@ -1212,11 +1195,6 @@ public class Ledger
         uint[] missing_validators_lower_bound = validators.enumerate
             .filter!(kv => kv.value.preimage.height < height)
             .map!(kv => cast(uint) kv.index).array();
-
-        // trying to retrieve preimages that - based on the consensus data -
-        // was shared with other nodes
-        foreach (const validator_ind; setDifference(missing_validators_lower_bound, missing_validators))
-            this.enrolls_keys_for_unknown_preimages.put(validators[validator_ind].utxo());
 
         // NodeA will check the candidate from NodeB in the following way:
         //

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -983,33 +983,6 @@ public class NetworkManager
 
     /***************************************************************************
 
-        Retrieves the missing preimages that other nodes indirectly indicated
-        (through consensus data shared during nomination) they possess.
-
-        Params:
-            ledger = ledger instance
-
-    ***************************************************************************/
-
-    public void retrievePreimages (Ledger ledger) @safe nothrow
-    {
-        auto enroll_keys = ledger.getEnrollKeysForUnknownPreimages();
-
-        foreach (peer; this.peers[])
-        {
-            if (enroll_keys.empty())
-                break;
-
-            foreach (const ref preimage_info; peer.client.getPreimagesForEnrollKeys(enroll_keys))
-                if (ledger.addPreimage(preimage_info))
-                    enroll_keys.remove(preimage_info.utxo);
-        }
-
-        () @trusted {enroll_keys.clear();}();
-    }
-
-    /***************************************************************************
-
         Retrieve any missing block signatures from the connected nodes for
         blocks since the last fee payment block.
 

--- a/source/agora/test/PreimageSharing.d
+++ b/source/agora/test/PreimageSharing.d
@@ -20,18 +20,18 @@ import agora.consensus.data.PreImageInfo;
 import agora.utils.Test;
 import agora.test.Base;
 
-/// doesn't reveal any preimages, except during nomination or when
-/// reveal_preimage is set to true
-public class NoPreImageExceptNominationVN : NoPreImageVN
+/// Doesn't actively reveal any preimages, but can be queried for it
+public class NoActivePINode : TestValidatorNode
 {
     ///
     mixin ForwardCtor!();
 
-    /// GET: /preimages_for_enroll_keys
-    public override PreImageInfo[] getPreimagesForEnrollKeys (Set!Hash enroll_keys = Set!Hash.init) @safe nothrow
-    {
-        return TestValidatorNode.getPreimagesForEnrollKeys(enroll_keys);
-    }
+    ///
+    public override void onPreImageRevealTimer () @safe {}
+
+    /// To be extra sure, we also disable receiving a pre-image
+    /// so that the node may gossip them
+    public override void receivePreimage (in PreImageInfo preimage) @safe {}
 }
 
 unittest
@@ -42,7 +42,7 @@ unittest
     conf.consensus.quorum_threshold = 100;
 
     // set up nodes
-    auto network = makeTestNetwork!(LazyAPIManager!NoPreImageExceptNominationVN)(conf);
+    auto network = makeTestNetwork!(TestNetwork!NoActivePINode)(conf);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();


### PR DESCRIPTION
Previously, we were only catching up with pre-images we've seen as missing
through side effects of the `isInvalidPreimageRootReason`.
This `private` member of the `Ledger` was then cleared in the `NetworkManager`.

Instead of relying on this tight coupling and hard to follow logic,
and as we want to try to catch-up with all missing pre-images anyways,
we can just add a task in `Validator` which behaves similarly to the block catchup.