### PR TITLE
Update Dockerfile for LDC v1.28.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 FROM bosagora/agora-builder:latest AS Builder
 ARG DUB_OPTIONS
 ARG AGORA_VERSION="HEAD"
-RUN apk --no-cache add linux-headers python3 npm
 ADD . /root/agora/
 WORKDIR /root/agora/talos/
 RUN npm ci && npm run build
@@ -21,10 +20,7 @@ FROM alpine:edge
 # The following makes debugging Agora much easier on server
 # Since it's a tiny configuration file read by GDB at init, it won't affect release build
 COPY devel/dotgdbinit /root/.gdbinit
-COPY --from=Builder /root/packages/ /root/packages/
-RUN apk --no-cache add --allow-untrusted -X /root/packages/build/ ldc-runtime=1.26.0-r0 \
-    && rm -rf /root/packages/
-RUN apk --no-cache add llvm-libunwind libgcc libsodium libstdc++ sqlite-libs
+RUN apk --no-cache add ldc-runtime llvm-libunwind libgcc libsodium libstdc++ sqlite-libs
 COPY --from=Builder /root/agora/talos/build/ /usr/share/agora/talos/
 COPY --from=Builder /root/agora/build/agora /usr/local/bin/agora
 COPY --from=Builder /root/agora/build/agora-client /usr/local/bin/agora-client


### PR DESCRIPTION
> linux-headers python3 npm

Already installed in `agora-builder`

> ldc-runtime=1.26.0-r0

We can use upstream's now.