### PR TITLE
Tests: Move well known pre-images to the WK namespace

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -1352,7 +1352,7 @@ public class Ledger
                     log.info("Skip add preimage for validator idx {} at height {} as requested by test", idx, height);
                 else
                     addPreimageLog(val.address, PreImageInfo(val.preimage.utxo,
-                        getWellKnownPreimages(WK.Keys[val.address])[height], height));
+                        WK.PreImages[WK.Keys[val.address]][height], height));
             });
         } catch (Exception e)
         {
@@ -1689,7 +1689,6 @@ public class ValidatingLedger : Ledger
 version (unittest)
 {
     import agora.consensus.PreImage;
-    import agora.consensus.validation.Block: getWellKnownPreimages;
     import agora.node.Config;
     version (unittest) import agora.test.Base;
     import core.stdc.time : time;

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -560,7 +560,7 @@ public Block makeNewBlock (Transactions)(const ref Block prev_block,
 version (unittest)
 {
     import agora.consensus.data.genesis.Test: genesis_validator_keys;
-    import agora.consensus.validation.Block: wellKnownPreimages;
+    import agora.utils.Test;
 
     public Block makeNewTestBlock (Transactions)(const ref Block prev_block,
         Transactions txs,
@@ -570,7 +570,7 @@ version (unittest)
         ulong time_offset = 0) @safe nothrow
     {
         auto revealed = key_pairs.enumerate.filter!(en => !missing_validators.canFind(en.index)).map!(en => en.value).array;
-        Hash[] pre_images = wellKnownPreimages(prev_block.header.height + 1, revealed);
+        Hash[] pre_images = WK.PreImages.at(prev_block.header.height + 1, revealed);
         assert(revealed.length == key_pairs.length - missing_validators.length);
         try
         {

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -551,45 +551,6 @@ version (unittest)
     import std.array;
     import std.range;
 
-    PreImageCycle[] wellKnownPreimageCycles;
-    ulong[PublicKey] publicKeyToIndex;
-
-    public ref PreImageCycle getWellKnownPreimages (KeyPair kp) @safe nothrow
-    {
-        const uint Cycle = 20;
-        if (kp.address !in publicKeyToIndex)
-        {
-            publicKeyToIndex[kp.address] = wellKnownPreimageCycles.length;
-            wellKnownPreimageCycles ~= PreImageCycle(kp.secret, Cycle);
-        }
-        return wellKnownPreimageCycles[publicKeyToIndex[kp.address]];
-    }
-
-    public Hash[] wellKnownPreimages (Keys)(Height height, Keys key_pairs) @safe nothrow
-    in
-    {
-        static assert(isInputRange!Keys);
-        static assert (is(ElementType!Keys : KeyPair));
-    }
-    do
-    {
-        return key_pairs.map!(kp => getWellKnownPreimages(kp)[height]).array;
-    }
-
-    // Check that cached cycles can handle being used with previous cycle heights
-    unittest
-    {
-        auto only_node2 = only(WK.Keys.NODE2);
-        Hash[] preimages_height_0 = wellKnownPreimages(Height(0), only_node2);
-        Hash[] preimages_height_1 = wellKnownPreimages(Height(1), only_node2);
-        // fetch from previous height within the first cycle
-        assert(wellKnownPreimages(Height(0), only_node2) == preimages_height_0);
-        // preimage from second cycle
-        Hash[] preimages_height_21 = wellKnownPreimages(Height(21), only_node2);
-        // check we can fetch preimages from previous cycle
-        assert(wellKnownPreimages(Height(1), only_node2) == preimages_height_1);
-    }
-
     public string isValidcheck (in Block block, Engine engine, Height prev_height,
         Hash prev_hash, scope UTXOFinder findUTXO,
         size_t enrolled_validators, scope FeeChecker checkFee,


### PR DESCRIPTION
```
This makes it consistent with well-known keypair and a bit easier to use,
as one doesn't have to import agora.consensus.validation.Block.
```

Requirement to fix https://github.com/bosagora/agora/pull/2552 properly.