### PR TITLE
Issue2548 replace `getUTXOs` with `getSpendables`

### DIFF
--- a/source/agora/consensus/pool/Transaction.d
+++ b/source/agora/consensus/pool/Transaction.d
@@ -504,6 +504,12 @@ public class TransactionPool
         return txs;
     }
 
+    /// Can be used in unit tests to prevent spending the same utxo
+    version (unittest) public bool spending (in Hash utxo) @safe nothrow
+    {
+        return !!(utxo in this.spenders);
+    }
+
     /***************************************************************************
 
         Callback used

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1455,7 +1455,8 @@ public interface TestAPI : API
 
     ***************************************************************************/
 
-    public UTXOPair[] getSpendables (Amount minimum);
+    public UTXOPair[] getSpendables (Amount minimum,
+        OutputType output_type = OutputType.Payment);
 
     /***************************************************************************
 
@@ -1629,16 +1630,20 @@ private mixin template TestNodeMixin ()
     }
 
     ///
-    public override UTXOPair[] getSpendables (Amount minimum)
+    public override UTXOPair[] getSpendables (Amount minimum,
+        OutputType output_type = OutputType.Payment)
     {
         UTXOPair[] result;
         Amount accumulated;
         foreach (const ref Hash key, const ref UTXO value; this.utxo_set)
         {
-            result ~= UTXOPair(key, value);
-            accumulated += value.output.value;
-            if (accumulated >= minimum)
-                return result;
+            if (value.output.type == output_type && !this.pool.spending(key))
+            {
+                result ~= UTXOPair(key, value);
+                accumulated += value.output.value;
+                if (accumulated >= minimum)
+                    return result;
+            }
         }
         throw new Exception("Exhausted UTXO without finding enough coins!");
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1443,16 +1443,42 @@ public interface TestAPI : API
 
     /***************************************************************************
 
-        Provides access to the state of the UTXO set
+        Get unspent outputs from the test UTXO set
+
+        Params:
+            minimum = minimum Amount needed in the returned unspent UTXOs
+            output_type = output type (payment / freeze) of desired utxos
+
+        Returns:
+            Array of `UTXOPair` that can be used by calling test code to create
+            a `Transaction` using `TxBuilder`
 
     ***************************************************************************/
 
-    public UTXOPair[] getUTXOs (Amount minimum);
+    public UTXOPair[] getSpendables (Amount minimum);
 
-    ///
+    /***************************************************************************
+
+        Params:
+            owner = PublicKey of utxo owner
+
+        Returns:
+            Array of `UTXOPair` that belong to the provided owner
+
+    ***************************************************************************/
+
     public UTXOPair[] getUTXOs (PublicKey owner);
 
-    /// Ditto
+    /***************************************************************************
+
+        Params:
+            hash = utxo hash value
+
+        Returns:
+            UTXO for provided hash value
+
+    ***************************************************************************/
+
     public UTXO getUTXO (Hash hash);
 
     /***************************************************************************
@@ -1603,7 +1629,7 @@ private mixin template TestNodeMixin ()
     }
 
     ///
-    public override UTXOPair[] getUTXOs (Amount minimum)
+    public override UTXOPair[] getSpendables (Amount minimum)
     {
         UTXOPair[] result;
         Amount accumulated;

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -52,7 +52,7 @@ version(none) unittest
 
     Amount expected = Amount.MinFreezeAmount;
     assert(expected.mul(keys.length));
-    auto utxos = nodes[0].getUTXOs(expected);
+    auto utxos = nodes[0].getSpendables(expected);
 
     // Block 19 we add the freeze utxos for set_b validators
     // prepare frozen outputs for outsider validators to enroll


### PR DESCRIPTION
Taking first two commits of PR https://github.com/bosagora/agora/pull/2561 to detect which commit causes ci to fail.