### PR TITLE
NetMan: Remove redundant connected_peers variable

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -386,9 +386,6 @@ public class NetworkManager
     /// All connected nodes (Validators & FullNodes)
     public DList!NodeConnInfo peers;
 
-    /// Easy lookup of currently connected peers
-    protected Set!Address connected_peers;
-
     /// All known addresses so far (used for getNodeInfo())
     protected Set!Address known_addresses;
 
@@ -466,7 +463,6 @@ public class NetworkManager
     /// Called after a node's handshake is complete
     private void onHandshakeComplete (scope ref NodeConnInfo node)
     {
-        this.connected_peers.put(node.client.address);
         this.peers.insertBack(node);
 
         if (node.isValidator())
@@ -775,9 +771,9 @@ public class NetworkManager
     private bool shouldEstablishConnection (Address address)
     {
         return !this.banman.isBanned(address) &&
-            address !in this.connected_peers &&
             address !in this.connection_tasks &&
-            address !in this.todo_addresses;
+            address !in this.todo_addresses &&
+            !this.peers[].map!(p => p.address).canFind(address);
     }
 
     /// Received new set of addresses, put them in the todo address list

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -76,6 +76,12 @@ public class NetworkManager
         /// Client
         NetworkClient client;
 
+        /// Convenience function to access the client's address
+        public Address address () const scope @safe pure nothrow @nogc
+        {
+            return this.client.address;
+        }
+
         ///
         public bool isValidator () const scope @safe pure nothrow @nogc
         {


### PR DESCRIPTION
```
We already have 'peers' which contains 'address', so this is redundant.
Additionally, we do not actually know if the peer is connected:
it might have timed out / been disconnected, and since we never clean
this Set, we might end up with stale information.
The only benefit we're loosing is the amortized O(1) lookup.
```