### PR TITLE
Fix #2572: Use only IPv6 to avoid dual stack issue

### DIFF
--- a/source/agora/stats/Server.d
+++ b/source/agora/stats/Server.d
@@ -40,6 +40,9 @@ public class StatsServer
         router.get("/metrics", &handle_metrics);
 
         auto settings = new HTTPServerSettings;
+        // Vibe.d uses both IPv6 and IPv4 all-interfaces at once, which causes
+        // problems on Linux because of dual stack (the second listen fails)
+        settings.bindAddresses = [ "::" ];
         settings.port = port;
         // The following correspond to your scraping interval in Prometheus
         // The default value for Prometheus is 1 minute:


### PR DESCRIPTION
As mentioned in the issue, Vibe.d's default is problematic, so override it.
This still accepts IPv4 connections on Linux and Windows.