### PR TITLE
Fix `TransactionPool` double spend detection implementation

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -1217,7 +1217,7 @@ public class Ledger
         {
             auto coinbase_tx = this.getCoinbaseTX(expect_height);
             auto coinbase_tx_hash = coinbase_tx.hashFull();
-            log.info("getValidTXSet: Coinbase hash={}, tx={}", coinbase_tx_hash, coinbase_tx.prettify);
+            log.trace("getValidTXSet: Coinbase hash={}, tx={}", coinbase_tx_hash, coinbase_tx.prettify);
             assert(coinbase_tx.outputs.length > 0);
 
             // Because CB TXs are never in the pool, they will always end up in


### PR DESCRIPTION
Bug found whilst working on PR https://github.com/bosagora/agora/pull/2557.
`TransactionPool.spenders` which keeps track of transactions in the pool which use the same unspent outputs should use `utxo` not hash of `input` (which is hash of `utxo` and `unlock_age`).