### PR TITLE
Extend Vibe's URL implementation for normalization and agora schema

### DIFF
--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -20,6 +20,11 @@ public import agora.crypto.Types;
 
 import geod24.bitblob;
 
+import std.array : appender;
+import std.conv : to;
+import std.string: lastIndexOf, toLower;
+import std.uri: encode;
+
 /// Represents a specific point in time, it should be changed to time_t
 /// after time_t became platform independent
 public alias TimePoint = ulong;
@@ -29,6 +34,180 @@ public alias cstring = const(char)[];
 
 /// A network address
 public alias Address = string;
+
+/// Extension of Vibe.d's URL with normalization and `agora` schema capabilities
+public struct URL
+{
+    import vibe.inet.url : VibeURL = URL, isCommonInternetSchema;
+
+    /// Base Vibe.d URL implementation
+    public VibeURL inner;
+
+    /***************************************************************************
+         
+         Params:
+           url = Plain URL
+
+        Notes:
+            - `url` must be plain and not percent-encoded
+            - `url` host name can only contain ASCII characters, 
+              [puny codes](https://github.com/vibe-d/vibe.d/issues/492) are not
+              supported
+            - `url` schema [must be](https://github.com/vibe-d/vibe.d/issues/2619)
+              lowercase
+
+    ***************************************************************************/
+
+    public this (string url)
+    {
+        this.inner = VibeURL(url.encode);
+    }
+
+    /// The port part of the URL (optional, supports `agora` schema)
+    @property ushort port() const nothrow 
+    {
+        return inner.port ? inner.port : defaultPort(inner.schema); 
+    }
+
+    /// ditto
+    @property port(ushort v) nothrow { inner.port = v; }
+
+    /// Get the default port for the given schema or 0 (supports `agora` schema)
+    static ushort defaultPort(string schema)
+    nothrow {
+        switch (schema) {
+            case "agora": return 2826;
+            default:
+                return VibeURL.defaultPort(schema);
+        }
+    }
+
+    /// ditto
+    ushort defaultPort()
+    const nothrow {
+        return defaultPort(inner.schema);
+    }
+
+    /***************************************************************************
+         
+        Normalizes URL by;
+            - Lowering letter cases for schema and host
+            - Hiding default port for the schema
+            - Normalizing the path
+            - Removing file segment from the path
+            - Adding trailing slash
+            - Removing the anchor
+
+        Returns:
+           url = Normalized representation of URL
+
+        Notes:
+            - Original URL is not modified
+
+    ***************************************************************************/
+
+    public string normalized()
+    {
+        auto urlbuilder = appender!string();
+
+        // std.uri.encode percent encodes with Uppercase and passes unreserved 
+        // characters (ALPHA, NUMERIC, - . _ ~) while encoding
+
+        // Schema to lower case
+        urlbuilder.put(inner.schema.toLower());
+        urlbuilder.put(":");
+        if (isCommonInternetSchema(inner.schema))
+            urlbuilder.put("//");
+        
+        if (inner.username || inner.password)
+        {
+            urlbuilder.put(inner.username);
+            if (inner.password)
+            {
+                urlbuilder.put(':');
+                urlbuilder.put(inner.password);    
+            }
+            urlbuilder.put('@');
+        }
+
+        import std.algorithm : canFind;
+        if (inner.host.canFind(":"))
+        { // ipv6
+		    urlbuilder.put('[');
+		    urlbuilder.put(host);
+		    urlbuilder.put(']');
+        }
+        else
+        {
+            // Host name to lower case
+		    urlbuilder.put(inner.host.toLower());
+        }
+
+        // Pass default for the schema
+        if (inner.port != defaultPort(inner.schema))
+        {
+            urlbuilder.put(':');
+			urlbuilder.put(to!string(inner.port));
+        }
+
+        if (inner.pathString.length)
+        {
+            auto path = inner.path.normalized();
+            auto str_path = path.toString();
+
+            if (!path.fileExtension.empty)
+            { // File segment is not necessary for normalized URLs
+                str_path = str_path[0..str_path.lastIndexOf('/')];
+            }
+
+            // Normalized path
+            urlbuilder.put(str_path);
+        }
+
+        // Always with trailing slash
+        if (!path.endsWithSlash)
+            urlbuilder.put("/");
+
+        if (inner.queryString.length)
+        {
+            urlbuilder.put("?");
+            urlbuilder.put(inner.queryString);
+        }
+
+        // Anchors are not necessary for normalized URLs
+        // TODO We can reverse lookup DNS for IP addresses    
+
+        return urlbuilder.data;
+    }
+
+    public alias inner this;
+
+    unittest
+    {
+        import vibe.inet.url : VibeURL = URL, registerCommonInternetSchema;
+        assert(URL.defaultPort("http") == VibeURL.defaultPort("http"));
+        assert(URL("http://example.com").port == URL.defaultPort("http"));
+        
+        registerCommonInternetSchema("agora");
+        assert(URL.defaultPort("agora") == 2826);
+        assert(URL("agora://example.com:1234").port == 1234);
+        assert(URL("agora://example.com").port == URL.defaultPort("agora"));
+    }
+
+    unittest
+    {
+        assert(URL("http://example.com").normalized == "http://example.com/");
+        assert(URL("http://example.com:80/").normalized == "http://example.com/");
+        assert(URL("http://example.com/foo//bar").normalized == "http://example.com/foo/bar/");
+        assert(URL("https://example.com/example/path//").normalized == "https://example.com/example/path/");
+        assert(URL("http://example.com/foo/./bar/baz/../qux").normalized == "http://example.com/foo/bar/qux/");
+        assert(URL("http://example.com/bar.html#section1").normalized == "http://example.com/");
+        assert(URL("https://example.com/hello/world//file.txt").normalized == "https://example.com/hello/world/");
+        assert(URL("http://User@Example.COM/Foo").normalized == "http://User@example.com/Foo/");
+        // Disabled due to https://github.com/vibe-d/vibe.d/issues/2619
+        // assert(URL("HTTP://User@Example.COM/Foo").normalized == "http://User@example.com/Foo");
+    }
+}
 
 /// The definition of a Quorum
 public struct QuorumConfig

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -47,7 +47,6 @@ import agora.utils.Utility;
 
 import vibe.http.common;
 import vibe.web.rest;
-import vibe.inet.url;
 
 import std.algorithm;
 import std.array;

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -26,8 +26,6 @@ import agora.crypto.Key;
 import agora.flash.Config;
 import agora.utils.Log;
 
-import vibe.inet.url;
-
 import std.algorithm.iteration : splitter;
 import std.algorithm.searching : all;
 import std.exception;


### PR DESCRIPTION
Fixes #2566 
Vibe.d's URL implementation is extended. Some of the Vibe.d's URL limitations are fixed;

- Users should input plain URLs, percent-encoding will be handled (`http://example.com/hello~🌍` is valid)
- Puny-codes are not supported (`http://i👍c.io/` is invalid)
- Plain URL will be untouched, normalized representation will be calculated when requested as follows
- URL schema [must be](https://github.com/vibe-d/vibe.d/issues/2619) lowercase and must exist
- `agora` schema support is added with default port as `2826`

**URL Normalization**

1. Lowercase schema and host name (`http://eXAMplE.com` -> `http://example.com/`)
2. Strip default port for schema (`agora://myserver.com:2826` -> `agora://myserver.com/`)
3. Normalize URL path (`/path/./try//` -> `/path/try/`)
4. Add trailing slash (`http://example.com/mypath` -> `http://example.com/mypath/`)
5. Strip files (`http://example.com/path/inner.html` -> `http://example.com/path/`) 
6. Strip anchor (`http://example.com/path/inner.html#anchor` -> `http://example.com/path/`)

**What can be done?**
Following items can also be implemented but didn't implement due to low probability of use cases,

1. Reverse lookup for IP addresses (`http://142.251.36.238/` -> `http://google.com/`)
2. Punycode support
3. Query ordering
