### PR TITLE
Fixes issue 2498: Ensure no trailing slash in node addresses

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -766,6 +766,11 @@ public class NetworkManager
     /// Ditto
     private void addAddress (Address address)
     {
+        // Ensure we do not have a trailing slash for address
+        while (address.length && address[$ - 1] == '/')
+            address.length -= 1;
+        if (!address.length) return;
+
         if (this.shouldEstablishConnection(address))
             this.todo_addresses.put(address);
 


### PR DESCRIPTION
Prevent potential duplicate registered nodes where address are included with and without a trailing slash.