### PR TITLE
Restore enrollments from other nodes

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -46,6 +46,10 @@ node:
   # from all other nodes
   block_catchup_interval:
     seconds: 20
+  # The duration between requests for retrieving the missing enrollments
+  # from all other nodes
+  enrollment_catchup_interval:
+    seconds: 40
   # The maximum number of transactions relayed in every batch.
   # Value 0 means no limit.
   relay_tx_max_num: 100

--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -364,4 +364,21 @@ public interface API
 
     @method(HTTPMethod.GET)
     public Enrollment getEnrollment (in Hash enroll_hash);
+
+    /***************************************************************************
+
+        API:
+            GET /enrollments
+
+        Params:
+            height = the height of proposed block
+            exclude_enrolls = the enrollments that should be excluded
+
+        Returns:
+            All the enrollments for the height in the enrollment pool
+
+    ***************************************************************************/
+
+    @method(HTTPMethod.GET)
+    public Enrollment[] getEnrollments (ulong height, Set!uint exclude_enrolls);
 }

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -566,6 +566,10 @@ public class Ledger
                 assert(0);
             }
         }
+
+        // update frozen UTXOs in the enrollment manager
+        auto frozen_utxos = this.utxo_set.getUTXOs(OutputType.Freeze);
+        this.enroll_man.updateFrozenUTXO(block.header.height, frozen_utxos);
     }
 
     /***************************************************************************

--- a/source/agora/consensus/pool/Enrollment.d
+++ b/source/agora/consensus/pool/Enrollment.d
@@ -283,6 +283,43 @@ public class EnrollmentPool
 
     /***************************************************************************
 
+        Get the enrollment with the key and the height
+
+        Params:
+            enroll_hash = key for the enrollment which has the frozen UTXO
+            height = the height of proposed block
+
+        Returns:
+            Return an `Enrollment` if the enrollment is found, otherwise
+                `Enrollment.init`
+
+    ***************************************************************************/
+
+    public Enrollment getEnrollment (in Hash enroll_hash, in Height height)
+        @trusted nothrow
+    {
+        try
+        {
+            auto results = this.db.execute("SELECT key, val FROM enrollment_pool " ~
+                "WHERE key = ? AND avail_height = ?", enroll_hash, height.value);
+
+            foreach (row; results)
+            {
+                return deserializeFull!Enrollment(row.peek!(ubyte[])(1));
+            }
+        }
+        catch (Exception ex)
+        {
+            log.error("Exception occured on getEnrollment: {}, " ~
+                "Key for enrollment: {}", ex.msg, enroll_hash);
+            return Enrollment.init;
+        }
+
+        return Enrollment.init;
+    }
+
+    /***************************************************************************
+
         Get the height when the enrollment will be available
 
         Params:

--- a/source/agora/consensus/state/UTXOCache.d
+++ b/source/agora/consensus/state/UTXOCache.d
@@ -115,6 +115,20 @@ abstract class UTXOCache
 
     /***************************************************************************
 
+        Get UTXOs from the UTXO set by the output type
+
+        Params:
+            type = the output type by which to search UTXOs in UTXOSet
+
+        Returns:
+            the associative array for UTXOs
+
+    ***************************************************************************/
+
+    public abstract UTXO[Hash] getUTXOs (in OutputType type) nothrow @safe;
+
+    /***************************************************************************
+
         Get an UTXO from the UTXO set.
 
         Params:
@@ -320,6 +334,16 @@ public class TestUTXOSet : UTXOCache
         UTXO[Hash] utxos;
         foreach (const ref key_val; storage.byKeyValue)
             if (key_val.value.output.lock.bytes[] == pubkey[])
+                utxos[key_val.key] = key_val.value;
+        return utxos;
+    }
+
+    ///
+    public override UTXO[Hash] getUTXOs (in OutputType type) nothrow @safe
+    {
+        UTXO[Hash] utxos;
+        foreach (const ref key_val; storage.byKeyValue)
+            if (key_val.value.output.type == type)
                 utxos[key_val.key] = key_val.value;
         return utxos;
     }

--- a/source/agora/consensus/state/UTXOSet.d
+++ b/source/agora/consensus/state/UTXOSet.d
@@ -83,6 +83,12 @@ public class UTXOSet : UTXOCache
     }
 
     ///
+    public override UTXO[Hash] getUTXOs (in OutputType type) nothrow @safe
+    {
+        return this.utxo_db.getUTXOs(type);
+    }
+
+    ///
     public override bool peekUTXO (in Hash utxo, out UTXO value) nothrow @safe
     {
         return this.utxo_db.find(utxo, value);

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -510,6 +510,26 @@ public class NetworkClient
 
     /***************************************************************************
 
+        Get the array of the enrollments in the enrollment pool
+
+        Params:
+            height = the height of proposed block
+            exclude_enrolls = the enrollments that should be excluded
+
+        Returns:
+            All the enrollments in the enrollment pool
+
+    ***************************************************************************/
+
+    public Enrollment[] getEnrollments (in Height height, Set!uint exclude_enrolls)
+        @trusted nothrow
+    {
+        return this.attemptRequest!(API.getEnrollments, Throw.No)(
+            this.api, height, exclude_enrolls);
+    }
+
+    /***************************************************************************
+
         Attempt a request up to 'this.max_retries' attempts, and make the task
         wait this.retry_delay between each attempt.
 

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -231,6 +231,9 @@ public struct NodeConfig
     /// from all other nodes
     public Duration block_catchup_interval = 20.seconds;
 
+    /// The duration between requests for retrieving the missing enrollments
+    public Duration enrollment_catchup_interval = 40.seconds;
+
     /// The new block time offset has to be greater than the previous block time offset,
     /// but less than current time + block_time_offset_tolerance
     public Duration block_time_offset_tolerance = 60.seconds;
@@ -641,12 +644,15 @@ unittest
 node:
   data_dir: .cache
   commons_budget_address: boa1xrzwvvw6l6d9k84ansqgs9yrtsetpv44wfn8zm9a7lehuej3ssskxth867s
+  enrollment_catchup_interval:
+    seconds: 60
 network:
  - "something"
 `;
     auto config = parseConfigString!Config(conf_example, "/dev/null");
     assert(config.node.min_listeners == 2);
     assert(config.node.max_listeners == 10);
+    assert(config.node.enrollment_catchup_interval == 60.seconds);
     assert(config.node.data_dir == ".cache");
     assert(config.node.commons_budget_address.toString() == "boa1xrzwvvw6l6d9k84ansqgs9yrtsetpv44wfn8zm9a7lehuej3ssskxth867s");
 }

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -1059,6 +1059,16 @@ public class FullNode : API
         return this.enroll_man.getEnrollment(enroll_hash);
     }
 
+    /// GET: /enrollments
+    public override Enrollment[] getEnrollments (ulong height, Set!uint exclude_enrolls)
+        @safe
+    {
+        if (height != this.getBlockHeight() + 1)
+            return Enrollment[].init;
+
+        return this.enroll_man.getExclusiveEnrollments(Height(height), exclude_enrolls);
+    }
+
     /// POST /preimage
     public override void postPreimage (in PreImageInfo preimage) @safe
     {

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2024,6 +2024,9 @@ public struct TestConf
         // Catchup needs to happens much more frequently than in production
         block_catchup_interval: 1.seconds,
 
+        // Catchup period for missing enrollments
+        enrollment_catchup_interval: 1.seconds,
+
         // The default is much longer, but in unittests latency is negligible
         retry_delay: 300.msecs,
         timeout: 300.msecs,

--- a/source/agora/test/GetEnrollments.d
+++ b/source/agora/test/GetEnrollments.d
@@ -1,0 +1,129 @@
+/*******************************************************************************
+
+    Contains tests for getting missing enrollments from the network
+
+    Copyright:
+        Copyright (c) 2019-2021 BOSAGORA Foundation
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.GetEnrollments;
+
+version (unittest):
+
+import agora.test.Base;
+
+import core.atomic : atomicLoad;
+
+/// Situation: There are six validators enrolled in Genesis block.
+///     But a validator can not receive any enrollments in the case
+///     of an abnormal situation. The validator tries to get missing
+///     enrollments periodically
+/// Expectation: The validator ends up restoring misssing enrollments
+///     from other nodes.
+unittest
+{
+    static class CustomValidator : TestValidatorNode
+    {
+        mixin ForwardCtor!();
+
+        private shared bool* enable_catchup;
+
+        ///
+        public this (Parameters!(TestValidatorNode.__ctor) args,
+            shared(bool)* enable_catchup)
+        {
+            this.enable_catchup = enable_catchup;
+            super(args);
+        }
+
+        ///
+        protected override void catchupTask () nothrow
+        {
+            if (atomicLoad(*this.enable_catchup))
+                super.catchupTask();
+        }
+    }
+
+    static class CustomAPIManager : TestAPIManager
+    {
+        mixin ForwardCtor!();
+
+        public static shared bool enable_catchup = false;
+
+        /// set base class
+        public override void createNewNode (Config conf, string file, int line)
+        {
+            if (this.nodes.length == GenesisValidators - 1)
+                this.addNewNode!CustomValidator(conf, &this.enable_catchup,
+                    file, line);
+            else
+                super.createNewNode(conf, file, line);
+        }
+    }
+
+    TestConf conf = {
+        outsider_validators : 1,
+        recurring_enrollment : false
+    };
+    auto all_validators = GenesisValidators + conf.outsider_validators;
+    auto network = makeTestNetwork!CustomAPIManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto delayed_node = GenesisValidators - 1;
+    auto outsider = network.nodes[GenesisValidators];
+
+    network.generateBlocks(Height(GenesisValidatorCycle - 2));
+
+    // make sure outsiders are up to date
+    network.expectHeight(iota(GenesisValidators, all_validators),
+        Height(GenesisValidatorCycle - 2));
+
+    // the delayed_node validator becomes unresponsive
+    network.clients[delayed_node].filter!(API.postTransaction);
+
+    // prepare frozen outputs for the outsider validator to enroll
+    const key = outsider.getPublicKey().key;
+    network.blocks[0].spendable().drop(1).takeExactly(1)
+        .map!(txb => txb
+            .split([key]).sign(OutputType.Freeze))
+            .each!(tx => network.nodes[0].postTransaction(tx));
+
+    // Block 19 we add the frozen utxo for the outsider validator
+    // The delayed validator don't receive this `postTransaction` request
+    network.generateBlocks(iota(GenesisValidators - 1), Height(GenesisValidatorCycle - 1));
+    network.expectHeight([GenesisValidators], Height(GenesisValidatorCycle - 1));
+
+    // enroll the outsider
+    auto enroll = network.clients[GenesisValidators].setRecurringEnrollment(true);
+    assert(enroll != Enrollment.init);
+
+    // re-enroll all the validators
+    iota(GenesisValidators).each!(i => network.enroll(iota(GenesisValidators), i));
+
+    // check that the delayed validator doesn't have the enrollment of the outsider
+    assert(network.clients[delayed_node].getEnrollment(enroll.utxo_key) == Enrollment.init);
+
+    // enable `catchupTask` for the delayed validator and clear filter
+    CustomAPIManager.enable_catchup = true;
+    network.clients[delayed_node].clearFilter();
+    network.expectHeight([delayed_node], Height(GenesisValidatorCycle - 1));
+
+    // check the missing enrollment to be restored
+    retryFor(network.clients[delayed_node].getEnrollment(enroll.utxo_key) == enroll,
+        2 * conf.node.enrollment_catchup_interval,
+        format!"The enrollment (%s) not in pool of the delayed validator"(enroll.utxo_key));
+
+    // Block 20 and check the all the enrollments to be validators
+    network.generateBlocks(iota(GenesisValidators), Height(GenesisValidatorCycle));
+    network.expectHeight(iota(all_validators), Height(GenesisValidatorCycle));
+    auto b20 = network.nodes[0].getBlocksFrom(GenesisValidatorCycle, 1)[0];
+    assert(b20.header.enrollments.length == 7);
+}


### PR DESCRIPTION
Added the API endpoint called `getEnrollments` to get missing enrollments from other nodes and make the network manager periodically call the function on other nodes to add received enrollments into the enrollment pool.

Fixes #755 