### PR TITLE
DUB: Use `-lowmem` when compiling by default

### DIFF
--- a/dub.settings.json
+++ b/dub.settings.json
@@ -1,3 +1,4 @@
 {
-    "defaultCompiler": "ldc2"
+    "defaultCompiler": "ldc2",
+    "defaultLowMemory": true
 }


### PR DESCRIPTION
```
This is an attempt at reducing the memory usage of the compiler when
building Agora, which sometimes results in the CI killing the compiler (!).
```

@mkykadir reported that it didn't have much effect to him, but if it can get us under the CI's threshold, that'd be great.