### PR TITLE
Not empty array for addresses of Agora servers

### DIFF
--- a/source/agora/utils/InetUtils.d
+++ b/source/agora/utils/InetUtils.d
@@ -292,7 +292,7 @@ struct InetUtils
     {
         if (ip.canFind(':'))
         {
-            if(ip == "" || ip == "::" || "::1") // Loopback
+            if(ip == "" || ip == "::" || ip == "::1") // Loopback
                 return true;
             ushort[] ip_parts = ip.split("::").map!(ip_part => to!ushort(ip_part,16)).array();
             if(ip_parts.length >= 1)


### PR DESCRIPTION
Tested on the server as part of #2392 , we got an empty array. This might be due to Agora running in Docker though.
This was a blocker for the deployment of TestNet. So we solve this problem by applying [the `ipify` API](https://www.ipify.org/).

Fixes #2395 