### PR TITLE
DNS: Listen to TCP port, make authoritative zones configurable, other minor fixes

### DIFF
--- a/source/agora/common/DNS.d
+++ b/source/agora/common/DNS.d
@@ -168,7 +168,7 @@ public struct Message
 
     ***************************************************************************/
 
-    public ref Message fill (in Header query) return
+    public ref Message fill (in Header query) return @safe pure nothrow @nogc
     {
         this.header.ID = query.ID;
         this.header.QR = true;

--- a/source/agora/registry/Config.d
+++ b/source/agora/registry/Config.d
@@ -18,7 +18,10 @@ module agora.registry.Config;
 import agora.common.Config;
 import agora.utils.Log;
 
+import std.algorithm.iteration : splitter;
 import std.conv;
+import std.exception;
+import std.format;
 import std.getopt;
 
 ///
@@ -55,6 +58,48 @@ public struct Config
         console: true,
         additive: true,
     } ];
+
+    /// Validate the semantic of the user-provided configuration
+    public void validate () const
+    {
+        if (this.dns.enabled)
+        {
+            enforce(this.dns.address.length, "DNS is enabled but no `address` is provided");
+            enforce(this.dns.port > 0, "dns.port: 0 is not a valid value");
+            enforce(this.dns.authoritative.length, "No authoritative zones provided");
+
+            foreach (idx, domain; this.dns.authoritative)
+            {
+                auto rng = domain.splitter('.');
+                enforce(!rng.empty, format!"dns.authoritative: Empty array entry at index %d"(idx));
+                enforce(rng.front.length > 0,
+                       format!"dns.authoritative: Value '%s' at index '%s' starts with a dot ('.'), which is not allowed. Remove it."
+                       (domain, idx)
+                    );
+
+                do {
+                    // It might be the empty label, in which case it needs to be last
+                    if (rng.front.length == 0)
+                    {
+                        rng.popFront();
+                        enforce(rng.empty,
+                                format!"dns.authoritative: Value '%s' at index '%s' contains an empty label, which is not allowed. Remove the double dot."
+                                (domain, idx));
+                        break;
+                    }
+                    enforce(rng.front.length <= 63,
+                            format!("dns.authoritative: Value '%s' at index '%s' contains a label ('%s') " ~
+                                    "which is longer than 63 characters (%s characters), which is not allowed.")
+                            (domain, idx, rng.front, rng.front.length)
+                        );
+                    rng.popFront();
+                } while (!rng.empty);
+            }
+        }
+
+        enforce(this.http.address.length, "Missing http.address field");
+        enforce(this.http.port > 0, "http.port: 0 is not a valid value");
+    }
 }
 
 ///
@@ -76,6 +121,9 @@ public struct DNSConfig
 
     /// The port to bind to - Default to the standard DNS port (53)
     public ushort port = 53;
+
+    /// Which zones this server is authoritative for
+    public string[] authoritative;
 }
 
 ///

--- a/source/agora/registry/Config.d
+++ b/source/agora/registry/Config.d
@@ -88,5 +88,5 @@ public struct HTTPConfig
     public ushort port = 3003;
 
     /// Port on which to offer the stats interface - disabled by default
-    public ushort stats_port = 0;
+    public @Optional ushort stats_port = 0;
 }

--- a/source/agora/registry/Server.d
+++ b/source/agora/registry/Server.d
@@ -47,6 +47,9 @@ public final class NameRegistry: NameRegistryAPI
         Utils.getCollectorRegistry().addCollector(&this.collectRegistryStats);
     }
 
+    ///
+    mixin DefineCollectorForStats!("registry_stats", "collectRegistryStats");
+
     /***************************************************************************
 
         Get network addresses corresponding to a public key
@@ -196,8 +199,6 @@ public final class NameRegistry: NameRegistryAPI
         return Header.RCode.NoError;
     }
 
-    ///
-    mixin DefineCollectorForStats!("registry_stats", "collectRegistryStats");
 }
 
 /// Simplistic parsing function for domain name

--- a/source/agora/registry/Server.d
+++ b/source/agora/registry/Server.d
@@ -126,7 +126,7 @@ public final class NameRegistry: NameRegistryAPI
 
     ***************************************************************************/
 
-    public Message answerQuestions (in Message query)
+    public Message answerQuestions (in Message query) @safe
     {
         Message reply;
         reply.header.RA = false; // TODO: Implement
@@ -173,7 +173,7 @@ public final class NameRegistry: NameRegistryAPI
     ***************************************************************************/
 
     private Header.RCode getValidatorDNSRecord (
-        in Question question, ref ResourceRecord answer)
+        const ref Question question, ref ResourceRecord answer) @safe
     {
         const public_key = parsePublicKeyFromDomain(question.qname);
         if (public_key is PublicKey.init)

--- a/source/agora/registry/Server.d
+++ b/source/agora/registry/Server.d
@@ -52,6 +52,9 @@ public final class NameRegistry: NameRegistryAPI
     {
         this.config = config;
         this.log = Logger(__MODULE__);
+        if (this.config.dns.enabled)
+            this.log.info("Starting authoritative DNS server for zones: {}",
+                          this.config.dns.authoritative);
         Utils.getCollectorRegistry().addCollector(&this.collectRegistryStats);
     }
 

--- a/source/agora/registry/main.d
+++ b/source/agora/registry/main.d
@@ -79,7 +79,7 @@ private int main (string[] strargs)
     scope (exit) if (stats_server !is null) stats_server.shutdown();
 
     auto router = new URLRouter();
-    auto registry = new NameRegistry();
+    auto registry = new NameRegistry(config);
     router.registerRestInterface(registry);
 
     auto settings = new HTTPServerSettings;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -858,7 +858,9 @@ public class TestAPIManager
 
     public void createNameRegistry ()
     {
-        auto registry = RemoteAPI!NameRegistryAPI.spawn!NameRegistry();
+        static import agora.registry.Config;
+        auto registry = RemoteAPI!NameRegistryAPI.spawn!NameRegistry(
+            agora.registry.Config.Config.init);
         this.nreg.register("name.registry", registry.ctrl.listener());
     }
 


### PR DESCRIPTION
In order to make the registry usable independently for flash, testnet and coinnet, we need to be able to configure it.
This allows this, and brings the domain parsing code closer to the RFC's requirements.
Next step is to add SOA record so recursion can work.