### PR TITLE
Normalize URLs in Agora

### DIFF
--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -35,20 +35,21 @@ public alias TimePoint = ulong;
 /// An array of const characters
 public alias cstring = const(char)[];
 
-/// A network address, extended version of Vibe.d's URL with serialization
+/// A normalized network address, extended version of Vibe.d's URL with serialization
 public struct Address
 {
 @safe:
     URL inner;
 
-    public this (URL url) immutable
+    public this (URL url)
     {
         this.inner = url;
+        this.inner.normalize(true);
     }
 
     public this (string url)
     {
-        this.inner = URL(url);
+        this(URL(url));
     }
 
     /// Serialization hook

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -817,12 +817,6 @@ public class NetworkManager
     /// Ditto
     private void addAddress (Address address)
     {
-        // TODO normalize
-        // Ensure we do not have a trailing slash for address
-        auto path = address.path;
-        path.endsWithSlash = false;
-        address.path = path;
-
         if (this.shouldEstablishConnection(address))
             this.todo_addresses.put(address);
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -387,7 +387,7 @@ public class FullNode : API
             config.event_handlers.filter!(h => h.type == HandlerType.BlockExternalized)
                 .each!(handler => handler.addresses
                     .each!((string address) {
-                        auto url = Address(address); // TODO normalize
+                        auto url = Address(address);
                         this.block_handlers[url] = this.network.getBlockExternalizedHandler(url);
                     }));
 
@@ -395,7 +395,7 @@ public class FullNode : API
             config.event_handlers.filter!(h => h.type == HandlerType.BlockHeaderUpdated)
                 .each!(handler => handler.addresses
                     .each!((string address) {
-                        auto url = Address(address); // TODO normalize
+                        auto url = Address(address);
                         this.block_header_handlers[url] = this.network.getBlockHeaderUpdatedHandler(url);   
                     }));
 
@@ -403,7 +403,7 @@ public class FullNode : API
             config.event_handlers.filter!(h => h.type == HandlerType.PreimageReceived)
                 .each!(handler => handler.addresses
                     .each!((string address) {
-                        auto url = Address(address); // TODO normalize
+                        auto url = Address(address);
                         this.preimage_handlers[url] = this.network.getPreImageReceivedHandler(url);
                     }));
 
@@ -411,7 +411,7 @@ public class FullNode : API
             config.event_handlers.filter!(h => h.type == HandlerType.TransactionReceived)
                 .each!(handler => handler.addresses
                     .each!((string address) {
-                        auto url = Address(address); // TODO normalize
+                        auto url = Address(address);
                         this.transaction_handlers[url] = this.network.getTransactionReceivedHandler(url);
                     }));
         }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -610,7 +610,7 @@ public class TestAPIManager
     public auto validators ()
     {
         // This is a crude way to get validators, but it works
-        return this.nodes.filter!(n => n.address.startsWith("Validator-")).map!(np => np.client);
+        return this.nodes.filter!(n => n.address.startsWith("validator-")).map!(np => np.client);
     }
 
     /// Registry holding the nodes
@@ -1348,7 +1348,7 @@ public class TestNetworkManager : NetworkManager
         (Address address)
     {
         import std.typecons : BlackHole;
-        auto tid = this.registry.locate!BlockExternalizedHandler(address.toString);
+        auto tid = this.registry.locate!BlockExternalizedHandler(address.host);
         if (tid != typeof(tid).init)
             return new RemoteAPI!BlockExternalizedHandler(tid, 5.seconds);
 

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -196,7 +196,7 @@ public class TestFlashNode : FlashNode, TestFlashAPI
         Listener!TestFlashAPI tid;
         foreach (i; 0 .. 5)
         {
-            tid = this.registry.locate!TestFlashAPI(address.toString);
+            tid = this.registry.locate!TestFlashAPI(address.host);
             if (tid != typeof(tid).init)
                 break;
 
@@ -212,7 +212,7 @@ public class TestFlashNode : FlashNode, TestFlashAPI
     protected override TestFlashListenerAPI getFlashListenerClient (
         Address address, Duration timeout) @trusted
     {
-        auto tid = this.registry.locate!TestFlashListenerAPI(address.toString);
+        auto tid = this.registry.locate!TestFlashListenerAPI(address.host);
         assert(tid != typeof(tid).init);
         return new RemoteAPI!TestFlashListenerAPI(tid, timeout);
     }
@@ -389,7 +389,7 @@ public class FlashNodeFactory : TestAPIManager
 
         this.addresses ~= kp.address;
         this.flash_nodes ~= api;
-        this.registry.register("http://"~kp.address.to!string, api.listener());
+        this.registry.register(kp.address.to!string, api.listener());
         api.registerKey(kp);
 
         return api;
@@ -401,7 +401,7 @@ public class FlashNodeFactory : TestAPIManager
     {
         auto api = RemoteAPI!TestFlashListenerAPI.spawn!Listener(
             &this.registry, this.nodes[0].address, 5.seconds);
-        this.registry.register(address, api.listener());
+        this.registry.register(Address(address).host, api.listener());
         this.listener_addresses ~= address;
         this.listener_nodes ~= api;
         return api;


### PR DESCRIPTION
Fixes #2566 

- Upgrades vibe.d to URL normalization capable version (now we can configure `https://hello-🌍.com/뉴스` URLs)
- Normalizes URLs used through Agora

By default, we will expect folder endpoints from configuration file and always add a trailing slash to URLs