### PR TITLE
Always instantiate a name registry

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -683,7 +683,7 @@ public class NetworkManager
     /// Discover the network, connect to all required peers
     /// Some nodes may want to connect to specific peers before
     /// discovery() is considered complete
-    public void discover (NameRegistry registry = null, UTXO[Hash] required_peer_utxos = null) nothrow
+    public void discover (NameRegistry registry, UTXO[Hash] required_peer_utxos = null) nothrow
     {
         this.quorum_set_keys.from(Set!Hash.init);
         this.required_peers.from(Set!Hash.init);
@@ -761,9 +761,8 @@ public class NetworkManager
 
         try
         {
-            if (registry !is null)
-                foreach(addr; registry.getValidatorsAddresses())
-                    this.addAddress(addr);
+            foreach (addr; registry.getValidatorsAddresses())
+                this.addAddress(addr);
         }
         catch (Exception ex)
             log.info("Cannot fetch validator addresses from our registry {}",

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -282,9 +282,8 @@ public class FullNode : API
             Clock.currTime!(ClockType.second)(UTC()).toISOString(),
         );
 
-        if (config.registry.enabled)
-            this.registry = new NameRegistry(config.node.realm, config.registry,
-                                             this.ledger, this.cacheDB);
+        this.registry = new NameRegistry(config.node.realm, config.registry,
+                                         this.ledger, this.cacheDB);
     }
 
     mixin DefineCollectorForStats!("app_stats", "collectAppStats");

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -82,7 +82,6 @@ public class NameRegistry: NameRegistryAPI
     public this (string realm, RegistryConfig config, Ledger ledger,
         ManagedDatabase cache_db)
     {
-        assert(config.enabled, "Registry instantiated but not enabled");
         assert(realm.length > 0, "No 'realm' provided");
         assert(ledger !is null);
         assert(cache_db !is null);


### PR DESCRIPTION
As we want to cache the addresses of validators locally,
and we have to implement the logic in the registry for secondary servers,
it makes sense to re-use this logic for clients as well.

With this change, the `enabled` boolean now means "publicly available",
rather than "internally instantiate a NameRegistry object".