### PR TITLE
Fix #2320: Improve address registration UX

### DIFF
--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -41,7 +41,7 @@ public struct Address
 @safe:
     URL inner;
 
-    public this (URL url) immutable
+    public this (inout(URL) url) inout
     {
         this.inner = url;
     }

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -176,8 +176,8 @@ public struct InterfaceConfig
     /// Default values when none is given in the config file
     private static immutable InterfaceConfig[Type.max] Default = [
         // Publicly enabled by default
-        { type: Type.http, address: "0.0.0.0", port: 0xB0A, },
-        { type: Type.tcp,  address: "0.0.0.0", port: 0xA0B, },
+        { type: Type.tcp,  address: "0.0.0.0", port: 0xB0A, },
+        { type: Type.http, address: "0.0.0.0", port: 8080, },
     ];
 }
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2126,6 +2126,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
         InterfaceConfig conf =
         {
             address : address,
+            hostname: address,
         };
 
         return conf;
@@ -2175,7 +2176,6 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
         const ValidatorConfig validator = {
             enabled : true,
             key_pair : key_pair,
-            addresses_to_register : [self_address.toString],
             registry_address : "http://name.registry",
             recurring_enrollment : test_conf.recurring_enrollment,
             name_registration_interval : 10.seconds,


### PR DESCRIPTION
```
This removes 'addresses_to_register' from validator, and instead add it to
the related entry in 'interfaces'.
It simplifies things for the user as the port does not need to be repeated,
nor the scheme, and when adding / removing interfaces, only one place
needs to be edited. The port was also made optional now that we have default ports.
```