### PR TITLE
Registry: Move instantiation to FullNode

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -1081,7 +1081,7 @@ public class FullNode : API
         if (known < start_height)
             return null;
 
-        // Bounds check end_height and make the API prractical
+        // Bounds check end_height and make the API practical
         if (known < end_height)
             end_height = known;
         else if (end_height < start_height)

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -45,6 +45,7 @@ import agora.network.Clock;
 import agora.network.Manager;
 import agora.node.BlockStorage;
 import agora.node.Config;
+import agora.node.Registry;
 import agora.consensus.Ledger;
 import agora.node.TransactionRelayer;
 import agora.script.Engine;
@@ -221,6 +222,14 @@ public class FullNode : API
     /// Ditto
     protected TransactionReceivedHandler[Address] transaction_handlers;
 
+    /// Name registry, if enabled for this node
+    protected NameRegistry registry;
+
+    /// Used by `Runner`
+    package NameRegistry getRegistry () @safe pure nothrow @nogc return
+    {
+        return this.registry;
+    }
 
     /***************************************************************************
 
@@ -274,6 +283,9 @@ public class FullNode : API
             // Use second precision to simplify aggregation
             Clock.currTime!(ClockType.second)(UTC()).toISOString(),
         );
+
+        if (config.registry.enabled)
+            this.registry = new NameRegistry(config.node.realm, config.registry, this);
     }
 
     mixin DefineCollectorForStats!("app_stats", "collectAppStats");


### PR DESCRIPTION
```
By keeping a reference to the Registry from the FullNode, we can ensure that
the FullNode is able to use it (e.g. in its network manager) and ideally
control it (e.g. forward shutdown() instructions), instead of having them
separated as currently is.
```

Extracted from #2487 to make it move forward.