### PR TITLE
Tests: Reduce amount of imports boilerplate

### DIFF
--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -16,9 +16,6 @@ module agora.test.BanManager;
 
 version (unittest):
 
-import agora.common.Types;
-import agora.consensus.data.Transaction;
-import agora.crypto.Hash;
 import agora.test.Base;
 import core.thread;
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -24,22 +24,17 @@ version (unittest):
 
 import agora.api.FullNode : NodeInfo, NetworkState;
 import agora.api.Registry;
-import agora.api.Validator : ValidatorAPI = API, Identity;
 import agora.api.Handlers;
-import agora.common.Amount;
 import agora.common.BanManager;
 import agora.common.BitMask;
 import agora.common.ManagedDatabase;
 import agora.common.Set;
 import agora.common.Task;
 import agora.common.Types;
-import agora.consensus.data.Block;
-import agora.consensus.data.Enrollment;
 import agora.consensus.data.genesis.Test;
 import agora.consensus.data.Params;
 import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.ValidatorBlockSig;
-import agora.consensus.data.Transaction;
 import agora.consensus.EnrollmentManager;
 import agora.consensus.Fee;
 import agora.consensus.Ledger;
@@ -82,7 +77,14 @@ import core.thread;
 
 /* The following imports are frequently needed in tests */
 
+public import agora.common.Amount;
 public import agora.common.Types;
+public import agora.consensus.data.Block;
+public import agora.consensus.data.Enrollment;
+public import agora.consensus.data.Transaction;
+
+/// In order to `filter` (LocalRest) any method, the `API` type is needed
+public import agora.api.Validator;
 /// Any test implementing their own nodes will need to use `Config`
 public import agora.node.Config : Config;
 /// Allows to easily configure the loggers
@@ -1326,7 +1328,7 @@ public class TestNetworkManager : NetworkManager
 
     API implemented by the test nodes runs by LocalRest
 
-    This API inherits from ValidatorAPI, and simply adds a few functions that
+    This API inherits from the validator API, and simply adds a few functions that
     should not be public in a real-world scenario, but are needed in our test
     setup. Those functions trigger a specific action (e.g. `start`, `printLog`),
     or in rare cases are a way to force a node to take a specific action.
@@ -1342,7 +1344,7 @@ public class TestNetworkManager : NetworkManager
 
 *******************************************************************************/
 
-public interface TestAPI : ValidatorAPI
+public interface TestAPI : API
 {
     /***************************************************************************
 

--- a/source/agora/test/BlockRewards.d
+++ b/source/agora/test/BlockRewards.d
@@ -15,11 +15,7 @@ module agora.test.BlockRewards;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.common.Amount;
-import agora.consensus.data.Block;
 import agora.consensus.data.Params: ConsensusConfig;
-import agora.consensus.data.Transaction;
 import agora.consensus.Fee: calculateDataFee;
 import agora.consensus.protocol.Nominator;
 import agora.test.Base;

--- a/source/agora/test/BlockTimeConsensus.d
+++ b/source/agora/test/BlockTimeConsensus.d
@@ -15,9 +15,6 @@ module agora.test.BlockTimeConsensus;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.consensus.data.Transaction;
-import agora.crypto.Hash;
 import agora.test.Base;
 
 ///

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -16,29 +16,19 @@ module agora.test.Byzantine;
 
 version (unittest):
 
-import agora.api.Validator;
 import agora.common.Task;
-import agora.common.Types;
-import agora.consensus.data.Block;
 import agora.consensus.EnrollmentManager;
 import agora.consensus.data.Params;
-import agora.consensus.data.Transaction;
 import agora.consensus.protocol.Data;
 import agora.consensus.protocol.Nominator;
 import agora.crypto.Schnorr;
 import agora.network.Clock;
-import agora.consensus.Ledger;
 import agora.test.Base;
-import agora.utils.SCPPrettyPrinter;
 
 import scpd.types.Stellar_SCP;
 import scpd.types.Stellar_types : NodeID;
 
-import std.algorithm;
 import std.exception;
-import std.format;
-import std.range;
-import std.stdio;
 
 import core.exception;
 import core.stdc.inttypes;

--- a/source/agora/test/EmptyBlocks.d
+++ b/source/agora/test/EmptyBlocks.d
@@ -15,8 +15,6 @@ module agora.test.EmptyBlocks;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.consensus.data.Transaction;
 import agora.test.Base;
 
 /// EmptyBlocks test

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -15,9 +15,6 @@ module agora.test.EnrollDifferentUTXOs;
 
 version (unittest):
 
-import agora.common.Amount;
-import agora.consensus.data.Enrollment;
-import agora.consensus.data.Transaction;
 import agora.consensus.data.genesis.Test: genesis_validator_keys;
 import agora.test.Base;
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -19,15 +19,10 @@ version (unittest):
 import agora.common.Set;
 import agora.consensus.data.Params;
 import agora.consensus.data.PreImageInfo;
-import agora.consensus.data.Transaction;
 import agora.consensus.validation.PreImage;
 import agora.test.Base;
 
-import std.algorithm.searching : any;
-import std.range : only;
-
 import core.thread;
-import core.time;
 
 /// test for enrollment process & revealing a pre-image periodically
 unittest

--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -14,8 +14,6 @@
 module agora.test.Fee;
 
 import agora.test.Base;
-import agora.consensus.data.Transaction;
-import agora.common.Amount;
 
 // Normal operation, every `payout_period`th block should
 // include coinbase outputs to validators
@@ -81,7 +79,6 @@ unittest
 version (none)
 unittest
 {
-    import agora.consensus.data.Block;
     import core.thread;
 
     TestConf conf;
@@ -143,7 +140,6 @@ unittest
 // at different heights. With 80 quorum threshold, consensus should be reached
 unittest
 {
-    import agora.consensus.data.Block;
     import core.thread;
 
     TestConf conf;

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -17,12 +17,9 @@ version (unittest):
 
 import agora.api.FullNode : FullNodeAPI = API;
 import agora.api.Registry;
-import agora.common.Amount;
 import agora.common.ManagedDatabase;
 import agora.common.Task;
 import agora.consensus.data.genesis.Test;
-import agora.consensus.data.Block;
-import agora.consensus.data.Transaction;
 import agora.consensus.data.UTXO;
 import agora.crypto.ECC;
 import agora.crypto.Hash;
@@ -50,12 +47,9 @@ import agora.utils.Log;
 import geod24.LocalRest : Listener;
 import geod24.Registry;
 
-import std.algorithm;
-import std.conv;
 import std.exception;
 
 import core.stdc.time;
-import core.time;
 import core.thread;
 
 mixin AddLogger!();

--- a/source/agora/test/FutureEnrollment.d
+++ b/source/agora/test/FutureEnrollment.d
@@ -15,13 +15,6 @@ module agora.test.FutureEnrollment;
 
 version (unittest):
 
-import agora.api.FullNode;
-import agora.common.Amount;
-import agora.consensus.data.Block;
-import agora.consensus.data.Enrollment;
-import agora.consensus.data.Transaction;
-import agora.crypto.Key;
-import agora.node.Config;
 import agora.test.Base;
 
 import core.atomic : atomicLoad;

--- a/source/agora/test/GenesisBlock.d
+++ b/source/agora/test/GenesisBlock.d
@@ -16,9 +16,6 @@ module agora.test.GenesisBlock;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.consensus.data.Block;
-import agora.consensus.data.Transaction;
 import agora.test.Base;
 
 /// ditto

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -16,31 +16,16 @@ module agora.test.InvalidBlockSigByzantine;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.common.Task;
-import agora.consensus.data.Block;
 import agora.consensus.protocol.Nominator;
 import agora.crypto.ECC;
 import agora.crypto.Schnorr;
 import agora.test.Base;
-import agora.utils.SCPPrettyPrinter;
 import agora.utils.Log;
-import agora.utils.PrettyPrinter;
-
 
 import scpd.types.Stellar_SCP;
 import scpd.types.Stellar_types : NodeID;
 
-import std.algorithm;
-import std.exception;
-import std.format;
-import std.range;
-import std.stdio;
-
-import core.exception;
 import core.stdc.inttypes;
-import core.thread;
-import core.atomic;
 
 mixin AddLogger!();
 

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -16,10 +16,6 @@ module agora.test.Ledger;
 
 version (unittest):
 
-import agora.common.Amount;
-import agora.common.Types;
-import agora.consensus.data.Block;
-import agora.consensus.data.Transaction;
 import agora.consensus.data.UTXO;
 import agora.consensus.Fee;
 import agora.consensus.validation;

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -16,9 +16,6 @@ module agora.test.LocalTransactions;
 
 version (unittest):
 
-import agora.consensus.data.Transaction;
-import agora.consensus.Fee;
-import agora.common.Task;
 import agora.crypto.Hash;
 import agora.consensus.Ledger;
 import agora.test.Base;

--- a/source/agora/test/LockHeight.d
+++ b/source/agora/test/LockHeight.d
@@ -16,7 +16,6 @@ module agora.test.LockHeight;
 version (unittest):
 
 import agora.api.Validator;
-import agora.consensus.data.Transaction;
 import agora.crypto.Hash;
 import agora.test.Base;
 

--- a/source/agora/test/ManyValidators.d
+++ b/source/agora/test/ManyValidators.d
@@ -15,22 +15,13 @@ module agora.test.ManyValidators;
 
 version (unittest):
 
+import agora.test.Base;
+
 import core.thread;
 import core.time;
 
 void manyValidators (size_t validators)
 {
-    import agora.test.Base : TestConf, GenesisValidators, GenesisValidatorCycle,
-        makeTestNetwork, TestAPIManager;
-    import agora.common.Types : Height;
-    import agora.consensus.data.Transaction;
-    import agora.utils.Test : genesisSpendable, retryFor;
-    import std.algorithm;
-    import std.format;
-    import std.range;
-    import core.time : seconds;
-    import agora.crypto.Key;
-
     TestConf conf = { outsider_validators : validators - GenesisValidators };
     conf.node.network_discovery_interval = 2.seconds;
     conf.node.retry_delay = 250.msecs;

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -15,15 +15,10 @@ module agora.test.MissingPreImageDetection;
 
 version (unittest):
 
-import agora.common.Task;
-import agora.consensus.data.Enrollment;
-import agora.consensus.data.PreImageInfo;
-import agora.consensus.EnrollmentManager;
 import agora.consensus.protocol.Data;
 import agora.consensus.protocol.Nominator;
 import agora.serialization.Serializer;
 import agora.test.Base;
-import agora.utils.Test;
 
 import scpd.types.Stellar_SCP;
 import scpd.types.Utils;

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -18,16 +18,7 @@ module agora.test.MultiRoundConsensus;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.common.Task;
-import agora.consensus.data.Block;
-import agora.consensus.data.Params;
-import agora.consensus.EnrollmentManager;
 import agora.consensus.protocol.Nominator;
-import agora.consensus.data.Transaction;
-import agora.consensus.data.genesis.Test;
-import agora.network.Clock;
-import agora.consensus.Ledger;
 import agora.test.Base;
 
 import core.stdc.inttypes;

--- a/source/agora/test/NameRegistry.d
+++ b/source/agora/test/NameRegistry.d
@@ -14,8 +14,6 @@ module agora.test.NameRegistry;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.consensus.data.Transaction;
 import agora.test.Base;
 
 /// Simple test

--- a/source/agora/test/NetworkClient.d
+++ b/source/agora/test/NetworkClient.d
@@ -15,10 +15,7 @@ module agora.test.NetworkClient;
 
 version (unittest):
 
-import agora.consensus.data.Block;
-import agora.common.Types;
 import agora.consensus.data.genesis.Test;
-import agora.consensus.data.Transaction;
 import agora.test.Base;
 
 import core.thread;

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -15,10 +15,7 @@ module agora.test.NetworkManager;
 
 version (unittest):
 
-import agora.api.FullNode;
-import agora.consensus.data.Block;
 import agora.consensus.data.Params;
-import agora.consensus.data.Transaction;
 import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.script.Lock;

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -18,7 +18,6 @@ module agora.test.PeriodicCatchup;
 version (unittest):
 
 import agora.common.BitMask;
-import agora.consensus.data.Block;
 import agora.consensus.data.ValidatorBlockSig;
 import agora.consensus.protocol.Nominator;
 import agora.crypto.Schnorr: Signature;

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -16,19 +16,8 @@ module agora.test.Quorum;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.common.Amount;
-import agora.consensus.data.Params;
-import agora.consensus.data.Block;
-import agora.consensus.data.Enrollment;
-import agora.consensus.data.Transaction;
-import agora.crypto.Key;
 import agora.node.FullNode;
 import agora.test.Base;
-
-import std.algorithm;
-import std.format;
-import std.range;
 
 import core.thread;
 import core.time;

--- a/source/agora/test/QuorumPreimage.d
+++ b/source/agora/test/QuorumPreimage.d
@@ -16,11 +16,7 @@ module agora.test.QuorumPreimage;
 version (unittest):
 
 import agora.api.Validator;
-import agora.common.Amount;
 import agora.consensus.data.Params;
-import agora.consensus.data.Block;
-import agora.consensus.data.Enrollment;
-import agora.consensus.data.Transaction;
 import agora.consensus.data.genesis.Test;
 import agora.crypto.Key;
 import agora.node.FullNode;
@@ -28,17 +24,12 @@ import agora.test.Base;
 import agora.utils.Log;
 import agora.utils.PrettyPrinter;
 
-import std.algorithm;
-import std.format;
-import std.range;
-
 import core.thread;
 import core.time;
 
 /// test preimage changing quorum configs
 unittest
 {
-    import agora.common.Types;
     TestConf conf = {
         recurring_enrollment : false,
         outsider_validators : 2,

--- a/source/agora/test/QuorumShuffle.d
+++ b/source/agora/test/QuorumShuffle.d
@@ -15,14 +15,9 @@ module agora.test.QuorumShuffle;
 
 version (unittest):
 
-import agora.common.Types;
-import agora.consensus.data.Block;
-import agora.consensus.data.Enrollment;
-import agora.consensus.data.Transaction;
 import agora.crypto.Key;
 import agora.test.Base;
 import agora.utils.Log;
-import agora.utils.PrettyPrinter;
 
 mixin AddLogger!();
 

--- a/source/agora/test/Restart.d
+++ b/source/agora/test/Restart.d
@@ -15,9 +15,7 @@ module agora.test.Restart;
 
 version (unittest):
 
-import agora.api.Validator;
 import agora.common.ManagedDatabase;
-import agora.consensus.data.Block;
 import agora.consensus.data.Params;
 import agora.test.Base;
 

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -16,21 +16,8 @@ module agora.test.RestoreSCPState;
 version (unittest):
 
 import agora.common.ManagedDatabase;
-import agora.common.Task;
-import agora.consensus.EnrollmentManager;
 import agora.consensus.protocol.Nominator;
-import agora.consensus.data.Block;
-import agora.consensus.data.Params;
-import agora.consensus.data.Transaction;
-import agora.consensus.Ledger;
-import agora.node.Validator;
-import agora.network.Clock;
 import agora.test.Base;
-
-import scpd.Cpp;
-import scpd.types.Stellar_SCP;
-
-import core.thread;
 
 /// A test to store SCP state and recover SCP state
 unittest

--- a/source/agora/test/RestoreSlashingInfo.d
+++ b/source/agora/test/RestoreSlashingInfo.d
@@ -16,12 +16,7 @@ module agora.test.RestoreSlashingInfo;
 
 version (unittest):
 
-import agora.api.FullNode;
-import agora.consensus.data.Enrollment;
-import agora.consensus.data.Transaction;
-import agora.crypto.Key;
 import agora.test.Base;
-import agora.utils.PrettyPrinter;
 
 import core.thread;
 

--- a/source/agora/test/Script.d
+++ b/source/agora/test/Script.d
@@ -15,9 +15,7 @@ module agora.test.Script;
 
 version (unittest):
 
-import agora.api.Validator;
 import agora.consensus.data.genesis.Test;
-import agora.consensus.data.Transaction;
 import agora.crypto.Key;
 import agora.crypto.Schnorr;
 import agora.script.Lock;
@@ -30,7 +28,8 @@ import Schnorr = agora.crypto.Schnorr;
 
 import std.bitmanip;
 
-alias LockType = agora.script.Lock.LockType;
+// Needed to avoid conflict with `std.stdio.LockType`
+private alias LockType = agora.script.Lock.LockType;
 
 /// OP.VERIFY_LOCK_HEIGHT
 unittest

--- a/source/agora/test/Simple.d
+++ b/source/agora/test/Simple.d
@@ -21,8 +21,6 @@ module agora.test.Simple;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.consensus.data.Transaction;
 import agora.test.Base;
 
 /// Simple test

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -16,20 +16,8 @@ module agora.test.SlashingMisbehavingValidator;
 
 version (unittest):
 
-import agora.common.ManagedDatabase;
-import agora.consensus.data.Block;
-import agora.consensus.data.Params;
-import agora.consensus.data.PreImageInfo;
-import agora.consensus.data.Transaction;
-import agora.consensus.EnrollmentManager;
-import agora.consensus.state.UTXOSet;
 import agora.crypto.Schnorr;
-import agora.crypto.Key;
-import agora.utils.Test;
 import agora.test.Base;
-
-import std.exception;
-import std.path : buildPath;
 
 import core.atomic;
 import core.stdc.stdint;

--- a/source/agora/test/TimeBlockInterval.d
+++ b/source/agora/test/TimeBlockInterval.d
@@ -15,13 +15,7 @@ module agora.test.TimeBlockInterval;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.consensus.data.Transaction;
-import agora.crypto.Hash;
 import agora.test.Base;
-
-import std.range;
-import std.algorithm;
 
 ///
 unittest

--- a/source/agora/test/TimeDrift.d
+++ b/source/agora/test/TimeDrift.d
@@ -15,14 +15,9 @@ module agora.test.TimeDrift;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.consensus.data.Transaction;
 import agora.crypto.Hash;
 import agora.test.Base;
 import agora.consensus.data.genesis.Test : GenesisBlock;
-
-import std.exception;
-import std.range;
 
 ///
 unittest

--- a/source/agora/test/Timeout.d
+++ b/source/agora/test/Timeout.d
@@ -15,8 +15,6 @@ module agora.test.Timeout;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.consensus.data.Transaction;
 import agora.test.Base;
 
 ///

--- a/source/agora/test/TransactionReplacement.d
+++ b/source/agora/test/TransactionReplacement.d
@@ -16,9 +16,7 @@ module agora.test.TransactionReplacement;
 version (unittest):
 
 import agora.api.Validator;
-import agora.common.Amount;
 import agora.consensus.data.genesis.Test;
-import agora.consensus.data.Transaction;
 import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.test.Base;

--- a/source/agora/test/UnlockAge.d
+++ b/source/agora/test/UnlockAge.d
@@ -15,8 +15,6 @@ module agora.test.UnlockAge;
 
 version (unittest):
 
-import agora.api.Validator;
-import agora.consensus.data.Transaction;
 import agora.test.Base;
 
 /// Ditto

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -17,9 +17,6 @@ module agora.test.ValidatorCleanRestart;
 version (unittest):
 
 import agora.api.FullNode;
-import agora.common.Amount;
-import agora.consensus.data.Enrollment;
-import agora.consensus.data.Transaction;
 import agora.crypto.Key;
 import agora.test.Base;
 

--- a/source/agora/test/ValidatorCount.d
+++ b/source/agora/test/ValidatorCount.d
@@ -23,7 +23,6 @@ module agora.test.ValidatorCount;
 version (unittest):
 
 import agora.consensus.data.Params;
-import agora.consensus.data.Transaction;
 import agora.test.Base;
 
 import core.thread;

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -19,9 +19,6 @@ version (unittest):
 import agora.test.Base;
 
 import agora.consensus.protocol.Data;
-import agora.consensus.data.Enrollment;
-import agora.consensus.data.Transaction;
-import agora.consensus.data.Block;
 import agora.consensus.EnrollmentManager;
 import agora.consensus.PreImage;
 import agora.consensus.protocol.Nominator;

--- a/source/agora/test/VariableBlockSize.d
+++ b/source/agora/test/VariableBlockSize.d
@@ -17,12 +17,7 @@ version (unittest):
 
 import agora.api.Validator;
 import agora.consensus.data.genesis.Test: GenesisBlock;
-import agora.utils.Test: genesisSpendable;
-import agora.consensus.data.Transaction;
 import agora.test.Base;
-
-import std.algorithm;
-import std.range;
 
 ///
 unittest


### PR DESCRIPTION
Writing a tests historically required a lot of boilerplate,
but this was gradually trimmed down as our test framework evolved.
This is another attempt at trimming it down by removing a lot of
no-longer-needed imports, as well as adding common ones to Base
as public imports (e.g. almost every tests use 'Transaction').