### PR TITLE
DScanner: Clear up remaining warnings

### DIFF
--- a/devel/dscanner.ini
+++ b/devel/dscanner.ini
@@ -51,7 +51,7 @@ comma_expression_check="enabled"
 ;  used with D versions older than 2.071.0
 local_import_check="disabled"
 ; Checks for variables that could be declared immutable
-could_be_immutable_check="enabled"
+could_be_immutable_check="disabled"
 ; Checks for redundant expressions in if statements
 redundant_if_check="enabled"
 ; Checks for redundant parenthesis

--- a/devel/dscanner.ini
+++ b/devel/dscanner.ini
@@ -61,7 +61,7 @@ mismatched_args_check="enabled"
 ; Checks for labels with the same name as variables
 label_var_same_name_check="enabled"
 ; Checks for lines longer than 120 characters
-long_line_check="enabled"
+long_line_check="disabled"
 ; Checks for assignment to auto-ref function parameters
 auto_ref_assignment_check="enabled"
 ; Checks for incorrect infinite range definitions

--- a/source/agora/api/Registry.d
+++ b/source/agora/api/Registry.d
@@ -45,9 +45,9 @@ public struct RegistryPayloadData
     /***************************************************************************
 
         Orders payload data according to `public_key`, when `public_key`s are
-        equal, `opEquals` is considered for equality. Comparison falls back to 
-        `seq`, length of `addresses` and individual addresses in respective order 
-        when `opEquals` fail. This will eventually result in different equality 
+        equal, `opEquals` is considered for equality. Comparison falls back to
+        `seq`, length of `addresses` and individual addresses in respective order
+        when `opEquals` fail. This will eventually result in different equality
         from `opEquals`
 
     ***************************************************************************/
@@ -63,7 +63,7 @@ public struct RegistryPayloadData
 
             if (this.addresses.length != other.addresses.length)
                 return this.addresses.length < other.addresses.length ? -1 : 1;
-            
+
             foreach (thisAddr, otherAddr; this.addresses.zip(other.addresses))
                 if (auto c = thisAddr.opCmp(otherAddr))
                     return c;

--- a/source/agora/api/Registry.d
+++ b/source/agora/api/Registry.d
@@ -42,6 +42,17 @@ public struct RegistryPayloadData
             && (this.addresses.isPermutation(other.addresses));
     }
 
+    /// Overload for `toHash`, required when implementing `opEquals`
+    public size_t toHash () const scope @trusted pure nothrow @nogc
+    {
+        // If you have one, please let us know, we'd like to hear about it.
+        static assert(PublicKey.sizeof >= size_t.sizeof,
+                      "512 bits machines are not supported");
+
+        // The last bytes represent the checksum
+        return *(cast(size_t*) this.public_key[][$ - size_t.sizeof .. $].ptr);
+    }
+
     /***************************************************************************
 
         Orders payload data according to `public_key`, when `public_key`s are
@@ -87,6 +98,12 @@ public struct RegistryPayload
     bool opEquals (in RegistryPayload other) const nothrow @safe
     {
         return this.data == other.data;
+    }
+
+    /// Required when `opEquals` is implemented
+    public size_t toHash () const scope @safe pure nothrow @nogc
+    {
+        return this.data.toHash();
     }
 
     /// Orders payload according to `data`

--- a/source/agora/cli/vanity/main.d
+++ b/source/agora/cli/vanity/main.d
@@ -251,6 +251,7 @@ unittest
 /// Returns: The index of a given pattern
 private size_t nameIndex (scope const(char)[] name) pure nothrow @nogc @safe
 {
+    assert(name.length >= 1);
     assert(name.length <= Name.length, name);
     size_t result;
     foreach (size_t index, char c; name)

--- a/source/agora/common/DNS.d
+++ b/source/agora/common/DNS.d
@@ -939,8 +939,7 @@ public struct Domain
         // If we get '.' there is no way to tell (using splitter)
         // the difference with 'foo..bar', so we just trim the trailing
         // dot and reject any empty label.
-        size_t end = this.value.length ?
-            (this.value.length - 1) : this.value.length;
+        size_t end = this.value.length > 0 ? (this.value.length - 1) : 0;
 
         this.value[0 .. end].splitter('.').each!(
             (const(char)[] label) {

--- a/source/agora/common/DNS.d
+++ b/source/agora/common/DNS.d
@@ -590,7 +590,7 @@ public struct ResourceRecord
     /// Make a record of the given type
     public static ResourceRecord make (TYPE type) (Domain name, uint ttl, ubyte[] rdata)
     {
-        return ResourceRecord(name, type, CLASS.IN, ttl, data);
+        return ResourceRecord(name, type, CLASS.IN, ttl, rdata);
     }
 
     /// Make a record of SOA type

--- a/source/agora/common/Ensure.d
+++ b/source/agora/common/Ensure.d
@@ -67,11 +67,11 @@ private final class FormattedException : Exception
     {
         import core.internal.string : unsignedToTempString;
 
-        char[20] buffer = void;
+        char[20] buff = void;
 
         sink(typeid(this).name);
         sink("@"); sink(file);
-        sink("("); sink(unsignedToTempString(line, buffer)); sink(")");
+        sink("("); sink(unsignedToTempString(line, buff)); sink(")");
 
         if (this.end > 0)
         {

--- a/source/agora/common/Set.d
+++ b/source/agora/common/Set.d
@@ -305,6 +305,7 @@ unittest
 private void dropIndex (T) (ref T[] arr, size_t index)
 {
     assert(index < arr.length);
+    // Since `index` cannot be less than 0, we know `arr.length > 0`
     immutable newLen = arr.length - 1;
 
     if (index != newLen)

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -376,7 +376,7 @@ public struct Block
         nothrow @safe @nogc
     in
     {
-        assert(txs !is null, "When calling buildMerkleTreeImpl, `txs` must not be null.");
+        assert(txs.length > 0);
     }
     do
     {

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -156,6 +156,8 @@ public struct BlockHeader
         const @safe nothrow
     {
         const Scalar challenge = this.hashFull();
+        // Note: This triggers a false positive with dscanner:
+        // https://github.com/dlang-community/D-Scanner/issues/851
         return BlockHeader.verify(pubkey, Scalar(preimage), sig, challenge);
     }
 

--- a/source/agora/consensus/validation/PreImage.d
+++ b/source/agora/consensus/validation/PreImage.d
@@ -37,8 +37,8 @@ version (unittest)
             (n = difference of two heights).
 
     Params:
-        new_image = The pre-image information to check
-        prev_image = The previous pre-image information
+        newer = The pre-image information to check
+        previous = The previous pre-image information
 
     Returns:
         `null` if the pre-image is valid, otherwise a string
@@ -46,19 +46,19 @@ version (unittest)
 
 *******************************************************************************/
 
-public string isInvalidReason (in PreImageInfo new_image,
-    in PreImageInfo prev_image) nothrow @safe
+public string isInvalidReason (in PreImageInfo newer,
+    in PreImageInfo previous) nothrow @safe
 {
-    if (new_image.utxo != prev_image.utxo)
+    if (newer.utxo != previous.utxo)
         return "The pre-image's UTXO differs from its descendant";
 
-    if (new_image.height <= prev_image.height)
+    if (newer.height <= previous.height)
         return "The height of new pre-image is not greater than that of the previous one";
 
-    Hash temp_hash = new_image.hash;
-    foreach (_; prev_image.height .. new_image.height)
+    Hash temp_hash = newer.hash;
+    foreach (_; previous.height .. newer.height)
         temp_hash = hashFull(temp_hash);
-    if (temp_hash != prev_image.hash)
+    if (temp_hash != previous.hash)
         return "The pre-image has a invalid hash value";
 
     return null;
@@ -66,10 +66,10 @@ public string isInvalidReason (in PreImageInfo new_image,
 
 /// Ditto but returns `bool`, only usable in unittests
 version (unittest)
-public bool isValid (in PreImageInfo prev_image,
-    in PreImageInfo new_image) nothrow @safe
+public bool isValid (in PreImageInfo newer,
+    in PreImageInfo previous) nothrow @safe
 {
-    return isInvalidReason(prev_image, new_image) is null;
+    return isInvalidReason(newer, previous) is null;
 }
 
 /// test for validity of pre-image

--- a/source/agora/crypto/Bech32.d
+++ b/source/agora/crypto/Bech32.d
@@ -147,7 +147,7 @@ public DecodeResult decodeBech32 (in char[] str)
 
     ubyte[] values;
     values.length = str.length - 1 - pos;
-    for (size_t i = 0; i < str.length - 1 - pos; ++i)
+    for (size_t i = 0; i < values.length; ++i)
     {
         ubyte c = str[i + pos + 1];
         byte rev = CHARSET_REV[c];

--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -1482,14 +1482,15 @@ LOuter: while (1)
         new_balance.payment_amount = old_balance.payment_amount;
 
         // assocArray doesn't work with const..
-        version (none)
-            Hash[Hash] payment_hashes = secrets
+        /*
+            Hash[Hash] payments = secrets
                 .map!(s => tuple(s.hashFull, s))
                 .assocArray;
+        */
 
-        Hash[Hash] payment_hashes;
+        Hash[Hash] payments;
         foreach (secret; secrets)
-            payment_hashes[secret.hashFull()] = secret;
+            payments[secret.hashFull()] = secret;
 
         // fold outgoing HTLCs
         foreach (payment_hash, htlc; old_balance.outgoing_htlcs)
@@ -1500,7 +1501,7 @@ LOuter: while (1)
                 if (!new_balance.refund_amount.add(htlc.amount))
                     assert(0);
             }
-            else if (payment_hash in payment_hashes)  // fold secret HTLC
+            else if (payment_hash in payments)  // fold secret HTLC
             {
                 log.info("{}: Fold: Folded outgoing secret-revealed HTLC: {}", this.own_pk.flashPrettify, payment_hash.flashPrettify);
                 if (!new_balance.payment_amount.add(htlc.amount))
@@ -1522,7 +1523,7 @@ LOuter: while (1)
                 if (!new_balance.payment_amount.add(htlc.amount))
                     assert(0);
             }
-            else if (payment_hash in payment_hashes)  // fold secret HTLC
+            else if (payment_hash in payments)  // fold secret HTLC
             {
                 log.info("{}: Fold: Folded incoming secret-revealed HTLC: {}", this.own_pk.flashPrettify, payment_hash.flashPrettify);
                 if (!new_balance.refund_amount.add(htlc.amount))

--- a/source/agora/flash/Network.d
+++ b/source/agora/flash/Network.d
@@ -95,7 +95,7 @@ public class Network
         if (peer1_pk !in this.nodes)
             this.nodes[peer1_pk] = NetworkNode.init;
 
-        if (auto chns = (peer2_pk in this.nodes[peer1_pk].channels))
+        if (auto chns = peer2_pk in this.nodes[peer1_pk].channels)
             chns.put(chan_id);
         else
             this.nodes[peer1_pk].channels[peer2_pk] = Set!Hash.from([chan_id]);

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -1014,6 +1014,7 @@ public class FlashNode : FlashControlAPI
         if (auto path = err.payment_hash in this.payment_path)
         {
             auto shared_secrets = this.shared_secrets[err.payment_hash];
+            assert(path.length >= 1);
             assert(shared_secrets.length == path.length);
 
             auto chans = (*path).map!(hop => hop.chan_id);

--- a/source/agora/flash/api/FlashAPI.d
+++ b/source/agora/flash/api/FlashAPI.d
@@ -175,6 +175,13 @@ public struct ChannelUpdate
             && this.fixed_fee == other.fixed_fee
             && this.proportional_fee == other.proportional_fee;
     }
+
+    /// Required when `opEquals` is implemented
+    public size_t toHash () const scope @trusted pure nothrow @nogc
+    {
+        static assert(this.chan_id.sizeof >= size_t.sizeof);
+        return *(cast(size_t*) this.chan_id[].ptr);
+    }
 }
 
 unittest

--- a/source/agora/network/RPC.d
+++ b/source/agora/network/RPC.d
@@ -174,7 +174,7 @@ public class RPCClient (API) : API
                  uint concurrency, ThisEndAPI impl)
         @trusted
     {
-        const Config config = {
+        const Config conf = {
             host:               host,
             port:               port,
 
@@ -186,7 +186,7 @@ public class RPCClient (API) : API
             write_timeout:      wtimeout,
             concurrency:        concurrency,
         };
-        this(config, impl);
+        this(conf, impl);
     }
 
     /// Ditto

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -458,6 +458,9 @@ private void restErrorHandler (
     HTTPServerRequest req, HTTPServerResponse res, RestErrorInformation info)
     @trusted
 {
+    // We don't use any info from the caller
+    cast(void) req;
+
     static struct ErrorInfo
     {
         /// The error message itself

--- a/source/agora/node/admin/Setup.d
+++ b/source/agora/node/admin/Setup.d
@@ -79,7 +79,7 @@ public class SetupInterface
         // If the user asked for the admin interface, make sure it exists
         // It can be located in a few places (to accomodate for different setups),
         // however if it can't be found in any of them, this will throw.
-        string path = this.getStaticFilePath();
+        const string static_files_path = this.getStaticFilePath();
 
         auto settings = new HTTPServerSettings(url.host);
         settings.port = url.port;
@@ -92,7 +92,7 @@ public class SetupInterface
         // Handle CORS
         router.match(HTTPMethod.OPTIONS, "*", &this.handleAllOptions);
         // By default, match the underlying files
-        router.match(HTTPMethod.GET, "*", serveStaticFiles(path));
+        router.match(HTTPMethod.GET, "*", serveStaticFiles(static_files_path));
 
         this.listener = listenHTTP(settings, router);
     }

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -113,22 +113,17 @@ private struct QuorumFmt
             if (this.getQSet !is null)
                 qset = this.getQSet(this.node_id);
 
-            string node_id;
             if (this.node_id == ulong.max)
-                node_id = "<unknown>";
+                sink("{ id: <unknown>, ");
             else
-                node_id = (cast(ulong)this.node_id).to!string;
+                formattedWrite(sink, "{ id: %d, ", this.node_id);
 
-            if (qset.ptr !is null)
+            if (qset.ptr is null)
+                sink("quorum: <unknown> }");
+            else
             {
                 auto qconf = toQuorumConfig(*qset.ptr);
-                formattedWrite(sink, "{ id: %s, quorum: %s }",
-                     node_id, prettify(qconf));
-            }
-            else
-            {
-                formattedWrite(sink, "{ id: %s, quorum: <unknown> }",
-                     node_id);
+                formattedWrite(sink, "quorum: %s }", prettify(qconf));
             }
         }
         catch (Exception ex)

--- a/source/scpd/Cpp.d
+++ b/source/scpd/Cpp.d
@@ -41,13 +41,13 @@ public enum CppCtor { Use = 0 }
 public alias std_string = basic_string!char;
 
 extern(C++) {
-@trusted nothrow @nogc:
+nothrow @nogc:
     void defaultCtorCPPObject(T) (T* ptr);
     void dtorCPPObject(T) (T* ptr);
     void opAssignCPPObject(T) (T* lhs, T* rhs);
     void copyCtorCPPObject(T) (T* ptr, inout(T)* rhs);
     void copyCtorCPPObject(T) (immutable(T)* ptr, inout(T)* rhs);
-    int getCPPSizeof(T) ();
+    int getCPPSizeof(T) () @safe;
     std_string sliceToStdString (const(char)* ptr, size_t length);
 }
 

--- a/source/scpd/quorum/QuorumIntersectionChecker.d
+++ b/source/scpd/quorum/QuorumIntersectionChecker.d
@@ -13,7 +13,7 @@
 
 module scpd.quorum.QuorumIntersectionChecker;
 
-nothrow @trusted @nogc:
+nothrow @nogc:
 
 import scpd.Cpp;
 import scpd.quorum.QuorumTracker;
@@ -24,7 +24,7 @@ import scpd.types.Stellar_types;
 // since the changes to `NodeID` had to be moved to D.
 extern (C++, "_GLOBAL__N_1") {
     extern class QuorumIntersectionCheckerImpl {
-        std_string nodeName (const NodeID node) const
+        std_string nodeName (const NodeID node) const @trusted
         {
             import std.conv;
             auto slice = node.to!string;

--- a/source/scpd/quorum/QuorumIntersectionChecker.d
+++ b/source/scpd/quorum/QuorumIntersectionChecker.d
@@ -20,7 +20,7 @@ import scpd.quorum.QuorumTracker;
 import scpd.types.Stellar_types;
 
 // Quorum intersection checker implementation
-// This method was originally implemented in C++ but 
+// This method was originally implemented in C++ but
 // since the changes to `NodeID` had to be moved to D.
 extern (C++, "_GLOBAL__N_1") {
     extern class QuorumIntersectionCheckerImpl {

--- a/source/scpd/quorum/QuorumTracker.d
+++ b/source/scpd/quorum/QuorumTracker.d
@@ -16,7 +16,7 @@
 
 module scpd.quorum.QuorumTracker;
 
-@trusted @nogc nothrow:
+@nogc nothrow:
 
 import scpd.Cpp;
 import scpd.scp.SCP;

--- a/source/scpd/scp/BallotProtocol.d
+++ b/source/scpd/scp/BallotProtocol.d
@@ -135,7 +135,7 @@ extern(C++, class) public struct BallotProtocol
 
     void setStateFromEnvelope(SCPEnvelopeWrapperPtr e);
 
-    public alias ENVCallback = extern(C++) bool function(ref SCPEnvelope);
+    alias ENVCallback = extern(C++) bool function(ref SCPEnvelope);
 
     bool processCurrentState(CPPDelegate!ENVCallback* f,
                              bool forceSelf) const;


### PR DESCRIPTION
See each commit for what steps are taken. In practice, we end up with:
```
% dscanner --skipTests --config devel/dscanner.ini --styleCheck source
source/agora/consensus/data/Block.d(161:35)[warn]: Argument 2 is named 'sig', but this is the name of parameter 3
source/agora/consensus/data/Block.d(394:48)[warn]: Avoid subtracting from '.length' as it may be unsigned.
source/agora/crypto/Bech32.d(149:25)[warn]: Avoid subtracting from '.length' as it may be unsigned.
source/agora/test/Base.d(308:16)[warn]: Catching Error or Throwable is almost always a bad idea.
source/agora/network/RPC.d(455:43)[warn]: Parameter api is never used.
source/agora/cli/vanity/main.d(261:57)[warn]: Avoid subtracting from '.length' as it may be unsigned.
source/agora/flash/Channel.d(829:57)[warn]: Parameter tx is never used.
source/agora/flash/OnionPacket.d(162:47)[warn]: Parameter payment_hash is never used.
source/agora/flash/OnionPacket.d(184:29)[warn]: Avoid subtracting from '.length' as it may be unsigned.
source/agora/flash/Node.d(1022:53)[warn]: Avoid subtracting from '.length' as it may be unsigned.
source/agora/flash/Node.d(1321:44)[warn]: Parameter reg_pk is never used.
source/agora/common/DNS.d(852:58)[warn]: Avoid subtracting from '.length' as it may be unsigned.
source/agora/common/Set.d(309:28)[warn]: Avoid subtracting from '.length' as it may be unsigned.
source/agora/common/Ensure.d(94:20)[warn]: Catching Error or Throwable is almost always a bad idea.
```

I have checked every instance, except for the "unused parameters" on flash, which I've forwarded to @omerfirmak .
Either they are correct, or a bug in D-Scanner.