### PR TITLE
Ledger: Remove import to agora.test.Base

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -1657,7 +1657,6 @@ version (unittest)
 {
     import agora.consensus.PreImage;
     import agora.node.Config;
-    version (unittest) import agora.test.Base;
     import core.stdc.time : time;
 
     /// A `Ledger` with sensible defaults for `unittest` blocks


### PR DESCRIPTION
Nothing should import into the test package, even in unittest,
as it otherwise creates a mess of dependency (for example,
this means that Ledger transitively import AdminInterface,
which requires the Barcode submodule).