### PR TITLE
Fix errors of fee calculation on flash transactions

### DIFF
--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -1418,9 +1418,7 @@ public class FlashNode : FlashControlAPI
             return FeeUTXOs.init;
         // Always pay with the node key
         auto utxos = this.listener.getFeeUTXOs(this.conf.key_pair.address, per_byte);
-        // reuse total_value as refund amount
-        if (!utxos.total_value.sub(per_byte))
-            utxos.total_value = Amount(0);
+
         return utxos;
     }
 

--- a/source/agora/flash/api/FlashListenerAPI.d
+++ b/source/agora/flash/api/FlashListenerAPI.d
@@ -35,6 +35,9 @@ struct FeeUTXOs
 
     /// Total value stored in `utxos`
     Amount total_value;
+
+    /// Total fee calculated in `utxos`
+    Amount total_fee;
 }
 
 /// This is the API that each Flash listener must implement, for example wallets


### PR DESCRIPTION
This is a PR in the middle of solving the #2494 which needs some information for the problem that occurs in collecting close transaction signatures. I solved the errors in calculating fees on `funding tx`, `update tx`, and `settle tx`. But in the middle of solving the problem on the `close tx`, I might need to get some clues or prerequisite knowledge from @omerfirmak.

I will open another PR and make the PR fail on the second unit test in source/agora/test/Flash.d intentionally for some discussion. Before that, can you review the code for solving the problem of fee calculation on `funding tx`, `update tx`, and `settle tx`?
 
Fixes #2494