### PR TITLE
Do not add `Address.init` to `whitelisted`

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -265,8 +265,8 @@ public class BanManager
 
     public void banUntil (Address address, TimePoint banned_until) @safe nothrow
     {
-        if (this.isWhitelisted(address))
-            return; // Whitelisted address
+        if (address is Address.init || this.isWhitelisted(address))
+            return; // no address or Whitelisted address
 
         log.info("BanManager: Address {} banned until {}", address, banned_until);
         try
@@ -304,6 +304,9 @@ public class BanManager
 
     public void whitelist (Address address) @safe nothrow
     {
+        if (address is Address.init)
+            return;
+
         this.whitelisted.put(address);
         this.storeWhitelisted(address);
     }

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -239,7 +239,7 @@ public class NetworkManager
             const is_validator = key != PublicKey.init;
             if (is_validator)
             {
-                if (address !is Address.init
+                if (this.address !is Address.init
                     && key == this.outer.validator_config.key_pair.address)
                 {
                     // either we connected to ourself, or someone else is pretending


### PR DESCRIPTION
Currently rpc is using Address.init for the address and this later gets added to the `whitelist`. 
It is better we filter these for the addresses to be added.