### PR TITLE
Minor improvements to `Ledger.simulatePreimages` and `Registry`'s usage of `ZoneInfo`

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -1335,29 +1335,23 @@ public class Ledger
     version (unittest):
 
     /// Make sure the preimages are available when the block is validated
-    private void simulatePreimages (in Height height, uint[] skip_indexes = null) @safe nothrow
+    private void simulatePreimages (in Height height, uint[] skip_indexes = null) @safe
     {
-        try
-        {
-            auto validators = this.getValidators(height);
+        auto validators = this.getValidators(height);
 
-            void addPreimageLog (in PublicKey public_key, in PreImageInfo preimage_info)
-            {
-                log.info("Adding test preimages for height {} for validator {}: {}", height, public_key, preimage_info);
-                this.addPreimage(preimage_info);
-            }
-            validators.enumerate.each!((idx, val)
-            {
-                if (skip_indexes.length && skip_indexes.canFind(idx))
-                    log.info("Skip add preimage for validator idx {} at height {} as requested by test", idx, height);
-                else
-                    addPreimageLog(val.address, PreImageInfo(val.preimage.utxo,
-                        WK.PreImages[WK.Keys[val.address]][height], height));
-            });
-        } catch (Exception e)
+        void addPreimageLog (in PublicKey public_key, in PreImageInfo preimage_info)
         {
-            log.error("simulatePreimages: height: {} exception thrown: {}", height, e);
+            log.info("Adding test preimages for height {} for validator {}: {}", height, public_key, preimage_info);
+            this.addPreimage(preimage_info);
         }
+        validators.enumerate.each!((idx, val)
+        {
+            if (skip_indexes.length && skip_indexes.canFind(idx))
+                log.info("Skip add preimage for validator idx {} at height {} as requested by test", idx, height);
+            else
+                addPreimageLog(val.address, PreImageInfo(val.preimage.utxo,
+                    WK.PreImages[WK.Keys[val.address]][height], height));
+        });
     }
 }
 


### PR DESCRIPTION
Was looking into other stuff and noticed the `Registry` could use more `ref`.
Also saw that `simulatePreimages` was needlessly `nothrow`, which could, in some cases, hide an issue.