### PR TITLE
CI: Update compiler support to LDC v1.28.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,14 +26,14 @@ jobs:
         ## See https://github.com/ldc-developers/ldc/issues/3702
         # os: [ ubuntu-20.04, macOS-10.15, windows-2019 ]
         os: [ ubuntu-20.04, macOS-10.15]
-        dc: [ ldc-master, ldc-1.26.0 ]
+        dc: [ ldc-master, ldc-1.28.0 ]
         # Define job-specific parameters
         include:
           # By default, don't generate artifacts nor run extra checks for push
           - { artifacts: false, run_extra_checks: false }
           # Only generate when the latest ldc is used
           # IMPORTANT: Update this when the compiler support is changed!
-          - { dc: ldc-1.26.0, artifacts: true, run_extra_checks: true }
+          - { dc: ldc-1.28.0, artifacts: true, run_extra_checks: true }
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ On older distributions (e.g. Ubuntu 18.04), `libsodium` might not be at version 
 #
 # Then, install the LDC compiler (you might want to use a newer version)
 # This will also install dub, the D package manager / build tool
-curl https://dlang.org/install.sh | bash -s ldc-1.26.0
+curl https://dlang.org/install.sh | bash -s ldc-1.28.0
 # Add LDC to the $PATH
-source ~/dlang/ldc-1.26.0/activate
+source ~/dlang/ldc-1.28.0/activate
 # Clone this repository
 git clone https://github.com/bosagora/agora.git
 # Use the git root as working directory


### PR DESCRIPTION
Jumping a whole version. The Docker image still needs to be updated.