### PR TITLE
Config: Change the default ports

### DIFF
--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -178,8 +178,8 @@ public struct InterfaceConfig
     /// Default values when none is given in the config file
     private static immutable InterfaceConfig[Type.max] Default = [
         // Publicly enabled by default
-        { type: Type.http, address: "0.0.0.0", port: 0xB0A, },
-        { type: Type.tcp,  address: "0.0.0.0", port: 0xA0B, },
+        { type: Type.tcp,  address: "0.0.0.0", port: 0xB0A, },
+        { type: Type.http, address: "0.0.0.0", port: 8080, },
     ];
 }
 


### PR DESCRIPTION
Now that we are moving away from the HTTP interface as the default,
we should edit the default to reflect this, and use the default port
for the 'agora://' scheme as well.
The port 8080 is used for HTTP to avoid needing 'sudo' by default on Linux.