### PR TITLE
Fixes Issue 2284: Use secret nonce for block signatures - but cancellation attack is possible

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -935,29 +935,9 @@ public class Ledger
                           block.header.height, K, idx);
                 continue;
             }
-
-            const CR = this.enroll_man.getCommitmentNonce(K, block.header.height);  // commited R
-            if (CR == Point.init)
-            {
-                log.error("Block#{}: Validator {} (idx: {}) Couldn't find commitment for this validator",
-                          block.header.height, K, idx);
-                return "Block: Couldn't find commitment for this validator";
-            }
-            assert(validator.preimage.height >= block.header.height);
-            const hash = validator.preimage[block.header.height];
-            Point R = CR + Scalar(hash).toPoint();
             sum_K = sum_K + K;
-            sum_R = sum_R + R;
         }
-
         assert(sum_K != Point.init, "Block has validators but no signature");
-
-        if (sum_R != block.header.signature.R)
-        {
-            log.error("Block#{}: Signature's `R` mismatch: Expected {}, got {}",
-                      block.header.height, sum_R, block.header.signature.R);
-            return "Block: Invalid schnorr signature (R)";
-        }
         if (!verify(block.header.signature, challenge, sum_K))
         {
             log.error("Block#{}: Invalid signature: {}", block.header.height,

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -118,10 +118,7 @@ public struct BlockHeader
     {
         // challenge = Hash(block) to Scalar
         const Scalar challenge = this.hashFull();
-        // rc = r used in signing the commitment
-        const Scalar rc = Scalar(hashMulti(secret_key, "consensus.signature.noise", offset));
-        const Scalar reduced_preimage = Scalar(preimage);
-        const Scalar r = rc + reduced_preimage; // make it unique for block height
+        const Scalar r = Scalar(hashMulti(secret_key, preimage)); // make it unique for block height
         const Point R = r.toPoint();
         return sign(secret_key, R, r, challenge);
     }
@@ -848,8 +845,7 @@ unittest
     Scalar v = genesis_validator_keys[0].secret;
     assert(v.isValid(), "v is not a valid Scalar!");
     Point V = v.toPoint();
-    const Scalar rc = Scalar(hashMulti(v, "consensus.signature.noise", 0));
-    const Scalar r = rc + Scalar(preimage);
+    const Scalar r = Scalar(hashMulti(v, preimage));
     const Point R = r.toPoint();
 
     // Two messages

--- a/source/agora/consensus/data/ValidatorBlockSig.d
+++ b/source/agora/consensus/data/ValidatorBlockSig.d
@@ -68,18 +68,13 @@ public struct ValidatorBlockSig
     public Hash utxo;
 
     /// The block signature as s of Signature (R, s) for the validator
-    public SigScalar signature;
+    public Signature signature;
 
-    public this (Height height, Hash utxo, SigScalar signature) @safe @nogc nothrow
+    public this (Height height, Hash utxo, Signature signature) @safe @nogc nothrow
     {
         this.height = height;
         this.utxo = utxo;
         this.signature = signature;
-    }
-
-    public this (Height height, Hash utxo, Scalar signature) @safe @nogc nothrow
-    {
-        this(height, utxo, SigScalar(signature));
     }
 }
 
@@ -92,7 +87,9 @@ unittest
 
     Height height = Height(100);
     Hash hash = "Hello world".hashFull();
-    Scalar signature = Scalar("0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778");
+    Scalar s = Scalar("0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778");
+    Point R = Point("0x921405afbfa97813293770efd55865c01055f39ad2a70f2b7a04ac043766a693");
+    Signature signature = Signature(R, s);
     ValidatorBlockSig sig = ValidatorBlockSig(height, hash, signature);
     testSymmetry(sig);
 
@@ -100,5 +97,6 @@ unittest
     assert(sig.serializeToJsonString() == "{\"height\":\"100\"," ~
         "\"utxo\":\"0xee438b9928cd623262b040b3b2b1522235b8a92269d1a724cd53c25" ~
            "d1042ec86b2d178cef755014a5892706e689cd82e00de9f1225e87dcc0600b2c8b2be9931\"," ~
-        "\"signature\":\"0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778\"}");
+        "\"signature\":\"0x921405afbfa97813293770efd55865c01055f39ad2a70f2b7a04ac043766a6930" ~
+        "e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778\"}");
 }

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -875,14 +875,8 @@ extern(D):
                      validator.utxo(), validator.preimage.height, block_sig);
             return false;
         }
-        // Fetch the R from enrollment commitment for signing validator
-        const CR = this.enroll_man.getCommitmentNonce(validator.address, block_sig.height);
-        // Determine the R of signature (R, s)
-        Point R = CR + Scalar(validator.preimage[block_sig.height]).toPoint();
-        // Compose the signature (R, s)
-        const sig = Signature(R, block_sig.signature);
         // Check this signature is valid for this block and signing validator
-        if (!verify(sig, block_challenge, validator.address))
+        if (!verify(block_sig.signature, block_challenge, validator.address))
         {
             log.warn("collectBlockSignature: INVALID Block signature received for slot {} from node {}",
                 block_sig.height, block_sig.utxo);
@@ -891,7 +885,7 @@ extern(D):
         log.trace("collectBlockSignature: VALID block signature at height {} for node {}",
             block_sig.height, block_sig.utxo);
         // collect the signature
-        this.slot_sigs[block_sig.height][block_sig.utxo] = Signature(R, block_sig.signature);
+        this.slot_sigs[block_sig.height][block_sig.utxo] = block_sig.signature;
         return true;
     }
 
@@ -989,7 +983,7 @@ extern(D):
             const self = this.enroll_man.getEnrollmentKey();
             this.slot_sigs[height][self] = this.createBlockSignature(block);
             this.gossipBlockSignature(ValidatorBlockSig(height, self,
-                this.slot_sigs[height][self].s));
+                this.slot_sigs[height][self]));
             this.ledger.addHeightAsExternalizing(height);
             this.verifyBlock(this.updateMultiSignature(block));
         }

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -391,7 +391,7 @@ public class Validator : FullNode, API
             log.trace("This node's signature is already in the block signature");
             // Gossip this signature as it may have been only shared via ballot signing
             this.network.gossipBlockSignature(
-                ValidatorBlockSig(block.header.height, this_utxo, sig.s));
+                ValidatorBlockSig(block.header.height, this_utxo, sig));
         }
         else
         {


### PR DESCRIPTION
Each Validator signs the block with `s = r + v.c` where `r = Scalar(HashMulti(v, preimage))`, `v = secret key` and `c = hash of block`.
Block signature is sent as `(R, s)` and can be verified as `s.G = R + V.c` on receipt of a signature before it is added to the aggregated signature.
The aggregated signature can be verified by `s.G = R + (V1 + V2 + ...).c` where `R = R1 + R2 + ...`