### PR TITLE
Part 2 of Issue246: Store the validator stake in the database

### DIFF
--- a/doc/Database.md
+++ b/doc/Database.md
@@ -60,7 +60,7 @@ Note sure why we need this.
 | Field name | SQL Type | D type     | Attributes  | Comment             |
 |------------|----------|------------|-------------|---------------------|
 | public_key | TEXT     | PublicKey  | PRIMARY KEY |                     |
-| fee        | TEXT     | Enrollment |             | Should be `INTEGER` |
+| fee        | INTEGER  | Amount     |             |                     |
 
 ## Cache DB
 

--- a/doc/Database.md
+++ b/doc/Database.md
@@ -32,6 +32,7 @@ Should be cleaned up and make readable. Once `utxo` is usable, both can be used 
 | enrolled_height | INTEGER  | Height           | PRIMARY KEY (with `key`)             |                                                    |
 | nonce           | TEXT     | Point            |                                      | The `R` used to sign the `Enrollment`              |
 | slashed_height  | INTEGER  | Height           |                                      | Height at which a validator is slashed or null     |
+| stake           | INTEGER  | Amount           |                                      | Frozen Amount staked when enrolling                |
 
 ### `preimages` table
 

--- a/source/agora/api/spec.yaml
+++ b/source/agora/api/spec.yaml
@@ -379,6 +379,8 @@ components:
           type: string
         address:
           type: string
+        stake:
+          type: string
         preimage:
           $ref: '#/components/schemas/PreImage'
 

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -748,27 +748,6 @@ public class EnrollmentManager
     {
         return &this.validator_set.findRecentEnrollment;
     }
-
-    /***************************************************************************
-
-        Query stakes of active Validators
-
-        Params:
-            height = block height
-            peekUTXO = A delegate to query UTXOs
-            utxos = Array to save the stakes
-
-        Returns:
-            Staked UTXOs of existing Validators
-
-    ***************************************************************************/
-
-    public UTXO[] getValidatorStakes (in Height height, scope UTXOFinder peekUTXO, ref UTXO[] utxos,
-        in uint[] missing_validators) @trusted nothrow
-    {
-        return this.validator_set.getValidatorStakes(height, peekUTXO, utxos,
-            missing_validators);
-    }
 }
 
 /// tests for member functions of EnrollmentManager

--- a/source/agora/consensus/Fee.d
+++ b/source/agora/consensus/Fee.d
@@ -211,7 +211,7 @@ public class FeeManager
     private void init ()
     {
         this.db.execute("CREATE TABLE IF NOT EXISTS accumulated_fees " ~
-            "(public_key TEXT PRIMARY KEY, fee TEXT)");
+            "(public_key TEXT PRIMARY KEY, fee INTEGER)");
 
         auto results = this.db.execute("SELECT public_key, fee " ~
             " FROM accumulated_fees");
@@ -219,7 +219,7 @@ public class FeeManager
         foreach (ref row; results)
         {
             const key = PublicKey.fromString(row.peek!(char[])(0));
-            const fee = Amount.fromString(row.peek!(char[])(1));
+            const fee = Amount(row.peek!(ulong)(1));
             this.accumulated_fees[key] = fee;
         }
     }
@@ -388,7 +388,7 @@ public class FeeManager
 
             this.db.execute(
                 "REPLACE INTO accumulated_fees (fee, public_key) VALUES (?,?)",
-                this.accumulated_fees[stake.output.address], stake.output.address);
+                this.accumulated_fees[stake.output.address].tupleof[0], stake.output.address);
         }
         this.accumulated_fees.update(this.params.CommonsBudgetAddress,
                 { return commons_fees; },
@@ -399,7 +399,7 @@ public class FeeManager
             );
         this.db.execute(
                 "REPLACE INTO accumulated_fees (fee, public_key) VALUES (?,?)",
-                this.accumulated_fees[this.params.CommonsBudgetAddress], this.params.CommonsBudgetAddress);
+                this.accumulated_fees[this.params.CommonsBudgetAddress].tupleof[0], this.params.CommonsBudgetAddress);
     }
 
     /***************************************************************************

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -213,7 +213,7 @@ public class Ledger
         Expose the list of validators at a given height
 
         The `ValidatorInfo` struct contains the validator's UTXO hash, address,
-        and currently highest known pre-image.
+        stake and currently highest known pre-image.
         It always returns valid historical data (although the pre-image might
         be the current one).
 
@@ -1060,10 +1060,7 @@ public class Ledger
             return;
         }
 
-        UTXO[] stakes;
-        this.enroll_man.getValidatorStakes(block.header.height, &this.utxo_set.peekUTXO, stakes,
-            block.header.missing_validators);
-        this.fee_man.accumulateFees(block, stakes, &this.utxo_set.peekUTXO);
+        this.fee_man.accumulateFees(block, this.getValidators(block.header.height), &this.utxo_set.peekUTXO);
     }
 
     /***************************************************************************

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -338,7 +338,8 @@ public class Ledger
             min_fee_pct = See `Config.node.min_fee_pct`
 
         Returns:
-            true if the transaction is valid and was added to the pool
+            reason why invalid or null if the transaction is valid and was added
+            to the pool
 
     ***************************************************************************/
 
@@ -352,9 +353,10 @@ public class Ledger
         // If we were looking for this TX, stop
         this.unknown_txs.remove(tx_hash);
 
-        if (tx.isCoinbase ||
-            this.pool.hasTransactionHash(tx_hash))
-            return "Coinbase or existing TX";
+        if (tx.isCoinbase)
+            return "Coinbase transaction";
+        if (this.pool.hasTransactionHash(tx_hash))
+            return "Transaction already in the pool";
 
         Amount fee_rate;
         auto checkAndSave = (in Transaction tx, Amount tx_fee)

--- a/source/agora/consensus/data/ValidatorInfo.d
+++ b/source/agora/consensus/data/ValidatorInfo.d
@@ -13,6 +13,7 @@
 
 module agora.consensus.data.ValidatorInfo;
 
+import agora.common.Amount;
 import agora.common.Types;
 import agora.consensus.data.PreImageInfo;
 import agora.crypto.Key;
@@ -31,6 +32,10 @@ public struct ValidatorInfo
 
     /// Public key associated with the UTXO
     public PublicKey address;
+
+    /// Value of frozen UTXO this validator has staked to enroll
+    /// This will be used to determine the share of fees and rewards paid for each signed block
+    public Amount stake;
 
     /// The most up-to-date pre-image
     public PreImageInfo preimage;

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -47,6 +47,7 @@ version (unittest)
         enrollment = The enrollment of the target to be verified
         findUTXO = delegate to find the referenced unspent UTXOs with
         height = The `Height` that this `Enrollment` is proposed at
+        stake = an output param for the staked `Amount` for this enroll
 
     Returns:
         `null` if the validator's UTXO is valid, otherwise a string
@@ -58,12 +59,23 @@ public string isInvalidReason (in Enrollment enrollment,
     scope UTXOFinder findUTXO, in Height height,
     scope EnrollmentFinder findEnrollment) nothrow @safe
 {
+    Amount stake; // The stake is not always needed by the caller, hence this overload
+    return isInvalidReason(enrollment, findUTXO, height, findEnrollment, stake);
+}
+
+/// Ditto
+public string isInvalidReason (in Enrollment enrollment,
+    scope UTXOFinder findUTXO, in Height height,
+    scope EnrollmentFinder findEnrollment, out Amount stake) nothrow @safe
+{
     UTXO utxo_set_value;
     if (!findUTXO(enrollment.utxo_key, utxo_set_value))
         return "Enrollment: UTXO not found";
 
     if (utxo_set_value.output.type != OutputType.Freeze)
         return "Enrollment: UTXO is not frozen";
+
+    stake = utxo_set_value.output.value;
 
     Point address = utxo_set_value.output.address;
 


### PR DESCRIPTION
This PR is to prepare some things to facilitate paying out the fees and rewards at the end of the next payment cycle when UTXO set may no longer have our inputs which we need to get the values from.  