### PR TITLE
Revert "Fix deploy action to also tag the registry"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,14 +20,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: "Agora: Set ${{ github.event.inputs.tag }} as latest"
+      - name: Set ${{ github.event.inputs.tag }} as latest
         uses: akhilerm/tag-push-action@v1.1.0
         with:
           src: docker.io/bosagora/agora:${{ github.event.inputs.tag }}
           dst: docker.io/bosagora/agora:latest
-
-      - name: "Registry: Set ${{ github.event.inputs.tag }} as latest"
-        uses: akhilerm/tag-push-action@v1.1.0
-        with:
-          src: docker.io/bosagora/registry:${{ github.event.inputs.tag }}
-          dst: docker.io/bosagora/registry:latest


### PR DESCRIPTION
This reverts commit 5015385f404106a73d2647b2ae34d4cc1465c9c0.
The registry has since been merged into Agora, so this would error out.