### PR TITLE
Fix #2593: Assert triggered when looking up merkle path on empty block

### DIFF
--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -483,6 +483,10 @@ public struct Block
 
     public size_t findHashIndex (in Hash hash) const @safe nothrow
     {
+        // An empty block doesn't have any transaction
+        if (this.txs.length == 0)
+            return 0;
+
         immutable pow2_size = getPow2Aligned(this.txs.length);
         assert(this.merkle_tree.length == (pow2_size * 2) - 1,
             "Block hasn't been fully initialized");

--- a/source/agora/test/API.d
+++ b/source/agora/test/API.d
@@ -1,0 +1,37 @@
+/*******************************************************************************
+
+    Test the public API with invalid parameters
+
+    Copyright:
+        Copyright (c) 2019-2021 BOSAGORA Foundation
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.API;
+
+version (unittest):
+
+import agora.crypto.Hash;
+import agora.test.Base;
+
+/// https://github.com/bosagora/agora/issues/2593
+unittest
+{
+    auto network = makeTestNetwork!TestAPIManager(TestConf.init);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[0];
+
+    // Generate an empty block
+    network.generateBlocks(Height(1), true);
+    assert(node_1.getBlock(1).txs.length == 0);
+    assert(node_1.getMerklePath(1, "Hello World".hashFull()).length == 0);
+}


### PR DESCRIPTION
The merkle path code was written at a time where we did not have empty blocks,
hence this case wasn't correctly handled.