### PR TITLE
HTTP interface: Properly print error messages

### DIFF
--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -39,7 +39,7 @@ import vibe.http.router;
 import vibe.web.rest;
 import vibe.stream.tls;
 
-import std.algorithm : any, filter;
+import std.algorithm : among, any, filter;
 import std.file;
 import std.format;
 import std.functional : toDelegate;
@@ -90,7 +90,8 @@ public Listeners runNode (Config config)
     mkdirRecurse(config.node.data_dir);
 
     Listeners result;
-    const bool hasHTTPInterface = config.interfaces.any!(i => i.type == InterfaceConfig.Type.http);
+    const bool hasHTTPInterface = config.interfaces.any!(
+        i => i.type.among(InterfaceConfig.Type.http, InterfaceConfig.Type.https));
     URLRouter router;
     RestInterfaceSettings settings;
     if (hasHTTPInterface)

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -180,7 +180,7 @@ public Listeners runNode (Config config)
         {
             if (!tls_ctx)
                 throw new Exception(tls_user_help ~
-                    "Otherwise disable tls by setting `admin.tls` to `false` in the config file " ~
+                    ". Otherwise disable tls by setting `admin.tls` to `false` in the config file " ~
                     "or use `-O admin.tls=false` as command line argument.");
             adminsettings.tlsContext = tls_ctx;
         }
@@ -198,8 +198,9 @@ public Listeners runNode (Config config)
         if (interface_.type == InterfaceConfig.Type.https)
         {
             if (!tls_ctx)
-                throw new Exception(tls_user_help ~
-                    format!"Otherwise set type to `http` for interface `%s:%s` in the config file."(interface_.address, httpsettings.port));
+                throw new Exception(
+                    format!"%s. Otherwise set type to `http` for interface `%s:%s` in the config file."
+                    (tls_user_help, interface_.address, httpsettings.port));
             httpsettings.tlsContext = tls_ctx;
         }
         log.info("Node is listening on interface: http{}://{}:{}",
@@ -272,7 +273,7 @@ private TLSContext getTLSContext (out string user_help_message)
         else
         {
             user_help_message = format("To enable tls add a key file named `%s` to one of `%s` " ~
-                "and a certificate file named `%s` to corresponding path of `%s`. ",
+                "and a certificate file named `%s` to corresponding path of `%s`",
                 key_file, key_search_paths, cert_file, cert_search_paths);
         }
     }


### PR DESCRIPTION
Before:
```
2021-11-11 01:17:37,226 Info [agora.network.Manager] - Couldn't register our address: vibe.web.common.RestException@submodules/vibe.d/web/vibe/web/rest.d(2080): An Exception occured
----------------
submodules/vibe.d/web/vibe/web/rest.d:2007 @safe vibe.http.client.HTTPClientResponse vibe.web.rest.request(vibe.inet.url.URL, void delegate(vibe.http.client.HTTPClientRequest) @safe, scope void delegate(vibe.http.client.HTTPClientRequest, scope vibe.core.stream.InputStream) @safe, vibe.http.common.HTTPMethod, immutable(char)[], scope ref const(vibe.utils.dictionarylist.DictionaryList!(immutable(char)[], false, 12uL, false).DictionaryList), immutable(char)[], immutable(char)[], ref vibe.utils.dictionarylist.DictionaryList!(immutable(char)[], false, 12uL, false).DictionaryList, ref vibe.utils.dictionarylist.DictionaryList!(immutable(char)[], false, 12uL, false).DictionaryList, in vibe.http.client.HTTPClientSettings) [0x5592f96eb490]
submodules/vibe.d/web/vibe/web/rest.d:1825 @safe void vibe.web.rest.executeClientMethod!(agora.api.Registry.NameRegistryAPI, 1, vibe.web.rest.RestInterfaceClient!(agora.api.Registry.NameRegistryAPI).RestInterfaceClient.__mixin20.postValidator(agora.api.Registry.RegistryPayload).registry_payload).executeClientMethod(scope ref const(vibe.web.internal.rest.common.RestInterface!(agora.api.Registry.NameRegistryAPI).RestInterface), void delegate(vibe.http.client.HTTPClientRequest) @safe, scope void delegate(vibe.http.client.HTTPClientRequest, scope vibe.core.stream.InputStream) @safe) [0x5592f930b8f0]
submodules/vibe.d/utils/vibe/internal/meta/codegen.d-mixin-301:302 @safe void vibe.web.rest.RestInterfaceClient!(agora.api.Registry.NameRegistryAPI).RestInterfaceClient.__mixin20.postValidator(agora.api.Registry.RegistryPayload) [0x5592f930b870]
source/agora/network/Manager.d:853 @safe void agora.network.Manager.NetworkManager.onRegisterName() [0x5592f8ecff80]
source/agora/network/Manager.d:666 agora.common.Task.ITimer agora.network.Manager.NetworkManager.startPeriodicNameRegistration() [0x5592f90b26b0]
source/agora/node/Validator.d:210 void agora.node.Validator.Validator.start() [0x5592f90b23f0]
submodules/vibe-core/source/vibe/core/core.d:1052 nothrow @trusted void vibe.core.core.setTimer(core.time.Duration, void delegate(), bool).__lambda4() [0x5592f996bf30]
submodules/vibe-core/source/vibe/core/core.d:1110 nothrow @safe void vibe.core.core.createTimer(void delegate() nothrow @safe).C.opCall(vibe.core.core.Timer).__lambda2(vibe.core.core.Timer) [0x5592f996c0c0]
submodules/vibe-core/source/vibe/core/task.d:708 nothrow void vibe.core.task.TaskFuncInfo.set!(void delegate(vibe.core.core.Timer) nothrow @safe, vibe.core.core.Timer).set(ref void delegate(vibe.core.core.Timer) nothrow @safe, ref vibe.core.core.Timer).callDelegate(ref vibe.core.task.TaskFuncInfo) [0x5592f99abea0]
submodules/vibe-core/source/vibe/core/task.d:737 void vibe.core.task.TaskFuncInfo.call() [0x5592f99a98a0]
submodules/vibe-core/source/vibe/core/task.d:403 nothrow void vibe.core.task.TaskFiber.run() [0x5592f99a8db0]
??:? fiber_entryPoint [0x7fe5ab26bd50]. Trying again later..
```

After:
```
2021-11-11 03:19:24,797 Info [agora.network.Manager] - Couldn't register our address: vibe.web.common.RestException@submodules/vibe.d/web/vibe/web/rest.d(2080): Can only have one domain name (CNAME) for payload, not: { data: { public_key: boa1xzval2a3cdxv28n6slr62wlczslk3juvk7cu05qt3z55ty2rlfqfc6egsh2, addresses: [agora://v2.bosagora.io:2735/, https://v2.bosagora.io/], seq: 1636600676 }, signature: 0x65ee668e250f5cdc776997aff494c5bc8398806eb492f45f5c1309345464325a02e76722f1ecc13b9f47bc8b0305e7df4270d17acfc17131563b8684af7423c2 }
----------------
submodules/vibe.d/web/vibe/web/rest.d:2007 @safe vibe.http.client.HTTPClientResponse vibe.web.rest.request(vibe.inet.url.URL, void delegate(vibe.http.client.HTTPClientRequest) @safe, scope void delegate(vibe.http.client.HTTPClientRequest, scope vibe.core.stream.InputStream) @safe, vibe.http.common.HTTPMethod, immutable(char)[], scope ref const(vibe.utils.dictionarylist.DictionaryList!(immutable(char)[], false, 12uL, false).DictionaryList), immutable(char)[], immutable(char)[], ref vibe.utils.dictionarylist.DictionaryList!(immutable(char)[], false, 12uL, false).DictionaryList, ref vibe.utils.dictionarylist.DictionaryList!(immutable(char)[], false, 12uL, false).DictionaryList, in vibe.http.client.HTTPClientSettings) [0x55d6a125d490]
submodules/vibe.d/web/vibe/web/rest.d:1825 @safe void vibe.web.rest.executeClientMethod!(agora.api.Registry.NameRegistryAPI, 1, vibe.web.rest.RestInterfaceClient!(agora.api.Registry.NameRegistryAPI).RestInterfaceClient.__mixin20.postValidator(agora.api.Registry.RegistryPayload).registry_payload).executeClientMethod(scope ref const(vibe.web.internal.rest.common.RestInterface!(agora.api.Registry.NameRegistryAPI).RestInterface), void delegate(vibe.http.client.HTTPClientRequest) @safe, scope void delegate(vibe.http.client.HTTPClientRequest, scope vibe.core.stream.InputStream) @safe) [0x55d6a0e7d8f0]
submodules/vibe.d/utils/vibe/internal/meta/codegen.d-mixin-301:302 @safe void vibe.web.rest.RestInterfaceClient!(agora.api.Registry.NameRegistryAPI).RestInterfaceClient.__mixin20.postValidator(agora.api.Registry.RegistryPayload) [0x55d6a0e7d870]
source/agora/network/Manager.d:853 @safe void agora.network.Manager.NetworkManager.onRegisterName() [0x55d6a0a41f80]
submodules/vibe-core/source/vibe/core/core.d:1052 nothrow @trusted void vibe.core.core.setTimer(core.time.Duration, void delegate(), bool).__lambda4() [0x55d6a14ddf30]
submodules/vibe-core/source/vibe/core/core.d:1110 nothrow @safe void vibe.core.core.createTimer(void delegate() nothrow @safe).C.opCall(vibe.core.core.Timer).__lambda2(vibe.core.core.Timer) [0x55d6a14de0c0]
submodules/vibe-core/source/vibe/core/task.d:708 nothrow void vibe.core.task.TaskFuncInfo.set!(void delegate(vibe.core.core.Timer) nothrow @safe, vibe.core.core.Timer).set(ref void delegate(vibe.core.core.Timer) nothrow @safe, ref vibe.core.core.Timer).callDelegate(ref vibe.core.task.TaskFuncInfo) [0x55d6a151dea0]
submodules/vibe-core/source/vibe/core/task.d:737 void vibe.core.task.TaskFuncInfo.call() [0x55d6a151b8a0]
submodules/vibe-core/source/vibe/core/task.d:403 nothrow void vibe.core.task.TaskFiber.run() [0x55d6a151adb0]
??:? fiber_entryPoint [0x7f6fa8726d50]. Trying again later..
```