### PR TITLE
Change Address alias to Vibe URL

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -42,7 +42,7 @@ public struct NodeInfo
     public NetworkState state;
 
     /// Partial or full view of the addresses of the node's quorum (based on is_complete)
-    public Set!string addresses;
+    public Set!Address addresses;
 }
 
 /// Identity of a Validator node

--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -17,8 +17,16 @@ import agora.crypto.ECC;
 import agora.crypto.Key;
 import agora.crypto.Schnorr;
 public import agora.crypto.Types;
+import agora.serialization.Serializer;
+
+import vibe.inet.url;
 
 import geod24.bitblob;
+
+shared static this () 
+{
+    registerCommonInternetSchema("agora"); // TODO default port: 2826
+}
 
 /// Represents a specific point in time, it should be changed to time_t
 /// after time_t became platform independent
@@ -27,8 +35,39 @@ public alias TimePoint = ulong;
 /// An array of const characters
 public alias cstring = const(char)[];
 
-/// A network address
-public alias Address = string;
+/// A network address, extended version of Vibe.d's URL with serialization
+public struct Address 
+{
+@safe:
+    URL inner;
+
+    public this (URL url) immutable
+    {
+        this.inner = url;
+    }
+
+    public this (string url)
+    {
+        this.inner = URL(url);
+    }
+
+    /// Serialization hook
+    public void serialize (scope SerializeDg dg) const @safe
+    {
+        serializePart(inner.toString(), dg);
+    }
+
+    /// Deserialization hook
+    public static T fromBinary (T) (
+        scope DeserializeDg dg, in DeserializerOptions opts) @safe
+    {
+        return () @trusted {
+            return T(deserializeFull!string(dg));
+        }();
+    }
+
+    public alias inner this;
+}
 
 /// The definition of a Quorum
 public struct QuorumConfig

--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -115,7 +115,7 @@ public class Channel
 
     /// Fetch the Flash Client for the peer
     private FlashAPI delegate (in PublicKey peer_pk, Duration timeout,
-        string address = null) getFlashClient;
+        Address address = Address.init) getFlashClient;
 
     /// Retry delay algorithm
     private Backoff backoff;
@@ -210,7 +210,8 @@ public class Channel
         OnPaymentComplete onPaymentComplete,
         OnUpdateComplete onUpdateComplete,
         GetFeeUTXOs getFeeUTXOs,
-        FlashAPI delegate (in PublicKey peer_pk, Duration timeout, string address = null) getFlashClient,
+        FlashAPI delegate (in PublicKey peer_pk, Duration timeout, 
+            Address address = Address.init) getFlashClient,
         ManagedDatabase db)
     {
         this.db = db;
@@ -254,7 +255,8 @@ public class Channel
 
     public static Channel[Hash] loadChannels (FlashConfig flash_conf,
         ManagedDatabase db,
-        FlashAPI delegate (in PublicKey peer_pk, Duration timeout, string address = null) getFlashClient,
+        FlashAPI delegate (in PublicKey peer_pk, Duration timeout, 
+            Address address = Address.init) getFlashClient,
         Engine engine, ITaskManager taskman,
         void delegate (in Transaction) txPublisher, PaymentRouter paymentRouter,
         OnChannelNotify onChannelNotify,

--- a/source/agora/flash/api/FlashAPI.d
+++ b/source/agora/flash/api/FlashAPI.d
@@ -230,7 +230,7 @@ public interface FlashAPI
     ***************************************************************************/
 
     public Result!PublicNonce openChannel (/* in */ ChannelConfig chan_conf,
-        /* in */ PublicNonce peer_nonce, /* in */ string funder_address);
+        /* in */ PublicNonce peer_nonce, /* in */ Address funder_address);
 
     /***************************************************************************
 

--- a/source/agora/flash/api/FlashControlAPI.d
+++ b/source/agora/flash/api/FlashControlAPI.d
@@ -111,7 +111,7 @@ public interface FlashControlAPI : FlashAPI, BlockExternalizedHandler
     public Result!Hash openNewChannel (/* in */ UTXO funding_utxo,
         /* in */ Hash funding_utxo_hash, /* in */ Amount capacity,
         /* in */ uint settle_time, /* in */ Point peer_pk,
-        /* in */ bool is_private, /* in */ string peer_address);
+        /* in */ bool is_private, /* in */ Address peer_address);
 
     /***************************************************************************
 

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -124,7 +124,7 @@ public struct Config
     {
         if (this.validator.enabled)
             enforce(this.network.length ||
-                    this.validator.registry_address != "disabled" ||
+                    this.validator.registry_address != string.init ||
                     // Allow single-network validator (assume this is NODE6)
                     this.node.limit_test_validators == 1,
                     "Either the network section must not be empty, or 'validator.registry_address' must be set");
@@ -374,7 +374,7 @@ public struct ValidatorConfig
     public @Optional immutable string[] addresses_to_register;
 
     // Registry address
-    public string registry_address;
+    public @Optional string registry_address;
 
     // If the enrollments will be renewed or not at the end of the cycle
     public bool recurring_enrollment = true;
@@ -615,7 +615,6 @@ validator:
         immutable conf_str = `
 validator:
   enabled: true
-  registry_address: disabled
   seed:    SDV3GLVZ6W7R7UFB2EMMY4BBFJWNCQB5FTCXUMD5ZCFTDEVZZ3RQ2BZI
   recurring_enrollment: true
   preimage_reveal_interval:

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -386,26 +386,34 @@ public class FullNode : API
             // Make `BlockExternalizedHandler`s from config
             config.event_handlers.filter!(h => h.type == HandlerType.BlockExternalized)
                 .each!(handler => handler.addresses
-                    .each!((string address) =>
-                        this.block_handlers[address] = this.network.getBlockExternalizedHandler(address)));
+                    .each!((string address) {
+                        auto url = Address(address); // TODO normalize
+                        this.block_handlers[url] = this.network.getBlockExternalizedHandler(url);
+                    }));
 
             // Make `BlockHeaderUpdatedHandler`s from config
             config.event_handlers.filter!(h => h.type == HandlerType.BlockHeaderUpdated)
                 .each!(handler => handler.addresses
-                    .each!((string address) =>
-                        this.block_header_handlers[address] = this.network.getBlockHeaderUpdatedHandler(address)));
+                    .each!((string address) {
+                        auto url = Address(address); // TODO normalize
+                        this.block_header_handlers[url] = this.network.getBlockHeaderUpdatedHandler(url);   
+                    }));
 
             // Make `PreImageReceivedHandler`s from config
             config.event_handlers.filter!(h => h.type == HandlerType.PreimageReceived)
                 .each!(handler => handler.addresses
-                    .each!((string address) =>
-                        this.preimage_handlers[address] = this.network.getPreImageReceivedHandler(address)));
+                    .each!((string address) {
+                        auto url = Address(address); // TODO normalize
+                        this.preimage_handlers[url] = this.network.getPreImageReceivedHandler(url);
+                    }));
 
             // Make `TransactionReceivedHandler`s from config
             config.event_handlers.filter!(h => h.type == HandlerType.TransactionReceived)
                 .each!(handler => handler.addresses
-                    .each!((string address) =>
-                        this.transaction_handlers[address] = this.network.getTransactionReceivedHandler(address)));
+                    .each!((string address) {
+                        auto url = Address(address); // TODO normalize
+                        this.transaction_handlers[url] = this.network.getTransactionReceivedHandler(url);
+                    }));
         }
 
         if (config.node.stats_listening_port != 0)

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -145,7 +145,7 @@ public class NameRegistry: NameRegistryAPI
         TYPE payload_type;
         foreach (idx, const ref addr; payload.data.addresses)
         {
-            const this_type = addr.guessAddressType();
+            const this_type = addr.host.guessAddressType();
             ensure(this_type != TYPE.CNAME || payload.data.addresses.length == 1,
                     "Can only have one domain name (CNAME) for payload, not: {}",
                     payload);
@@ -475,7 +475,7 @@ public class NameRegistry: NameRegistryAPI
         {
             foreach (idx, addr; tp.payload.data.addresses)
             {
-                uint ip4addr = InternetAddress.parse(addr);
+                uint ip4addr = InternetAddress.parse(addr.host);
                 ensure(ip4addr != InternetAddress.ADDR_NONE,
                        "DNS: Address '{}' (index: {}) is not an A record (record: {})",
                        addr, idx, tp);
@@ -771,7 +771,7 @@ private struct ZoneData
         const Signature signature = Signature.fromString(results.front["signature"].as!string);
         const Hash utxo = Hash.fromString(results.front["utxo"].as!string);
 
-        const auto addresses = results.map!(r => r["address"].as!Address).array;
+        const auto addresses = results.map!(r => Address(r["address"].as!string)).array;
 
         const RegistryPayload payload =
         {
@@ -1002,7 +1002,7 @@ unittest
     ledger.forceCreateBlock();
     assert(ledger.getBlockHeight() == 1);
 
-    auto payload = RegistryPayload(RegistryPayloadData(WK.Keys[0].address, ["address"], 0));
+    auto payload = RegistryPayload(RegistryPayloadData(WK.Keys[0].address, [Address("agora://address")], 0));
     payload.signPayload(WK.Keys[0]);
 
     try

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -18,6 +18,7 @@ import agora.api.Validator;
 import agora.common.DNS;
 import agora.common.Ensure;
 import agora.common.Task : Periodic;
+import agora.common.Types : Address;
 import agora.flash.api.FlashAPI;
 import agora.flash.Node;
 import agora.network.RPC;
@@ -139,7 +140,10 @@ public Listeners runNode (Config config)
     }
 
     bool delegate (in NetworkAddress address) @safe nothrow isBannedDg = (in address) @safe nothrow {
-        return result.node.getBanManager().isBanned(address.toAddressString());
+        try
+            return result.node.getBanManager().isBanned(Address("agora://" ~ address.toAddressString()));
+        catch (Exception e)
+            assert(false, e.msg);
     };
 
     setTimer(0.seconds, &result.node.start, Periodic.No);  // asynchronous

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -147,6 +147,6 @@ unittest
     // All nodes should've banned impersonator_node
     foreach (node; network.nodes)
         if (node != impersonator_node)
-            retryFor(node.client.isBanned(impersonator_node.address), 1.seconds,
+            retryFor(node.client.isBanned(Address("http://"~impersonator_node.address)), 1.seconds,
                 format!"Node %s did not ban %s"(node.address, impersonator_node.address));
 }

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -47,8 +47,6 @@ validator:
   # When validating, the `seed` of an eligible account is required
   # An eligible account has at least 40k coins frozen in it
   enabled: false
-  # Address of the name registry
-  registry_address: disabled
 
 ################################################################################
 ##                               Node discovery                               ##

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -52,8 +52,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xzval2a3cdxv28n6slr62wlczslk3juvk7cu05qt3z55ty2rlfqfc6egsh2
   seed: SAQXRDHTWME4GUIVNYCKPN433VJ4BJP2L2T7UWHGSSW47VFC67EQFY3S
-  # Address of the name registry
-  registry_address: disabled
 
 ################################################################################
 ##                               Node discovery                               ##

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -52,8 +52,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xzval3ah8z7ewhuzx6mywveyr79f24w49rdypwgurhjkr8z2ke2mycftv9n
   seed: SC3H3ADGT3YGLMDWCLKZ2GILDHDTC4WDE7M3G4URQPWJZZM43TTAM2QG
-  # Address of the name registry
-  registry_address: disabled
 
 ################################################################################
 ##                               Node discovery                               ##

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -52,8 +52,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xzval4nvru2ej9m0rptq7hatukkavemryvct4f8smyy3ky9ct5u0s8w6gfy
   seed: SBIJAVYYCSRV5RNO2WVTT25H6VZTEV3YSE7U7WT7UQUNSVBUGB6QNBWG
-  # Address of the name registry
-  registry_address: disabled
 
 ################################################################################
 ##                               Node discovery                               ##

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -52,8 +52,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8
   seed: SAZO4WA5SXUN3J6XBXZCFPXJJZ62IQAJYAG2KBVWF2QZKTU2WK3QTNMV
-  # Address of the name registry
-  registry_address: disabled
 
 ################################################################################
 ##                               Node discovery                               ##

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -52,8 +52,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xrval6hd8szdektyz69fnqjwqfejhu4rvrpwlahh9rhaazzpvs5g6lh34l5
   seed: SAFIQC7HRZPVPEG47ZHS3OBBCYDREHNC4DEKM3QODM7WKPZPU7VQXCPI
-  # Address of the name registry
-  registry_address: disabled
 
 ################################################################################
 ##                               Node discovery                               ##

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -52,8 +52,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xrval7gwhjz4k9raqukcnv2n4rl4fxt74m2y9eay6l5mqdf4gntnzhhscrh
   seed: SAWI3JZWDDSQR6AX4DRG2OMS26Y6XY4X2WA3FK6D5UW4WTU74GUQXRZP
-  # Address of the name registry
-  registry_address: disabled
 
 ################################################################################
 ##                               Node discovery                               ##

--- a/tests/unit/BanManager.d
+++ b/tests/unit/BanManager.d
@@ -14,6 +14,7 @@
 module unit.BanManager;
 
 import agora.common.BanManager;
+import agora.common.Types : Address;
 import agora.network.Clock;
 import agora.utils.Test;
 
@@ -37,7 +38,7 @@ private void main ()
     auto banman = new BanManager(conf, new Clock(null, null), buildPath(path, "banned.dat"));
     banman.load();  // should not throw
 
-    const IP = "127.0.0.1";
+    const IP = Address("http://127.0.0.1");
     10.iota.each!(_ => banman.onFailedRequest(IP));
     banman.isBanned(IP);
     assert(banman.isBanned(IP));


### PR DESCRIPTION
Part of #2566 

- Remove `string` alias of `Address`
- Extend Vibe's `URL` with serialization under `Address` structure

It might be better to change URL expecting inputs of `Config` from `string` to `Address`. It is not a problem for mapping types (as in `Proxy` config) but sequence types cannot be parsed with string inputs into `URL` struct yet. This way we would be able to throw error at configuration parsing when user is provided invalid URL from config file.