### PR TITLE
DNS message header, bitwise operation fixes

### DIFF
--- a/source/agora/common/DNS.d
+++ b/source/agora/common/DNS.d
@@ -252,7 +252,7 @@ public struct Header
     /// query (0), or a response (1).
     public bool QR () const scope { return !!(this.field2 & 0b1_0000_0_0_0_0_000_0000); }
     /// Ditto
-    public void QR (bool val) scope { this.field2 |= 1 << (ushort.sizeof * 8 - 1); }
+    public void QR (bool val) scope { this.field2 |= val << (ushort.sizeof * 8 - 1); }
 
     /// A four bit field that specifies kind of query in this message.
     /// This value is set by the originator of a query and copied into the response.
@@ -294,13 +294,13 @@ public struct Header
 
     public bool AA () const scope { return !!(this.field2 & 0b0_0000_1_0_0_0_000_0000); }
     /// Ditto
-    public void AA (bool val) scope { this.field2 |= 1 << (ushort.sizeof * 8 - 6); }
+    public void AA (bool val) scope { this.field2 |= val << (ushort.sizeof * 8 - 6); }
 
     /// TrunCation - specifies that this message was truncated
     /// due to length greater than that permitted on the transmission channel.
     public bool TC () const scope { return !!(this.field2 & 0b0_0000_0_1_0_0_000_0000); }
     /// Ditto
-    public void TC (bool val) scope { this.field2 |= 1 << (ushort.sizeof * 8 - 7); }
+    public void TC (bool val) scope { this.field2 |= val << (ushort.sizeof * 8 - 7); }
 
     /// Recursion Desired
     /// This bit may be set in a query and is copied into the response.
@@ -308,14 +308,14 @@ public struct Header
     /// Recursive query support is optional.
     public bool RD () const scope { return !!(this.field2 & 0b0_0000_0_0_1_0_000_0000); }
     /// Ditto
-    public void RD (bool val) scope { this.field2 |= 1 << (ushort.sizeof * 8 - 8); }
+    public void RD (bool val) scope { this.field2 |= val << (ushort.sizeof * 8 - 8); }
 
     /// Recursion Available
     /// This bit is set or cleared in a response, and denotes whether recursive
     /// query support is available in the name server.
     public bool RA () const scope { return !!(this.field2 & 0b0_0000_0_0_0_1_000_0000); }
     /// Ditto
-    public void RA (bool val) scope { this.field2 |= 1 << (ushort.sizeof * 8 - 9); }
+    public void RA (bool val) scope { this.field2 |= val << (ushort.sizeof * 8 - 9); }
 
     /// Reserved for future use. Must be zero in all queries and responses.
     public ubyte Z () const scope { return (this.field2 & 0b0_0000_0_0_0_0_111_0000) >> 4; }

--- a/source/agora/common/DNS.d
+++ b/source/agora/common/DNS.d
@@ -359,7 +359,10 @@ public struct Header
         return cast(RCode) val;
     }
     /// Ditto
-    public void RCODE (RCode val) scope { this.field2 |= val; }
+    public void RCODE (RCode val) scope
+    {
+        this.field2 = (0xfff0 & this.field2) | val;
+    }
 
     /// 16 bits backing the second "line" of the header, see RFC1035, 4.1.1
     private ushort field2;

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -346,12 +346,9 @@ public class NameRegistry: NameRegistryAPI
             }
             else if (q.qtype.among(QTYPE.A, QTYPE.CNAME, QTYPE.ALL))
             {
-                auto rcode = this.getValidatorDNSRecord(q, reply);
-                if (rcode != Header.RCode.NoError)
-                {
-                    reply.header.RCODE = rcode;
+                reply.header.RCODE = this.getValidatorDNSRecord(q, reply);
+                if (reply.header.RCODE != Header.RCode.NoError)
                     break;
-                }
             }
             else
             {


### PR DESCRIPTION
Fixes bitwise operations in DNS message `Header`. After this fixes, my test fails with 

```
BadResponse: A DNS query response does not respond to the question asked.
```

for following query and answer

``` 
Fullfilled DNS query: 
{ header: ID: a760 QUERY rd NoError, Query: 1, Answer: 0, Authority: 0, Additional: 0, questions: [{ qname: { value: "**masked**.validators.localhost" }, qtype: const(QTYPE).A, qclass: const(QCLASS).IN }], answers: [], authorities: [], additionals: [] } 
=> 
{ header: ID: a760 QUERY qr aa rd NoError, Query: 0, Answer: 1, Authority: 0, Additional: 0, questions: [], answers: [{ name: { value: "**masked**.validators.localhost" }, type: TYPE.A, class_: CLASS.IN, ttl: 0, rdata: [172, 72, 12, 123] }], authorities: [], additionals: [] }
```

Further investigation might be required. Since it returned `FormatError` previously, it couldn't get to the `BadResponse` exception.