### PR TITLE
Part 4 of Issue246: Include the block rewards

### DIFF
--- a/source/agora/common/BitMask.d
+++ b/source/agora/common/BitMask.d
@@ -127,6 +127,14 @@ public struct BitMask
         return this.setIndices.count!(i => this[i]);
     }
 
+    /// return the percentage of bits set to `true`
+    public ubyte percentage () const
+    {
+        ulong percentage = 100 * this.setCount / this.length;
+        assert(percentage <= 100);
+        return cast(ubyte)percentage;
+    }
+
     /// Support for sorting by count of set bits not value
     public int opCmp (in typeof(this) rhs) const
     {
@@ -230,4 +238,17 @@ unittest
     assert(bitmask2.length == bitmask.length);
     assert(bitmask2.setCount == bitmask.setCount);
     assert(bitmask2 == bitmask);
+}
+
+/// Test percentage
+unittest
+{
+    auto bitmask50 = BitMask.fromString("010110");
+    assert(bitmask50.percentage == 50);
+    auto bitmask85 = BitMask.fromString("0111111");
+    assert(bitmask85.percentage == 85);
+    auto bitmask0 = BitMask.fromString("0000000");
+    assert(bitmask0.percentage == 0);
+    auto bitmask100 = BitMask.fromString("1111111111111111111111111");
+    assert(bitmask100.percentage == 100);
 }

--- a/source/agora/consensus/Fee.d
+++ b/source/agora/consensus/Fee.d
@@ -325,7 +325,8 @@ public class FeeManager
         foreach (share; normalized_shares)
         {
             auto validator_fee = tx_fees;
-            validator_fee.mul(share);
+            if (!validator_fee.mul(share))
+                assert(0, "getValidatorPayouts: Overflow when multiplying validator fee with share");
             validator_fees ~= validator_fee;
         }
         return validator_fees;

--- a/source/agora/consensus/Fee.d
+++ b/source/agora/consensus/Fee.d
@@ -318,6 +318,7 @@ public class FeeManager
         auto normalized_shares = shares.map!(share => share / shares_gcd);
 
         // tx_fees now equals "share value", which is the amount each share will get
+        // Ignore remainder as any left over after `Validator` payouts goes to `Commons Budget`
         tx_fees.div(normalized_shares.sum());
 
         Amount[] validator_fees;


### PR DESCRIPTION
This adds block rewards to the outputs with fees to the `Commons Budget` and the `Validators` based on which blocks they signed.