### PR TITLE
Part of #2363: Rename and organize FullNode & Validator APIs

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -119,24 +119,19 @@ public interface API
     /***************************************************************************
 
         Returns:
-            Return true if the node has this transaction hash.
+            The local clock time of this node (not network-adjusted)
 
         API:
-            GET /has_transaction_hash
+            GET /local_time
+
+        Warning: this request should be protected via node-to-node encryption,
+        or else be signed with a unique challenge/response. Otherwise a
+        byzantine node can cache a node's older response and feed it to a
+        victim node (replay attack).
 
     ***************************************************************************/
 
-    @method(HTTPMethod.GET)
-    public bool hasTransactionHash (in Hash tx);
-
-    /***************************************************************************
-
-        API:
-            PUT /transaction
-
-    ***************************************************************************/
-
-    public void putTransaction (in Transaction tx);
+    public TimePoint getLocalTime ();
 
     /***************************************************************************
 
@@ -149,6 +144,24 @@ public interface API
     ***************************************************************************/
 
     public ulong getBlockHeight ();
+
+    /***************************************************************************
+
+        Expose blocks as a REST collection
+
+        API:
+            GET /blocks/:height
+
+        Params:
+            _height = The height of the block to return
+
+        Returns:
+            The block at height `_height`, or throw an `Exception` (404).
+
+    ***************************************************************************/
+
+    @path("/blocks/:height")
+    public const(Block) getBlock (ulong _height);
 
     /***************************************************************************
 
@@ -175,24 +188,6 @@ public interface API
 
     /***************************************************************************
 
-        Expose blocks as a REST collection
-
-        API:
-            GET /blocks/:height
-
-        Params:
-            _height = The height of the block to return
-
-        Returns:
-            The block at height `_height`, or throw an `Exception` (404).
-
-    ***************************************************************************/
-
-    @path("/blocks/:height")
-    public const(Block) getBlock (ulong _height);
-
-    /***************************************************************************
-
         Get the array of hashes which form the merkle path
 
         API:
@@ -211,35 +206,18 @@ public interface API
 
     /***************************************************************************
 
-        Enroll as a validator
-
         API:
-            POST /enroll_validator
+            GET /block_headers
 
         Params:
-            enroll = the Enrollment object, the information about an validator
-
-    ***************************************************************************/
-
-    public void enrollValidator (in Enrollment enroll);
-
-    /***************************************************************************
-
-        Get an enrollment data if the data exists in the enrollment pool
-
-        API:
-            GET /enrollment
-
-        Params:
-            enroll_hash = key for an enrollment data which is hash of frozen UTXO
+            heights = A set of block heights to fetch headers for
 
         Returns:
-            the enrollment data if exists, otherwise Enrollment.init
+            Block headers for requested heights
 
     ***************************************************************************/
 
-    @method(HTTPMethod.GET)
-    public Enrollment getEnrollment (in Hash enroll_hash);
+    public BlockHeader[] getBlockHeaders (Set!ulong heights);
 
     /***************************************************************************
 
@@ -281,6 +259,31 @@ public interface API
 
     /***************************************************************************
 
+        API:
+            GET /validators
+
+        Params:
+            height = Height at which the information is desired
+                     (default: current)
+
+    ***************************************************************************/
+
+    public ValidatorInfo[] getValidators (ulong height);
+
+    /// Ditto
+    public ValidatorInfo[] getValidators ();
+
+    /***************************************************************************
+
+        API:
+            PUT /transaction
+
+    ***************************************************************************/
+
+    public void putTransaction (in Transaction tx);
+
+    /***************************************************************************
+
         Reveals a pre-image
 
         API:
@@ -295,20 +298,30 @@ public interface API
 
     /***************************************************************************
 
-        Returns:
-            The local clock time of this node (not network-adjusted)
+        Enroll as a validator
 
         API:
-            GET /local_time
+            POST /enroll_validator
 
-        Warning: this request should be protected via node-to-node encryption,
-        or else be signed with a unique challenge/response. Otherwise a
-        byzantine node can cache a node's older response and feed it to a
-        victim node (replay attack).
+        Params:
+            enroll = the Enrollment object, the information about an validator
 
     ***************************************************************************/
 
-    public TimePoint getLocalTime ();
+    public void enrollValidator (in Enrollment enroll);
+
+    /***************************************************************************
+
+        Returns:
+            Return true if the node has this transaction hash.
+
+        API:
+            GET /has_transaction_hash
+
+    ***************************************************************************/
+
+    @method(HTTPMethod.GET)
+    public bool hasTransactionHash (in Hash tx);
 
     /***************************************************************************
 
@@ -328,32 +341,19 @@ public interface API
 
     /***************************************************************************
 
+        Get an enrollment data if the data exists in the enrollment pool
+
         API:
-            GET /block_headers
+            GET /enrollment
 
         Params:
-            heights = A set of block heights to fetch headers for
+            enroll_hash = key for an enrollment data which is hash of frozen UTXO
 
         Returns:
-            Block headers for requested heights
+            the enrollment data if exists, otherwise Enrollment.init
 
     ***************************************************************************/
 
-    public BlockHeader[] getBlockHeaders (Set!ulong heights);
-
-    /***************************************************************************
-
-        API:
-            GET /validators
-
-        Params:
-            height = Height at which the information is desired
-                     (default: current)
-
-    ***************************************************************************/
-
-    public ValidatorInfo[] getValidators (ulong height);
-
-    /// Ditto
-    public ValidatorInfo[] getValidators ();
+    @method(HTTPMethod.GET)
+    public Enrollment getEnrollment (in Hash enroll_hash);
 }

--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -276,10 +276,13 @@ public interface API
     /***************************************************************************
 
         API:
-            PUT /transaction
+            POST /transaction
 
     ***************************************************************************/
 
+    public void postTransaction (in Transaction tx);
+
+    /// Alias for backward compatibility with Faucet
     public void putTransaction (in Transaction tx);
 
     /***************************************************************************
@@ -287,28 +290,28 @@ public interface API
         Reveals a pre-image
 
         API:
-            POST /receive_preimage
+            POST /preimage
 
         Params:
             preimage = a PreImageInfo object which contains a hash and a height
 
     ***************************************************************************/
 
-    public void receivePreimage (in PreImageInfo preimage);
+    public void postPreimage (in PreImageInfo preimage);
 
     /***************************************************************************
 
         Enroll as a validator
 
         API:
-            POST /enroll_validator
+            POST /enrollment
 
         Params:
             enroll = the Enrollment object, the information about an validator
 
     ***************************************************************************/
 
-    public void enrollValidator (in Enrollment enroll);
+    public void postEnrollment (in Enrollment enroll);
 
     /***************************************************************************
 

--- a/source/agora/api/Validator.d
+++ b/source/agora/api/Validator.d
@@ -98,11 +98,11 @@ public interface API : agora.api.FullNode.API
             envelope = Envelope to process (See Stellar_SCP)
 
         API:
-            POST /receive_envelope
+            POST /envelope
 
     ***************************************************************************/
 
-    public void receiveEnvelope (SCPEnvelope envelope);
+    public void postEnvelope (SCPEnvelope envelope);
 
    /***************************************************************************
 
@@ -115,9 +115,9 @@ public interface API : agora.api.FullNode.API
             block_sig = Signature to be added
 
         API:
-            PUT /receive_block_signature
+            POST /block_signature
 
     ***************************************************************************/
 
-    public void receiveBlockSignature (ValidatorBlockSig block_sig);
+    public void postBlockSignature (ValidatorBlockSig block_sig);
 }

--- a/source/agora/cli/client/GenTxProcess.d
+++ b/source/agora/cli/client/GenTxProcess.d
@@ -153,7 +153,7 @@ public int genTxProcess (string[] args, ref string[] outputs,
     // function to generate and send transactions
     void genTxs ()
     {
-        txs.each!(tx => node.putTransaction(tx));
+        txs.each!(tx => node.postTransaction(tx));
         writefln("%s transactions sent to %s.\nTransactions:",
             op.count, ip_address);
         txs.each!(tx => writeln(prettify(tx)));

--- a/source/agora/cli/client/SendTxProcess.d
+++ b/source/agora/cli/client/SendTxProcess.d
@@ -210,7 +210,7 @@ public int sendTxProcess (string[] args, ref string[] outputs, APIMaker api_make
     auto node = api_maker(ip_address);
 
     // send the transaction
-    node.putTransaction(tx);
+    node.postTransaction(tx);
 
     return CLIENT_SUCCESS;
 }
@@ -227,7 +227,7 @@ unittest
         /// Contains the transaction cache
         private Transaction[Hash] tx_cache;
 
-        public override void putTransaction (in Transaction tx) @safe
+        public override void postTransaction (in Transaction tx) @safe
         {
             this.tx_cache[hashFull(tx)] = tx.serializeFull().deserializeFull!Transaction;
         }

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -201,27 +201,27 @@ public class NetworkClient
         switch (event.type) with (GossipType)
         {
         case Tx:
-            this.attemptRequest!(API.putTransaction, Throw.No)(this.api,
+            this.attemptRequest!(API.postTransaction, Throw.No)(this.api,
                 event.tx);
             break;
 
         case Envelope:
-            this.attemptRequest!(API.receiveEnvelope, Throw.No)(this.api,
+            this.attemptRequest!(API.postEnvelope, Throw.No)(this.api,
                 event.envelope);
             break;
 
         case ValidatorBlockSig:
-            this.attemptRequest!(API.receiveBlockSignature, Throw.No)(this.api,
+            this.attemptRequest!(API.postBlockSignature, Throw.No)(this.api,
                 event.block_sig);
             break;
 
         case Enrollment:
-            this.attemptRequest!(API.enrollValidator, Throw.No)(this.api,
+            this.attemptRequest!(API.postEnrollment, Throw.No)(this.api,
                 event.enrollment);
             break;
 
         case Preimage:
-            this.attemptRequest!(API.receivePreimage, Throw.No)(this.api,
+            this.attemptRequest!(API.postPreimage, Throw.No)(this.api,
                 event.preimage);
             break;
 
@@ -565,7 +565,7 @@ public class NetworkClient
         If all requests fail and 'ex' is not null, throw the exception.
 
         Params:
-            endpoint = the API endpoint (e.g. `API.putTransaction`)
+            endpoint = the API endpoint (e.g. `API.postTransaction`)
             DT = whether to throw an exception if the request failed after
                  all attempted retries
             log_level = the logging level to use for logging failed requests

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -937,14 +937,14 @@ public class FullNode : API
         Receive a transaction.
 
         API:
-            PUT /transaction
+            POST /transaction
 
         Params:
             tx = the received transaction
 
     ***************************************************************************/
 
-    public override void putTransaction (in Transaction tx) @safe
+    public override void postTransaction (in Transaction tx) @safe
     {
         this.recordReq("transaction");
         auto tx_hash = hashFull(tx);
@@ -963,6 +963,12 @@ public class FullNode : API
         this.tx_stats.increaseMetricBy!"agora_transactions_accepted_total"(1);
         this.transaction_relayer.addTransaction(tx);
         this.pushTransaction(tx);
+    }
+
+    /// Ditto
+    public override void putTransaction (in Transaction tx) @safe
+    {
+        this.postTransaction(tx);
     }
 
     /// GET: /has_transaction_hash
@@ -1016,10 +1022,10 @@ public class FullNode : API
         return block.getMerklePath(index);
     }
 
-    /// PUT: /enroll_validator
-    public override void enrollValidator (in Enrollment enroll) @safe
+    /// POST /enrollment
+    public override void postEnrollment (in Enrollment enroll) @safe
     {
-        this.recordReq("enroll_validator");
+        this.recordReq("postEnrollment");
 
         UTXO utxo;
         this.utxo_set.peekUTXO(enroll.utxo_key, utxo);
@@ -1035,14 +1041,14 @@ public class FullNode : API
     /// GET: /enrollment
     public override Enrollment getEnrollment (in Hash enroll_hash) @safe
     {
-        this.recordReq("enrollment");
+        this.recordReq("getEnrollment");
         return this.enroll_man.getEnrollment(enroll_hash);
     }
 
-    /// PUT: /receive_preimage
-    public override void receivePreimage (in PreImageInfo preimage) @safe
+    /// POST /preimage
+    public override void postPreimage (in PreImageInfo preimage) @safe
     {
-        this.recordReq("receive_preimage");
+        this.recordReq("postPreimage");
         log.trace("Received Preimage: {}", prettify(preimage));
 
         if (this.ledger.addPreimage(preimage))

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -103,7 +103,7 @@ public Listeners runNode (Config config)
         auto flash = new AgoraFlashNode(config.flash,
             config.node.data_dir, params.Genesis.hashFull(),
             result.node.getEngine(),
-            result.node.getTaskManager(), &result.node.putTransaction,
+            result.node.getTaskManager(), &result.node.postTransaction,
             result.node.getNetworkManager());
         router.registerRestInterface!FlashAPI(flash);
         result.flash = flash;

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -407,16 +407,16 @@ public class Validator : FullNode, API
         Receive an SCP envelope.
 
         API:
-            PUT /envelope
+            POST /envelope
 
         Params:
             envelope = the SCP envelope
 
     ***************************************************************************/
 
-    public override void receiveEnvelope (SCPEnvelope envelope) @safe
+    public override void postEnvelope (SCPEnvelope envelope) @safe
     {
-        this.recordReq("receive_envelope");
+        this.recordReq("postEnvelope");
         this.nominator.receiveEnvelope(envelope);
     }
 
@@ -425,16 +425,16 @@ public class Validator : FullNode, API
         Receive a block signature.
 
         API:
-            PUT /block_sig
+            POST /block_signature
 
         Params:
             block_sig = the block signature of a validator (part of multisig)
 
     ***************************************************************************/
 
-    public override void receiveBlockSignature (ValidatorBlockSig block_sig) @safe
+    public override void postBlockSignature (ValidatorBlockSig block_sig) @safe
     {
-        this.recordReq("receive_block_signature");
+        this.recordReq("postBlockSignature");
         this.nominator.receiveBlockSignature(block_sig);
     }
 

--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -22,7 +22,7 @@ import agora.crypto.Hash;
 import agora.test.Base;
 import core.thread;
 
-/// test node banning after putTransaction fails a number of times
+/// test node banning after postTransaction fails a number of times
 unittest
 {
     TestConf conf =
@@ -71,7 +71,7 @@ unittest
          return txes;
     }
 
-    genBlockTransactions(1).each!(tx => nodes[0].putTransaction(tx));
+    genBlockTransactions(1).each!(tx => nodes[0].postTransaction(tx));
     // wait until the transactions were gossiped
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
@@ -82,7 +82,7 @@ unittest
     // full node will be banned if it cannot communicate
     // validators refuse to to send blocks
     nodes[0 .. GenesisValidators].each!(node => node.filter!(node.getBlocksFrom));
-    nodes[full_node_idx].filter!(nodes[full_node_idx].putTransaction); // full node won't receive transactions
+    nodes[full_node_idx].filter!(nodes[full_node_idx].postTransaction); // full node won't receive transactions
 
     // leftover txs which full node will reject due to its filter
     Transaction[] left_txs;
@@ -91,19 +91,19 @@ unittest
     {
         auto new_tx = genBlockTransactions(1);
         left_txs ~= new_tx;
-        new_tx.each!(tx => nodes[0].putTransaction(tx));
+        new_tx.each!(tx => nodes[0].postTransaction(tx));
         network.expectHeightAndPreImg(iota(0, 4), Height(1 + block_idx + 1), network.blocks[0].header);
         retryFor(nodes[full_node_idx].getBlockHeight() == 1, 1.seconds,
             format!"Expected Full node height of exactly 1 not %s"(nodes[full_node_idx].getBlockHeight()));
     }
 
-    // wait for full node to be banned and all putTransaction requests to time-out
+    // wait for full node to be banned and all postTransaction requests to time-out
     Thread.sleep(2.seconds);
 
     // sanity check: block height should not be updated, full node is not a validator and cannot make new blocks,
     // it may only add to its ledger through the getBlocksFrom() API.
     nodes[full_node_idx].clearFilter();
-    left_txs.each!(tx => nodes[full_node_idx].putTransaction(tx));
+    left_txs.each!(tx => nodes[full_node_idx].postTransaction(tx));
     retryFor(nodes[full_node_idx].getBlockHeight() == 1, 1.seconds);
 
     // clear the filter
@@ -115,6 +115,6 @@ unittest
 
     auto new_tx = genBlockTransactions(1);
     left_txs ~= new_tx;
-    new_tx.each!(tx => nodes[0].putTransaction(tx));
+    new_tx.each!(tx => nodes[0].postTransaction(tx));
     network.expectHeight(Height(6));
 }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1075,7 +1075,7 @@ public class TestAPIManager
             {
                 // Send transaction to the first client
                 auto tx = spendables.takeExactly(1).map!(txb => txb.sign()).front;
-                first_client.putTransaction(tx);
+                first_client.postTransaction(tx);
                 // Wait for tx gossipping before setting time for block
                 client_idxs.each!(idx =>
                     retryFor(this.clients[idx].hasTransactionHash(tx.hashFull()),
@@ -1201,7 +1201,7 @@ public class TestAPIManager
     /// Ensure that a transaction is accepted by a node (put in the tx pool)
     public void ensureTxInPool (Idxs) (in Transaction tx, Idxs indices)
     {
-        indices.each!(idx => this.clients[idx].putTransaction(tx));
+        indices.each!(idx => this.clients[idx].postTransaction(tx));
         this.ensureTxInPool(tx.hashFull(), indices);
     }
 
@@ -1649,9 +1649,9 @@ private mixin template TestNodeMixin ()
 
     ***************************************************************************/
 
-    public override void putTransaction (in Transaction tx) @safe
+    public override void postTransaction (in Transaction tx) @safe
     {
-        super.putTransaction(tx);
+        super.postTransaction(tx);
         const tx_hash = tx.hashFull();
         if (tx_hash !in this.accepted_txs &&
             this.pool.hasTransactionHash(tx_hash))
@@ -1786,13 +1786,13 @@ public class TestFullNode : FullNode, TestAPI
     }
 
     /// FullNode does not implement this
-    public override void receiveEnvelope (SCPEnvelope envelope) @safe
+    public override void postEnvelope (SCPEnvelope envelope) @safe
     {
         assert(0);
     }
 
     /// ditto
-    public override void receiveBlockSignature (ValidatorBlockSig block_sig) @safe
+    public override void postBlockSignature (ValidatorBlockSig block_sig) @safe
     {
         assert(0);
     }

--- a/source/agora/test/BlockTimeConsensus.d
+++ b/source/agora/test/BlockTimeConsensus.d
@@ -42,7 +42,7 @@ unittest
     void checkHeight(Height height)
     {
         network.waitForPreimages(b0.header.enrollments, height);
-        nodes[0].putTransaction(txs[height.value]);
+        nodes[0].postTransaction(txs[height.value]);
         network.setTimeFor(height);
         network.assertSameBlocks(height);
         auto time_offset = nodes[0].getBlocksFrom(height, 1)[0].header.time_offset;

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -210,7 +210,7 @@ unittest
     auto node_1 = nodes[$ - 1];
     assert(node_1.getQuorumConfig().threshold == 6); // We should need all 6 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
-    txes.each!(tx => node_1.putTransaction(tx));
+    txes.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 }
 
@@ -229,7 +229,7 @@ unittest
     auto node_1 = nodes[$ - 1];
     assert(node_1.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
-    txes.each!(tx => node_1.putTransaction(tx));
+    txes.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 }
 
@@ -248,7 +248,7 @@ unittest
     auto node_1 = nodes[$ - 1];
     assert(node_1.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
-    txes.each!(tx => node_1.putTransaction(tx));
+    txes.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 }
 
@@ -280,7 +280,7 @@ unittest
     auto node_1 = nodes[$ - 1];
     assert(node_1.getQuorumConfig().threshold == 4); // We should need 4 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
-    txes.each!(tx => node_1.putTransaction(tx));
+    txes.each!(tx => node_1.postTransaction(tx));
     network.waitForPreimages(network.blocks[0].header.enrollments, Height(6));
     network.setTimeFor(Height(1));  // trigger consensus
     waitForCount(1, &network.envelope_type_counts.externalize_count, "externalize");
@@ -303,7 +303,7 @@ unittest
     auto node_1 = nodes[$ - 1];
     assert(node_1.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
-    txes.each!(tx => node_1.putTransaction(tx));
+    txes.each!(tx => node_1.postTransaction(tx));
     network.waitForPreimages(network.blocks[0].header.enrollments, Height(6));
     network.setTimeFor(Height(1));  // trigger consensus
     Thread.sleep(2.seconds);

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -223,7 +223,7 @@ unittest
     // Make a block using Genesis
     genesisSpendable().take(8).enumerate()
         .map!(en => en.value.refund(WK.Keys.A.address).sign())
-        .each!(tx => validator.putTransaction(tx));
+        .each!(tx => validator.postTransaction(tx));
     network.waitForPreimages(b0.header.enrollments, Height(1));
     network.setTimeFor(Height(1));  // trigger consensus
 

--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -46,7 +46,7 @@ unittest
             .deduct(Amount.UnitPerCoin).sign()).array();
 
         // send them to all nodes
-        txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));
+        txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));
 
         network.expectHeightAndPreImg(new_height, blocks[0].header);
 
@@ -129,7 +129,7 @@ unittest
         .deduct(Amount.UnitPerCoin).sign()).array();
 
     // send them to all valid nodes
-    txs.each!(tx => valid_nodes.each!(node => node.putTransaction(tx)));
+    txs.each!(tx => valid_nodes.each!(node => node.postTransaction(tx)));
 
     network.setTimeFor(Height(1));
     Thread.sleep(1.seconds);
@@ -191,7 +191,7 @@ unittest
             .deduct(Amount.UnitPerCoin).sign()).array();
 
         // send them to all valid nodes
-        txs.each!(tx => valid_nodes.each!(node => node.putTransaction(tx)));
+        txs.each!(tx => valid_nodes.each!(node => node.postTransaction(tx)));
 
         network.expectHeightAndPreImg(iota(1, GenesisValidators),
             new_height, blocks[0].header);

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -325,10 +325,10 @@ public class TestFlashNode : ThinFlashNode, TestFlashAPI
     }
 
     ///
-    protected override void putTransaction (Transaction tx)
+    protected override void postTransaction (Transaction tx)
     {
         if (this.allow_publish)
-            super.putTransaction(tx);
+            super.postTransaction(tx);
         else
             log.info("Skipping publishing {}", tx);
     }
@@ -635,7 +635,7 @@ unittest
 
     foreach (idx, tx; txs)
     {
-        node_1.putTransaction(tx);
+        node_1.postTransaction(tx);
         network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
@@ -735,7 +735,7 @@ unittest
 
     foreach (idx, tx; txs[0 .. 4])
     {
-        node_1.putTransaction(tx);
+        node_1.postTransaction(tx);
         network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
@@ -811,13 +811,13 @@ unittest
 
     // at `Settle_4_Blocks` blocks need to be externalized before a settlement
     // can be attached to the update transaction
-    node_1.putTransaction(txs[4]);
+    node_1.postTransaction(txs[4]);
     network.expectHeightAndPreImg(Height(8), network.blocks[0].header);
-    node_1.putTransaction(txs[5]);
+    node_1.postTransaction(txs[5]);
     network.expectHeightAndPreImg(Height(9), network.blocks[0].header);
-    node_1.putTransaction(txs[6]);
+    node_1.postTransaction(txs[6]);
     network.expectHeightAndPreImg(Height(10), network.blocks[0].header);
-    node_1.putTransaction(txs[7]);
+    node_1.postTransaction(txs[7]);
     network.expectHeightAndPreImg(Height(11), network.blocks[0].header);
 
     // and then a settlement will be automatically published
@@ -861,7 +861,7 @@ unittest
 
     foreach (idx, tx; txs)
     {
-        node_1.putTransaction(tx);
+        node_1.postTransaction(tx);
         network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
@@ -962,7 +962,7 @@ unittest
 
     foreach (idx, tx; txs)
     {
-        node_1.putTransaction(tx);
+        node_1.postTransaction(tx);
         network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
@@ -1111,7 +1111,7 @@ unittest
 
     foreach (idx, tx; txs)
     {
-        node_1.putTransaction(tx);
+        node_1.postTransaction(tx);
         network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
@@ -1282,7 +1282,7 @@ unittest
 
     foreach (idx, tx; txs)
     {
-        node_1.putTransaction(tx);
+        node_1.postTransaction(tx);
         network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
@@ -1508,7 +1508,7 @@ unittest
 
     foreach (idx, tx; txs)
     {
-        node_1.putTransaction(tx);
+        node_1.postTransaction(tx);
         network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
@@ -1592,7 +1592,7 @@ unittest
 
     foreach (idx, tx; txs)
     {
-        node_1.putTransaction(tx);
+        node_1.postTransaction(tx);
         network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
@@ -1682,7 +1682,7 @@ unittest
 
     foreach (idx, tx; txs)
     {
-        node_1.putTransaction(tx);
+        node_1.postTransaction(tx);
         network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
@@ -1896,7 +1896,7 @@ unittest
 
     foreach (idx, tx; txs)
     {
-        node_1.putTransaction(tx);
+        node_1.postTransaction(tx);
         network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
@@ -2009,7 +2009,7 @@ unittest
 
     foreach (idx, tx; txs)
     {
-        node_1.putTransaction(tx);
+        node_1.postTransaction(tx);
         network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
@@ -2078,7 +2078,7 @@ unittest
 
     foreach (idx, tx; txs)
     {
-        node_1.putTransaction(tx);
+        node_1.postTransaction(tx);
         network.expectHeightAndPreImg(Height(idx + 1), network.blocks[0].header);
     }
 
@@ -2143,7 +2143,7 @@ unittest
     bob.setPublishEnable(false);
 
     auto update_tx = alice.getPublishUpdateIndex(alice_pk, chan_id, 0);
-    node_1.putTransaction(update_tx);
+    node_1.postTransaction(update_tx);
     network.expectTxExternalization(update_tx);
     factory.listener.waitUntilChannelState(chan_id,
         ChannelState.StartedUnilateralClose);
@@ -2151,12 +2151,12 @@ unittest
 
     // publish an older update
     update_tx = alice.getPublishUpdateIndex(alice_pk, chan_id, 2);
-    node_1.putTransaction(update_tx);
+    node_1.postTransaction(update_tx);
     network.expectTxExternalization(update_tx);
 
     // an even older update can not be externalized anymore
     update_tx = alice.getPublishUpdateIndex(alice_pk, chan_id, 1);
-    node_1.putTransaction(update_tx);
+    node_1.postTransaction(update_tx);
     assertThrown!Exception(network.expectTxExternalization(update_tx));
 
     // allow normal node operation again

--- a/source/agora/test/GenesisBlock.d
+++ b/source/agora/test/GenesisBlock.d
@@ -37,6 +37,6 @@ unittest
         .retryFor(2.seconds);
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
-    txes.each!(tx => node_1.putTransaction(tx));
+    txes.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 }

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -39,14 +39,14 @@ unittest
 
     auto send_txs = txs[0..$-1];
     // send it to tx to node
-    send_txs.each!(tx => node_1.putTransaction(tx));
+    send_txs.each!(tx => node_1.postTransaction(tx));
     // gossip was complete
     nodes.each!(node =>
        send_txs.each!(tx =>
            node.hasAcceptedTxHash(hashFull(tx)).retryFor(2.seconds)
     ));
     // When a block is created, the transaction is deleted from the transaction pool.
-    node_1.putTransaction(txs[$-1]);
+    node_1.postTransaction(txs[$-1]);
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     nodes.each!(node =>
@@ -75,7 +75,7 @@ unittest
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
 
     auto send_txs = txs[0 .. $ - 1];  // 1 short of making a block (don't start consensus)
-    send_txs.each!(tx => node_1.putTransaction(tx));
+    send_txs.each!(tx => node_1.postTransaction(tx));
     nodes.each!(node =>
        send_txs.each!(tx =>
            node.hasTransactionHash(hashFull(tx)).retryFor(5.seconds)

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -148,7 +148,7 @@ unittest
     auto last_node = nodes[$ - 1];
     assert(last_node.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().takeExactly(1).map!(txb => txb.sign()).array();
-    txes.each!(tx => last_node.putTransaction(tx));
+    txes.each!(tx => last_node.postTransaction(tx));
     // Trigger generation of block
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
     // Make sure the client we will check is in sync with others (except for byzantine)
@@ -171,7 +171,7 @@ unittest
     auto last_node = nodes[$ - 1];
     assert(last_node.getQuorumConfig().threshold == 5); // We should need 5 nodes
     auto txes = genesisSpendable().takeExactly(1).map!(txb => txb.sign()).array();
-    txes.each!(tx => last_node.putTransaction(tx));
+    txes.each!(tx => last_node.postTransaction(tx));
     // Trigger generation of block
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
     // Make sure the client we will check is in sync with others (except for byzantine)

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -57,7 +57,7 @@ unittest
         Transaction[] txs = blocks[block_idx].spendable().map!(txb => txb.sign()).array;
 
         // send each tx to one node
-        txs.each!(tx => node_1.putTransaction(tx));
+        txs.each!(tx => node_1.postTransaction(tx));
         // wait for all nodes get the txs
         txs.each!(tx =>
             nodes.each!(node =>
@@ -105,14 +105,14 @@ unittest
     auto node_1 = nodes[0];
 
     // ignore transaction propagation and periodically retrieve blocks via getBlocksFrom
-    nodes[GenesisValidators .. $].each!(node => node.filter!(node.putTransaction));
+    nodes[GenesisValidators .. $].each!(node => node.filter!(node.postTransaction));
 
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
-    txs.each!(tx => node_1.putTransaction(tx));
+    txs.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
-    txs.each!(tx => node_1.putTransaction(tx));
+    txs.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
 }
 
@@ -131,7 +131,7 @@ unittest
 
     auto gen_key_pair = WK.Keys.Genesis;
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
-    txs.each!(tx => node_1.putTransaction(tx));
+    txs.each!(tx => node_1.postTransaction(tx));
 
     Hash[] hashes;
     hashes.reserve(txs.length);
@@ -192,12 +192,12 @@ unittest
     auto node_1 = nodes[0];
 
     auto txs = network.blocks[0].spendable.map!(txb => txb.sign()).array();
-    txs.each!(tx => node_1.putTransaction(tx));
+    txs.each!(tx => node_1.postTransaction(tx));
 
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
-    txs.each!(tx => node_1.putTransaction(tx));
+    txs.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
@@ -225,12 +225,12 @@ unittest
         }, Height(0),
         checker);
     assert(reason is null, reason);
-    txs.each!(tx => node_1.putTransaction(tx));
+    txs.each!(tx => node_1.postTransaction(tx));
 
     Thread.sleep(2.seconds);  // wait for propagation
     network.expectHeight(Height(2));  // no new block yet (1 rejected tx)
 
-    node_1.putTransaction(backup_tx);
+    node_1.postTransaction(backup_tx);
     network.expectHeightAndPreImg(Height(3), network.blocks[0].header);  // new block finally created
 }
 
@@ -256,7 +256,7 @@ unittest
         ).front;
 
     assert(tx.outputs.length == 2);
-    network.clients[0].putTransaction(tx);
+    network.clients[0].postTransaction(tx);
 
     // Wait for the block to be created
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
@@ -267,7 +267,7 @@ unittest
     auto tx2 = TxBuilder(b1.txs[0], 0).sign();
     assert(tx2.outputs.length == 1);
 
-    network.clients[0].putTransaction(tx2);
+    network.clients[0].postTransaction(tx2);
     network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
     assert(network.clients[0].getBlock(2).txs.length == 1);
 }

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -108,7 +108,7 @@ unittest
                 &this.onAcceptedBlock);
         }
 
-        public override void putTransaction (in Transaction tx) @safe
+        public override void postTransaction (in Transaction tx) @safe
         {
             // Dont accept any incoming TXs
             log.info("Picky node ignoring TX {}", tx);
@@ -150,7 +150,7 @@ unittest
     assert(blocks.length == 1);
 
     auto txs = blocks[0].spendable().takeExactly(1).map!(txb => txb.sign());
-    txs.each!(tx => node.putTransaction(tx));
+    txs.each!(tx => node.postTransaction(tx));
     Thread.sleep(1.seconds);
     txs.each!(tx => assert(!picky_node.hasTransactionHash(tx.hashFull())));
 

--- a/source/agora/test/LockHeight.d
+++ b/source/agora/test/LockHeight.d
@@ -34,7 +34,7 @@ unittest
 
     // height 1
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
-    txs.each!(tx => node_1.putTransaction(tx));
+    txs.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     const Height UnlockHeight_2 = Height(2);
@@ -49,10 +49,10 @@ unittest
 
     // these should all be rejected, or alternatively accepted by the pool but
     // not added to the block at height 2
-    unlock_3_txs.each!(tx => node_1.putTransaction(tx));
+    unlock_3_txs.each!(tx => node_1.postTransaction(tx));
 
     // should be accepted
-    unlock_2_txs.each!(tx => node_1.putTransaction(tx));
+    unlock_2_txs.each!(tx => node_1.postTransaction(tx));
 
     network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
 

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -48,7 +48,7 @@ void manyValidators (size_t validators)
         // prepare frozen outputs for outsider validators to enroll
         genesisSpendable().dropExactly(1).takeExactly(1)
             .map!(txb => txb.split(keys).sign(OutputType.Freeze))
-            .each!(tx => network.clients[0].putTransaction(tx));
+            .each!(tx => network.clients[0].postTransaction(tx));
     }
 
     // block 19

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -129,7 +129,7 @@ unittest
     auto txs = spendable[0 .. 8].map!(txb => txb.sign()).array;
 
     // block 1
-    txs.each!(tx => nodes[0].putTransaction(tx));
+    txs.each!(tx => nodes[0].postTransaction(tx));
     // Exclude first node from the check as it is not sending pre-image
     network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(1), network.blocks[0].header);
 }
@@ -179,6 +179,6 @@ unittest
     auto txs = spendable[0 .. 8].map!(txb => txb.sign()).array;
 
     // try to make block 1
-    txs.each!(tx => nodes[0].putTransaction(tx));
+    txs.each!(tx => nodes[0].postTransaction(tx));
     network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(1), network.blocks[0].header);
 }

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -107,7 +107,7 @@ unittest
 
     // Block 1 with multiple consensus rounds
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
-    txs.each!(tx => validator.putTransaction(tx));
+    txs.each!(tx => validator.postTransaction(tx));
 
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header, conf.node.timeout + 5.seconds);
     assert(CustomNominator.round_number >= 2,

--- a/source/agora/test/NameRegistry.d
+++ b/source/agora/test/NameRegistry.d
@@ -32,6 +32,6 @@ unittest
     auto node_1 = nodes[0];
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
-    txes.each!(tx => node_1.putTransaction(tx));
+    txes.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 }

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -40,13 +40,13 @@ unittest
     node_1.filter!(node_1.getBlocksFrom);
 
     // reject inbound requests
-    nodes[1 .. $].each!(node => node.filter!(node.putTransaction));
+    nodes[1 .. $].each!(node => node.filter!(node.postTransaction));
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
 
     // node 1 will keep trying to send transactions up to
     // (max_retries * retry_delay) seconds (see Base.d)
-    txes.each!(tx => node_1.putTransaction(tx));
+    txes.each!(tx => node_1.postTransaction(tx));
 
     // clear filter after 100 msecs, the above requests will eventually be gossiped
     Thread.sleep(100.msecs);
@@ -78,7 +78,7 @@ unittest
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
 
-    txes.each!(tx => node_1.putTransaction(tx));
+    txes.each!(tx => node_1.postTransaction(tx));
 
     // node 1 will keep trying to send transactions up to
     // max_retries * (retry_delay + timeout) seconds (see Base.d),

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -45,7 +45,7 @@ unittest
     nodes.take(GenesisValidators / 2).each!(node => node.filter!(API.getBlockHeight));
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
-    txes.each!(tx => node_1.putTransaction(tx));
+    txes.each!(tx => node_1.postTransaction(tx));
 
     nodes.take(GenesisValidators / 2).each!(node => node.clearFilter());
 
@@ -151,19 +151,19 @@ unittest
     // enable filtering first
     node_validators.each!(node => node.filter!(API.getBlocksFrom));
     node_bad.filter!(API.getBlocksFrom);
-    node_test.filter!(API.putTransaction);
+    node_test.filter!(API.postTransaction);
 
     Transaction[] last_txs;
 
     // create genesis block
     last_txs = genesisSpendable().map!(txb => txb.sign()).array();
-    last_txs.each!(tx => node_validators[0].putTransaction(tx));
+    last_txs.each!(tx => node_validators[0].postTransaction(tx));
     network.expectHeight(iota(GenesisValidators), Height(1));
 
     // create 1 additional block and enough `tx`es
     auto txs = last_txs.map!(tx => TxBuilder(tx).sign()).array();
     // send it to one node
-    txs.each!(tx => node_validators[0].putTransaction(tx));
+    txs.each!(tx => node_validators[0].postTransaction(tx));
     network.expectHeight(iota(GenesisValidators), Height(2));
     last_txs = txs;
 

--- a/source/agora/test/PreimageSharing.d
+++ b/source/agora/test/PreimageSharing.d
@@ -31,7 +31,7 @@ public class NoActivePINode : TestValidatorNode
 
     /// To be extra sure, we also disable receiving a pre-image
     /// so that the node may gossip them
-    public override void receivePreimage (in PreImageInfo preimage) @safe {}
+    public override void postPreimage (in PreImageInfo preimage) @safe {}
 }
 
 unittest
@@ -51,7 +51,7 @@ unittest
     // create and send txs to nodes
     auto nodes = network.clients;
     auto txs = network.blocks[$ - 1].spendable().map!(txb => txb.sign()).array;
-    txs.each!(tx => nodes[0].putTransaction(tx));
+    txs.each!(tx => nodes[0].postTransaction(tx));
 
     // block should be created even though the validators didn't reveal their
     // preimages in advance, as preimage sharing is also done during SCP run

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -60,7 +60,7 @@ unittest
     // Freeze outputs for outsiders
     genesisSpendable.drop(2).takeExactly(1)
         .map!(txb => txb.split(keys).sign(OutputType.Freeze))
-        .each!(tx => nodes[0].putTransaction(tx));
+        .each!(tx => nodes[0].postTransaction(tx));
 
     // at block height 19 the freeze tx's are available
     network.generateBlocks(Height(GenesisValidatorCycle - 1));

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -105,7 +105,7 @@ unittest
     // prepare frozen outputs for outsider validators to enroll
     genesisSpendable().dropExactly(1).takeExactly(1)
         .map!(txb => txb.split(keys).sign(OutputType.Freeze))
-        .each!(tx => network.clients[0].putTransaction(tx));
+        .each!(tx => network.clients[0].postTransaction(tx));
 
     // block 19
     network.generateBlocks(Height(GenesisValidatorCycle - 1));

--- a/source/agora/test/Restart.d
+++ b/source/agora/test/Restart.d
@@ -35,7 +35,7 @@ unittest
     auto node_1 = nodes[0];
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
-    txes.each!(tx => node_1.putTransaction(tx));
+    txes.each!(tx => node_1.postTransaction(tx));
     network.expectHeight(Height(1));
 
     // Now shut down & restart one node
@@ -117,7 +117,7 @@ unittest
     auto node_1 = nodes[0];
 
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
-    txes.each!(tx => node_1.putTransaction(tx));
+    txes.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     // Now shut down & restart one node

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -110,7 +110,7 @@ unittest
 
     auto re_validator = network.clients[0];
     auto txes = genesisSpendable().map!(txb => txb.sign()).array();
-    txes.each!(tx => re_validator.putTransaction(tx));
+    txes.each!(tx => re_validator.postTransaction(tx));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     Checked = true;

--- a/source/agora/test/RestoreSlashingInfo.d
+++ b/source/agora/test/RestoreSlashingInfo.d
@@ -57,7 +57,7 @@ unittest
     blocks[0].spendable().drop(1).takeExactly(1)
         .map!(txb => txb
             .split(keys).sign(OutputType.Freeze))
-            .each!(tx => set_a[0].putTransaction(tx));
+            .each!(tx => set_a[0].postTransaction(tx));
 
     network.generateBlocks(Height(GenesisValidatorCycle - 1));
 

--- a/source/agora/test/Script.d
+++ b/source/agora/test/Script.d
@@ -63,7 +63,7 @@ unittest
             .map!(idx => TxBuilder(tx, cast(uint)idx, lock)))
         .joiner().map!(txb => txb.sign());
 
-    lock_txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));
+    lock_txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));
     network.expectHeightAndPreImg(Height(6), network.blocks[0].header);
 
     const block_6 = node_1.getBlocksFrom(6, 1)[0];
@@ -79,9 +79,9 @@ unittest
             .lock(lock_height_3).sign()).array;
 
     // txs with unlock height 2 should be rejected by the lock script
-    unlock_height_2.each!(tx => nodes.each!(node => node.putTransaction(tx)));
+    unlock_height_2.each!(tx => nodes.each!(node => node.postTransaction(tx)));
     // unlock height 3 accepted
-    unlock_height_3.each!(tx => nodes.each!(node => node.putTransaction(tx)));
+    unlock_height_3.each!(tx => nodes.each!(node => node.postTransaction(tx)));
     network.expectHeightAndPreImg(Height(7), network.blocks[0].header);
 
     const block_7 = node_1.getBlocksFrom(7, 1)[0];
@@ -116,7 +116,7 @@ unittest
         .split(key_lock.repeat.take(8)).sign();
 
     // height 1, many Outputs
-    txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));
+    txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     auto split_up = txs
@@ -128,21 +128,21 @@ unittest
     auto txs_1 = split_up[1].map!(txb => txb.sign()).array;
     auto txs_2 = split_up[2].map!(txb => txb.sign()).array;
 
-    txs_0.each!(tx => nodes.each!(node => node.putTransaction(tx)));      // accepted
+    txs_0.each!(tx => nodes.each!(node => node.postTransaction(tx)));      // accepted
     network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
     auto blocks = node_1.getBlocksFrom(2, 1);
     assert(blocks.length == 1);
     sort(txs_0);
     assert(blocks[0].txs == txs_0);
 
-    txs_1.each!(tx => nodes.each!(node => node.putTransaction(tx)));      // accepted
+    txs_1.each!(tx => nodes.each!(node => node.postTransaction(tx)));      // accepted
     network.expectHeightAndPreImg(Height(3), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(3, 1);
     assert(blocks.length == 1);
     sort(txs_1);
     assert(blocks[0].txs == txs_1);
 
-    txs_2.each!(tx => nodes.each!(node => node.putTransaction(tx)));      // accepted
+    txs_2.each!(tx => nodes.each!(node => node.postTransaction(tx)));      // accepted
     network.expectHeightAndPreImg(Height(4), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(4, 1);
     assert(blocks.length == 1);
@@ -163,8 +163,8 @@ unittest
         .map!(t => t.sign(OutputType.Payment, UnlockAge_3))
         .array();
 
-    age_2_txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));
-    age_3_txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));
+    age_2_txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));
+    age_3_txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));
     network.expectHeightAndPreImg(Height(5), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(5, 1);
     assert(blocks.length == 1);
@@ -206,7 +206,7 @@ unittest
         .split(key_lock.repeat.take(8)).sign();
 
     // height 1, many Outputs
-    txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));
+    txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     auto split_up = txs
@@ -215,7 +215,7 @@ unittest
 
     auto txs_0 = split_up[0].map!(txb => txb.sign()).array;
 
-    txs_0.each!(tx => nodes.each!(node => node.putTransaction(tx)));
+    txs_0.each!(tx => nodes.each!(node => node.postTransaction(tx)));
     network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
     auto blocks = node_1.getBlocksFrom(2, 1);
     assert(blocks.length == 1);
@@ -236,8 +236,8 @@ unittest
 
     // We don't want to rely on gossip before we set time for nominate or we will not know
     //  the chosen tx set for sure. We just send to all so that all will be included next block.
-    true_a_txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));
-    true_b_txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));
+    true_a_txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));
+    true_b_txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));
     network.expectHeightAndPreImg(Height(3), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(3, 1);
     assert(blocks.length == 1);
@@ -256,8 +256,8 @@ unittest
             .unlockSigner(&TxBuilder.signWithSpecificKey!(kp_b, [ubyte(OP.FALSE)])).sign())
         .array();
 
-    false_a_txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));
-    false_b_txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));
+    false_a_txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));
+    false_b_txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));
     network.expectHeightAndPreImg(Height(4), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(4, 1);
     assert(blocks.length == 1);

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -78,7 +78,7 @@ unittest
     auto utxos = nodes[0].getUTXOs(bad_address);
     auto original_stake = utxos[0].utxo.output.value;
     // block 1
-    txs.each!(tx => nodes[0].putTransaction(tx));
+    txs.each!(tx => nodes[0].postTransaction(tx));
     // Node index is 5 for bad node so we do not expect pre-image from it
     network.expectHeightAndPreImg(iota(0, 5), Height(1), network.blocks[0].header);
 
@@ -125,7 +125,7 @@ unittest
 
     // block 1 must not be created because all the validators do not
     // reveal any pre-images after their enrollments.
-    txs.each!(tx => nodes[0].putTransaction(tx));
+    txs.each!(tx => nodes[0].postTransaction(tx));
     Thread.sleep(2.seconds); // Give time before checking still height 0
     network.expectHeight(Height(0));
 

--- a/source/agora/test/TimeBlockInterval.d
+++ b/source/agora/test/TimeBlockInterval.d
@@ -41,7 +41,7 @@ unittest
     genesisSpendable.map!(txb =>
         txb.sign())
         .chunks(2).enumerate.each!((en) {
-            en.value.each!(tx => node_1.putTransaction(tx));
+            en.value.each!(tx => node_1.postTransaction(tx));
             network.expectHeightAndPreImg(Height(en.index + 1));
         });
     assert(node_1.getNetworkTime() >= startTime + (4 * conf.consensus.block_interval_sec));

--- a/source/agora/test/TimeDrift.d
+++ b/source/agora/test/TimeDrift.d
@@ -88,7 +88,7 @@ unittest
         .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
         .array;
 
-    txs.take(2).each!(tx => nodes[0].putTransaction(tx));
+    txs.take(2).each!(tx => nodes[0].postTransaction(tx));
     // wait for propagation
     nodes.each!(node =>
        txs.take(2).each!(tx =>
@@ -115,7 +115,7 @@ unittest
     // Make sure nodes have revealed their preimage for height 2
     network.waitForPreimages(GenesisBlock.header.enrollments, Height(2));
 
-    txs.take(2).each!(tx => nodes[0].putTransaction(tx));
+    txs.take(2).each!(tx => nodes[0].postTransaction(tx));
     // wait for propagation
     nodes.each!(node =>
        txs.take(2).each!(tx =>

--- a/source/agora/test/TransactionReplacement.d
+++ b/source/agora/test/TransactionReplacement.d
@@ -49,20 +49,20 @@ unittest
         .sign()).array();
 
     // send the transaction with 10000 fee to node0
-    nodes[0].putTransaction(txs[0]);
+    nodes[0].postTransaction(txs[0]);
 
     // wait until the transaction propages to all nodes
     nodes.each!(node => node.hasTransactionHash(hashFull(txs[0])).retryFor(2.seconds));
 
     // send transactions with fee 10100, 10200, 11000 to node0
-    txs[1 .. 4].each!(tx => node0.putTransaction(tx));
+    txs[1 .. 4].each!(tx => node0.postTransaction(tx));
 
     // wait 2 seconds and make sure none of the nodes have those transactions
     Thread.sleep(2.seconds);
     txs[1 .. 4].each!(tx => nodes.each!(node => !node.hasTransactionHash(tx.hashFull())));
 
     // send a transaction with 13000s fee to node0
-    nodes[0].putTransaction(txs[4]);
+    nodes[0].postTransaction(txs[4]);
 
     // wait until the transaction propages to all nodes
     nodes.each!(node => node.hasTransactionHash(hashFull(txs[4])).retryFor(2.seconds));

--- a/source/agora/test/UnlockAge.d
+++ b/source/agora/test/UnlockAge.d
@@ -37,7 +37,7 @@ unittest
         WK.Keys.Genesis.address.repeat.take(8)).sign()).array;
 
     // height 1, many Outputs
-    txs.each!(tx => node_1.putTransaction(tx));
+    txs.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     auto split_up = txs
@@ -52,31 +52,31 @@ unittest
     const uint UnlockAge_3 = 3;
     auto age_3_txs = split_up[3].map!(txb => txb.sign(OutputType.Payment, UnlockAge_3)).array();
 
-    age_3_txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));  // rejected, wrong age
-    txs_0.each!(tx => nodes.each!(node => node.putTransaction(tx)));      // accepted
+    age_3_txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));  // rejected, wrong age
+    txs_0.each!(tx => nodes.each!(node => node.postTransaction(tx)));      // accepted
     network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
     auto blocks = node_1.getBlocksFrom(2, 1);
     assert(blocks.length == 1);
     sort(txs_0);
     assert(blocks[0].txs == txs_0);
 
-    age_3_txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));  // rejected again
-    txs_1.each!(tx => nodes.each!(node => node.putTransaction(tx)));      // accepted
+    age_3_txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));  // rejected again
+    txs_1.each!(tx => nodes.each!(node => node.postTransaction(tx)));      // accepted
     network.expectHeightAndPreImg(Height(3), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(3, 1);
     assert(blocks.length == 1);
     sort(txs_1);
     assert(blocks[0].txs == txs_1);
 
-    age_3_txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));  // rejected again
-    txs_2.each!(tx => nodes.each!(node => node.putTransaction(tx)));      // accepted
+    age_3_txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));  // rejected again
+    txs_2.each!(tx => nodes.each!(node => node.postTransaction(tx)));      // accepted
     network.expectHeightAndPreImg(Height(4), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(4, 1);
     assert(blocks.length == 1);
     sort(txs_2);
     assert(blocks[0].txs == txs_2);
 
-    age_3_txs.each!(tx => nodes.each!(node => node.putTransaction(tx)));  // finally accepted
+    age_3_txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));  // finally accepted
     network.expectHeightAndPreImg(Height(5), network.blocks[0].header);
     blocks = node_1.getBlocksFrom(5, 1);
     assert(blocks.length == 1);

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -62,7 +62,7 @@ version(none) unittest
     TxBuilder txb = TxBuilder(WK.Keys.AAA.address); // Refund
     utxos.each!(pair => txb.attach(pair.utxo.output, pair.hash));
     auto to_send = txb.draw(Amount.MinFreezeAmount, keys).sign(OutputType.Freeze);
-    set_a.each!(n => n.putTransaction(to_send));
+    set_a.each!(n => n.postTransaction(to_send));
 
     // wait for other nodes to get to same block height
     network.assertSameBlocks(Height(GenesisValidatorCycle - 1));
@@ -130,7 +130,7 @@ unittest
 
     // Create a block from the Genesis block
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
-    txs.each!(tx => node_1.putTransaction(tx));
+    txs.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     // node_1 restarts and becomes unresponsive
@@ -139,12 +139,12 @@ unittest
 
     // Make 2 blocks
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
-    txs.each!(tx => node_2.putTransaction(tx));
+    txs.each!(tx => node_2.postTransaction(tx));
     network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(2), network.blocks[0].header);
     network.expectHeight(iota(1, nodes.length), Height(2));
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
-    txs.each!(tx => node_2.putTransaction(tx));
+    txs.each!(tx => node_2.postTransaction(tx));
     network.expectHeightAndPreImg(iota(1,nodes.length), Height(3), network.blocks[0].header);
 
     // Wait for node_1 to wake up
@@ -163,7 +163,7 @@ unittest
 
     // A new block is in the middle of a consensus.
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
-    txs.each!(tx => node_1.putTransaction(tx));
+    txs.each!(tx => node_1.postTransaction(tx));
 
     // The new block has been inserted to the ledger with the approval
     // of the node_1, although node_2 was shutdown.

--- a/source/agora/test/ValidatorCount.d
+++ b/source/agora/test/ValidatorCount.d
@@ -55,7 +55,7 @@ unittest
         txs = blocks[block_idx - 1].spendable().map!(txb => txb.sign()).array();
 
         // send it to one node
-        txs.each!(tx => node_1.putTransaction(tx));
+        txs.each!(tx => node_1.postTransaction(tx));
         network.expectHeightAndPreImg(Height(block_idx), blocks[0].header);
 
         // add next block
@@ -66,7 +66,7 @@ unittest
     {
         blocks[GenesisValidatorCycle - 1].spendable()
             .map!(txb => txb.sign())
-            .each!(tx => node_1.putTransaction(tx));
+            .each!(tx => node_1.postTransaction(tx));
 
         // try to add next block
          blocks ~= node_1.getBlocksFrom(GenesisValidatorCycle, 1);

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -53,7 +53,7 @@ unittest
         txs = blocks[new_height - 1].spendable().map!(txb => txb.sign()).array();
 
         // send it to one node
-        txs.each!(tx => node_0.putTransaction(tx));
+        txs.each!(tx => node_0.postTransaction(tx));
 
         network.expectHeightAndPreImg(new_height, blocks[0].header);
 
@@ -138,7 +138,7 @@ unittest
             .array();
 
         // send it to one node
-        txs.each!(tx => node_0.putTransaction(tx));
+        txs.each!(tx => node_0.postTransaction(tx));
 
         network.expectHeightAndPreImg(new_height, blocks[0].header);
 

--- a/source/agora/test/VariableBlockSize.d
+++ b/source/agora/test/VariableBlockSize.d
@@ -42,7 +42,7 @@ unittest
     only(1, 3, 4).each!((i) {
         txs.takeExactly(i).each!(tx =>
             network.clients.each!(node =>
-                node.putTransaction(tx)));
+                node.postTransaction(tx)));
         txs = txs.drop(i);
         height++;
         network.expectHeightAndPreImg(height, GenesisBlock.header, 5.seconds);


### PR DESCRIPTION
This is the first half of #2363 which also mentions that the names used for getting txs and enrollments aren't great, since a user might expect to get an externalized tx rather than one in the pool.
The main part is a major rename for consistency. See the commit message for a detailed explanation about the whys and whats.