### PR TITLE
Simplify block externalization code and improve some test code along the way

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -1012,6 +1012,36 @@ public class Ledger
 
     /***************************************************************************
 
+        Create a new block based on the current previous block.
+
+        This function only builds a block and will not externalize it.
+        See `acceptBlock` for this.
+
+        Params:
+          txs = An `InputRange` of `Transaction`s
+          time_offset = The `time_offset` of the block compared to the old one
+          enrollments = New enrollments for this block (can be `null`)
+          missing_validators = Indices of slashed validators (may be `null`)
+
+        Returns:
+          A newly created block based on the current block
+          (See `Ledger.getLastBlock()` and `Ledger.getBlockHeight()`)
+
+    ***************************************************************************/
+
+    public Block buildBlock (Transactions) (Transactions txs, ulong time_offset,
+        Enrollment[] enrollments, uint[] missing_validators)
+        @safe
+    {
+        const height = this.getBlockHeight() + 1;
+        Hash random_seed = this.getRandomSeed(height, missing_validators);
+        const validators = this.getValidators(height).length;
+        return this.last_block.makeNewBlock(
+            txs, time_offset, random_seed, validators, enrollments, missing_validators);
+    }
+
+    /***************************************************************************
+
         Get the random seed reduced from the preimages of validators
         except the provided 'missing_validators'.
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -55,7 +55,6 @@ import scpd.types.XDRBase : opaque_array;
 import geod24.bitblob;
 
 import core.stdc.stdint;
-import core.stdc.stdlib : abort;
 
 import std.algorithm;
 import std.container : DList;
@@ -962,7 +961,7 @@ extern(D):
         catch (Exception exc)
         {
             log.fatal("Deserialization of C++ Value failed: {}", exc);
-            abort();
+            assert(0, exc.message);
         }
 
         log.info("Externalized consensus data set at {}: {}", height, prettify(data));
@@ -996,7 +995,7 @@ extern(D):
         catch (Exception exc)
         {
             log.fatal("Externalization of SCP data failed: {}", exc);
-            abort();
+            assert(0, exc.message);
         }
         this.nomination_start_time = 0;
         this.initial_missing_validators = [];

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -47,7 +47,6 @@ import scpd.types.Stellar_types : NodeID;
 import std.algorithm;
 import std.range : array, enumerate;
 
-import core.stdc.stdlib : abort;
 import core.time;
 
 /*******************************************************************************

--- a/source/agora/test/VariableBlockSize.d
+++ b/source/agora/test/VariableBlockSize.d
@@ -35,9 +35,7 @@ unittest
     auto height = Height(0);
     // variable number of txs for each block
     only(1, 3, 4).each!((i) {
-        txs.takeExactly(i).each!(tx =>
-            network.clients.each!(node =>
-                node.postTransaction(tx)));
+        txs.takeExactly(i).each!(tx => network.postAndEnsureTxInPool(tx));
         txs = txs.drop(i);
         height++;
         network.expectHeightAndPreImg(height, GenesisBlock.header, 5.seconds);

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -426,7 +426,7 @@ Validators: 0/0 !(),
 Random seed: [0x0000...0000],
 Slashed validators: []`;
     const actual = format("%s", BlockHeaderFmt(GenesisBlock.header));
-    assert(GenesisHStr == actual, actual);
+    assert(GenesisHStr == actual);
 }
 
 /// Format a whole block
@@ -479,7 +479,7 @@ Outputs (6):
 boa1xzval2a3...gsh2(2,000,000)<Freeze>, boa1xzval3ah...tv9n(2,000,000)<Freeze>, boa1xzval4nv...6gfy(2,000,000)<Freeze>,
 boa1xrval5rz...jkm8(2,000,000)<Freeze>, boa1xrval6hd...34l5(2,000,000)<Freeze>, boa1xrval7gw...scrh(2,000,000)<Freeze>`;
     const actual = format("%s", BlockFmt(GenesisBlock));
-    assert(ResultStr == actual, actual);
+    assert(ResultStr == actual);
 }
 
 /// Format inputRange (e.g. range of blocks)
@@ -568,7 +568,7 @@ Outputs (1): boa1xzgenes5...gm67(60,999,999.9,920,9)<Payment>
     const block2 = second_block.updateSignature(signature, validators);
     const(Block)[] blocks = [GenesisBlock, block2];
     const actual = format("%s", prettify(blocks));
-    assert(ResultStr == actual, actual);
+    assert(ResultStr == actual);
 }
 
 /// Formatting struct for `Enrollment`


### PR DESCRIPTION
It started with `buildBlock`, but as I was doing some changes, I was hit by other issues:
- The usual spurious failure due to `postTransaction`;
- The unittest `abort`ing with no message whatsoever when a consensus rule is broken;
- Lack of information when the `Ledger` test fails;
- That ugly useless `nothrow` which didn't make sense;
- Redundancy with `-checkaction=context`;