### PR TITLE
Ledger: Minor improvements to reduce `makeNewTestBlock` dependencies

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -1798,11 +1798,6 @@ unittest
 
     Block invalid_block;  // default-initialized should be invalid
     assert(ledger.acceptBlock(invalid_block));
-
-    auto txs = genesisSpendable().map!(txb => txb.sign()).array();
-    const block = makeNewTestBlock(ledger.params.Genesis, txs);
-    ledger.simulatePreimages(ledger.getBlockHeight() + 1);
-    assert(!ledger.acceptBlock(block));
 }
 
 /// Situation: Ledger is constructed with blocks present in storage

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -243,6 +243,11 @@ public class Ledger
     public ValidatorInfo[] getValidators (in Height height, bool empty = false)
         scope @safe
     {
+        // There are no validators at Genesis, and no one able to sign the block
+        // This is by design, and to allow calling code to work correctly without
+        // special-casing height == 0, we just return `null`.
+        if (height == 0) return null;
+
         auto result = this.enroll_man.validator_set.getValidators(height);
         ensure(empty || result.length > 0,
                "Ledger.getValidators didn't find any validator at height {}", height);

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -1572,20 +1572,19 @@ public class ValidatingLedger : Ledger
 
     private string externalize (ConsensusData data) @trusted
     {
-        import agora.utils.Test : WK;
-
-        auto next_block = Height(this.last_block.header.height + 1);
-        auto key_pairs = this.getValidators(next_block)
-            .map!(vi => WK.Keys[vi.address])
-            .array();
+        const height = Height(this.last_block.header.height + 1);
 
         Transaction[] externalized_tx_set;
         if (auto fail_reason = this.getValidTXSet(data, externalized_tx_set))
         {
-            log.info("Ledger.externalize, can not create new block at Height {} : {}. Fail reason : {}",
-                next_block, data.prettify, fail_reason);
+            log.info("Ledger.externalize: can not create new block at Height {} : {}. Fail reason : {}",
+                height, data.prettify, fail_reason);
             return fail_reason;
         }
+
+        auto key_pairs = this.getValidators(height)
+            .map!(vi => WK.Keys[vi.address])
+            .array();
         const block = makeNewTestBlock(this.last_block,
             externalized_tx_set, key_pairs,
             data.enrolls, data.missing_validators, data.time_offset);

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -552,9 +552,7 @@ public class FullNode : API
 
     protected string acceptBlock (in Block block) @trusted
     {
-        auto old_validators = block.header.height > 1 ?
-            this.ledger.getValidators(this.ledger.getBlockHeight()) :
-            null;
+        auto old_validators = this.ledger.getValidators(this.ledger.getBlockHeight());
         // Attempt to add block to the ledger (it may be there by other means)
         if (auto fail_msg = this.ledger.acceptBlock(block))
             return fail_msg;
@@ -1321,8 +1319,6 @@ public class FullNode : API
     public ValidatorInfo[] getValidators (ulong height)
     {
         this.recordReq("validators");
-        if (height == 0)
-            return null;
         return this.ledger.getValidators(Height(height), true);
     }
 


### PR DESCRIPTION
It became evident a while ago that we need to better expose the Ledger's ability to generate blocks.
The original approach taken by `makeNewBlock` doesn't quite scale, and requires passing a lot of context nowadays.
In tests, this becomes even more problematic, as we for example need valid block (signed by a majority of validators) for some tests.

For a while, `makeNewTestBlock` was used to work around that problem, but it just shift things. Moving those functionalities to the `Ledger` seems to be the best way forward. Hence the few commits here, and the many that will follow.