### PR TITLE
Override `opAssign` of `Domain` to always add root domain

### DIFF
--- a/source/agora/common/DNS.d
+++ b/source/agora/common/DNS.d
@@ -371,7 +371,7 @@ public struct Header
     public ushort ID;
 
     /***************************************************************************
-        
+
         Function prototype for setting or getting specified bit(s) of field
 
         Params:
@@ -724,13 +724,21 @@ public struct Domain
     /// The domain name
     public const(char)[] value = ".";
 
-    /// Creates domain name with always trailing root
-    public this (inout const(char)[] v) @safe inout
+    private inout(const(char)[]) insertRootDomain (inout const(char)[] v)
+    @safe inout pure
     {
-        if (v.length && v[$-1] == '.')
-            this.value = v.idup;
-        else
-            this.value = v.idup ~ '.';
+        return v.length && v[$-1] == '.' ? v.idup : v.idup ~ '.';
+    }
+
+    /// Creates domain name with always trailing root
+    public this (inout const(char)[] v) @safe inout pure
+    {
+        this.value = insertRootDomain(v);
+    }
+
+    public void opAssign (const(char)[] v) @safe pure
+    {
+        this.value = insertRootDomain(v);
     }
 
     ///


### PR DESCRIPTION
Commit 1cc5276d4d006555615f7bf8c33ea470ce2375ef implements always adding
root domain (trailing dot) but missed overriding `opAssign`. Thus
assignments missed trailing dot, which causes removing last character from
domain during serialization.