### PR TITLE
ValidatorSet: Remove getEnrollmentForKey

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -869,7 +869,7 @@ public class Ledger
                 return "Block: Couldn't find commitment for this validator";
             }
             const preimage_info = this.enroll_man.validator_set.getPreimageAt(
-                this.enroll_man.validator_set.getEnrollmentForKey(block.header.height, K), block.header.height);
+                validator.utxo(), block.header.height);
             if (preimage_info.hash == Hash.init)
             {
                 log.error("Block#{}: Validator {} (idx: {}) Couldn't find pre-image for validator",

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -382,36 +382,6 @@ public class ValidatorSet
 
     /***************************************************************************
 
-        Get the utxo_key used for enrollment for the given public key
-
-        Params:
-            height = block height to fetch utxo_key
-            public_key = public key of the validator
-
-        Returns:
-            Return UTXO key as Hash
-
-    ***************************************************************************/
-
-    public Hash getEnrollmentForKey (in Height height, in PublicKey public_key) @trusted nothrow
-    {
-        try
-        {
-            auto results = this.db.execute("SELECT key FROM validator " ~
-                "WHERE public_key = ? AND enrolled_height >= ? AND enrolled_height < ? ",
-                public_key, this.minEnrollmentHeight(height), height);
-            if (!results.empty && results.oneValue!(byte[]).length != 0)
-                return Hash(results.front.peek!(char[])(0));
-        }
-        catch (Exception ex)
-        {
-            log.error("ManagedDatabase operation error: {}", ex.msg);
-        }
-        return Hash.init;
-    }
-
-    /***************************************************************************
-
         Gets the number of active validators at a given block height.
 
         This function finds validators that should be active at a given height,


### PR DESCRIPTION
There was a single usage of this function remaining,
but it was better done by using the already fetched
ValidatorInfo.