### PR TITLE
Fix #2284: Schnorr signatures misusage leaks private keys

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -388,27 +388,6 @@ public class EnrollmentManager
 
     /***************************************************************************
 
-        Retrieves the R from the (R, s) of the signature in the commitment
-        for the associated public key
-
-        Params:
-            key = the public key to look up
-            height = height of block the R will be used to check the signature
-
-        Returns:
-            The `R` used in the signature of the Enrollment,
-            or `Point.init` if one is not found
-
-    ***************************************************************************/
-
-    public Point getCommitmentNonce (in PublicKey key, in Height height)
-        @trusted nothrow
-    {
-        return this.validator_set.getCommitmentNonce(key, height);
-    }
-
-    /***************************************************************************
-
         Get all the enrolled validator's UTXO keys.
 
         Params:

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -933,7 +933,6 @@ public class Ledger
     private string validateBlockSignature (in Block block) @safe nothrow
     {
         import agora.crypto.ECC;
-        import agora.crypto.Schnorr;
 
         Point sum_K;
         Point sum_R;
@@ -990,7 +989,7 @@ public class Ledger
                       block.header.height, sum_R, block.header.signature.R);
             return "Block: Invalid schnorr signature (R)";
         }
-        if (!verify(block.header.signature, challenge, sum_K))
+        if (!BlockHeader.verify(sum_K, block.header.signature, challenge))
         {
             log.error("Block#{}: Invalid signature: {}", block.header.height,
                       block.header.signature);

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -457,7 +457,6 @@ public struct Block
 ///
 unittest
 {
-    import agora.crypto.Schnorr;
     immutable Hash merkle =
         Hash(`0xdb6e67f59fe0b30676037e4970705df8287f0de38298dcc09e50a8e85413` ~
         `959ca4c52a9fa1edbe6a47cbb6b5e9b2a19b4d0877cc1f5955a7166fe6884eecd2c3`);
@@ -825,7 +824,6 @@ unittest
 {
     import agora.consensus.data.genesis.Test: GenesisBlock;
     import agora.crypto.ECC: Scalar, Point;
-    import agora.crypto.Schnorr;
     import agora.utils.Test;
     import std.format;
 

--- a/source/agora/consensus/data/ValidatorBlockSig.d
+++ b/source/agora/consensus/data/ValidatorBlockSig.d
@@ -16,42 +16,6 @@ module agora.consensus.data.ValidatorBlockSig;
 
 import agora.common.Types;
 import agora.crypto.ECC;
-import agora.crypto.Key;
-import agora.crypto.Schnorr;
-
-import std.format;
-
-/*******************************************************************************
-
-    The `s` of a Schnorr signature (R, s) needs to be transferred via vibe.d to
-    other nodes in the clear print format. SigScalar is used to enable this.
-
-*******************************************************************************/
-
-public struct SigScalar
-{
-    public Scalar data;
-
-    alias data this;
-
-    public static SigScalar fromString (in char[] str) @safe
-    {
-        return SigScalar(Scalar.fromString(str));
-    }
-
-    public string toString () const @safe
-    {
-        return this.data.toString(PrintMode.Clear);
-    }
-
-    public void toString (scope void delegate (scope const(char)[]) @safe sink)
-        const @safe
-    {
-        FormatSpec!char spec;
-        spec.spec = 'c';
-        this.data.toString(sink, spec);
-    }
-}
 
 /*******************************************************************************
 
@@ -67,38 +31,12 @@ public struct ValidatorBlockSig
     /// The stake of the validator
     public Hash utxo;
 
-    /// The block signature as s of Signature (R, s) for the validator
-    public SigScalar signature;
-
-    public this (Height height, Hash utxo, SigScalar signature) @safe @nogc nothrow
-    {
-        this.height = height;
-        this.utxo = utxo;
-        this.signature = signature;
-    }
-
-    public this (Height height, Hash utxo, Scalar signature) @safe @nogc nothrow
-    {
-        this(height, utxo, SigScalar(signature));
-    }
+    /// The block signature as `R` of Signature (R, s) for the validator
+    public Point signature;
 }
 
 unittest
 {
-    import agora.crypto.Hash;
     import agora.serialization.Serializer;
-
     testSymmetry!ValidatorBlockSig();
-
-    Height height = Height(100);
-    Hash hash = "Hello world".hashFull();
-    Scalar signature = Scalar("0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778");
-    ValidatorBlockSig sig = ValidatorBlockSig(height, hash, signature);
-    testSymmetry(sig);
-
-    import vibe.data.json;
-    assert(sig.serializeToJsonString() == "{\"height\":\"100\"," ~
-        "\"utxo\":\"0xee438b9928cd623262b040b3b2b1522235b8a92269d1a724cd53c25" ~
-           "d1042ec86b2d178cef755014a5892706e689cd82e00de9f1225e87dcc0600b2c8b2be9931\"," ~
-        "\"signature\":\"0x0e00a8df701806cb4deac9bb09cc85b097ee713e055b9d2bf1daf668b3f63778\"}");
 }

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -734,18 +734,18 @@ extern(D):
 
     /***************************************************************************
 
-        Create the block signature for this node.
-        This signature will be combined with other validator's signatures
-        using Schnorr multisig.
+        Sign this block using our private key / pre-image.
+
+        This will only returns the new signature, the block won't be modified.
 
         Params:
             block = the block to sign
 
     ***************************************************************************/
 
-    public Signature createBlockSignature (in Block block) @safe nothrow
+    public Signature signBlock (in Block block) @safe nothrow
     {
-        return block.header.createBlockSignature(this.kp.secret,
+        return block.header.sign(this.kp.secret,
             this.enroll_man.getOurPreimage(block.header.height),
             ulong((block.header.height - 1) / this.params.ValidatorCycle));
     }
@@ -981,7 +981,7 @@ extern(D):
             // Now we add our signature and gossip to other nodes
             log.trace("ADD BLOCK SIG at height {} for this node {}", height, this.kp.address);
             const self = this.enroll_man.getEnrollmentKey();
-            this.slot_sigs[height][self] = this.createBlockSignature(block);
+            this.slot_sigs[height][self] = this.signBlock(block);
             this.gossipBlockSignature(ValidatorBlockSig(height, self,
                 this.slot_sigs[height][self].s));
             this.ledger.addHeightAsExternalizing(height);

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -881,7 +881,7 @@ extern(D):
         // Compose the signature (R, s)
         const sig = Signature(R, block_sig.signature);
         // Check this signature is valid for this block and signing validator
-        if (!verify(sig, block_challenge, validator.address))
+        if (!BlockHeader.verify(validator.address, sig, block_challenge))
         {
             log.warn("collectBlockSignature: INVALID Block signature received for slot {} from node {}",
                 block_sig.height, block_sig.utxo);

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -746,8 +746,7 @@ extern(D):
     public Signature signBlock (in Block block) @safe nothrow
     {
         return block.header.sign(this.kp.secret,
-            this.enroll_man.getOurPreimage(block.header.height),
-            ulong((block.header.height - 1) / this.params.ValidatorCycle));
+            this.enroll_man.getOurPreimage(block.header.height));
     }
 
     extern (C++):
@@ -867,21 +866,16 @@ extern(D):
             return false;
         }
 
-        const Scalar block_challenge = block_hash;
         if (validator.preimage.height < block_sig.height)
         {
             log.warn("collectBlockSignature: Validator {} has preimage at height {} but sig: {}",
                      validator.utxo(), validator.preimage.height, block_sig);
             return false;
         }
-        // Fetch the R from enrollment commitment for signing validator
-        const CR = this.enroll_man.getCommitmentNonce(validator.address, block_sig.height);
-        // Determine the R of signature (R, s)
-        Point R = CR + Scalar(validator.preimage[block_sig.height]).toPoint();
-        // Compose the signature (R, s)
-        const sig = Signature(R, block_sig.signature);
-        // Check this signature is valid for this block and signing validator
-        if (!BlockHeader.verify(validator.address, sig, block_challenge))
+
+        if (!BlockHeader.verify(
+                validator.address, validator.preimage[block_sig.height],
+                block_sig.signature, block_hash))
         {
             log.warn("collectBlockSignature: INVALID Block signature received for slot {} from node {}",
                 block_sig.height, block_sig.utxo);
@@ -890,7 +884,8 @@ extern(D):
         log.trace("collectBlockSignature: VALID block signature at height {} for node {}",
             block_sig.height, block_sig.utxo);
         // collect the signature
-        this.slot_sigs[block_sig.height][block_sig.utxo] = Signature(R, block_sig.signature);
+        const Scalar s = validator.preimage[block_sig.height];
+        this.slot_sigs[block_sig.height][block_sig.utxo] = Signature(block_sig.signature, s);
         return true;
     }
 
@@ -983,7 +978,7 @@ extern(D):
             const self = this.enroll_man.getEnrollmentKey();
             this.slot_sigs[height][self] = this.signBlock(block);
             this.gossipBlockSignature(ValidatorBlockSig(height, self,
-                this.slot_sigs[height][self].s));
+                this.slot_sigs[height][self].R));
             this.ledger.addHeightAsExternalizing(height);
             this.verifyBlock(this.updateMultiSignature(block));
         }

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -426,46 +426,6 @@ public class ValidatorSet
 
     /***************************************************************************
 
-        Extract the `R` used in the signing of the associated enrollment
-        We do not check the active flag as we may get block signatures afer
-        the next cycle has started
-
-        Params:
-            key = The public key of the validator
-            height = height of block being signed
-
-        Returns:
-            the `R` that was used in the signing of the Enrollment,
-            or `Point.init` if one was not found
-
-    ***************************************************************************/
-
-    public Point getCommitmentNonce (const ref PublicKey key, in Height height) @trusted nothrow
-    {
-        try
-        {
-            auto results = this.db.execute("SELECT nonce FROM validator " ~
-                "WHERE public_key = ? AND enrolled_height >= ? " ~
-                "AND enrolled_height < ?",
-                key, this.minEnrollmentHeight(height), height);
-
-            if (!results.empty && results.oneValue!(string).length != 0)
-            {
-                auto row = results.front;
-                return Point(row.peek!(string)(0));
-            }
-        }
-        catch (Exception ex)
-        {
-            log.error("Exception occured on getCommitmentNonce: {}, " ~
-                "for public key: {}", ex.msg, key);
-        }
-
-        return Point.init;
-    }
-
-    /***************************************************************************
-
         Get validator's pre-image from the validator set
 
         Params:

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -393,7 +393,7 @@ public class Validator : FullNode, API
             log.trace("This node's signature is already in the block signature");
             // Gossip this signature as it may have been only shared via ballot signing
             this.network.gossipBlockSignature(
-                ValidatorBlockSig(block.header.height, this_utxo, sig.s));
+                ValidatorBlockSig(block.header.height, this_utxo, sig.R));
         }
         else
         {

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -385,7 +385,7 @@ public class Validator : FullNode, API
         }
 
         const this_utxo = this.enroll_man.getEnrollmentKey();
-        auto sig = this.nominator.createBlockSignature(block);
+        auto sig = this.nominator.signBlock(block);
         assert(node_validator_index < block.header.validators.count,
             format!"The validator index %s is invalid"(node_validator_index));
         if (signed_validators[node_validator_index])

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -45,7 +45,7 @@ private extern(C++) class BadBlockSigningNominator : Nominator
         this.reason = reason;
     }
 
-    extern(D) override protected Signature createBlockSignature(in Block block)
+    extern(D) override protected Signature signBlock (in Block block)
         @trusted nothrow
     {
         import agora.crypto.Hash;


### PR DESCRIPTION
Based on #2552

Only the last commit belongs to this PR.
```
This effectively changes the formula used for signing blocks, turning it upside-down:
Instead of offsetting the 'R' by the pre-image as a point,
we commit to the pre-image being the 's' of the signature,
and provide 'R' such as 'S == c * R + X'.
In order to find the adequate 'R' value, one has to know both 'x' and 'r',
as one may only derive CR from the known values, and CR cannot be divided by 'c'.
In the process of this change, the no-longer-used 'getCommitmentNonce' was removed.
```