### PR TITLE
Use correct format specifier on log call

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -625,7 +625,7 @@ public class Ledger
             if (pair.value > Amount(0))
                 coinbase_tx_outputs ~= Output(pair.value, pair.key, OutputType.Coinbase);
             else
-                log.error("Zero valued Coinbase output for key %s", pair.key);
+                log.error("Zero valued Coinbase output for key {}", pair.key);
         }
         coinbase_tx_outputs.sort;
         return Transaction([Input(height)], coinbase_tx_outputs);


### PR DESCRIPTION
This used '%s' instead of '{}', mixing the format of Ocean and std.format.

Part of #2461 