### PR TITLE
SOA record: Correctly write the mname

### DIFF
--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -518,7 +518,7 @@ unittest
 private SOA fromConfig (in ZoneConfig zone, Domain name, uint serial) @safe pure
 {
     SOA soa;
-    soa.mname = Domain(format("ns1.%s.", name));
+    soa.mname = Domain(format("ns1.%s", name.value));
     soa.rname = Domain(zone.email.value.replace('@', '.'));
     soa.serial = serial;
     // Casts are safe as the values are validated during config parsing


### PR DESCRIPTION
Otherwise we get:
```
boa1xrval6hd8szdektyz69fnqjwqfejhu4rvrpwlahh9rhaazzpvs5g6lh34l5.validators.testnet.bosagora.io.	0 IN CNAME v6.bosagora.io.
validators.testnet.bosagora.io.	0 IN	SOA	ns1.Domain\(\"validators.testnet.bosagora.io.\"\). dev.bosagora.io. 1637745305 540 10 6000 120
;; Received 371 bytes from 188.165.202.109#53(ns1.bosagora.io) in 28 ms
```