### PR TITLE
Registry: Add a configuration file

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -86,7 +86,7 @@
                 "source/agora/cli/multi/*",
                 "source/agora/cli/vanity/*",
                 "source/agora/cli/version/*",
-                "source/agora/registry/main.d",
+                "source/agora/registry/*.d",
                 "source/agora/test/*",
                 "source/agora/utils/gc/*"
             ]

--- a/source/agora/cli/configdump.d
+++ b/source/agora/cli/configdump.d
@@ -16,7 +16,6 @@
 module agora.cli.configdump;
 
 import agora.common.Config;
-import agora.node.Config;
 
 import std.getopt;
 import std.stdio;
@@ -61,6 +60,13 @@ public int main (string[] args)
     switch (cmdln.type)
     {
     case "agora":
+        import agora.node.Config;
+        auto config = parseConfigFile!(Config)(cmdln);
+        writeln("Configuration for ", cmdln.type, " successfully parsed:");
+        writeln(config);
+        return 0;
+    case "registry":
+        import agora.registry.Config;
         auto config = parseConfigFile!(Config)(cmdln);
         writeln("Configuration for ", cmdln.type, " successfully parsed:");
         writeln(config);

--- a/source/agora/cli/configdump.d
+++ b/source/agora/cli/configdump.d
@@ -22,42 +22,51 @@ import std.getopt;
 import std.stdio;
 
 ///
+private struct AppCLIArgs
+{
+    ///
+    public CLIArgs base;
+
+    ///
+    public alias base this;
+
+    /// Type of configuration to parse
+    public string type = "agora";
+
+    /// Parse the command-line arguments and return a GetoptResult
+    public GetoptResult parse (ref string[] args)
+    {
+        auto r = this.base.parse(args);
+        if (r.helpWanted) return r;
+        return getopt(
+            args,
+            "type|t",
+               "Type of config to parse (agora, registry). Default to: " ~ this.type,
+                &this.type,
+        );
+    }
+}
+
+///
 public int main (string[] args)
 {
-    CommandLine cmdln;
-    string type;
-    auto help = parseCommandLine(cmdln, type, args);
+    AppCLIArgs cmdln;
+    auto help = cmdln.parse(args);
     if (help.helpWanted)
     {
         defaultGetoptPrinter("Config dumper", help.options);
         return 0;
     }
 
-    switch (type)
+    switch (cmdln.type)
     {
     case "agora":
         auto config = parseConfigFile!(Config)(cmdln);
-        writeln("Configuration for ", type, " successfully parsed:");
+        writeln("Configuration for ", cmdln.type, " successfully parsed:");
         writeln(config);
         return 0;
     default:
-        stderr.writeln("No such type: ", type);
+        stderr.writeln("No such type: ", cmdln.type);
         return 1;
     }
-}
-
-/// Parse the command-line arguments and return a GetoptResult
-private GetoptResult parseCommandLine (
-    ref CommandLine cmdline, ref string type, string[] args)
-{
-    return getopt(
-        args,
-        "config|c",
-            "Path to the config file. Defaults to: " ~ CommandLine.init.config_path,
-            &cmdline.config_path,
-
-        "type|t",
-            "Type of config to parse (agora, registry). Default to 'agora'",
-            &type,
-        );
 }

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -39,6 +39,28 @@ import core.time;
 /// Path to the import file containing the version information
 public immutable VersionFileName = "VERSION";
 
+/// Agora-specific command line arguments
+public struct AgoraCLIArgs
+{
+    /// Base command line arguments
+    public CLIArgs base;
+
+    ///
+    public alias base this;
+
+    /// If non-`null`, what address to bind the setup interface to
+    public string initialize;
+
+    /// check state of config file and exit early
+    public bool config_check;
+
+    /// Do not output anything
+    public bool quiet;
+
+    /// Print the version information
+    public bool version_;
+}
+
 /// Main config
 public struct Config
 {
@@ -309,31 +331,25 @@ public struct EventHandlerConfig
 }
 
 /// Parse the command-line arguments and return a GetoptResult
-public GetoptResult parseCommandLine (ref CommandLine cmdline, string[] args)
+public GetoptResult parseCommandLine (ref AgoraCLIArgs cmdline, string[] args)
 {
+    auto intermediate = cmdline.base.parse(args);
+    if (intermediate.helpWanted)
+        return intermediate;
+
     return getopt(
         args,
         "initialize",
             "The address at which to offer a web-based configuration interface",
             &cmdline.initialize,
 
-        "config|c",
-            "Path to the config file. Defaults to: " ~ CommandLine.init.config_path,
-            &cmdline.config_path,
-
         "config-check",
             "Check the state of the config and exit",
             &cmdline.config_check,
 
         "quiet|q",
-           "Do not output anything (currently only affects `--config-check`)",
+            "Do not output anything (currently only affects `--config-check`)",
             &cmdline.quiet,
-
-        "override|O",
-            "Override a config file value\n" ~
-            "Example: ./agora -O node.validator=true -o dns=1.1.1.1 -o dns=2.2.2.2\n" ~
-            "Array values are additive, other items are set to the last override",
-            &cmdline.overridesHandler,
 
         "version",
             "Print Agora's version and build informations, then exit",

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -188,49 +188,6 @@ public Listeners runNode (Config config)
 
 /*******************************************************************************
 
-    Set Vibe.d log level according to the configuration's log level
-
-    This is used to ensure we get the right amount of information from Vibe.d
-    Since a log level is the "minimum accepted" level, some level values might
-    not match. For example, if we want Vibe.d's "diagnostic" to be part of
-    the output when we set the loglevel to info, then that's what we must pass
-    to Vibe's `setLogLevel` (and since diagnostic < info, it will include the
-    latter too).
-
-    Params:
-        level = The level at which we want to set the logger
-
-*******************************************************************************/
-
-private void setVibeLogLevel (ILogger.Level level) @safe
-{
-    import vibe.core.log;
-
-    final switch (level)
-    {
-    case ILogger.Level.Trace:
-        setLogLevel(LogLevel.trace);
-        break;
-    case ILogger.Level.Info:
-        setLogLevel(LogLevel.diagnostic);
-        break;
-    case ILogger.Level.Warn:
-        setLogLevel(LogLevel.warn);
-        break;
-    case ILogger.Level.Error:
-        setLogLevel(LogLevel.error);
-        break;
-    case ILogger.Level.Fatal:
-        setLogLevel(LogLevel.critical);
-        break;
-    case ILogger.Level.None:
-        setLogLevel(LogLevel.none);
-        break;
-    }
-}
-
-/*******************************************************************************
-
     Search multiple paths for SSL certificate and create the TLS context
 
     Returns:

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -51,7 +51,7 @@ static this ()
 /// Application entry point
 private int main (string[] args)
 {
-    CommandLine cmdln;
+    AgoraCLIArgs cmdln;
 
     stAssertError = new AssertError("You should not see this");
     assertHandler = &handleAssertion;

--- a/source/agora/registry/Config.d
+++ b/source/agora/registry/Config.d
@@ -15,46 +15,78 @@
 
 module agora.registry.Config;
 
+import agora.common.Config;
+import agora.utils.Log;
+
 import std.conv;
 import std.getopt;
 
 ///
-public struct CLIArgs
+public struct RegistryCLIArgs
 {
-    /// Network interface to bind to
-    public string bind_address = "0.0.0.0";
+    /// Base command line arguments
+    public CLIArgs base;
 
-    /// TCP port to bind to
-    public ushort bind_port = 3003;
-
-    /// Port on which to offer the stats interface - disabled by default
-    public ushort stats_port = 0;
-
-    /// Be extra verbose (enable `Trace` level and Vibe.d debug)
-    public bool verbose = false;
-
-    /// Disable the DNS server
-    public bool nodns = false;
+    ///
+    public alias base this;
 }
 
 /// Parse the command-line arguments and return a GetoptResult
-public GetoptResult parseCommandLine (ref CLIArgs args, string[] strargs)
+public GetoptResult parseCommandLine (ref RegistryCLIArgs args, string[] strargs)
 {
-    return getopt(
-        strargs,
-        "bind-host|h",
-            "Address to bind the HTTP server to, defaults to: " ~ CLIArgs.init.bind_address,
-            &args.bind_address,
-        "bind-port|p",
-            "Port to bind the HTTP server to, defaults to: " ~ CLIArgs.init.bind_port.to!string,
-            &args.bind_port,
-        "stats-port",
-            "Port to bind the stats server to (0 to disable), defaults to: " ~ CLIArgs.init.stats_port.to!string,
-            &args.stats_port,
-        "no-dns",
-            "Disable the registry's DNS server",
-            &args.nodns,
-        "verbose",
-            &args.verbose,
-        );
+    return args.base.parse(strargs, false);
+}
+
+/// Configuration for the name registry
+public struct Config
+{
+    /// DNS server configuration
+    public DNSConfig dns;
+
+    /// HTTP server configuration
+    public HTTPConfig http;
+
+    /// Logging configuration
+    @Key("name")
+    public LoggerConfig[] logging = [ {
+        name: null,
+        level: LogLevel.Info,
+        propagate: true,
+        console: true,
+        additive: true,
+    } ];
+}
+
+///
+public struct DNSConfig
+{
+    /// Whether the DNS server is enabled at all
+    public bool enabled = true;
+
+    /***************************************************************************
+
+        The address to bind to - All interfaces by default
+
+        You might want to set this to your public IP address so it doesn't bind
+        to the local interface, which might be already used by systemd-resolvd.
+
+    ***************************************************************************/
+
+    public string address = "0.0.0.0";
+
+    /// The port to bind to - Default to the standard DNS port (53)
+    public ushort port = 53;
+}
+
+///
+public struct HTTPConfig
+{
+    /// Network interface to bind to
+    public string address = "0.0.0.0";
+
+    /// TCP port to bind to
+    public ushort port = 3003;
+
+    /// Port on which to offer the stats interface - disabled by default
+    public ushort stats_port = 0;
 }

--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -513,3 +513,46 @@ private extern(C++, "agora") int getLogLevel (const(char)* logger)
     assert(log !is null);
     return log.level();
 }
+
+/*******************************************************************************
+
+    Set Vibe.d log level according to the configuration's log level
+
+    This is used to ensure we get the right amount of information from Vibe.d
+    Since a log level is the "minimum accepted" level, some level values might
+    not match. For example, if we want Vibe.d's "diagnostic" to be part of
+    the output when we set the loglevel to info, then that's what we must pass
+    to Vibe's `setLogLevel` (and since diagnostic < info, it will include the
+    latter too).
+
+    Params:
+        level = The level at which we want to set the logger
+
+*******************************************************************************/
+
+public void setVibeLogLevel (Ocean.Level level) @safe
+{
+    import vibe.core.log : LogLevel, setLogLevel;
+
+    final switch (level)
+    {
+    case Ocean.Level.Trace:
+        setLogLevel(LogLevel.trace);
+        break;
+    case Ocean.Level.Info:
+        setLogLevel(LogLevel.diagnostic);
+        break;
+    case Ocean.Level.Warn:
+        setLogLevel(LogLevel.warn);
+        break;
+    case Ocean.Level.Error:
+        setLogLevel(LogLevel.error);
+        break;
+    case Ocean.Level.Fatal:
+        setLogLevel(LogLevel.critical);
+        break;
+    case Ocean.Level.None:
+        setLogLevel(LogLevel.none);
+        break;
+    }
+}


### PR DESCRIPTION
And voilà what it was all for: We can trivially add a configuration file to the registry.
The next step will improve the DNS server itself to dynamically define when it is authoritative (and which zones it should follow).