### PR TITLE
DNS: Allow users to configure a zone's SOA record

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -285,5 +285,15 @@ registry:
     address: 0.0.0.0
     port: 53
     authoritative:
-    - "validators.bosagora.io"
-    - "flash.bosagora.io"
+      validators.bosagora.io:
+        email: dns@validators.bosaagora.io
+      flash.bosagora.io:
+        email: dns.flash.bosagora.io
+        refresh:
+          minutes: 1
+        retry:
+          seconds: 30
+        expire:
+          minutes: 10
+        minimum:
+          minutes: 1


### PR DESCRIPTION
```
Since we're already parsing zone informations,
allow the users to specify each zone's SOA record.
```

This was also extracted from #2453 to make reviewing easier, and because we can just do all the v0.21.0 changes at once in production.