### PR TITLE
Tests: More use of base.d class functions for test code

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -68,6 +68,7 @@ import geod24.Registry;
 import std.array;
 import std.exception;
 import std.range;
+import std.typecons;
 
 import core.atomic : atomicLoad, atomicStore;
 import core.exception;
@@ -1090,6 +1091,37 @@ public class TestAPIManager
         const enroll_block = first_client.getBlock(enrolled_height);
         this.expectHeightAndPreImg(client_idxs, target_height,
             enroll_block.header, 10.seconds, file, line);
+    }
+
+    /**************************************************************************
+
+        Prepare frozen utxo for outsiders to enroll
+
+        This is a helper function to find unspent utxo and make a transaction
+            with frozen outputs to be used to enroll
+
+        Params:
+            client_idxs = client indices for the outsider validators
+
+    ***************************************************************************/
+
+    Transaction freezeUtxo (Idxs)(Idxs client_idxs)
+    {
+        static assert (isInputRange!Idxs);
+
+        auto first_client = this.clients[0];
+
+        const keys = client_idxs.map!(i => this.nodes[i].getPublicKey().key).array;
+
+        // Collect enough utxo for all to enroll
+        Amount expected = Amount.MinFreezeAmount;
+        assert(expected.mul(keys.length));
+        auto utxo_pairs = first_client.getSpendables(expected, OutputType.Payment);
+
+        return TxBuilder(WK.Keys.AAA.address) // Refund
+            .attach(utxo_pairs.map!(p => tuple(p.utxo.output, p.hash)))
+            .draw(Amount.MinFreezeAmount, keys) // draw min freeze to enroll for each
+            .sign(OutputType.Freeze);
     }
 
     /***************************************************************************

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1055,30 +1055,17 @@ public class TestAPIManager
         // target height will be one more than previous block
         Height target_height = Height(last_height + 1);
 
-        while (!no_txs)
+        if (!no_txs)
         {
-            const last_block = first_client.getBlock(last_height);
+            // create tx for a single block
+            auto utxo_pairs = first_client.getSpendables(222.coins, OutputType.Payment);
 
-            // Get spendables from a previous block
-            auto spendables = last_block.spendable().array;
-
-            if (spendables.length == 0)
-            {
-                assert(last_height != 0, "Can't find spendables");
-                last_height--;
-            }
-            else
-            {
-                // Send transaction to the first client
-                auto tx = spendables.takeExactly(1).map!(txb => txb.sign()).front;
-                first_client.postTransaction(tx);
-                // Wait for tx gossipping before setting time for block
-                client_idxs.each!(idx =>
-                    retryFor(this.clients[idx].hasTransactionHash(tx.hashFull()),
-                        4.seconds, format!"[%s:%s] Client #%s did not receive tx in expected time for height %s"
-                            (file, line, idx, target_height)));
-                break;
-            }
+            // create and send tx to all nodes
+            this.postAndEnsureTxInPool(client_idxs,
+                TxBuilder(WK.Keys.AAA.address)
+                    .attach(utxo_pairs.map!(p => tuple(p.utxo.output, p.hash)))
+                    .deduct(1.coins)
+                    .sign());
         }
 
         // Get preimage height from enrollment to this next block

--- a/source/agora/test/BlockRewards.d
+++ b/source/agora/test/BlockRewards.d
@@ -173,7 +173,10 @@ unittest
         .each!((Height h)
     {
         network.generateBlocks(iota(activeValidators), h, true); // Don't include node 5
-        network.assertSameBlocks(h, last_height + 1);
+        // To ensure we have expected percentage of signatures at each height wait long enough for first node to have them
+        auto required_sigs = (h % 2 == 0) ? 5 : 4;
+        retryFor(node_1.getBlocksFrom(h, 1).front.header.validators.setCount() == required_sigs, 5.seconds,
+            format!"First node failed to achieve desired signature count of %s at height %s"(required_sigs, h));
         last_height = h;
     });
 

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -94,52 +94,21 @@ unittest
     network.waitForDiscovery();
     auto nodes = network.clients;
 
-    // generate 16 blocks
-    network.generateBlocks(Height(16));
-    assert(network.blocks[0].header.enrollments.length >= 1);
-    network.expectHeightAndPreImg(Height(16), network.blocks[0].header, 5.seconds);
+    // generate 17 blocks
+    network.generateBlocks(Height(17));
 
-    // Discarded UTXOs (just to trigger block creation)
-    auto spendable = network.blocks[$ - 1].spendable().array;
-    auto txs = spendable[0 .. 4]
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
-        .array;
+    // get utxo to create frozen output for new enrollment
+    auto utxo_pairs = nodes[0].getSpendables(Amount.MinFreezeAmount, OutputType.Payment);
 
-    // 8 utxos for freezing, 24 utxos for creating a block later
-    txs ~= spendable[4].split(genesis_validator_keys[0].address.repeat(8)).sign();
-    txs ~= spendable[5].split(WK.Keys.Z.address.repeat(8)).sign();
-    txs ~= spendable[6].split(WK.Keys.Z.address.repeat(8)).sign();
-    txs ~= spendable[7].split(WK.Keys.Z.address.repeat(8)).sign();
-
-    // Block 17
-    txs.each!(tx => network.postAndEnsureTxInPool(tx));
-    network.expectHeightAndPreImg(Height(17), network.blocks[0].header, 10.seconds);
-
-    // Freeze builders
-    auto freezable = txs[$ - 4]
-        .outputs.length.iota
-        .takeExactly(8)
-        .map!(idx => TxBuilder(txs[$ - 4], cast(uint)idx));
-
-    // Create 8 freeze TXs
-    auto freeze_txs = freezable
-        .enumerate
-        .map!(pair => pair.value.refund(genesis_validator_keys[0].address)
-            .sign(OutputType.Freeze))
-        .array;
-    assert(freeze_txs.length == 8);
+    // create and send tx to all nodes
+    network.postAndEnsureTxInPool(iota(GenesisValidators),
+        network.freezeUtxo(iota(GenesisValidators)));
 
     // Block 18
-    freeze_txs.each!(tx => network.postAndEnsureTxInPool(tx));
     network.expectHeightAndPreImg(Height(18), network.blocks[0].header, 5.seconds);
 
     // Block 19
-    auto new_txs = txs[$ - 3]
-        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 3], cast(uint)idx))
-        .takeExactly(8)
-        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
-    new_txs.each!(tx => network.postAndEnsureTxInPool(tx));
-    network.expectHeightAndPreImg(Height(19), network.blocks[0].header, 5.seconds);
+    network.generateBlocks(Height(19));
 
     // Now we re-enroll the first validator with a new UTXO but it will fail
     // because an enrollment with same public key of the first validator is
@@ -158,12 +127,7 @@ unittest
     }
 
     // Block 20
-    new_txs = txs[$ - 2]
-        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 2], cast(uint)idx))
-        .takeExactly(8)
-        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
-    new_txs.each!(tx => network.postAndEnsureTxInPool(tx));
-    network.expectHeightAndPreImg(Height(20), network.blocks[0].header);
+    network.generateBlocks(Height(20));
     auto b20 = nodes[0].getBlocksFrom(20, 2)[0];
     assert(b20.header.enrollments.length == 5);
 
@@ -173,12 +137,7 @@ unittest
         retryFor(node.getEnrollment(new_enroll.utxo_key) == new_enroll, 5.seconds));
 
     // Block 21 created with the new enrollment
-    new_txs = txs[$ - 1]
-        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 1], cast(uint)idx))
-        .takeExactly(8)
-        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
-    new_txs.each!(tx => network.postAndEnsureTxInPool(tx));
-    network.expectHeightAndPreImg(Height(21), b20.header);
+    network.generateBlocks(Height(21));
     auto b21 = nodes[0].getBlocksFrom(21, 2)[0];
     assert(b21.header.enrollments.length == 1);
     assert(b21.header.enrollments[0] == new_enroll);

--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -15,6 +15,8 @@ module agora.test.Fee;
 
 import agora.test.Base;
 
+import std.typecons: tuple;
+
 // Normal operation, every `payout_period`th block should
 // include coinbase outputs to validators
 unittest
@@ -35,16 +37,16 @@ unittest
     auto blocks = node_1.getBlocksFrom(0, 2);
     assert(blocks.length == 1);
 
-    Transaction[] txs;
-
     void createAndExpectNewBlock (Height new_height)
     {
-        // create enough tx's for a single block
-        txs = blocks[new_height - 1].spendable().map!(txb => txb
-            .deduct(Amount.UnitPerCoin).sign()).array();
+        // create tx for a single block
+        auto utxo_pairs = node_1.getSpendables(100.coins, OutputType.Payment);
 
-        // send them to all nodes
-        txs.each!(tx => nodes.each!(node => node.postTransaction(tx)));
+        // create and send tx to all nodes
+        network.postAndEnsureTxInPool(
+            TxBuilder(WK.Keys.AAA.address)
+            .attach(utxo_pairs.map!(p => tuple(p.utxo.output, p.hash)))
+            .deduct(1.coins).sign());
 
         network.expectHeightAndPreImg(new_height, blocks[0].header);
 
@@ -179,16 +181,16 @@ unittest
     auto blocks = valid_nodes.front.getBlocksFrom(0, 2);
     assert(blocks.length == 1);
 
-    Transaction[] txs;
-
     void createAndExpectNewBlock (Height new_height)
     {
-        // create enough tx's for a single block
-        txs = blocks[new_height - 1].spendable().takeExactly(1).map!(txb => txb
-            .deduct(Amount.UnitPerCoin).sign()).array();
+        // create tx for a single block
+        auto utxo_pairs = valid_nodes.front.getSpendables(100.coins, OutputType.Payment);
 
-        // send them to all valid nodes
-        txs.each!(tx => valid_nodes.each!(node => node.postTransaction(tx)));
+        // create and send tx to all nodes
+        network.postAndEnsureTxInPool(
+            TxBuilder(WK.Keys.AAA.address)
+            .attach(utxo_pairs.map!(p => tuple(p.utxo.output, p.hash)))
+            .deduct(1.coins).sign());
 
         network.expectHeightAndPreImg(iota(1, GenesisValidators),
             new_height, blocks[0].header);

--- a/source/agora/test/FutureEnrollment.d
+++ b/source/agora/test/FutureEnrollment.d
@@ -90,11 +90,7 @@ unittest
         Height(GenesisValidatorCycle - 2));
 
     // prepare frozen outputs for the outsider validator to enroll
-    const key = outsider.getPublicKey().key;
-    network.blocks[0].spendable().drop(1).takeExactly(1)
-        .map!(txb => txb
-            .split([key]).sign(OutputType.Freeze))
-            .each!(tx => network.nodes[delayed_node].postTransaction(tx));
+    network.postAndEnsureTxInPool(network.freezeUtxo(only(GenesisValidators)));
 
     // the delayed validator becomes unresponsive
     network.clients[delayed_node].filter!(API.postTransaction);

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -53,11 +53,8 @@ unittest
         Transaction[] txs = blocks[block_idx].spendable().map!(txb => txb.sign()).array;
 
         // send each tx to one node
-        txs.each!(tx => node_1.postTransaction(tx));
-        // wait for all nodes get the txs
-        txs.each!(tx =>
-            nodes.each!(node =>
-                node.hasTransactionHash(hashFull(tx)).retryFor(2.seconds)));
+        txs.each!(tx => network.postAndEnsureTxInPool(tx));
+
         // now create the next block
         network.expectHeightAndPreImg(Height(block_idx + 1), blocks[0].header);
 

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -82,7 +82,7 @@ unittest
     }
 
     TestConf conf;
-    conf.consensus.quorum_threshold = 51;
+    conf.consensus.quorum_threshold = 100;
     conf.node.timeout = 5.seconds;
 
     auto network = makeTestNetwork!CustomAPIManager(conf);
@@ -93,8 +93,8 @@ unittest
     auto nodes = network.clients;
     auto validator = network.clients[0];
 
-    // Make four of six validators stop responding for a while
-    nodes.drop(1).take(4).each!(node => node.ctrl.sleep(conf.node.timeout, true));
+    // Make one of six validators stop responding for a while
+    nodes.drop(1).take(1).each!(node => node.ctrl.sleep(conf.node.timeout, true));
 
     // Block 1 with multiple consensus rounds
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();

--- a/source/agora/test/RestoreSlashingInfo.d
+++ b/source/agora/test/RestoreSlashingInfo.d
@@ -47,16 +47,10 @@ unittest
     // generate 18 blocks, 2 short of the enrollments expiring.
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    const keys = set_b.map!(node => node.getPublicKey().key).array;
-
-    auto blocks = nodes[0].getAllBlocks();
-
     // Block 19 we add the freeze utxos for set_b validators
     // prepare frozen outputs for outsider validators to enroll
-    blocks[0].spendable().drop(1).takeExactly(1)
-        .map!(txb => txb
-            .split(keys).sign(OutputType.Freeze))
-            .each!(tx => set_a[0].postTransaction(tx));
+    network.postAndEnsureTxInPool(iota(GenesisValidators + 1),
+        network.freezeUtxo(iota(GenesisValidators, GenesisValidators + 3)));
 
     network.generateBlocks(Height(GenesisValidatorCycle - 1));
 

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -28,41 +28,40 @@ import agora.test.Base;
 ///     process of set B have finished, a new block is being nominated,
 ///     and a consensus round for the new block is being made.
 /// Expectation: The new block is approved and inserted into the ledger.
-version(none) unittest
+unittest
 {
     TestConf conf = {
-        timeout : 10.seconds,
         outsider_validators : 3,
         recurring_enrollment : false
     };
+    conf.node.timeout = 10.seconds;
+    conf.node.network_discovery_interval = 2.seconds;
+    conf.node.retry_delay = 250.msecs;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto nodes = network.clients;
-    auto set_a = network.clients[0 .. GenesisValidators];
-    auto set_b = network.clients[GenesisValidators .. $];
+    auto nodes = network.nodes;
+    auto set_a = network.nodes[0 .. GenesisValidators];
+    auto set_b = network.nodes[GenesisValidators .. $];
 
     // generate 18 blocks, 2 short of the enrollments expiring.
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    const keys = set_b.map!(node => node.getPublicKey()).array;
-
-    Amount expected = Amount.MinFreezeAmount;
-    assert(expected.mul(keys.length));
-    auto utxos = nodes[0].getSpendables(expected);
-
     // Block 19 we add the freeze utxos for set_b validators
     // prepare frozen outputs for outsider validators to enroll
-    TxBuilder txb = TxBuilder(WK.Keys.AAA.address); // Refund
-    utxos.each!(pair => txb.attach(pair.utxo.output, pair.hash));
-    auto to_send = txb.draw(Amount.MinFreezeAmount, keys).sign(OutputType.Freeze);
-    set_a.each!(n => n.postTransaction(to_send));
+    network.postAndEnsureTxInPool(iota(GenesisValidators),
+        network.freezeUtxo(iota(GenesisValidators, GenesisValidators + 3)));
+
+    network.generateBlocks(Height(GenesisValidatorCycle - 1));
 
     // wait for other nodes to get to same block height
-    network.assertSameBlocks(Height(GenesisValidatorCycle - 1));
+    set_b.enumerate.each!((idx, node) =>
+        retryFor(node.getBlockHeight() == GenesisValidatorCycle - 1, 5.seconds,
+            format!"Expected block height %s but outsider %s has height %s."
+                (GenesisValidatorCycle - 1, idx, node.getBlockHeight())));
 
     // Now we enroll the set B validators.
     set_b.enumerate.each!((idx, _) => network.enroll(GenesisValidators + idx));
@@ -76,7 +75,7 @@ version(none) unittest
 
     // Now restarting the validators in the set B, all the data of those
     // validators has been wiped out.
-    set_b.each!(node => network.restart(node));
+    set_b.each!(node => network.restart(node.client));
     network.expectHeight(Height(GenesisValidatorCycle));
 
     // Sanity check
@@ -98,7 +97,7 @@ version(none) unittest
             5.seconds));
 
     // Make all the validators of the set A disable to respond
-    set_a.each!(node => node.ctrl.sleep(6.seconds, true));
+    set_a.each!(node => node.client.ctrl.sleep(6.seconds, true));
 
     // Block 21 with the new validators in the set B
     network.generateBlocks(iota(GenesisValidators, cast(size_t) nodes.length),


### PR DESCRIPTION
Make more use of `generateBlocks`, `getSpendables` and `postAndEnsureTxInPool` to reduce the lines of code in the tests and make it more maintainable and reliable.

First 3 commits are from PR https://github.com/bosagora/agora/pull/2561