### PR TITLE
Only start nomination for next block when half have signed the last block

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1006,6 +1006,13 @@ extern(D):
         this.network.gossipBlockSignature(block_sig);
     }
 
+    /// Were we active in this block (i.e. we are not catching up after being offline)
+    public bool safeToSign (in Height height)
+        nothrow
+    {
+        return !!(height in this.slot_sigs); // true if we were active in nomination during this block
+    }
+
     /// Create a combined Schnorr multisig and return the updated block
     private Block updateMultiSignature (in Block block) @safe
     {

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1131,8 +1131,9 @@ extern(D):
 
         /// Comparison function, which sorts by
         /// 1. length of missing validators (smallest first), or if it ties
-        /// 2. total adjusted fee (smallest last), or if it ties
-        /// 3. hash of the candidate (smallest last)
+        /// 2. length of enrollments (smallest last), or if it ties
+        /// 3. total adjusted fee (smallest last), or if it ties
+        /// 4. hash of the candidate (smallest last)
         public int opCmp (in CandidateHolder other) const @safe scope pure nothrow @nogc
         {
             if (this.consensus_data.missing_validators.length <
@@ -1140,6 +1141,11 @@ extern(D):
                     return -1;
             else if (this.consensus_data.missing_validators.length >
                      other.consensus_data.missing_validators.length)
+                return 1;
+
+            if (this.consensus_data.enrolls.length > other.consensus_data.enrolls.length)
+                return -1;
+            else if (this.consensus_data.enrolls.length < other.consensus_data.enrolls.length)
                 return 1;
 
             if (this.total_rate > other.total_rate)

--- a/source/agora/test/FutureEnrollment.d
+++ b/source/agora/test/FutureEnrollment.d
@@ -61,7 +61,7 @@ unittest
         /// set base class
         public override void createNewNode (Config conf, string file, int line)
         {
-            if (this.nodes.length == GenesisValidators - 1)
+            if (this.nodes.length == 0)
                 this.addNewNode!CustomValidator(conf, &this.enable_catchup,
                     file, line);
             else
@@ -80,7 +80,7 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto delayed_node = GenesisValidators - 1;
+    auto delayed_node = 0;
     auto outsider = network.nodes[GenesisValidators];
 
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
@@ -96,7 +96,7 @@ unittest
     network.clients[delayed_node].filter!(API.postTransaction);
 
     // Block 19 we add the frozen utxo for the outsider validator
-    network.generateBlocks(iota(GenesisValidators - 1), Height(GenesisValidatorCycle - 1));
+    network.generateBlocks(iota(1, GenesisValidators), Height(GenesisValidatorCycle - 1));
     network.expectHeight([GenesisValidators], Height(GenesisValidatorCycle - 1));
 
     // the delayed validator is a block behind from the latest height

--- a/tests/system/node/faucet/config.yaml
+++ b/tests/system/node/faucet/config.yaml
@@ -14,10 +14,10 @@ tx_generator:
   stats_port: 9113
 
   # How frequently we run our periodic task in seconds
-  send_interval: 5
+  send_interval: 2
 
   # Between how many addresses we split a transaction by
-  split_count: 1
+  split_count: 2
 
   # Maximum number of utxo before merging instead of splitting
   merge_threshold: 10

--- a/tests/system/source/main.d
+++ b/tests/system/source/main.d
@@ -126,7 +126,7 @@ int main (string[] args)
 
     size_t empty = 0;
     auto target_height = 42;
-    const LimitOfConsecutiveEmptyBlocks = 3;
+    const LimitOfConsecutiveEmptyBlocks = 5;
     iota(target_height + 1).each!((ulong h)
     {
         if (assertBlockHeightAtleast(h) == 0)


### PR DESCRIPTION
This should help ensure we get more signatures on blocks as there will be more chance to catch up on signing before the next block is created. This should also help prevent too many empty blocks in a row when block creation is delayed for some reason.