### PR TITLE
Stop storing duplicate entries in the cache.db network_manager table

### DIFF
--- a/doc/Database.md
+++ b/doc/Database.md
@@ -135,3 +135,14 @@ This contains Flash-related data.
 |------------|----------|--------|----------------------|---------------------------------|
 | meta       | BLOB     | Hash   | PRIMARY KEY NOT NULL | Only ever set to `1` if present |
 | data       | BLOB     |        | NOT NULL             | Binary-serialized `mixin`       |
+
+
+### `network_manager` table
+
+The primary key accross all three columns is just so that replace into does not create duplicate entries.
+
+| Field name | SQL Type | D type | Attributes           | Comment                           |
+|------------|----------|--------|----------------------|-----------------------------------|
+| utxo       | TEXT     | Hash   | PRIMARY KEY          | validator's frozen utxo           |
+| pubkey     | TEXT     | string | PRIMARY KEY NOT NULL | Node's PublicKey as string        |
+| address    | TEXT     | string | PRIMARY KEY NOT NULL | Node's registry address as string |

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -455,7 +455,7 @@ public class NetworkManager
 
         this.cacheDB.execute(
             "CREATE TABLE IF NOT EXISTS network_manager (" ~
-            "utxo TEXT, pubkey TEXT, address TEXT NOT NULL)");
+            "utxo TEXT, pubkey TEXT, address TEXT NOT NULL, PRIMARY KEY(utxo, pubkey, address))");
 
         auto results = this.cacheDB.execute("SELECT address FROM network_manager");
         foreach (ref row; results)


### PR DESCRIPTION
By making the `utxo` the Primary key of this table we will replace
records if we get an update from the registry. Currently we just keep
adding new records. The side effet of this fix is that we will not store
nodes that do not have a utxo (i.e. fullnodes).
When we start adding more information about peers into our cache we will
need to decide how to handle fullnodes as well as banned and whitelisted
info.