### PR TITLE
Docker: Allow to skip Talos and CLI build and use it in integration test 

### DIFF
--- a/ci/system_integration_test.d
+++ b/ci/system_integration_test.d
@@ -22,7 +22,9 @@ immutable EnvFile = IntegrationPath.buildPath("environment.sh");
 /+ ***************************** Commands to run **************************** +/
 /// A simple test to ensure that the container works correctly,
 /// e.g. all dependencies are installed and the binary isn't corrupt.
-immutable BuildImg = [ "docker", "build", "--build-arg", `DUB_OPTIONS=-b cov`,
+immutable BuildImg = [ "docker", "build",
+                       "--build-arg", `DUB_OPTIONS=-b cov`,
+                       "--build-arg", `AGORA_STANDALONE=true`,
                        "-t", "agora", RootPath, ];
 immutable TestContainer = [ "docker", "run", "--rm", "agora", "--help", ];
 immutable DockerCompose = [ "docker-compose", "-f", ComposeFile, "--env-file", EnvFile ];

--- a/scripts/cli_placeholder.sh
+++ b/scripts/cli_placeholder.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Agora was built standalone, '$(basename $0)' is not available!"
+exit 1


### PR DESCRIPTION
The Talos build and CLI tools take more time combined than Agora, and are not used in integration test.
The also represent a major slowdown when a developer wants to try out something locally.

This brings the timing on building on my machine from:
```
 => [builder 4/8] RUN if [ -z ${AGORA_STANDALONE+x} ]; then npm ci && npm run build; else mkdir -p build; fi                    364.2s
 => [builder 5/8] WORKDIR /root/agora/                                                                                            0.0s
 => [builder 6/8] RUN AGORA_VERSION=HEAD dub build --skip-registry=all --compiler=ldc2 ${DUB_OPTIONS}                           298.0s
 => [builder 7/8] RUN if [ -z ${AGORA_STANDALONE+x} ]; then dub build --skip-registry=all --compiler=ldc2 -c client;     else c  33.5s
 => [builder 8/8] RUN if [ -z ${AGORA_STANDALONE+x} ]; then dub build --skip-registry=all --compiler=ldc2 -c config-dumper;     263.2s
```

to:

```
 => [builder 4/8] RUN if [ -z ${AGORA_STANDALONE+x} ]; then npm ci && npm run build; else mkdir -p build; fi                      0.5s
 => [builder 5/8] WORKDIR /root/agora/                                                                                            0.0s
 => [builder 6/8] RUN AGORA_VERSION=HEAD dub build --skip-registry=all --compiler=ldc2 ${DUB_OPTIONS}                           376.4s
 => [builder 7/8] RUN if [ -z ${AGORA_STANDALONE+x} ]; then dub build --skip-registry=all --compiler=ldc2 -c client;     else cp  0.7s
 => [builder 8/8] RUN if [ -z ${AGORA_STANDALONE+x} ]; then dub build --skip-registry=all --compiler=ldc2 -c config-dumper;       0.4s
```

Which is saving over 10 minutes of build time.