### PR TITLE
Improve Config validation and prepare for scheme-less hostnames

### DIFF
--- a/devel/config-fullnode.yaml
+++ b/devel/config-fullnode.yaml
@@ -10,6 +10,7 @@
 # ./build/agora -c devel/config-fullnode.yaml
 
 node:
+  realm: "testnet.bosagora.io"
   testing: true
   data_dir: .fullnode/data/
   # Can be used with curl or just a browser
@@ -31,11 +32,10 @@ validator:
 
 registry:
   enabled: true
-  authoritative:
-    flash.local:
-      email: github@bosagora.io
-    validators.local:
-      email: github@bosagora.io
+  flash:
+    email: github@bosagora.io
+  validators:
+    email: github@bosagora.io
 
 # Note: You may want to comment some of those to selectively test
 network:

--- a/devel/config-single.yaml
+++ b/devel/config-single.yaml
@@ -10,6 +10,7 @@
 # ./build/agora -c devel/config-single.yaml
 
 node:
+  realm: "localhost"
   testing: true
   limit_test_validators: 1
   data_dir: .single/data/

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -139,6 +139,11 @@ public struct Config
 
         if (this.consensus.quorum_threshold < 1 || this.consensus.quorum_threshold > 100)
             throw new Exception("consensus.quorum_threshold is a percentage and must be between 1 and 100, included");
+
+        // Work around https://github.com/bosagora/config/issues/3
+        this.node.validate();
+        if (this.registry.enabled)
+            this.registry.validate();
     }
 }
 
@@ -282,7 +287,7 @@ public struct NodeConfig
     public string realm = "coinnet.bosagora.io";
 
     /// Validate this struct
-    public void validate () const
+    public void validate () const scope @safe
     {
         ensure(this.realm.length > 0, "node.realm cannot be empty");
 
@@ -450,7 +455,7 @@ public struct RegistryConfig
     public immutable(ZoneConfig) flash;
 
     /// Validate the semantic of the user-provided configuration
-    public void validate () const
+    public void validate () const scope @safe
     {
         ensure(this.address.length > 0, "registry is enabled but no `address` is provided");
         ensure(this.port > 0, "registry.port: 0 is not a valid value");

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2173,12 +2173,12 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
 
     string validatorAddress (size_t idx, KeyPair key)
     {
-        return format("Validator #%s (%s)", idx, key.address);
+        return format("Validator-%s.%s.localrest", idx, key.address);
     }
 
     string fullNodeAddress (size_t idx)
     {
-        return format("FullNode #%s", idx);
+        return format("FullNode-%s.localrest", idx);
     }
 
     auto outsider_validators_keys = WK.Keys.byRange()


### PR DESCRIPTION
This fixes a few minor issues with config validation, in particular with nested config.
A couple of commits are also to enable storing scheme and path-less addresses in the registry.