### PR TITLE
Trivial: Print the correct line / column for unexpected key

### DIFF
--- a/source/agora/common/Config.d
+++ b/source/agora/common/Config.d
@@ -352,7 +352,7 @@ private T parseMapping (T)
         const fmt = path.length ? "Unexpected key '%s' in section '%s'. There are %s valid keys: %-(%s, %)" :
             "Unexpected key '%s' in document root%s. There are %s valid keys: %-(%s, %)";
         foreach (const ref Node key, const ref Node value; node)
-            node.enforce(fieldNames.canFind(key.as!string),
+            key.enforce(fieldNames.canFind(key.as!string),
                          fmt, key.as!string.paint(Red), path.paint(Green),
                          fieldNames.length.paint(Yellow), fieldNames.map!(f => f.paint(Green)));
     }


### PR DESCRIPTION
Before it was  using the line / column infos of the containing node,
e.g. `0:0` at the document root.