### PR TITLE
Fix #2577 - BlockHeader.computeHash is misleading

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -2072,11 +2072,11 @@ unittest
     {
         assert(ex.message ==
                "Genesis block loaded from disk " ~
-               "(0xe9de4d480b4f141634634e1d977a938115c894b2eb6c12bef9961584ff6ff6b" ~
-               "bb4d4bcd0486496eae2dd7dc9334e913b34a3fafafc166eeec4fc2c5d06c4fbb5) " ~
+               "(0x67a40d4e4149c9c64efdbeabcb35d466bff111d7298f80ab310a514c15ba0e1" ~
+               "63c6ff78b1c60ad7fcb7e125a4738163343b62462ba9ce24ae576f01bbc5ce11c) " ~
                "is different from the one in the config file " ~
-               "(0x8d8c0e7d98b346bb7431417384b026c6010f44fce05d4bbca96105fff2a3fbe" ~
-               "d27f72cae8f71bb9b8dcedf44b5a7768cacfe9104db52c9e4d5b9b3397aab3419)");
+               "(0xa8382c87eed66f5468b41a81a448b1c8056ed8fccd0934acd3440b3457f8fdc" ~
+               "0e49b6388815cf8caef50be2c00dc72a001c53f8ba56aed2fb5cdd1d3a47307d7)");
     }
 
     immutable good_params = new immutable(ConsensusParams)();

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -92,11 +92,12 @@ public struct BlockHeader
         @safe pure nothrow @nogc
     {
         dg(this.prev_block[]);
-        hashPart(this.height.value, dg);
         dg(this.merkle_root[]);
+        hashPart(this.height.value, dg);
+        foreach (const ref h; this.preimages)
+            dg(h[]);
         foreach (enrollment; this.enrollments)
             hashPart(enrollment, dg);
-        hashPart(this.preimages, dg);
         hashPart(this.time_offset, dg);
     }
 
@@ -191,7 +192,7 @@ unittest
     BlockHeader header = { merkle_root : tx.hashFull() };
 
     auto hash = hashFull(header);
-    auto exp_hash = Hash("0xb6319105c3f97e63df13081ee8cae7c7237b844907cfa3cb1342baf1bdf3c8d714b38dd4938836cb33a07e8cf2271ebe63b248aa6b3dabce94add0bde77ffe28");
+    auto exp_hash = Hash("0xde4132329e5e3d7acb2efc075c0d67f4e29995d49a813445cf7ad74f66140df014f411dc71529142e2f0223578195a6cb22662ee990992b510b74e56a02dae87");
     assert(hash == exp_hash);
 }
 

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -529,7 +529,7 @@ Outputs (6):
 boa1xzval2a3...gsh2(2,000,000)<Freeze>, boa1xzval3ah...tv9n(2,000,000)<Freeze>, boa1xzval4nv...6gfy(2,000,000)<Freeze>,
 boa1xrval5rz...jkm8(2,000,000)<Freeze>, boa1xrval6hd...34l5(2,000,000)<Freeze>, boa1xrval7gw...scrh(2,000,000)<Freeze>
 ====================================================
-Height: 1, Prev: 0xe9de...fbb5, Root: 0xb039...ee32, Enrollments: []
+Height: 1, Prev: 0x67a4...e11c, Root: 0xb039...ee32, Enrollments: []
 Signature: 0x000000000000000000016f605ea9638d7bff58d2c0cc2467c18e38b36367be78000000000000000000016f605ea9638d7bff58d2c0cc2467c18e38b36367be78,
 Validators: 4/6 !(1, 4),
 Pre-images: [0xe998...9b3f, 0x4afa...b699, 0x31a2...e601, 0x62c3...6572, 0x58a4...9659, 0x2787...82ae],


### PR DESCRIPTION
```
Make sure the hashing order follows the order of fields in the BlockHeader.
Also do not (redundantly) hash the length of the array, just individual elements.
```

CC @TrustHenry 