### PR TITLE
Simplify test utxo freezing

### DIFF
--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -94,52 +94,18 @@ unittest
     network.waitForDiscovery();
     auto nodes = network.clients;
 
-    // generate 16 blocks
-    network.generateBlocks(Height(16));
-    assert(network.blocks[0].header.enrollments.length >= 1);
-    network.expectHeightAndPreImg(Height(16), network.blocks[0].header, 5.seconds);
+    // generate 17 blocks
+    network.generateBlocks(Height(17));
 
-    // Discarded UTXOs (just to trigger block creation)
-    auto spendable = network.blocks[$ - 1].spendable().array;
-    auto txs = spendable[0 .. 4]
-        .map!(txb => txb.refund(WK.Keys.Genesis.address).sign())
-        .array;
-
-    // 8 utxos for freezing, 24 utxos for creating a block later
-    txs ~= spendable[4].split(genesis_validator_keys[0].address.repeat(8)).sign();
-    txs ~= spendable[5].split(WK.Keys.Z.address.repeat(8)).sign();
-    txs ~= spendable[6].split(WK.Keys.Z.address.repeat(8)).sign();
-    txs ~= spendable[7].split(WK.Keys.Z.address.repeat(8)).sign();
-
-    // Block 17
-    txs.each!(tx => network.postAndEnsureTxInPool(tx));
-    network.expectHeightAndPreImg(Height(17), network.blocks[0].header, 10.seconds);
-
-    // Freeze builders
-    auto freezable = txs[$ - 4]
-        .outputs.length.iota
-        .takeExactly(8)
-        .map!(idx => TxBuilder(txs[$ - 4], cast(uint)idx));
-
-    // Create 8 freeze TXs
-    auto freeze_txs = freezable
-        .enumerate
-        .map!(pair => pair.value.refund(genesis_validator_keys[0].address)
-            .sign(OutputType.Freeze))
-        .array;
-    assert(freeze_txs.length == 8);
+    // create and send tx to all nodes
+    network.postAndEnsureTxInPool(iota(GenesisValidators),
+        network.freezeUTXO(iota(GenesisValidators)));
 
     // Block 18
-    freeze_txs.each!(tx => network.postAndEnsureTxInPool(tx));
     network.expectHeightAndPreImg(Height(18), network.blocks[0].header, 5.seconds);
 
     // Block 19
-    auto new_txs = txs[$ - 3]
-        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 3], cast(uint)idx))
-        .takeExactly(8)
-        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
-    new_txs.each!(tx => network.postAndEnsureTxInPool(tx));
-    network.expectHeightAndPreImg(Height(19), network.blocks[0].header, 5.seconds);
+    network.generateBlocks(Height(19));
 
     // Now we re-enroll the first validator with a new UTXO but it will fail
     // because an enrollment with same public key of the first validator is
@@ -158,12 +124,7 @@ unittest
     }
 
     // Block 20
-    new_txs = txs[$ - 2]
-        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 2], cast(uint)idx))
-        .takeExactly(8)
-        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
-    new_txs.each!(tx => network.postAndEnsureTxInPool(tx));
-    network.expectHeightAndPreImg(Height(20), network.blocks[0].header);
+    network.generateBlocks(Height(20));
     auto b20 = nodes[0].getBlocksFrom(20, 2)[0];
     assert(b20.header.enrollments.length == 5);
 
@@ -173,12 +134,7 @@ unittest
         retryFor(node.getEnrollment(new_enroll.utxo_key) == new_enroll, 5.seconds));
 
     // Block 21 created with the new enrollment
-    new_txs = txs[$ - 1]
-        .outputs.length.iota.map!(idx => TxBuilder(txs[$ - 1], cast(uint)idx))
-        .takeExactly(8)
-        .map!(txb => txb.refund(WK.Keys.Z.address).sign()).array;
-    new_txs.each!(tx => network.postAndEnsureTxInPool(tx));
-    network.expectHeightAndPreImg(Height(21), b20.header);
+    network.generateBlocks(Height(21));
     auto b21 = nodes[0].getBlocksFrom(21, 2)[0];
     assert(b21.header.enrollments.length == 1);
     assert(b21.header.enrollments[0] == new_enroll);

--- a/source/agora/test/FutureEnrollment.d
+++ b/source/agora/test/FutureEnrollment.d
@@ -90,11 +90,7 @@ unittest
         Height(GenesisValidatorCycle - 2));
 
     // prepare frozen outputs for the outsider validator to enroll
-    const key = outsider.getPublicKey().key;
-    network.blocks[0].spendable().drop(1).takeExactly(1)
-        .map!(txb => txb
-            .split([key]).sign(OutputType.Freeze))
-            .each!(tx => network.nodes[delayed_node].postTransaction(tx));
+    network.postAndEnsureTxInPool(network.freezeUTXO(only(GenesisValidators)));
 
     // the delayed validator becomes unresponsive
     network.clients[delayed_node].filter!(API.postTransaction);

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -43,15 +43,8 @@ unittest
     // generate 18 blocks, 1 short of the enrollments expiring.
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    const keys = nodes.map!(node => node.getPublicKey().key)
-        .dropExactly(GenesisValidators)
-        .takeExactly(conf.outsider_validators)
-        .array;
-
-    // Freeze outputs for outsiders
-    genesisSpendable.drop(2).takeExactly(1)
-        .map!(txb => txb.split(keys).sign(OutputType.Freeze))
-        .each!(tx => nodes[0].postTransaction(tx));
+    // prepare frozen outputs for the outsider validator to enroll
+    network.postAndEnsureTxInPool(network.freezeUTXO(iota(GenesisValidators, validators)));
 
     // at block height 19 the freeze tx's are available
     network.generateBlocks(Height(GenesisValidatorCycle - 1));

--- a/source/agora/test/RestoreSlashingInfo.d
+++ b/source/agora/test/RestoreSlashingInfo.d
@@ -47,16 +47,10 @@ unittest
     // generate 18 blocks, 2 short of the enrollments expiring.
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
 
-    const keys = set_b.map!(node => node.getPublicKey().key).array;
-
-    auto blocks = nodes[0].getAllBlocks();
-
     // Block 19 we add the freeze utxos for set_b validators
     // prepare frozen outputs for outsider validators to enroll
-    blocks[0].spendable().drop(1).takeExactly(1)
-        .map!(txb => txb
-            .split(keys).sign(OutputType.Freeze))
-            .each!(tx => set_a[0].postTransaction(tx));
+    network.postAndEnsureTxInPool(iota(GenesisValidators),
+        network.freezeUTXO(iota(GenesisValidators, GenesisValidators + 3)));
 
     network.generateBlocks(Height(GenesisValidatorCycle - 1));
 


### PR DESCRIPTION
Created a `base.d` function `freezeUTXO` which uses the new `getSpendables` that finds unspent `utxo` from the `utxo_set` of a node. Then replaced some of the complex code in the test cases by using `freezeUTXO`. 
In some cases the test could then also use `generateBlocks` to further simplify.