### PR TITLE
Fix #2447: Implement CNAME / A record distinction in registry + others

### DIFF
--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -208,13 +208,15 @@ public class NameRegistry: NameRegistryAPI
 
         Params:
           query = The query received by the server
-
-        Returns:
-          An answer that matches the query
+          sender = A delegate that allows to send a `Message` to the client.
+                   A server may send multiple `Message`s as a response to a
+                   single query, e.g. when doing zone transfer.
 
     ***************************************************************************/
 
-    public Message answerQuestions (in Message query) @safe
+    public void answerQuestions (
+        in Message query, scope void delegate (in Message) @safe sender)
+        @safe
     {
         Message reply;
         reply.header.RA = false; // TODO: Implement
@@ -253,7 +255,7 @@ public class NameRegistry: NameRegistryAPI
         log.trace("{} DNS query: {} => {}",
                   (reply.header.RCODE == Header.RCode.NoError) ? "Fullfilled" : "Unsuccessfull",
                   query, reply);
-        return reply.fill(query.header);
+        sender(reply.fill(query.header));
     }
 
     /***************************************************************************

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -225,7 +225,14 @@ public class NameRegistry: NameRegistryAPI
         // questions / will only ask one question at a time.
         foreach (const ref q; query.questions)
         {
-            if (q.qclass != QCLASS.ANY && q.qclass != QCLASS.IN)
+            // RFC1034: 3.7.1. Standard queries
+            // Since a particular name server may not know all of
+            // the classes available in the domain system, it can never know if it is
+            // authoritative for all classes. Hence responses to QCLASS=* queries can
+            // never be authoritative.
+            if (q.qclass == QCLASS.ANY)
+                reply.header.AA = false;
+            else if (q.qclass != QCLASS.IN)
             {
                 log.trace("DNS: Ignoring question with unknown QCLASS: {}", q);
                 continue;


### PR DESCRIPTION
The aim was to implement a fix for 2447 and 2451. 2451 proved harder than expected, as we need to start the transfer by sending SOA records. So this implement most of the SOA machinery.