### PR TITLE
Registry: Document and flatten configuration

### DIFF
--- a/devel/config-fullnode.yaml
+++ b/devel/config-fullnode.yaml
@@ -31,12 +31,11 @@ validator:
 
 registry:
   enabled: true
-  dns:
-    authoritative:
-      flash.local:
-        email: github@bosagora.io
-      validators.local:
-        email: github@bosagora.io
+  authoritative:
+    flash.local:
+      email: github@bosagora.io
+    validators.local:
+      email: github@bosagora.io
 
 # Note: You may want to comment some of those to selectively test
 network:

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -272,28 +272,55 @@ event_handlers:
 
 ################################################################################
 ##                             Registry configuration                         ##
-## Configuration for the name registry.                                       ##
 ##                                                                            ##
+## The registry is a DNS server used to resolve the address of validators or  ##
+## Flash nodes. It is also a Full Node (or validator if enabled), as it needs ##
+## to validate registration requests.                                         ##
+##                                                                            ##
+## The registry is optional, and disabled by default. Enabling it exposes an  ##
+## extra API for registration, and a DNS server (on port 53 by default).      ##
 ################################################################################
 registry:
   # If this node should also act as a registry
   enabled: true
 
-  # DNS server configuration
-  dns:
-    enabled: true
-    address: 0.0.0.0
-    port: 53
-    authoritative:
-      validators.bosagora.io:
-        email: dns@validators.bosaagora.io
-      flash.bosagora.io:
-        email: dns.flash.bosagora.io
-        refresh:
-          minutes: 1
-        retry:
-          seconds: 30
-        expire:
-          minutes: 10
-        minimum:
-          minutes: 1
+  # The address to bind the DNS server to (default: 0.0.0.0)
+  # On Linux system with systemd, one might want to specify the local IP,
+  # as systemd-resolvd binds to 127.0.0.53:53, which conflicts with this.
+  address: 0.0.0.0
+  # Port to bind to (default: 53, standard DNS port)
+  # Note that ports < 1024 are privileged ports and might require root powers
+  port: 53
+  # Zones for which this server is authoritative
+  authoritative:
+    # The zone responsible for validators registration
+    validators.bosagora.io:
+      ## The fields below define the SOA record for the DNS entry.
+      ##
+      ## If you are not familiar with DNS, simply enter a valid email address,
+      ## and use the default values.
+      ##
+      ## Those fields are ignored if the server is not authoritative for the zone.
+
+      # Email of the DNS server administrator
+      # This field is required for authoritative servers.
+      email: dns@validators.bosagora.io
+
+      # The rate at which secondary servers will refresh their zones from this server
+      refresh:
+        minutes: 1
+      # Time interval between two retries when a secondary server fails to retrieve data
+      retry:
+        seconds: 30
+      # Initial interval after which the zone data should be purged from cache
+      expire:
+        minutes: 10
+      # The minimum TTL to apply to the zone
+      minimum:
+        minutes: 1
+
+    # Zone responsible for flash nodes registration
+    flash.bosagora.io:
+      # `email` support DNS-style syntax, that is, using `.` instead of `@`
+      email: dns.flash.bosagora.io
+      # The rest of this zone uses the default values.

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -464,7 +464,7 @@ public struct RegistryConfig
             ensure(zone.expire <= intMaxSecs,
                    "registry.authoritative: Zone '%s' field 'expire' ({}) should be at most {}",
                    zone.name, zone.expire, intMaxSecs);
-            ensure(zone.minimum <= intMaxSecs,
+            ensure(zone.minimum <= uintMaxSecs,
                    "registry.authoritative: Zone '%s' field 'minimum' ({}) should be at most {}",
                    zone.name, zone.minimum, uintMaxSecs);
         }

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -80,22 +80,21 @@ public class NameRegistry: NameRegistryAPI
     ///
     public this (RegistryConfig config, FullNodeAPI agora_node)
     {
+        assert(config.enabled, "Registry instantiated but not enabled");
+
         this.config = config;
         this.log = Logger(__MODULE__);
         this.agora_node = agora_node;
         Utils.getCollectorRegistry().addCollector(&this.collectRegistryStats);
 
-        if (this.config.dns.enabled)
-        {
-            this.log.info("Starting authoritative DNS server for zones: {}",
-                          this.config.dns.authoritative.map!(z => z.name));
+        this.log.info("Starting authoritative DNS server for zones: {}",
+                      this.config.authoritative.map!(z => z.name));
 
-            auto currTime = Clock.currTime(UTC());
-            // Serial's value wraps around so the cast is safe
-            const serial = cast(uint) currTime.toUnixTime();
-            foreach (const ref zone; config.dns.authoritative)
-                this.zones ~= zone.fromConfig(serial);
-        }
+        auto currTime = Clock.currTime(UTC());
+        // Serial's value wraps around so the cast is safe
+        const serial = cast(uint) currTime.toUnixTime();
+        foreach (const ref zone; config.authoritative)
+            this.zones ~= zone.fromConfig(serial);
     }
 
     ///

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -849,8 +849,9 @@ public class TestAPIManager
 
     public void createNameRegistry ()
     {
+        RegistryConfig config = { enabled: true };
         auto registry = RemoteAPI!NameRegistryAPI.spawn!TestNameRegistry(
-            RegistryConfig.init, this.nodes[0].address, 5.seconds, &this.registry);
+            config, this.nodes[0].address, 5.seconds, &this.registry);
         this.registry.register("name.registry", registry.ctrl.listener());
     }
 


### PR DESCRIPTION
```
The registry configuration was a bit lacking, and this has been fixed.
Additionally, since the whole point of the 'registry' is now to have an 'enabled' boolean,
and then contain the DNS configuration, the two configurations were flattened.
One reason to do so is that we want to move towards the registry being mostly DNS-based
(as opposed to mostly HTTP-based, as currently), if not only DNS-based.
Hence, the registry and the DNS server are now tied together.
The original reason for allowing disabling the DNS server was to not impair
production if a bug was found in the DNS server, but this concern is no more.
```