### PR TITLE
Deserialize RDATA for supported types

### DIFF
--- a/source/agora/common/DNS.d
+++ b/source/agora/common/DNS.d
@@ -611,8 +611,9 @@ public struct ResourceRecord
     public static ResourceRecord make (TYPE type : TYPE.A) (
         Domain name, uint ttl, uint[] ipv4...) @trusted
     {
+
         auto rdata = (cast(ubyte*) ipv4.ptr)[0 .. uint.sizeof * ipv4.length].dup;
-        return ResourceRecord(name, TYPE.CNAME, CLASS.IN, ttl, rdata);
+        return ResourceRecord(name, TYPE.A, CLASS.IN, ttl, rdata);
     }
 
     /// A domain name to which this resource record pertains.

--- a/source/agora/common/DNS.d
+++ b/source/agora/common/DNS.d
@@ -611,8 +611,9 @@ public struct ResourceRecord
     public static ResourceRecord make (TYPE type : TYPE.A) (
         Domain name, uint ttl, uint[] ipv4...) @trusted
     {
-
-        auto rdata = (cast(ubyte*) ipv4.ptr)[0 .. uint.sizeof * ipv4.length].dup;
+        ubyte[] rdata;
+        foreach (ip; ipv4)
+            rdata ~= ip.serializeFull(CompactMode.No);
         return ResourceRecord(name, TYPE.A, CLASS.IN, ttl, rdata);
     }
 


### PR DESCRIPTION
For A, SOA and CNAME records RDATA will provide deserialized versions. This will help us to deserialize Resource Records fetched through AXFR query (`Domain` requires special deserializer context).

This PR also fixes an error introduced with 1bccc2c2c0a7c1642ef7cdee718728a3471b191e which caused A records to appear as CNAME records in the answer and IP octets sent in reverse order for addresses.