### PR TITLE
Remove clock from ledger

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -35,10 +35,6 @@ node:
   # is going to connect to, for example: http://0.0.0.0:8008
   # It can also be set to -1 do disable listening (default is -1)
   stats_listening_port: 9110
-  # The new block time offset has to be greater than the previous block time offset
-  # but less than current time + block_time_offset_tolerance
-  block_time_offset_tolerance:
-    seconds: 60
   # The duration between requests for doing periodic network discovery
   network_discovery_interval:
     seconds: 5

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -618,7 +618,7 @@ version (unittest)
         in KeyPair[] key_pairs = genesis_validator_keys,
         Enrollment[] enrollments = null,
         uint[] missing_validators = null,
-        ulong time_offset = 0) @safe nothrow
+        ulong time_offset = 600) @safe nothrow
     {
         Hash[] pre_images =
             WK.PreImages.at(prev_block.header.height + 1, key_pairs)
@@ -626,13 +626,8 @@ version (unittest)
             .array;
         try
         {
-            // the time_offset passed to makeNewBlock should really be
-            // prev_block.header.time_offset + ConsensusParams.BlockInterval instead of
-            // prev_block.header.time_offset + 1
-            // however many tests calling makeNewTestBlock have no access to ConsensusParams
-            auto block = makeNewBlock(prev_block, txs,
-                    time_offset ? time_offset : prev_block.header.time_offset + 1,
-                    pre_images, enrollments);
+            auto block = makeNewBlock(prev_block, txs, prev_block.header.time_offset + time_offset,
+                pre_images, enrollments);
             auto validators = BitMask(key_pairs.length);
             Signature[] sigs;
             key_pairs.enumerate.each!((i, k)

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -379,7 +379,7 @@ extern(D):
 
     protected bool prepareNominatingSet (out ConsensusData data) @safe
     {
-        this.ledger.prepareNominatingSet(data, MaxTransactionsPerBlock, this.nomination_start_time);
+        this.ledger.prepareNominatingSet(data, MaxTransactionsPerBlock);
 
         // check whether the consensus data is valid before nominating it.
         if (auto msg = this.ledger.validateConsensusData(data, data.missing_validators))

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -233,10 +233,6 @@ public struct NodeConfig
     /// from all other nodes
     public Duration block_catchup_interval = 20.seconds;
 
-    /// The new block time offset has to be greater than the previous block time offset,
-    /// but less than current time + block_time_offset_tolerance
-    public Duration block_time_offset_tolerance = 60.seconds;
-
     // The percentage by which the double spend transaction's fee should be
     // increased in order to be added to the transaction pool
     public ubyte double_spent_threshold_pct = 20;

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -871,8 +871,7 @@ public class FullNode : API
     protected Ledger makeLedger ()
     {
         return new Ledger(params, this.engine, this.utxo_set, this.storage,
-            this.enroll_man, this.pool, this.stateDB, this.clock,
-            &this.onAcceptedBlock);
+            this.enroll_man, this.pool, this.stateDB, &this.onAcceptedBlock);
     }
 
     /*+*************************************************************************

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -396,7 +396,7 @@ public class FullNode : API
                 .each!(handler => handler.addresses
                     .each!((string address) {
                         auto url = Address(address);
-                        this.block_header_handlers[url] = this.network.getBlockHeaderUpdatedHandler(url);   
+                        this.block_header_handlers[url] = this.network.getBlockHeaderUpdatedHandler(url);
                     }));
 
             // Make `PreImageReceivedHandler`s from config
@@ -872,7 +872,7 @@ public class FullNode : API
     {
         return new Ledger(params, this.engine, this.utxo_set, this.storage,
             this.enroll_man, this.pool, this.stateDB, this.clock,
-            config.node.block_time_offset_tolerance, &this.onAcceptedBlock);
+            &this.onAcceptedBlock);
     }
 
     /*+*************************************************************************

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -1075,7 +1075,7 @@ unittest
     import agora.consensus.data.UTXO;
 
     NameRegistry registry;
-    scope ledger = new TestLedger(genesis_validator_keys[0], null, null, null, (in Block block, bool changed) @safe {
+    scope ledger = new TestLedger(genesis_validator_keys[0], null, null, (in Block block, bool changed) @safe {
         registry.onAcceptedBlock(block, changed);
     });
     registry = new NameRegistry("test", RegistryConfig(true), ledger, new ManagedDatabase(":memory:"));

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -1075,7 +1075,7 @@ unittest
     import agora.consensus.data.UTXO;
 
     NameRegistry registry;
-    scope ledger = new TestLedger(genesis_validator_keys[0], null, null, 600.seconds, null, (in Block block, bool changed) @safe {
+    scope ledger = new TestLedger(genesis_validator_keys[0], null, null, null, (in Block block, bool changed) @safe {
         registry.onAcceptedBlock(block, changed);
     });
     registry = new NameRegistry("test", RegistryConfig(true), ledger, new ManagedDatabase(":memory:"));

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -490,8 +490,7 @@ public class Validator : FullNode, API
     {
         return new ValidatingLedger(this.params, this.engine,
             this.utxo_set, this.storage, this.enroll_man, this.pool,
-            this.stateDB, this.clock, config.node.block_time_offset_tolerance,
-            &this.onAcceptedBlock);
+            this.stateDB, this.clock, &this.onAcceptedBlock);
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -490,7 +490,7 @@ public class Validator : FullNode, API
     {
         return new ValidatingLedger(this.params, this.engine,
             this.utxo_set, this.storage, this.enroll_man, this.pool,
-            this.stateDB, this.clock, &this.onAcceptedBlock);
+            this.stateDB, &this.onAcceptedBlock);
     }
 
     /***************************************************************************

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -102,7 +102,7 @@ unittest
         {
             return new PickyLedger(this.params, this.engine,
                 this.utxo_set, this.storage, this.enroll_man, this.pool,
-                this.stateDB, this.clock, &this.onAcceptedBlock);
+                this.stateDB, &this.onAcceptedBlock);
         }
 
         public override void postTransaction (in Transaction tx) @safe

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -102,8 +102,7 @@ unittest
         {
             return new PickyLedger(this.params, this.engine,
                 this.utxo_set, this.storage, this.enroll_man, this.pool,
-                this.stateDB, this.clock, config.node.block_time_offset_tolerance,
-                &this.onAcceptedBlock);
+                this.stateDB, this.clock, &this.onAcceptedBlock);
         }
 
         public override void postTransaction (in Transaction tx) @safe


### PR DESCRIPTION
If we merge https://github.com/bosagora/agora/pull/2670 then we can remove the clock in the Ledger as it was only used when the current time was used for calculating the time offset in the next block.