### PR TITLE
Enable foreign key support on SQLite

### DIFF
--- a/source/agora/common/ManagedDatabase.d
+++ b/source/agora/common/ManagedDatabase.d
@@ -73,6 +73,7 @@ public class ManagedDatabase
         int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE)
     {
         this.database = emplace(cast(Database*) malloc(Database.sizeof), path, flags);
+        this.database.run("PRAGMA foreign_keys = ON");
         thread_dbs ~= this.database;
     }
 


### PR DESCRIPTION
Registry tables require foreign key support to remove stale addresses