### PR TITLE
Fix #2540: Do not pass log message to formattedWrite

### DIFF
--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -36,7 +36,6 @@ import ocean.util.log.Event;
 import Ocean = ocean.util.log.Logger;
 
 import std.algorithm : min;
-import std.format;
 import std.stdio;
 import std.range : Cycle, cycle, isOutputRange, take, takeExactly, put;
 
@@ -399,7 +398,7 @@ public class PhobosFileAppender : Appender
         this.layout.format(event,
             (cstring content)
             {
-                formattedWrite(writer, content);
+                writer.put(content);
             });
         version (Windows) writer.put("\r\n");
         else              writer.put("\n");


### PR DESCRIPTION
```
The message that caused it to crash was using '%' to signify a percentage.
```

Since it originated from this function: https://github.com/bosagora/agora/blob/d1b1fd103e34a192adcc0768f2977841a2433d2a/source/agora/consensus/Reward.d#L251