### PR TITLE
Flash: Introduce node key pair

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -170,6 +170,13 @@ flash:
   max_retry_time:
     msecs: 60000
 
+  # The seed to use for the keypair of this node
+  # This will only be used for paying on-chain fees in uncollaborative close attempts
+  #
+  # DO NOT USE THOSE VALUES ANYWHERE
+  # Public address:  boa1xrfl00xmyf28jxnnh2g3xvwgqffx4wxh6sdkn5mvqauygtv3vmpwq93vv77
+  seed: SBGQOIPUN4FV4TVDHJ7VLZ2NE5AC3G5WRGVKRKM7JO4BH57KE6IQFRZI
+
 ################################################################################
 ##                         Ban manager configuration                          ##
 ################################################################################

--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -121,8 +121,7 @@ public class Channel
     private Backoff backoff;
 
     /// Called when a channel update has been completed.
-    private alias GetFeeUTXOs = FeeUTXOs delegate (PublicKey pk,
-        ulong tx_size);
+    private alias GetFeeUTXOs = FeeUTXOs delegate (ulong tx_size);
     /// Ditto
     private GetFeeUTXOs getFeeUTXOs;
 
@@ -2236,7 +2235,7 @@ LOuter: while (1)
         auto update_input = update_tx.inputs[0];
         auto update_ouput = update_tx.outputs[0];
 
-        auto utxos = this.getFeeUTXOs(this.own_pk, update_tx.sizeInBytes());
+        auto utxos = this.getFeeUTXOs(update_tx.sizeInBytes());
         update_tx.inputs ~= utxos.utxos.map!(hash => Input(hash)).array;
         update_tx.inputs.sort();
 

--- a/source/agora/flash/Config.d
+++ b/source/agora/flash/Config.d
@@ -73,6 +73,11 @@ public struct FlashConfig
 
     /// Multiplier for the truncating exponential backoff retrying algorithm
     public uint retry_multiplier = 10;
+
+    /// The seed to use for the keypair of this node
+    /// This will only be used for paying on-chain fees in uncollaborative close attempts
+    @Converter!KeyPair((value) => KeyPair.fromSeed(SecretKey.fromString(value.as!string)))
+    public @Name("seed") immutable KeyPair key_pair;
 }
 
 /***************************************************************************

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -1411,12 +1411,13 @@ public class FlashNode : FlashControlAPI
     }
 
     ///
-    protected FeeUTXOs getFeeUTXOs (PublicKey pk, ulong tx_size)
+    protected FeeUTXOs getFeeUTXOs (ulong tx_size)
     {
         auto per_byte = this.listener.getEstimatedTxFee();
         if(!per_byte.mul(tx_size))
             return FeeUTXOs.init;
-        auto utxos = this.listener.getFeeUTXOs(pk, per_byte);
+        // Always pay with the node key
+        auto utxos = this.listener.getFeeUTXOs(this.conf.key_pair.address, per_byte);
         // reuse total_value as refund amount
         if (!utxos.total_value.sub(per_byte))
             utxos.total_value = Amount(0);

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -374,7 +374,9 @@ public class FlashNodeFactory : TestAPIManager
             max_retry_delay : 100.msecs,
             listener_address : ListenerAddress,
             registry_address : "name.registry",
-            addresses_to_register : [to!string(kp.address)]};
+            addresses_to_register : [to!string(kp.address)],
+            key_pair : kp,
+        };
         return this.createFlashNode!FlashNodeImpl(kp, conf, storage, file, line);
     }
 
@@ -1010,7 +1012,8 @@ unittest
         max_retry_time : 4.seconds,
         max_retry_delay : 100.msecs,
         registry_address : "name.registry",
-        addresses_to_register : [to!string(WK.Keys.A.address)]
+        addresses_to_register : [to!string(WK.Keys.A.address)],
+        key_pair : WK.Keys.A
     };
 
     auto alice = network.createFlashNode(WK.Keys.A, alice_conf);
@@ -1508,6 +1511,7 @@ unittest
         registry_address : "name.registry",
         addresses_to_register : [to!string(WK.Keys.C.address)],
         listener_address : network.ListenerAddress,
+        key_pair : WK.Keys.C
     };
     auto alice = network.createFlashNode(WK.Keys.A);
     auto charlie = network.createFlashNode(WK.Keys.C, charlie_conf);
@@ -1709,7 +1713,8 @@ unittest
         max_retry_time : 4.seconds,
         max_retry_delay : 10.msecs,
         registry_address : "name.registry",
-        addresses_to_register : [to!string(WK.Keys.A.address)]
+        addresses_to_register : [to!string(WK.Keys.A.address)],
+        key_pair : WK.Keys.A
     };
 
     auto alice = network.createFlashNode(WK.Keys.A, alice_conf);
@@ -1806,7 +1811,8 @@ unittest
         max_retry_time : 4.seconds,
         max_retry_delay : 10.msecs,
         registry_address : "name.registry",
-        addresses_to_register : [to!string(WK.Keys.A.address)]
+        addresses_to_register : [to!string(WK.Keys.A.address)],
+        key_pair : WK.Keys.A
     };
 
     auto alice = network.createFlashNode(WK.Keys.A, alice_conf);


### PR DESCRIPTION
We are gradually removing any dependency on user KeyPair in
Channel and the Flash node. But adding fees to the update and
settlement TXs require access to KeyPair in realtime. So Flash node
will be configured to use a single KeyPair to be used for all fee
bumping operations.