### PR TITLE
Flash: Drop ThinFlashNode & AgoraFlashNode

### DIFF
--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -63,7 +63,7 @@ mixin AddLogger!();
 public class Channel
 {
     /// Used to publish funding / trigger / update / settlement txs to blockchain
-    public const void delegate (Transaction) txPublisher;
+    public const void delegate (in Transaction) txPublisher;
 
     /// Database
     private ManagedDatabase db;
@@ -114,7 +114,8 @@ public class Channel
     private OnUpdateComplete onUpdateComplete;
 
     /// Fetch the Flash Client for the peer
-    private FlashAPI delegate (in PublicKey peer_pk, Duration timeout) getFlashClient;
+    private FlashAPI delegate (in PublicKey peer_pk, Duration timeout,
+        string address = null) getFlashClient;
 
     /// Retry delay algorithm
     private Backoff backoff;
@@ -151,7 +152,7 @@ public class Channel
     public this (FlashConfig flash_conf, ChannelConfig conf, in KeyPair kp,
         PrivateNonce priv_nonce, PublicNonce peer_nonce, FlashAPI peer,
         Engine engine, ITaskManager taskman,
-        void delegate (Transaction) txPublisher,
+        void delegate (in Transaction) txPublisher,
         PaymentRouter paymentRouter,
         OnChannelNotify onChannelNotify,
         OnPaymentComplete onPaymentComplete,
@@ -211,13 +212,13 @@ public class Channel
 
     public this (in PublicKey key, Hash chan_id, FlashConfig flash_conf, Engine engine,
         ITaskManager taskman,
-        void delegate (Transaction) txPublisher,
+        void delegate (in Transaction) txPublisher,
         PaymentRouter paymentRouter,
         OnChannelNotify onChannelNotify,
         OnPaymentComplete onPaymentComplete,
         OnUpdateComplete onUpdateComplete,
         GetFeeUTXOs getFeeUTXOs,
-        FlashAPI delegate (in PublicKey peer_pk, Duration timeout) getFlashClient,
+        FlashAPI delegate (in PublicKey peer_pk, Duration timeout, string address = null) getFlashClient,
         ManagedDatabase db)
     {
         this.db = db;
@@ -266,9 +267,9 @@ public class Channel
 
     public static Channel[Hash][PublicKey] loadChannels (FlashConfig flash_conf,
         ManagedDatabase db,
-        FlashAPI delegate (in PublicKey peer_pk, Duration timeout) getFlashClient,
+        FlashAPI delegate (in PublicKey peer_pk, Duration timeout, string address = null) getFlashClient,
         Engine engine, ITaskManager taskman,
-        void delegate (Transaction) txPublisher, PaymentRouter paymentRouter,
+        void delegate (in Transaction) txPublisher, PaymentRouter paymentRouter,
         OnChannelNotify onChannelNotify,
         OnPaymentComplete onPaymentComplete,
         OnUpdateComplete onUpdateComplete,

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -261,8 +261,7 @@ public class FlashNode : FlashControlAPI
         this.onRegisterName();  // avoid delay
         this.periodic_timer = this.taskman.setTimer(2.minutes,
             &this.onRegisterName, Periodic.Yes);
-        // todo: should additionally register as pushBlock() listener
-        this.monitor_timer = this.taskman.setTimer(1.seconds,
+        this.monitor_timer = this.taskman.setTimer(2.minutes,
             &this.monitorBlockchain, Periodic.Yes);
     }
 

--- a/source/agora/flash/api/FlashAPI.d
+++ b/source/agora/flash/api/FlashAPI.d
@@ -58,6 +58,8 @@ public interface FlashAPI
             chan_conf = contains all the static configuration for this channel.
             peer_nonce = the nonce pair that will be used for signing the
                 initial settlement & trigger transactions.
+            funder_address = network address of the funder node to bootstrap
+                the communication
 
         Returns:
             the nonce pair for the initial settle & trigger transactions,
@@ -65,8 +67,8 @@ public interface FlashAPI
 
     ***************************************************************************/
 
-    public Result!PublicNonce openChannel (
-        /* in */ ChannelConfig chan_conf, /* in */ PublicNonce peer_nonce);
+    public Result!PublicNonce openChannel (/* in */ ChannelConfig chan_conf,
+        /* in */ PublicNonce peer_nonce, /* in */ string funder_address);
 
     /***************************************************************************
 

--- a/source/agora/flash/api/FlashControlAPI.d
+++ b/source/agora/flash/api/FlashControlAPI.d
@@ -101,6 +101,8 @@ public interface FlashControlAPI : FlashAPI
             settle_time = closing settle time in number of blocks since last
                 setup / update tx was published on the blockchain
             peer_pk = the public key of the counter-party flash node
+            peer_address = network address of the peer to bootstrap the communication
+                in case the peer is not registered in the name registry
 
         Returns:
             The channel ID, or an error if this funding UTXO is
@@ -111,7 +113,7 @@ public interface FlashControlAPI : FlashAPI
     public Result!Hash openNewChannel (PublicKey reg_pk,
         /* in */ UTXO funding_utxo, /* in */ Hash funding_utxo_hash,
         /* in */ Amount capacity, /* in */ uint settle_time,
-        /* in */ Point peer_pk);
+        /* in */ Point peer_pk, /* in */ string peer_address);
 
     /***************************************************************************
 

--- a/source/agora/flash/api/FlashControlAPI.d
+++ b/source/agora/flash/api/FlashControlAPI.d
@@ -14,6 +14,7 @@
 
 module agora.flash.api.FlashControlAPI;
 
+import agora.api.Handlers;
 import agora.common.Amount;
 import agora.common.Types;
 import agora.crypto.ECC;
@@ -28,7 +29,7 @@ import agora.consensus.data.UTXO;
 import core.stdc.time;
 
 /// Ditto
-public interface FlashControlAPI : FlashAPI
+public interface FlashControlAPI : FlashAPI, BlockExternalizedHandler
 {
 @safe:
     /***************************************************************************

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -261,33 +261,6 @@ public class FullNode : API
         this.ledger = this.makeLedger();
         // Note: Needs to be instantiated after `ledger` as it depends on it
         this.transaction_relayer = this.makeTransactionRelayer();
-        // If we have handlers defined in the config
-        if (config.event_handlers.length > 0)
-        {
-            // Make `BlockExternalizedHandler`s from config
-            config.event_handlers.filter!(h => h.type == HandlerType.BlockExternalized)
-                .each!(handler => handler.addresses
-                    .each!((string address) =>
-                        this.block_handlers[address] = this.network.getBlockExternalizedHandler(address)));
-
-            // Make `BlockHeaderUpdatedHandler`s from config
-            config.event_handlers.filter!(h => h.type == HandlerType.BlockHeaderUpdated)
-                .each!(handler => handler.addresses
-                    .each!((string address) =>
-                        this.block_header_handlers[address] = this.network.getBlockHeaderUpdatedHandler(address)));
-
-            // Make `PreImageReceivedHandler`s from config
-            config.event_handlers.filter!(h => h.type == HandlerType.PreimageReceived)
-                .each!(handler => handler.addresses
-                    .each!((string address) =>
-                        this.preimage_handlers[address] = this.network.getPreImageReceivedHandler(address)));
-
-            // Make `TransactionReceivedHandler`s from config
-            config.event_handlers.filter!(h => h.type == HandlerType.TransactionReceived)
-                .each!(handler => handler.addresses
-                    .each!((string address) =>
-                        this.transaction_handlers[address] = this.network.getTransactionReceivedHandler(address)));
-        }
 
         Utils.getCollectorRegistry().addCollector(&this.collectAppStats);
         Utils.getCollectorRegistry().addCollector(&this.collectStats);
@@ -401,6 +374,34 @@ public class FullNode : API
 
     public void start ()
     {
+        // If we have handlers defined in the config
+        if (config.event_handlers.length > 0)
+        {
+            // Make `BlockExternalizedHandler`s from config
+            config.event_handlers.filter!(h => h.type == HandlerType.BlockExternalized)
+                .each!(handler => handler.addresses
+                    .each!((string address) =>
+                        this.block_handlers[address] = this.network.getBlockExternalizedHandler(address)));
+
+            // Make `BlockHeaderUpdatedHandler`s from config
+            config.event_handlers.filter!(h => h.type == HandlerType.BlockHeaderUpdated)
+                .each!(handler => handler.addresses
+                    .each!((string address) =>
+                        this.block_header_handlers[address] = this.network.getBlockHeaderUpdatedHandler(address)));
+
+            // Make `PreImageReceivedHandler`s from config
+            config.event_handlers.filter!(h => h.type == HandlerType.PreimageReceived)
+                .each!(handler => handler.addresses
+                    .each!((string address) =>
+                        this.preimage_handlers[address] = this.network.getPreImageReceivedHandler(address)));
+
+            // Make `TransactionReceivedHandler`s from config
+            config.event_handlers.filter!(h => h.type == HandlerType.TransactionReceived)
+                .each!(handler => handler.addresses
+                    .each!((string address) =>
+                        this.transaction_handlers[address] = this.network.getTransactionReceivedHandler(address)));
+        }
+
         if (config.node.stats_listening_port != 0)
             this.stats_server = this.makeStatsServer();
         this.transaction_relayer.start();

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -49,7 +49,7 @@ import core.time;
 public alias Listeners = Tuple!(
     FullNode, "node",
     AdminInterface, "admin",
-    AgoraFlashNode, "flash",
+    FlashNode, "flash",
     NameRegistry, "registry",
     HTTPListener[], "http"
  );
@@ -106,11 +106,11 @@ public Listeners runNode (Config config)
 
         log.trace("Started Flash node...");
         const params = FullNode.makeConsensusParams(config);
-        auto flash = new AgoraFlashNode(config.flash,
+        auto flash = new FlashNode(config.flash,
             config.node.data_dir, params.Genesis.hashFull(),
             result.node.getEngine(),
             result.node.getTaskManager(), &result.node.postTransaction,
-            &result.node.getBlock, result.node.getNetworkManager());
+            &result.node.getBlock, &result.node.getNetworkManager().getNameRegistryClient);
         router.registerRestInterface!FlashAPI(flash);
         result.flash = flash;
     }


### PR DESCRIPTION
```
We now only have a single Flash node class called FlashNode.
Anything related to a agora node is handled by delagates, so we still
can have a ThinFlashNode like operation.

This also makes use of the getFlashNode & putFlashNode endpoints of the
NameRegistry. Nodes now need a open channel to be able to register themselves.
In case a node has no open channels, they pass their address to their peer as
they are openning their first channel to bootstrap the communication.
```

I initially wanted to only use the new registry APIs but, having multiple Flash nodes made that harder and didn't make sense. We can simply have a single class and abstract away the network related stuff using delegates.