### PR TITLE
Fixes Issue2548: flakey fee test

### DIFF
--- a/source/agora/test/BlockRewards.d
+++ b/source/agora/test/BlockRewards.d
@@ -60,6 +60,8 @@ unittest
         .each!((Height h)
     {
         network.generateBlocks(h, emptyBlocks);
+        retryFor(node_1.getBlocksFrom(h, 1).front.header.validators.setCount() == 6, 5.seconds,
+            format!"First node failed to achieve desired signature count of %s at height %s"(6, h));
         network.assertSameBlocks(h, last_height + 1);
         last_height = h;
     });
@@ -104,6 +106,8 @@ unittest
         .each!((Height h)
     {
         network.generateBlocks(h);
+        retryFor(node_1.getBlocksFrom(h, 1).front.header.validators.setCount() == 6, 5.seconds,
+            format!"First node failed to achieve desired signature count of %s at height %s"(6, h));
         network.assertSameBlocks(h, last_height + 1);
         last_height = h;
     });
@@ -173,7 +177,10 @@ unittest
         .each!((Height h)
     {
         network.generateBlocks(iota(activeValidators), h, true); // Don't include node 5
-        network.assertSameBlocks(h, last_height + 1);
+        // To ensure we have expected percentage of signatures at each height wait long enough for first node to have them
+        auto required_sigs = (h % 2 == 0) ? 5 : 4;
+        retryFor(node_1.getBlocksFrom(h, 1).front.header.validators.setCount() == required_sigs, 5.seconds,
+            format!"First node failed to achieve desired signature count of %s at height %s"(required_sigs, h));
         last_height = h;
     });
 

--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -15,6 +15,8 @@ module agora.test.Fee;
 
 import agora.test.Base;
 
+import std.typecons: tuple;
+
 // Normal operation, every `payout_period`th block should
 // include coinbase outputs to validators
 unittest
@@ -35,16 +37,16 @@ unittest
     auto blocks = node_1.getBlocksFrom(0, 2);
     assert(blocks.length == 1);
 
-    Transaction[] txs;
-
     void createAndExpectNewBlock (Height new_height)
     {
-        // create enough tx's for a single block
-        txs = blocks[new_height - 1].spendable().map!(txb => txb
-            .deduct(Amount.UnitPerCoin).sign()).array();
+        // create tx for a single block
+        auto utxo_pairs = node_1.getSpendables(100.coins, OutputType.Payment);
 
-        // send them to all nodes
-        txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));
+        // create and send tx to all nodes
+        network.postAndEnsureTxInPool(
+            TxBuilder(WK.Keys.AAA.address)
+            .attach(utxo_pairs.map!(p => tuple(p.utxo.output, p.hash)))
+            .deduct(1.coins).sign());
 
         network.expectHeightAndPreImg(new_height, blocks[0].header);
 
@@ -179,16 +181,16 @@ unittest
     auto blocks = valid_nodes.front.getBlocksFrom(0, 2);
     assert(blocks.length == 1);
 
-    Transaction[] txs;
-
     void createAndExpectNewBlock (Height new_height)
     {
-        // create enough tx's for a single block
-        txs = blocks[new_height - 1].spendable().takeExactly(1).map!(txb => txb
-            .deduct(Amount.UnitPerCoin).sign()).array();
+        // create tx for a single block
+        auto utxo_pairs = valid_nodes.front.getSpendables(100.coins, OutputType.Payment);
 
-        // send them to all valid nodes
-        txs.each!(tx => valid_nodes.each!(node => node.postTransaction(tx)));
+        // create and send tx to all nodes
+        network.postAndEnsureTxInPool(
+            TxBuilder(WK.Keys.AAA.address)
+            .attach(utxo_pairs.map!(p => tuple(p.utxo.output, p.hash)))
+            .deduct(1.coins).sign());
 
         network.expectHeightAndPreImg(iota(1, GenesisValidators),
             new_height, blocks[0].header);

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -53,11 +53,8 @@ unittest
         Transaction[] txs = blocks[block_idx].spendable().map!(txb => txb.sign()).array;
 
         // send each tx to one node
-        txs.each!(tx => node_1.postTransaction(tx));
-        // wait for all nodes get the txs
-        txs.each!(tx =>
-            nodes.each!(node =>
-                node.hasTransactionHash(hashFull(tx)).retryFor(2.seconds)));
+        txs.each!(tx => network.postAndEnsureTxInPool(tx));
+
         // now create the next block
         network.expectHeightAndPreImg(Height(block_idx + 1), blocks[0].header);
 

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -82,7 +82,7 @@ unittest
     }
 
     TestConf conf;
-    conf.consensus.quorum_threshold = 51;
+    conf.consensus.quorum_threshold = 100;
     conf.node.timeout = 5.seconds;
 
     auto network = makeTestNetwork!CustomAPIManager(conf);
@@ -93,8 +93,8 @@ unittest
     auto nodes = network.clients;
     auto validator = network.clients[0];
 
-    // Make four of six validators stop responding for a while
-    nodes.drop(1).take(4).each!(node => node.ctrl.sleep(conf.node.timeout, true));
+    // Make one of six validators stop responding for a while
+    nodes.drop(1).take(1).each!(node => node.ctrl.sleep(conf.node.timeout, true));
 
     // Block 1 with multiple consensus rounds
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();


### PR DESCRIPTION
By using `node.getSpendables` and `network.postAndEnsureTxInPool` from `base.d` test class the test is now more reliable.
