### PR TITLE
Metrics: Do not count duplicates as rejected

### DIFF
--- a/source/agora/stats/Tx.d
+++ b/source/agora/stats/Tx.d
@@ -20,6 +20,7 @@ import agora.stats.Stats;
 public struct TxStatsValue
 {
     public ulong agora_transactions_received_total;
+    public ulong agora_transactions_duplicate_total;
     public ulong agora_transactions_accepted_total;
     public ulong agora_transactions_rejected_total;
     public ulong agora_transactions_poolsize_gauge;


### PR DESCRIPTION
If a `Transaction` that is already known is received then it is better to include it in a new  metric  `agora_transactions_duplicate_total`.