### PR TITLE
Add a configuration for vanity miner and fix a deprecation message

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -78,7 +78,6 @@
                 "source/agora/consensus/protocol/Nominator.d",
                 "source/agora/cli/checkvtable/*",
                 "source/agora/cli/multi/*",
-                "source/agora/cli/vanity/*",
                 "source/agora/test/*",
                 "source/agora/utils/gc/*"
             ]
@@ -122,7 +121,6 @@
             ],
 
             "excludedSourceFiles": [
-                "source/agora/cli/vanity/*",
                 "source/agora/cli/version/*"
             ],
             "debugVersions": [ "ConfigFillerDebug" ]
@@ -134,7 +132,14 @@
             "excludedSourceFiles": [
                 "source/agora/cli/checkvtable/*",
                 "source/agora/cli/client/*",
-                "source/agora/cli/vanity/*",
+                "source/agora/utils/gc/*"
+            ]
+        },
+        {
+            "name": "vanity",
+            "targetName": "agora-vanity-generator",
+            "mainSourceFile": "source/agora/cli/vanity/main.d",
+            "excludedSourceFiles": [
                 "source/agora/utils/gc/*"
             ]
         },
@@ -148,7 +153,6 @@
                 "source/agora/cli/checkvtable/check.d",
                 "source/agora/cli/client/*",
                 "source/agora/cli/multi/*",
-                "source/agora/cli/vanity/*",
                 "source/agora/utils/gc/*"
             ]
         },
@@ -163,7 +167,6 @@
                 "source/agora/cli/checkvtable/generate.d",
                 "source/agora/cli/client/*",
                 "source/agora/cli/multi/*",
-                "source/agora/cli/vanity/*",
                 "source/agora/utils/gc/*"
             ]
         }

--- a/tests/system/source/main.d
+++ b/tests/system/source/main.d
@@ -62,14 +62,14 @@ int main (string[] args)
     // keep polling the nodes for a complete network discovery, until a timeout
     writefln("%s waitForDiscovery", PREFIX);
     const discovery_duration = 60.seconds;
-    clients.enumerate.each!((idx, client) =>
+    clients.enumerate.each!((idx, client)
     {
         retryFor(client.getNodeInfo().ifThrown(NodeInfo.init)
             .state == NetworkState.Complete,
             discovery_duration,
             format("%s %s has not completed discovery after %s.",
                 PREFIX, nodeFromClientIndex(idx), discovery_duration * (idx + 1)));
-    }());
+    });
 
     /// Check block generation
     size_t assertBlockHeightAtleast (ulong height)
@@ -111,13 +111,13 @@ int main (string[] args)
         return tx_count;
     }
 
-    clients.enumerate.each!((idx, client) =>
+    clients.enumerate.each!((idx, client)
     {
         writefln("%s %s info: %s", PREFIX, nodeFromClientIndex(idx), client.getNodeInfo());
         const height = client.getBlockHeight();
         writefln("%s %s has block height %s", PREFIX, nodeFromClientIndex(idx), height);
         writefln("%s ----------------------------------------", PREFIX);
-    }());
+    });
 
     // Make sure the nodes use the test genesis block
     const blocks = clients[0].getBlocksFrom(0, 1);


### PR DESCRIPTION
Not much to it: I was debugging something else and the `vanity` main stood in the way, realized it was because there was no configuration for it. Additionally, the deprecation message was triggered in the CI. We're not doing it wrong, but we're not doing it clearly either.