### PR TITLE
Fixes Issue2680: Prefer candidate with more enrollments

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1131,8 +1131,9 @@ extern(D):
 
         /// Comparison function, which sorts by
         /// 1. length of missing validators (smallest first), or if it ties
-        /// 2. total adjusted fee (smallest last), or if it ties
-        /// 3. hash of the candidate (smallest last)
+        /// 2. length of enrollments (smallest last), or if it ties
+        /// 3. total adjusted fee (smallest last), or if it ties
+        /// 4. hash of the candidate (smallest last)
         public int opCmp (in CandidateHolder other) const @safe scope pure nothrow @nogc
         {
             if (this.consensus_data.missing_validators.length <
@@ -1140,6 +1141,11 @@ extern(D):
                     return -1;
             else if (this.consensus_data.missing_validators.length >
                      other.consensus_data.missing_validators.length)
+                return 1;
+
+            if (this.consensus_data.enrolls.length > other.consensus_data.enrolls.length)
+                return -1;
+            else if (this.consensus_data.enrolls.length < other.consensus_data.enrolls.length)
                 return 1;
 
             if (this.total_rate > other.total_rate)

--- a/source/agora/test/FutureEnrollment.d
+++ b/source/agora/test/FutureEnrollment.d
@@ -61,7 +61,7 @@ unittest
         /// set base class
         public override void createNewNode (Config conf, string file, int line)
         {
-            if (this.nodes.length == GenesisValidators - 1)
+            if (this.nodes.length == 0)
                 this.addNewNode!CustomValidator(conf, &this.enable_catchup,
                     file, line);
             else
@@ -80,7 +80,7 @@ unittest
     scope(failure) network.printLogs();
     network.waitForDiscovery();
 
-    auto delayed_node = GenesisValidators - 1;
+    auto delayed_node = 0;
     auto outsider = network.nodes[GenesisValidators];
 
     network.generateBlocks(Height(GenesisValidatorCycle - 2));
@@ -96,7 +96,7 @@ unittest
     network.clients[delayed_node].filter!(API.postTransaction);
 
     // Block 19 we add the frozen utxo for the outsider validator
-    network.generateBlocks(iota(GenesisValidators - 1), Height(GenesisValidatorCycle - 1));
+    network.generateBlocks(iota(1, GenesisValidators), Height(GenesisValidatorCycle - 1));
     network.expectHeight([GenesisValidators], Height(GenesisValidatorCycle - 1));
 
     // the delayed validator is a block behind from the latest height


### PR DESCRIPTION
It is desirable for the blockchain network to have as many active validators as possible. To help more timely enrollments then consensus candidates which contain more enrollments can be chosen.