### PR TITLE
LockHeight test: Wait for tx propagation

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1211,6 +1211,12 @@ public class TestAPIManager
     {
         retryFor(indices.each!(idx => this.clients[idx].hasTransactionHash(hash)), 3.seconds);
     }
+
+    /// Ditto
+    public void ensureTxInPool (in Hash hash)
+    {
+        this.ensureTxInPool(hash, iota(this.clients.length));
+    }
 }
 
 /*******************************************************************************

--- a/source/agora/test/LockHeight.d
+++ b/source/agora/test/LockHeight.d
@@ -17,6 +17,7 @@ version (unittest):
 
 import agora.api.Validator;
 import agora.consensus.data.Transaction;
+import agora.crypto.Hash;
 import agora.test.Base;
 
 /// Ditto
@@ -35,6 +36,7 @@ unittest
     // height 1
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
     txs.each!(tx => node_1.postTransaction(tx));
+    txs.each!(tx => network.ensureTxInPool(tx.hashFull()));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
     const Height UnlockHeight_2 = Height(2);
@@ -53,6 +55,7 @@ unittest
 
     // should be accepted
     unlock_2_txs.each!(tx => node_1.postTransaction(tx));
+    unlock_2_txs.each!(tx => network.ensureTxInPool(tx.hashFull()));
 
     network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
 


### PR DESCRIPTION
I have a suspicion that this is the problem, although it's hard to test.

Last time this triggered, this was the error message:
```
Unittesting agora.test.ManyBlocks (took 1 minute, 25 secs, 978 ms, 797 μs, and 3 hnsecs)
Unittesting agora.test.LockHeight================================ ASSERT HANDLER ===============================
[source/agora/test/LockHeight.d:63] Assertion thrown during test: [Transaction([Input(0x3c4e7fbcee9573ce228c9b20bada06febf999d64354aeae1cc6bdb1e1bc1cf1663ae2072a883fada60e00b503f3f5dcd9c2181df11743aaae3a09a568fc36230, Unlock([240, 141, 244, 209, 69, 84, 67, 16, 232, 129, 46, 244, 135, 7, 142, 229, 52, 24, 210, 17, 18, 173, 67, 174, 147, 241, 106, 143, 121, 87, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2), Transaction([Input(0x0a632b8f075691e5ffe4b120098d2da31d3d9ee65bdfd3d48f60ce447ffaf836e1b77933cb57316111520acb0d20badfb278fc9e7bc9a0d6fba8aeeb985ea96f, Unlock([0, 61, 164, 50, 92, 70, 165, 250, 105, 153, 179, 224, 224, 227, 194, 131, 21, 163, 226, 48, 52, 203, 235, 238, 160, 117, 75, 226, 110, 224, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2), Transaction([Input(0xe8ec29261356757f751adc684db09377526a6b73bfd8b984efe4b022b028fe19b48bc2eddcb2cab9ea8418722b18088488bacf8e2263d3be35b1db8b259fd071, Unlock([242, 219, 158, 212, 44, 150, 206, 72, 151, 52, 135, 21, 118, 153, 67, 100, 178, 178, 205, 14, 158, 191, 92, 53, 216, 84, 54, 103, 111, 127, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2), Transaction([Input(0x451290c72f40ac0a86a525117bf48fc3840867dfde9a7d3f8e1a314b742027a999f8300a7c251ed8f1d47ec7401a553381878acbf59be3106251624e76b42e5a, Unlock([117, 149, 105, 74, 224, 27, 227, 40, 13, 111, 237, 246, 38, 111, 211, 170, 142, 171, 137, 83, 232, 132, 203, 248, 43, 171, 110, 171, 197, 110, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2), Transaction([Input(0x9251d8f50b6e8b06e4e5fadf7dec581f4f5506c37c8740b5cefe60d10eb618ad59e4561cc4047a157cf55741836e55ee6477bb3b05316573edafc61eafdfe1f4, Unlock([54, 23, 145, 19, 97, 38, 193, 169, 15, 230, 199, 28, 45, 160, 138, 89, 52, 77, 234, 234, 22, 232, 129, 21, 132, 182, 19, 189, 91, 199, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2)] != [Transaction([Input(0x3c4e7fbcee9573ce228c9b20bada06febf999d64354aeae1cc6bdb1e1bc1cf1663ae2072a883fada60e00b503f3f5dcd9c2181df11743aaae3a09a568fc36230, Unlock([240, 141, 244, 209, 69, 84, 67, 16, 232, 129, 46, 244, 135, 7, 142, 229, 52, 24, 210, 17, 18, 173, 67, 174, 147, 241, 106, 143, 121, 87, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2), Transaction([Input(0x0a632b8f075691e5ffe4b120098d2da31d3d9ee65bdfd3d48f60ce447ffaf836e1b77933cb57316111520acb0d20badfb278fc9e7bc9a0d6fba8aeeb985ea96f, Unlock([0, 61, 164, 50, 92, 70, 165, 250, 105, 153, 179, 224, 224, 227, 194, 131, 21, 163, 226, 48, 52, 203, 235, 238, 160, 117, 75, 226, 110, 224, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2), Transaction([Input(0x4d34671110d6fe93683c7f619c0095908fa343d2e8ca09406180476d7e2f1fa227ac298906fbf28617c317065796ca4a87117a2453e201e9610928478bde8d98, Unlock([71, 7, 218, 28, 155, 145, 207, 187, 176, 53, 68, 77, 150, 142, 208, 192, 96, 8, 29, 204, 11, 19, 126, 160, 89, 205, 107, 253, 78, 143, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2), Transaction([Input(0xb9c77af3014dddd1a4ccf776daf5ef445ee1005231db73025f558aa155d6e18a87ac88dd8f549be7f2f31cba33e1767f075a8a6309728257261f20ad81ad1605, Unlock([193, 120, 21, 151, 192, 254, 13, 135, 8, 4, 122, 188, 64, 113, 43, 89, 52, 3, 47, 224, 24, 56, 131, 164, 102, 65, 122, 204, 254, 244, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2), Transaction([Input(0xe8ec29261356757f751adc684db09377526a6b73bfd8b984efe4b022b028fe19b48bc2eddcb2cab9ea8418722b18088488bacf8e2263d3be35b1db8b259fd071, Unlock([242, 219, 158, 212, 44, 150, 206, 72, 151, 52, 135, 21, 118, 153, 67, 100, 178, 178, 205, 14, 158, 191, 92, 53, 216, 84, 54, 103, 111, 127, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2), Transaction([Input(0x451290c72f40ac0a86a525117bf48fc3840867dfde9a7d3f8e1a314b742027a999f8300a7c251ed8f1d47ec7401a553381878acbf59be3106251624e76b42e5a, Unlock([117, 149, 105, 74, 224, 27, 227, 40, 13, 111, 237, 246, 38, 111, 211, 170, 142, 171, 137, 83, 232, 132, 203, 248, 43, 171, 110, 171, 197, 110, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2), Transaction([Input(0xc252952b3705405685f3b083dd823bbba23d3c2fc97b6d34f573f76eeae444468b1713193edfb7edd16ff7694ab15b9cbc6474d9768db9407cae9d0eb802dad1, Unlock([21, 175, 143, 206, 217, 97, 147, 82, 116, 232, 134, 184, 174, 97, 96, 131, 125, 169, 131, 129, 0, 34, 20, 139, 197, 231, 98, 194, 143, 254, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2), Transaction([Input(0x9251d8f50b6e8b06e4e5fadf7dec581f4f5506c37c8740b5cefe60d10eb618ad59e4561cc4047a157cf55741836e55ee6477bb3b05316573edafc61eafdfe1f4, Unlock([54, 23, 145, 19, 97, 38, 193, 169, 15, 230, 199, 28, 45, 160, 138, 89, 52, 77, 234, 234, 22, 232, 129, 21, 132, 182, 19, 189, 91, 199, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2)]
/home/runner/work/agora/agora/source/agora/test/LockHeight.d:63 void agora.test.LockHeight.__unittest_L23_C1() [0x5646940d6ad5]
/home/runner/work/agora/agora/source/agora/test/Base.d:274 bool agora.test.Base.customModuleUnitTester().runTest(agora.test.Base.customModuleUnitTester().ModTest) [0x5646942599f2]
/home/runner/work/agora/agora/source/agora/test/Base.d:301 core.runtime.UnitTestResult agora.test.Base.customModuleUnitTester() [0x564694041e86]
runtime.d:607 runModuleUnitTests [0x564694e48cf0]
```

In a more readable form:
```
[
Transaction([Input(0x3c4e7fbcee9573ce228c9b20bada06febf999d64354aeae1cc6bdb1e1bc1cf1663ae2072a883fada60e00b503f3f5dcd9c2181df11743aaae3a09a568fc36230, Unlock([240, 141, 244, 209, 69, 84, 67, 16, 232, 129, 46, 244, 135, 7, 142, 229, 52, 24, 210, 17, 18, 173, 67, 174, 147, 241, 106, 143, 121, 87, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2),
Transaction([Input(0x0a632b8f075691e5ffe4b120098d2da31d3d9ee65bdfd3d48f60ce447ffaf836e1b77933cb57316111520acb0d20badfb278fc9e7bc9a0d6fba8aeeb985ea96f, Unlock([0, 61, 164, 50, 92, 70, 165, 250, 105, 153, 179, 224, 224, 227, 194, 131, 21, 163, 226, 48, 52, 203, 235, 238, 160, 117, 75, 226, 110, 224, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2),
Transaction([Input(0xe8ec29261356757f751adc684db09377526a6b73bfd8b984efe4b022b028fe19b48bc2eddcb2cab9ea8418722b18088488bacf8e2263d3be35b1db8b259fd071, Unlock([242, 219, 158, 212, 44, 150, 206, 72, 151, 52, 135, 21, 118, 153, 67, 100, 178, 178, 205, 14, 158, 191, 92, 53, 216, 84, 54, 103, 111, 127, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2),
Transaction([Input(0x451290c72f40ac0a86a525117bf48fc3840867dfde9a7d3f8e1a314b742027a999f8300a7c251ed8f1d47ec7401a553381878acbf59be3106251624e76b42e5a, Unlock([117, 149, 105, 74, 224, 27, 227, 40, 13, 111, 237, 246, 38, 111, 211, 170, 142, 171, 137, 83, 232, 132, 203, 248, 43, 171, 110, 171, 197, 110, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2),
Transaction([Input(0x9251d8f50b6e8b06e4e5fadf7dec581f4f5506c37c8740b5cefe60d10eb618ad59e4561cc4047a157cf55741836e55ee6477bb3b05316573edafc61eafdfe1f4, Unlock([54, 23, 145, 19, 97, 38, 193, 169, 15, 230, 199, 28, 45, 160, 138, 89, 52, 77, 234, 234, 22, 232, 129, 21, 132, 182, 19, 189, 91, 199, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2)]

!=

[Transaction([Input(0x3c4e7fbcee9573ce228c9b20bada06febf999d64354aeae1cc6bdb1e1bc1cf1663ae2072a883fada60e00b503f3f5dcd9c2181df11743aaae3a09a568fc36230, Unlock([240, 141, 244, 209, 69, 84, 67, 16, 232, 129, 46, 244, 135, 7, 142, 229, 52, 24, 210, 17, 18, 173, 67, 174, 147, 241, 106, 143, 121, 87, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2),
Transaction([Input(0x0a632b8f075691e5ffe4b120098d2da31d3d9ee65bdfd3d48f60ce447ffaf836e1b77933cb57316111520acb0d20badfb278fc9e7bc9a0d6fba8aeeb985ea96f, Unlock([0, 61, 164, 50, 92, 70, 165, 250, 105, 153, 179, 224, 224, 227, 194, 131, 21, 163, 226, 48, 52, 203, 235, 238, 160, 117, 75, 226, 110, 224, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2),
Transaction([Input(0x4d34671110d6fe93683c7f619c0095908fa343d2e8ca09406180476d7e2f1fa227ac298906fbf28617c317065796ca4a87117a2453e201e9610928478bde8d98, Unlock([71, 7, 218, 28, 155, 145, 207, 187, 176, 53, 68, 77, 150, 142, 208, 192, 96, 8, 29, 204, 11, 19, 126, 160, 89, 205, 107, 253, 78, 143, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2),
Transaction([Input(0xb9c77af3014dddd1a4ccf776daf5ef445ee1005231db73025f558aa155d6e18a87ac88dd8f549be7f2f31cba33e1767f075a8a6309728257261f20ad81ad1605, Unlock([193, 120, 21, 151, 192, 254, 13, 135, 8, 4, 122, 188, 64, 113, 43, 89, 52, 3, 47, 224, 24, 56, 131, 164, 102, 65, 122, 204, 254, 244, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2),
Transaction([Input(0xe8ec29261356757f751adc684db09377526a6b73bfd8b984efe4b022b028fe19b48bc2eddcb2cab9ea8418722b18088488bacf8e2263d3be35b1db8b259fd071, Unlock([242, 219, 158, 212, 44, 150, 206, 72, 151, 52, 135, 21, 118, 153, 67, 100, 178, 178, 205, 14, 158, 191, 92, 53, 216, 84, 54, 103, 111, 127, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2),
Transaction([Input(0x451290c72f40ac0a86a525117bf48fc3840867dfde9a7d3f8e1a314b742027a999f8300a7c251ed8f1d47ec7401a553381878acbf59be3106251624e76b42e5a, Unlock([117, 149, 105, 74, 224, 27, 227, 40, 13, 111, 237, 246, 38, 111, 211, 170, 142, 171, 137, 83, 232, 132, 203, 248, 43, 171, 110, 171, 197, 110, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2),
Transaction([Input(0xc252952b3705405685f3b083dd823bbba23d3c2fc97b6d34f573f76eeae444468b1713193edfb7edd16ff7694ab15b9cbc6474d9768db9407cae9d0eb802dad1, Unlock([21, 175, 143, 206, 217, 97, 147, 82, 116, 232, 134, 184, 174, 97, 96, 131, 125, 169, 131, 129, 0, 34, 20, 139, 197, 231, 98, 194, 143, 254, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2),
Transaction([Input(0x9251d8f50b6e8b06e4e5fadf7dec581f4f5506c37c8740b5cefe60d10eb618ad59e4561cc4047a157cf55741836e55ee6477bb3b05316573edafc61eafdfe1f4, Unlock([54, 23, 145, 19, 97, 38, 193, 169, 15, 230, 199, 28, 45, 160, 138, 89, 52, 77, 234, 234, 22, 232, 129, 21, 132, 182, 19, 189, 91, 199, ...]), 0)], [Output(Payment, Lock(Key, [145, 153, 230, 20, 194, 78, 108, 254, 62, 72, 188, 84, 10, 21, 43, 41, 161, 79, 255, 183, 164, 239, 2, 24, 147, 191, 64, 235, 165, 17, ...]), 609999999750800)], [], 2)]
```