### PR TITLE
Unit tests: Fix ledger test and update name

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1210,14 +1210,20 @@ public class TestAPIManager
         throw new Exception(format!"TX (%s) was not externalized in %d blocks!"(tx_hash, n_blocks));
     }
 
-    /// Ensure that a transaction is accepted by a node (put in the tx pool)
-    public void ensureTxInPool (Idxs) (in Transaction tx, Idxs indices)
+    /// Post a transaction to clients and ensure it is accepted by them (put in the tx pool)
+    public void postAndEnsureTxInPool (in Transaction tx)
+    {
+        this.postAndEnsureTxInPool(tx, iota(this.clients.length));
+    }
+
+    /// Ditto
+    public void postAndEnsureTxInPool (Idxs) (in Transaction tx, Idxs indices)
     {
         indices.each!(idx => this.clients[idx].postTransaction(tx));
         this.ensureTxInPool(tx.hashFull(), indices);
     }
 
-    /// Ditto
+    /// Ensure that a transaction has been put in the tx pools of the client indices
     public void ensureTxInPool (Idxs) (in Hash hash, Idxs indices)
     {
         retryFor(indices.each!(idx => this.clients[idx].hasTransactionHash(hash)), 3.seconds);

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1213,26 +1213,26 @@ public class TestAPIManager
     /// Post a transaction to clients and ensure it is accepted by them (put in the tx pool)
     public void postAndEnsureTxInPool (in Transaction tx)
     {
-        this.postAndEnsureTxInPool(tx, iota(this.clients.length));
+        this.postAndEnsureTxInPool(iota(this.clients.length), tx);
     }
 
     /// Ditto
-    public void postAndEnsureTxInPool (Idxs) (in Transaction tx, Idxs indices)
+    public void postAndEnsureTxInPool (Idxs) (Idxs clients_idxs, in Transaction tx)
     {
-        indices.each!(idx => this.clients[idx].postTransaction(tx));
-        this.ensureTxInPool(tx.hashFull(), indices);
+        clients_idxs.each!(idx => this.clients[idx].postTransaction(tx));
+        this.ensureTxInPool(clients_idxs, tx.hashFull());
     }
 
     /// Ensure that a transaction has been put in the tx pools of the client indices
-    public void ensureTxInPool (Idxs) (in Hash hash, Idxs indices)
+    public void ensureTxInPool (Idxs) (Idxs clients_idxs, in Hash hash)
     {
-        retryFor(indices.each!(idx => this.clients[idx].hasTransactionHash(hash)), 3.seconds);
+        retryFor(clients_idxs.each!(idx => this.clients[idx].hasTransactionHash(hash)), 3.seconds);
     }
 
     /// Ditto
     public void ensureTxInPool (in Hash hash)
     {
-        this.ensureTxInPool(hash, iota(this.clients.length));
+        this.ensureTxInPool(iota(this.clients.length), hash);
     }
 }
 

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -267,7 +267,7 @@ unittest
     auto tx2 = TxBuilder(b1.txs[0], 0).sign();
     assert(tx2.outputs.length == 1);
 
-    network.clients[0].postTransaction(tx2);
+    network.postAndEnsureTxInPool(tx2); // Make sure it makes it into the block
     network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
     assert(network.clients[0].getBlock(2).txs.length == 1);
 }

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -74,7 +74,7 @@ unittest
     // Distribute them to different clients
     txs.takeExactly(6).enumerate.each!(
         (idx, tx) {
-            network.ensureTxInPool(tx, (idx % network.clients.length).only);
+            network.postAndEnsureTxInPool(tx, (idx % network.clients.length).only);
         });
     network.expectHeightAndPreImg(Height(1));
     network.assertSameBlocks(Height(1));

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -74,7 +74,7 @@ unittest
     // Distribute them to different clients
     txs.takeExactly(6).enumerate.each!(
         (idx, tx) {
-            network.postAndEnsureTxInPool(tx, (idx % network.clients.length).only);
+            network.postAndEnsureTxInPool((idx % network.clients.length).only, tx);
         });
     network.expectHeightAndPreImg(Height(1));
     network.assertSameBlocks(Height(1));

--- a/source/agora/test/LockHeight.d
+++ b/source/agora/test/LockHeight.d
@@ -54,8 +54,7 @@ unittest
     unlock_3_txs.each!(tx => node_1.postTransaction(tx));
 
     // should be accepted
-    unlock_2_txs.each!(tx => node_1.postTransaction(tx));
-    unlock_2_txs.each!(tx => network.ensureTxInPool(tx.hashFull()));
+    unlock_2_txs.each!(tx => network.postAndEnsureTxInPool(tx));
 
     network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
 


### PR DESCRIPTION
Improve the naming of a helper function in `base.d` and prevent spurious failures in `test.Ledger`.