### PR TITLE
Registry: Make it use its dedicated `FullNode` and use the `Ledger` directly

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -283,7 +283,8 @@ public class FullNode : API
         );
 
         if (config.registry.enabled)
-            this.registry = new NameRegistry(config.node.realm, config.registry, this, this.cacheDB);
+            this.registry = new NameRegistry(config.node.realm, config.registry,
+                                             this.ledger, this.cacheDB);
     }
 
     mixin DefineCollectorForStats!("app_stats", "collectAppStats");


### PR DESCRIPTION
The first commit is unrelated, but trivial enough that I lumped it here.

The last commit was my goal, however in the process of doing so I realized that the test suite was relying on calling a different node directly for validation! Besides being quite slow, it's also brittle (as `nodes[0]` is likely to be tested).
So the third commit fixes this, and the second commit was just an easy step in that direction.