### PR TITLE
Collection of trivial cleanups

### DIFF
--- a/source/agora/cli/client/GenTxProcess.d
+++ b/source/agora/cli/client/GenTxProcess.d
@@ -67,7 +67,7 @@ private struct GenTxOption
             args,
             "interval|t",
               "Interval of sending transactions (default: 5 seconds)",
-              (string options, string value) { this.interval = value.to!int.seconds; },
+              (string _, string value) { this.interval = value.to!int.seconds; },
 
             "count|c",
               "Number of transactions sent at once (default: 8)",

--- a/source/agora/cli/vanity/main.d
+++ b/source/agora/cli/vanity/main.d
@@ -253,7 +253,6 @@ private size_t nameIndex (scope const(char)[] name) pure nothrow @nogc @safe
 {
     assert(name.length <= Name.length, name);
     size_t result;
-    immutable bool needOffset = name.length > 1;
     foreach (size_t index, char c; name)
     {
         assert(c.isInRange());

--- a/source/agora/cli/vanity/main.d
+++ b/source/agora/cli/vanity/main.d
@@ -72,7 +72,7 @@ immutable string[] SpecialNames = [
 ];
 
 /// Stored globally to avoid large stack / TLS issues
-__gshared Scalar[KeyCountTarget + SpecialNames.length] result;
+__gshared Scalar[KeyCountTarget + SpecialNames.length] foundKeys;
 __gshared bool[KeyCountTarget + SpecialNames.length] foundMap;
 
 void main ()
@@ -85,7 +85,7 @@ void main ()
     foreach (_; parallel(iota(42)))
     {
     NextKey:
-        while (atomicLoad(found) < result.length)
+        while (atomicLoad(found) < foundKeys.length)
         {
             auto tmp = Pair.random();
 
@@ -151,7 +151,7 @@ void main ()
         }
     }
 
-    foreach (index, ref seed; result[0 .. KeyCountTarget])
+    foreach (index, ref seed; foundKeys[0 .. KeyCountTarget])
     {
         const name = indexName(index);
         auto kp = Pair.fromScalar(seed);
@@ -159,7 +159,7 @@ void main ()
     }
 
     writeln("==================================================");
-    foreach (index, ref seed; result[KeyCountTarget .. $])
+    foreach (index, ref seed; foundKeys[KeyCountTarget .. $])
     {
         auto kp = Pair.fromScalar(seed);
         printKey(SpecialNames[index], kp);
@@ -174,7 +174,7 @@ private bool onFound (ref shared size_t found, size_t index, Scalar value)
         return false;
 
     found.atomicOp!("+=")(1);
-    result[index] = value;
+    foundKeys[index] = value;
     stderr.write("\rKeys found: ", atomicLoad(found), "/", foundMap.length);
     stderr.flush();
     return true;

--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -23,7 +23,7 @@ import vibe.inet.url;
 
 import geod24.bitblob;
 
-shared static this () 
+shared static this ()
 {
     registerCommonInternetSchema("agora"); // TODO default port: 2826
 }
@@ -36,7 +36,7 @@ public alias TimePoint = ulong;
 public alias cstring = const(char)[];
 
 /// A network address, extended version of Vibe.d's URL with serialization
-public struct Address 
+public struct Address
 {
 @safe:
     URL inner;

--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -62,7 +62,7 @@ public struct Address
         scope DeserializeDg dg, in DeserializerOptions opts) @safe
     {
         return () @trusted {
-            return T(deserializeFull!string(dg));
+            return T(deserializeFull!string(dg, opts));
         }();
     }
 

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -1922,7 +1922,6 @@ private immutable(Block)[] genBlocksToIndex (
     foreach (_; 0 .. count)
     {
         auto txs = blocks[$ - 1].spendable().map!(txb => txb.sign());
-        auto cycle = blocks[$ - 1].header.height / params.ValidatorCycle;
         blocks ~= makeNewTestBlock(blocks[$ - 1], txs);
     }
     if (blocks)

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -585,10 +585,6 @@ public Block makeNewBlock (Transactions)(const ref Block prev_block,
     Block block;
     auto preimages_rng = preimages.filter!(pi => pi !is Hash.init);
     assert(!preimages_rng.empty);
-    auto random_seed = () {
-        scope (failure) assert(0, "Reduce threw despite non-empty range");
-        return preimages_rng.reduce!((a , b) => hashMulti(a, b));
-    }();
 
     block.header.prev_block = prev_block.header.hashFull();
     block.header.height = prev_block.header.height + 1;

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -839,7 +839,7 @@ extern(D):
         in Hash block_hash) @safe nothrow
     {
         auto sigs = block_sig.height in this.slot_sigs;
-        if (block_sig.height in this.slot_sigs && block_sig.utxo in this.slot_sigs[block_sig.height])
+        if (sigs && block_sig.utxo in (*sigs))
         {
             log.trace("Signature already collected for this node at height {}", block_sig.height);
             return false;

--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -210,7 +210,7 @@ public class Channel
         OnPaymentComplete onPaymentComplete,
         OnUpdateComplete onUpdateComplete,
         GetFeeUTXOs getFeeUTXOs,
-        FlashAPI delegate (in PublicKey peer_pk, Duration timeout, 
+        FlashAPI delegate (in PublicKey peer_pk, Duration timeout,
             Address address = Address.init) getFlashClient,
         ManagedDatabase db)
     {
@@ -255,7 +255,7 @@ public class Channel
 
     public static Channel[Hash] loadChannels (FlashConfig flash_conf,
         ManagedDatabase db,
-        FlashAPI delegate (in PublicKey peer_pk, Duration timeout, 
+        FlashAPI delegate (in PublicKey peer_pk, Duration timeout,
             Address address = Address.init) getFlashClient,
         Engine engine, ITaskManager taskman,
         void delegate (in Transaction) txPublisher, PaymentRouter paymentRouter,

--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -505,7 +505,6 @@ public class Channel
                     ErrorCode.None);
 
                 // initial output allocates all the funds back to the channel creator
-                const seq_id = 0;
                 Balance balance = { refund_amount : this.conf.capacity };
                 Output[] outputs = this.buildBalanceOutputs(balance);
 
@@ -977,7 +976,6 @@ LOuter: while (1)
         if (result.error)
             return; // TODO: is further error recovery needed?
 
-        const old_balance = this.cur_balance;
         this.cur_seq_id = new_seq_id;
         const peer_nonce = result.value;
 
@@ -1286,8 +1284,6 @@ LOuter: while (1)
 
     private void handleIncomingUpdate (IncomingUpdate update)
     {
-        const old_balance = this.cur_balance;
-
         assert(this.channel_updates[0].update_tx.outputs.length == 1);
         const update_utxo = UTXO(0,
             this.channel_updates[0].update_tx.outputs[0]);

--- a/source/agora/flash/OnionPacket.d
+++ b/source/agora/flash/OnionPacket.d
@@ -321,7 +321,6 @@ public EncryptedPayload encryptPayload (Payload payload, Pair ephemeral_kp,
     randombytes_buf(result.nonce.ptr, result.nonce.length);
 
     const data = payload.serializeFull();
-    auto ciphertext_len = crypto_secretbox_MACBYTES + data.length;
 
     shared_secret = generateSharedSecret(true, ephemeral_kp.v, target_pk);
     if (crypto_secretbox_easy(result.payload.ptr, data.ptr, data.length,

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -1371,7 +1371,7 @@ public class NetworkManager
     public void discoverFromClient (agora.api.Validator.API api) @trusted nothrow
     {
         new ConnectionTask(Address.init, api, &onHandshakeComplete,
-                           (in Address addr) { return false; }).start();
+                           (in Address _) { return false; }).start();
     }
 }
 

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -237,7 +237,7 @@ public class NetworkManager
             const is_validator = key != PublicKey.init;
             if (is_validator)
             {
-                if (address !is Address.init 
+                if (address !is Address.init
                     && key == this.outer.validator_config.key_pair.address)
                 {
                     // either we connected to ourself, or someone else is pretending

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -457,7 +457,6 @@ public class NetworkManager
             "utxo TEXT, pubkey TEXT, address TEXT NOT NULL)");
 
         auto results = this.cacheDB.execute("SELECT address FROM network_manager");
-        bool needSeeding = results.empty;
         foreach (ref row; results)
         {
             const address = row.peek!(string)(0);
@@ -944,7 +943,7 @@ public class NetworkManager
                 return Height(ulong.max);
         }
 
-        auto node_pair = this.peers[]
+        this.peers[]
             .map!(node => Pair(getHeight(node.client), node.client))
             .filter!(pair => pair.height != ulong.max)  // request failed
             .each!(pair => node_pairs ~= pair);

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -719,12 +719,12 @@ public class Validator : FullNode, API
         invalid
 
         Params:
-            data = Invalid ConsensusData
+            _ = Consensus data that triggered the error
             msg = Reason
 
     ***************************************************************************/
 
-    protected void invalidNominationHandler (in ConsensusData data, in string msg)
+    protected void invalidNominationHandler (in ConsensusData _, in string msg)
         @safe
     {
         // Network needs Validators, see if we can enroll

--- a/source/agora/stats/Stats.d
+++ b/source/agora/stats/Stats.d
@@ -32,10 +32,10 @@ import std.typecons : Tuple, tuple;
 public struct Stats (ValueType, LabelType)
 {
     ///
-    public alias ValueType ValueTypeT;
+    public alias ValueTypeT = ValueType;
 
     ///
-    public alias LabelType LabelTypeT;
+    public alias LabelTypeT = LabelType;
 
     ///
     public struct StatValueLabel

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1225,7 +1225,6 @@ public class TestAPIManager
         Height from = Height(0), string file = __FILE__, int line = __LINE__)
     {
         static assert (isInputRange!Idxs);
-        const MaxBlocks = 1024;
         assert(to >= from,
             format!"[%s:%s] Please provide valid heights as params. Not %s .. %s"
             (file, line, from, to));


### PR DESCRIPTION
The audit report included a section on D-Scanner.
Unfortunately, D-Scanner has a lot of false positive, so I couldn't exploit the full report, but it did caught a few issues, which are addressed in their own commits. Things that are not issues but could be expressed in a slightly better style to please D-Scanner (e.g. unused parameters, new alias syntax) were also fixed.