### PR TITLE
Cache the Coinbase tx

### DIFF
--- a/tests/system/node/faucet/config.yaml
+++ b/tests/system/node/faucet/config.yaml
@@ -14,13 +14,13 @@ tx_generator:
   stats_port: 9113
 
   # How frequently we run our periodic task in seconds
-  send_interval: 2
+  send_interval: 4
 
   # Between how many addresses we split a transaction by
-  split_count: 2
+  split_count: 4
 
   # Maximum number of utxo before merging instead of splitting
-  merge_threshold: 10
+  merge_threshold: 50
 
   # Addresses to send transactions
   addresses:


### PR DESCRIPTION
During nomination the Coinbase transaction is for the payout period preceding the current payout period. 
This means that no more signatures are added to these blocks as the catchup only signs those within the current payout period.
Therefore we only need to calculate the rewards and fees to be paid a single time and then use the cached result.