### PR TITLE
Introduce network 'realm', allow to configure non-authoritative zones

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -67,6 +67,10 @@ node:
   # The minimum percentage of average fee in the pool which the incoming
   # transaction should include
   min_fee_pct: 80
+  # Which 'realm' this node is connected to - By default, 'coinnet.bosagora.io'
+  # Do not change this unless you intend to maintain your own DNS servers,
+  # or want to join an alternative network.
+  realm: 'coinnet.bosagora.io'
 
 # Each entry in this array is an interface Agora will listen to, allowing to
 # expose the same node on more than one network interface or with different
@@ -291,36 +295,38 @@ registry:
   # Port to bind to (default: 53, standard DNS port)
   # Note that ports < 1024 are privileged ports and might require root powers
   port: 53
-  # Zones for which this server is authoritative
-  authoritative:
-    # The zone responsible for validators registration
-    validators.bosagora.io:
-      ## The fields below define the SOA record for the DNS entry.
-      ##
-      ## If you are not familiar with DNS, simply enter a valid email address,
-      ## and use the default values.
-      ##
-      ## Those fields are ignored if the server is not authoritative for the zone.
+  # The zone responsible for validators registration
+  validators:
+    # Whether this registry is authoritative for this zone, or just a secondary
+    authoritative: true
 
-      # Email of the DNS server administrator
-      # This field is required for authoritative servers.
-      email: dns@validators.bosagora.io
+    ## The fields below define the SOA record for the DNS entry.
+    ##
+    ## If you are not familiar with DNS, simply enter a valid email address,
+    ## and use the default values.
+    ##
+    ## Those fields are ignored if the server is not `authoritative` for the zone.
 
-      # The rate at which secondary servers will refresh their zones from this server
-      refresh:
-        minutes: 1
-      # Time interval between two retries when a secondary server fails to retrieve data
-      retry:
-        seconds: 30
-      # Initial interval after which the zone data should be purged from cache
-      expire:
-        minutes: 10
-      # The minimum TTL to apply to the zone
-      minimum:
-        minutes: 1
+    # Email of the DNS server administrator
+    # This field is required for authoritative servers.
+    # `email` support DNS-style syntax, that is, using `.` instead of `@`
+    email: dns@validators.bosagora.io
 
-    # Zone responsible for flash nodes registration
-    flash.bosagora.io:
-      # `email` support DNS-style syntax, that is, using `.` instead of `@`
-      email: dns.flash.bosagora.io
-      # The rest of this zone uses the default values.
+    # The rate at which secondary servers will refresh their zones from this server
+    refresh:
+      minutes: 1
+    # Time interval between two retries when a secondary server fails to retrieve data
+    retry:
+      seconds: 30
+    # Initial interval after which the zone data should be purged from cache
+    expire:
+      minutes: 10
+    # The minimum TTL to apply to the zone
+    minimum:
+      minutes: 1
+
+  # Zone responsible for flash nodes registration
+  flash:
+    # Having separate authoritative server increases redundancy and reduces load,
+    # hence this configuration, while unlikely in a small to medium network, is supported.
+    authoritative: false

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -128,7 +128,7 @@ public Listeners runNode (Config config)
 
     if (config.registry.enabled)
     {
-        result.registry = new NameRegistry(config.registry, result.node);
+        result.registry = new NameRegistry(config.node.realm, config.registry, result.node);
         router.registerRestInterface!(NameRegistryAPI)(result.registry);
         /* auto dnstask = */ runTask(() => runDNSServer(config.registry, result.registry));
         result.tcp ~= listenTCP(config.registry.port, (conn) => conn.runTCPDNSServer(result.registry),

--- a/source/agora/stats/Registry.d
+++ b/source/agora/stats/Registry.d
@@ -16,10 +16,10 @@ module agora.stats.Registry;
 import agora.stats.Stats;
 
 ///
-public struct RegistryStatsValue
+public struct RegistryStats
 {
-    public ulong registry_record_count;
+    /// Number of records in the 'validators' zone
+    public ulong registry_validator_record_count;
+    /// Number of records in the 'flash' zone
+    public ulong registry_flash_record_count;
 }
-
-///
-public alias RegistryStats = Stats!(RegistryStatsValue, NoLabel);

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -837,7 +837,7 @@ public class TestAPIManager
         {
             auto listener = reg.locate!TestAPI(agora_addr);
             assert(listener != typeof(listener).init);
-            super(config, new RemoteAPI!TestAPI(listener, timeout));
+            super("localrest", config, new RemoteAPI!TestAPI(listener, timeout));
         }
     }
 


### PR DESCRIPTION
```
This rework two main aspects of the configuration:
- It allows non-authoritative server, by making 'authoritative' a boolean of the zone;
- It restricts zone configuration to the currently envisioned zone split;

The second point warrant more explanation: previously, the DNS server was developed to be generic,
and thus allowed to declare arbitrary zone names in the configuration.
However, that wasn't yet used by the node. As we are preparing to use it, one fact came up:
the node will need to have a matching configuration, that is, know what domain to look the validators
and the flash nodes in. Worse, this flexibility was actually not usable,
as only enrolled nodes (or nodes with a channel) could actually register.

Hence, this change things to make client configuration much easier, with no expense for the DNS server:
validators now live under 'validators.realm', while flash nodes are found under 'flash.realm'.
Realm names are expected to be 'testnet.bosagora.io', 'coinnet.bosagora.io', and 'localhost' (for local dev).
```

The other changes derive from the first one (splitting the stats and using a common `struct`).