### PR TITLE
Implement secondary and caching registry

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -392,3 +392,8 @@ registry:
   # Zone responsible for realm
   realm:
     authoritative: false
+
+    # List of servers to update records cache from
+    # Default DNS resolvers are (i.e. 8.8.8.8 / 1.1.1.1) used when not configured
+    query_servers:
+      - ns1.bosagora.io

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -347,6 +347,7 @@ registry:
     allow_transfer:
       - 127.0.0.1
 
+    # SOA record for the zone, only applicable for primary servers
     soa:
       # Email of the DNS server administrator
       # This field is required for authoritative servers.
@@ -368,6 +369,26 @@ registry:
 
   # Zone responsible for flash nodes registration
   flash:
-    # Having separate authoritative server increases redundancy and reduces load,
+    # Having one or more secondary servers increase redundancy and reduces load,
     # hence this configuration, while unlikely in a small to medium network, is supported.
+    authoritative: true
+
+    # Redirect server for REST endpoints of the registry
+    redirect_register: http://nsHidden.bosagora.io
+
+    # List of servers to AXFR zone transfer from
+    #
+    # Servers are tried in the configuration order until zone transfer can be
+    # completed from a server.
+    query_servers:
+      - ns1.bosagora.io
+
+    # A secondary server can be an upstream of an another server, thus secondary
+    # servers can also limit AXFR zone transfers from them to a configured
+    # whitelist
+    allow_transfer:
+      - 127.0.0.1
+
+  # Zone responsible for realm
+  realm:
     authoritative: false

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -41,6 +41,7 @@ import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.network.Clock;
 import agora.network.Client;
+import agora.network.DNSResolver;
 import agora.network.RPC;
 import agora.node.Config;
 import agora.node.Registry : NameRegistry;
@@ -695,6 +696,24 @@ public class NetworkManager
         Clock clock, ManagedDatabase cache)
     {
         return new BanManager(banman_conf, clock, cache);
+    }
+
+    /***************************************************************************
+
+        Returns an instance of a DNSResolver
+
+        Params:
+            peer_addrs = Addresses of DNS servers that Resolver will send queries to
+        Returns:
+            the dns resolver
+
+    ***************************************************************************/
+
+    public DNSResolver makeDNSResolver (Address[] peer_addrs = null)
+    {
+        return (peer_addrs !is null)
+            ? new VibeDNSResolver(peer_addrs)
+            : new VibeDNSResolver();
     }
 
     /// register network addresses into the name registry

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -462,6 +462,10 @@ public struct RegistryConfig
                    "registry.{}: Authoritative zones require both 'primary' and " ~
                    "'email' fields to be set", name);
 
+            // Caching registry, nothing to validate
+            if (!zone.authoritative.set || zone.authoritative.value == false)
+                return;
+
             // Secondary registry
             if (!zone.primary.set && zone.authoritative.set)
             {
@@ -548,8 +552,8 @@ public struct ZoneConfig
     /// Servers that are allowed to do AXFR queries, applicable for authoritatives
     public @Optional immutable IPAddress[] allow_transfer;
 
-    /// Servers to zone transfer (AXFR) from, only applicaple and
-    /// required for secondary servers
+    /// Servers to zone transfer (AXFR) from, required for secondary servers
+    /// or servers to update record cache from for caching servers
     public @Optional immutable string[] query_servers;
 
     /// Rest interface of an Agora node with name registering capability,

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -44,7 +44,6 @@ import agora.crypto.Hash;
 import agora.crypto.Key;
 import agora.network.Client;
 import agora.network.Clock;
-import agora.network.DNSResolver;
 import agora.network.Manager;
 import agora.node.Config;
 import agora.node.Registry;
@@ -863,20 +862,6 @@ public class FullNode : API
     {
         return new EnrollmentManager(this.stateDB, this.cacheDB,
             this.config.validator, this.params);
-    }
-
-    /***************************************************************************
-
-        Returns an instance of a DNSResolver
-
-        Returns:
-            the dns resolver
-
-    ***************************************************************************/
-
-    protected DNSResolver makeDNSResolver ()
-    {
-        return new VibeDNSResolver();
     }
 
     /***************************************************************************

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -308,7 +308,8 @@ public class FullNode : API
         );
 
         this.registry = new NameRegistry(config.node.realm, config.registry,
-                                         this.ledger, this.cacheDB);
+                                         this.ledger, this.cacheDB, this.taskman,
+                                         this.network);
     }
 
     mixin DefineCollectorForStats!("app_stats", "collectAppStats");

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -305,7 +305,8 @@ private void runDNSServer_canThrow (in RegistryConfig config, NameRegistry regis
     // The `listenUDP` needs to be in the `runTask` otherwise we get
     // a fatal error due to a bug in vibe-core (see comment #2):
     /// https://github.com/vibe-d/vibe-core/issues/289
-    auto udp = listenUDP(config.port, config.address);
+    auto udp = listenUDP(config.port, config.address,
+        UDPListenOptions.reuseAddress | UDPListenOptions.reusePort);
     scope (exit) udp.close();
     // Otherwise `recv` allocates 65k per call (!!!)
     ubyte[2048] buffer;


### PR DESCRIPTION
This PR implements secondary and caching registry. Fixes of #2449 and Fixes #2647
With secondary registries we can create backup registry servers to improve availability, also this implementation enables us to create a hidden registry.

- It uses `DNSResolver`, depends on #2636 
- Requests AXFR over UDP
- SOA RR is checked periodically, depends on #2730 
- POST endpoints are redirected to actual primary
- Removes two `boolean` flags from configuration and creates three type registries
  - primary registry server, only this will have database modifying capabilities, authoritative
  - secondary registry server, this will do AXFR query to its primaries; secondary servers can be primary for other secondaries
  - caching server, not implemented yet but will be non-authoritative
- Previous Registry cache is removed when Zone type is updated
- Caching zone starts with clean storage and adds to cache according to query results up to TTL seconds of the record.
- Makes Registry enabled by default with caching zones

**DNSResolver**

- [ ] RFC recommends TCP for AXFR, currently using UDP