### PR TITLE
DNS: Actually use the configuration value 'primary'

### DIFF
--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -518,7 +518,7 @@ unittest
 private SOA fromConfig (in ZoneConfig zone, Domain name, uint serial) @safe pure
 {
     SOA soa;
-    soa.mname = Domain(format("ns1.%s", name.value));
+    soa.mname = Domain(zone.primary);
     soa.rname = Domain(zone.email.value.replace('@', '.'));
     soa.serial = serial;
     // Casts are safe as the values are validated during config parsing


### PR DESCRIPTION
We started reading that value in a previous PR, but didn't make use of it.