### PR TITLE
FullNode: Refactor getPreimagesRange to getPreimagesFrom

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -253,23 +253,17 @@ public interface API
         validator, not the bound of the pre-images.
 
         API:
-            GET /preimages_range
+            GET /preimages_from
 
         Params:
             start_height = the starting enrolled height to begin retrieval from
-            end_height = the end enrolled height to finish retrieval to.
-                         If the value provided is lower than `start_height`,
-                         only the pre-images for validators active at
-                         `start_height` will be returned.
-                         If the value is higher than the currently known block
-                         height, the return will be bound to that value.
 
         Returns:
             preimages' information of the validators
 
     ***************************************************************************/
 
-    public PreImageInfo[] getPreimagesRange (ulong start_height, ulong end_height);
+    public PreImageInfo[] getPreimagesFrom (ulong start_height);
 
     /***************************************************************************
 

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -524,18 +524,15 @@ public class EnrollmentManager
 
         Params:
             start_height = the starting enrolled height to begin retrieval from
-            end_height = the end enrolled height to finish retrieval to
 
         Returns:
             preimages' information of the validators
 
     ***************************************************************************/
 
-    public PreImageInfo[] getValidatorPreimages (
-        in Height start_height, in Height end_height) @safe nothrow
+    public PreImageInfo[] getValidatorPreimages (in Height start_height) @safe nothrow
     {
-        return this.validator_set.getPreimages(start_height,
-            end_height);
+        return this.validator_set.getPreimages(start_height);
     }
 
     /***************************************************************************

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -508,23 +508,20 @@ public class ValidatorSet
 
         Params:
             start_height = the starting enrolled height to begin retrieval from
-            end_height = the end enrolled height to finish retrieval to
 
         Returns:
             preimages' information of the validators
 
     ***************************************************************************/
 
-    public PreImageInfo[] getPreimages (Height start_height,
-        Height end_height) @trusted nothrow
+    public PreImageInfo[] getPreimages (Height start_height) @trusted nothrow
     {
         PreImageInfo[] preimages;
 
         try
         {
             auto results = this.db.execute("SELECT key, preimage, height " ~
-                "FROM preimages WHERE height >= ? AND height <= ?",
-                start_height, end_height);
+                "FROM preimages WHERE height >= ?", start_height);
 
             foreach (row; results)
             {
@@ -536,8 +533,8 @@ public class ValidatorSet
         }
         catch (Exception ex)
         {
-            log.error("Exception occured on getPreimages: {}, heights " ~
-                "[{}..{}]", ex.msg, start_height, end_height);
+            log.error("Exception occured on getPreimages: {}, height {}",
+                ex.msg, start_height);
         }
 
         return preimages;

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -517,7 +517,6 @@ public class NetworkClient
 
         Params:
             start_height = the starting enrolled height to begin retrieval from
-            end_height = the end enrolled height to finish retrieval to
 
         Returns:
             the array of preimages of validators enrolling from `enrolled_height`
@@ -527,11 +526,10 @@ public class NetworkClient
 
     ***************************************************************************/
 
-    public PreImageInfo[] getPreimagesRange (ulong start_height,
-        ulong end_height) nothrow
+    public PreImageInfo[] getPreimagesFrom (ulong start_height) nothrow
     {
-        return this.attemptRequest!(API.getPreimagesRange, Throw.No)(this.api,
-            start_height, end_height);
+        return this.attemptRequest!(API.getPreimagesFrom, Throw.No)(this.api,
+            start_height);
     }
 
     /***************************************************************************

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -922,7 +922,7 @@ public class NetworkManager
             log.info("Retrieving preimages from the height of {} from {}..",
                 start_height, pair.client.address);
 
-            auto preimages = pair.client.getPreimagesRange(start_height, start_height + MaxBlocks);
+            auto preimages = pair.client.getPreimagesFrom(start_height);
 
             log.info("Received {} preimages", preimages.length);
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -1059,9 +1059,8 @@ public class FullNode : API
         return preimage_infos;
     }
 
-    /// GET: /preimages_range
-    public override PreImageInfo[] getPreimagesRange (
-        ulong start_height, ulong end_height)
+    /// GET: /preimages_from
+    public override PreImageInfo[] getPreimagesFrom (ulong start_height)
         @safe nothrow
     {
         this.recordReq("preimages_range");
@@ -1071,14 +1070,7 @@ public class FullNode : API
         if (known < start_height)
             return null;
 
-        // Bounds check end_height and make the API practical
-        if (known < end_height)
-            end_height = known;
-        else if (end_height < start_height)
-            end_height = start_height;
-
-        return this.enroll_man.getValidatorPreimages(
-            Height(start_height), Height(end_height))
+        return this.enroll_man.getValidatorPreimages(Height(start_height))
             .array();
     }
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2318,13 +2318,12 @@ public class NoPreImageVN : TestValidatorNode
     }
 
     /// GET: /preimages
-    public override PreImageInfo[] getPreimagesRange (ulong start_height,
-        ulong end_height) @safe nothrow
+    public override PreImageInfo[] getPreimagesFrom (ulong start_height) @safe nothrow
     {
         if (atomicLoad(*this.reveal_preimage))
-            return super.getPreimagesRange(start_height, end_height);
+            return super.getPreimagesFrom(start_height);
         const ek = this.enroll_man.getEnrollmentKey();
-        return super.getPreimagesRange(start_height, end_height)
+        return super.getPreimagesFrom(start_height)
             .filter!(pi => pi.utxo != ek).array();
     }
 


### PR DESCRIPTION
Since some time ago, we only keep the latest preimage in our
storage. So retrieval from a range does not make sense anymore.

This could also make a node to never be able to catch up
if it falls too much behind. Imagine a network at height 2000, and a node
starting from scratch at height 0. Fetching preimages [0, 1024] would
always fail since no preimage in our database will pass the
height < end_height check.