### PR TITLE
Trivial: Slightly simplify NodePair

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -515,7 +515,10 @@ public struct NodePair
     private shared(TimePoint)* cur_time;
 
     ///
-    public TestAPI api;
+    public inout(TestAPI) api () inout @safe pure nothrow @nogc
+    {
+        return this.client;
+    }
 
     alias api this;
 
@@ -834,7 +837,7 @@ public class TestAPIManager
         foreach (ref interf; conf.interfaces)
         {
             assert(this.registry.register(interf.address, api.listener()));
-            this.nodes ~= NodePair(interf.address, api, time, api);
+            this.nodes ~= NodePair(interf.address, api, time);
         }
         return api;
     }


### PR DESCRIPTION
```
There's no way to have two fields containing the same object.
If the intent is to restrict access to control methods,
exposing a function is better suited, as was done here.
```