### PR TITLE
ValidatorSet: Reject preimages that are too distant to the prev one

### DIFF
--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -529,6 +529,10 @@ public class ValidatorSet
         if (prev_preimage.height >= preimage.height)
             return false;
 
+        // Ignore preimages beyond the current cycle
+        if (preimage.height - prev_preimage.height > this.params.ValidatorCycle)
+            return false;
+
         if (auto reason = isInvalidReason(preimage, prev_preimage))
         {
             log.info("Invalid pre-image data: {}. Pre-image: {}, previous: {}",
@@ -694,6 +698,11 @@ unittest
     assert(cache[FirstEnrollHeight] == enroll.commitment);
     auto preimage_11 = PreImageInfo(utxos[0], cache[SecondEnrollHeight + 2], SecondEnrollHeight + 2);
     assert(set.addPreimage(preimage_11));
+    assert(set.getPreimage(utxos[0]) == preimage_11);
+
+    auto far_height = Height(10000);
+    auto too_far_preimage = PreImageInfo(utxos[0], cache[far_height], far_height);
+    assert(!set.addPreimage(too_far_preimage));
     assert(set.getPreimage(utxos[0]) == preimage_11);
 
     // test for clear up expired validators


### PR DESCRIPTION
Fixes #2248

This will make sure that an attacker can't fool us into hashing
excessively. The genuine case where a node may want to reveal a
preimage too early is now discouraged since that preimage will not
be accepted and may cause the validator to be slashed.