### PR TITLE
Extend registry config to allow specifying `mname` and the realm zone

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -303,17 +303,37 @@ registry:
   # Port to bind to (default: 53, standard DNS port)
   # Note that ports < 1024 are privileged ports and might require root powers
   port: 53
+
+  ## The fields below define 3 SOA records, one for each zone required by the network.
+  ##
+  ## Those can typically be left empty, except for the primary server of the zone.
+  ## If non-empty, both `primary` and `email` must be provided.
+  ##
+  ## Others fields are ignored if the server is not authoritative for the zone.
+
   # The zone responsible for validators registration
   validators:
-    # Whether this registry is authoritative for this zone, or just a secondary
+    # Whether we should consider ourselves authoritative
+    #
+    # Authoritative servers should have an NS entry in the parent zone,
+    # for example the authoritative server for bosagora.io should have:
+    # NS ns1.bosagora.io.
+    # NS ns2.bosagora.io.
+    # By convention, ns1 is the primary (source of truth) and ns2 is a secondary,
+    # that periodically fetches records from ns1.
+    # Secondary servers should have `authoritative` set to `true`. Primary servers
+    # should have `authoritative` unset or set to `true`, and `primary` and `email` set.
     authoritative: true
 
-    ## The fields below define the SOA record for the DNS entry.
-    ##
-    ## If you are not familiar with DNS, simply enter a valid email address,
-    ## and use the default values.
-    ##
-    ## Those fields are ignored if the server is not `authoritative` for the zone.
+    # The *hostname* (not IP address) of the primary name server for this zone
+    #
+    # If this is set, `email` must be set too. If this isn't set, `email` must be unset.
+    #
+    # The value here is typically the hostname of the server itself.
+    # For example, if the node that read this configuration will be reachable via
+    # `agora.example.com`, then this string can be used.
+    # However, the typical naming convention would be to use `ns1.example.com`.
+    primary: ns1.bosagora.io
 
     # Email of the DNS server administrator
     # This field is required for authoritative servers.

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -486,6 +486,9 @@ public struct RegistryConfig
     /// The port to bind to - Default to the standard DNS port (53)
     public ushort port = 53;
 
+    /// The parent zone for validators and flash, as configured in the realm
+    public immutable(ZoneConfig) realm;
+
     /// The 'validators' zone
     public immutable(ZoneConfig) validators;
 
@@ -530,6 +533,7 @@ public struct RegistryConfig
                    name, zone.minimum, uintMaxSecs);
         }
 
+        validateZone("realm", this.realm);
         validateZone("validators", this.validators);
         validateZone("flash", this.flash);
     }

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -58,6 +58,9 @@ public class NameRegistry: NameRegistryAPI
     /// Zones of the registry
     private ZoneData[Domain] zones;
 
+    /// The domain for `realm`
+    private Domain realm;
+
     /// The domain of `validators` zone
     private Domain validators;
 
@@ -92,9 +95,13 @@ public class NameRegistry: NameRegistryAPI
 
         this.ledger = ledger;
 
+        this.realm = Domain(realm);
         this.validators = Domain("validators." ~ realm);
         this.flash = Domain("flash." ~ realm);
 
+
+        this.zones[this.realm] = ZoneData("realm", this.realm,
+            this.config.realm, cache_db, log);
         this.zones[this.validators] = ZoneData("validator", this.validators,
             this.config.validators, cache_db, log);
         this.zones[this.flash] = ZoneData("flash",  this.flash,

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -645,13 +645,14 @@ private struct ZoneData
         this.config = config;
         this.root = root;
 
-        static string serverType (bool auth)
+        static string serverType (bool auth, bool primary)
         {
-            return auth ? "authoritative" : "secondary";
+            return primary ? "primary" : (auth ? "secondary" : "caching");
         }
 
         this.log.info("Registry is {} DNS server for zone '{}'",
-            serverType(this.config.authoritative), this.root);
+            serverType(this.config.authoritative, this.config.primary.set),
+            this.root);
 
         this.query_count = format("SELECT COUNT(*) FROM registry_%s_signature",
             zone_name);
@@ -688,12 +689,12 @@ private struct ZoneData
         this.db.execute(query_sig_create);
         this.db.execute(query_addr_create);
 
-        // Serial's value wraps around so the cast is safe
-        const serial = cast(uint) Clock.currTime(UTC()).toUnixTime();
-        if (this.config.authoritative)
+        if (this.config.primary.set)
+        {
+            // Serial's value wraps around so the cast is safe
+            const serial = cast(uint) Clock.currTime(UTC()).toUnixTime();
             this.soa = this.config.fromConfig(this.root, serial);
-        else
-            this.soa.mname = Domain(format("ns1.%s", this.root));
+        }
     }
 
     /***************************************************************************


### PR DESCRIPTION
See each commit.

The first one is required for recursion to work properly, and the second one fixes #2537 