### PR TITLE
Move name registry to persistent storage

### DIFF
--- a/doc/Database.md
+++ b/doc/Database.md
@@ -86,6 +86,25 @@ Store the `Enrollment` that haven't made it to a `Block` yet. Should be made rea
 | val          | BLOB     | Enrollment |             | Binary serialized `Enrollment`, should be converted to text |
 | avail_height | INTEGER  | Height     |             | It's not actually a hash but the key, should be `TEXT`      |
 
+### `registry_validator_signature` and `registry_flash_signature` tables
+
+Stores signature and last sequence number of the name registry.
+
+| Field Name | SQL Type | D type | Attributes | Comment                                               |
+|------------|----------|--------|------------|-------------------------------------------------------|
+| pubkey     | TEXT     | string | PRIMARY KEY | String representation of Node's PublicKey             |
+| signature  | TEXT     | string | NOT NULL   | String representation of Registry Payload's signature |
+| sequence   | INTEGER  | ulong  | NOT NULL   | Sequence number of Registry Payload                   |
+
+### `registry_validator_addresses` and `registry_flash_addresses` tables
+
+Stores Addresses and `TYPE` of the name registry. These table have relationship with [signature](###-`registry_validator_signature`-and-`registry_flash_signature`-tables) tables over `pubkey` attribute. `DELETE` on signature table is cascaded.
+
+| Field Name | SQL Type | D type | Attributes               | Comment                                          |
+|------------|----------|--------|--------------------------|--------------------------------------------------|
+| pubkey     | TEXT     | string | PRIMARY KEY, FOREIGN KEY | String representation of Node's PublicKey        |
+| address    | TEXT     | string | PRIMARY KEY, NOT NULL    | String representation of Node's registry address |
+| type       | INTEGER  | ushort | NOT NULL                 | Short representation for registry address' TYPE  |
 
 ## SCP envelope DB
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -283,7 +283,7 @@ public class FullNode : API
         );
 
         if (config.registry.enabled)
-            this.registry = new NameRegistry(config.node.realm, config.registry, this);
+            this.registry = new NameRegistry(config.node.realm, config.registry, this, this.cacheDB);
     }
 
     mixin DefineCollectorForStats!("app_stats", "collectAppStats");

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -36,7 +36,7 @@ import std.array : replace;
 import std.datetime;
 import std.format;
 import std.range : zip;
-import std.socket;
+import std.socket : InternetAddress;
 static import std.uni;
 
 /// Implementation of `NameRegistryAPI` using associative arrays

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -845,7 +845,8 @@ public class TestAPIManager
         {
             auto listener = reg.locate!TestAPI(agora_addr);
             assert(listener != typeof(listener).init);
-            super("localrest", config, new RemoteAPI!TestAPI(listener, timeout));
+            super("localrest", config, new RemoteAPI!TestAPI(listener, timeout),
+                new ManagedDatabase(":memory:"));
         }
     }
 


### PR DESCRIPTION
Fixes #2290 

`Validator` and `Flash` nodes publish their registry information. Data is separately stored for different types even they publish same payload. Name registry information was stored on memory (Hash map) previously, storage is moved to persistent storage (Cache DB).

1. `ZoneData` is extended to provide DB access interface
2. Each node type has two tables, table schemes are same for different types, total of 4 tables are added to DB

### Database updates

**Validator and Flash Signature Table**
| Field Name | SQL Type | Attributes |
|------------|----------|------------|
| pubkey     | TEXT     |  PRIMARY KEY |
| signature  | TEXT     |  NOT NULL   |
| sequence   | INTEGER  | NOT NULL   |

**Validator and Flash Addresses Table**
| Field Name | SQL Type | Attributes               |
|------------|----------|--------------------------|
| pubkey     | TEXT     | PRIMARY KEY, FOREIGN KEY |
| address    | TEXT     | PRIMARY KEY, NOT NULL    |
| type       | INTEGER  | NOT NULL                 |

Addresses table is related with Signature table through `pubkey` foreign key. `pubkey` and `address` attributes are composite primary keys. `DELETE` operation on Signature table is cascaded to Addresses table to prevent stale address checks.