### PR TITLE
Validator: Reveal preimages on new block events

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -585,13 +585,7 @@ public class Validator : FullNode, API
                 ((block.header.height - 1) * this.params.BlockInterval.total!"seconds"))
             this.checkAndEnroll(block.header.height);
 
-        // FIXME: Add our pre-image to the validator set so that `getValidators`
-        // works as expected. This will need to be fixed in the Ledger in the
-        // future, as `onPreImageRevealTimer` has some issues, but doing it here
-        // allows us to unify usage of `getValidators`.
-        PreImageInfo self;
-        if (this.ledger.enrollment_manager.getNextPreimage(self, block.header.height))
-            this.ledger.addPreimage(self);
+        this.onPreImageRevealTimer();
 
         // note: may context switch, should be called last after quorums
         // are regenerated above.


### PR DESCRIPTION
On enrollment blocks, network is missing preimage of the newly
enrolled validator for the next block. In our production environment,
our block time is short enough that sometimes reveal timer is not triggered
before creation of the next block, resulting in the newly enrolled validator
to be slashed immediately.

onPreImageRevealTimer seems like re-entrant so this should not be a problem
that we call it from outside of the timer.