### PR TITLE
CI: Fix GeoIP action

### DIFF
--- a/.github/workflows/geoip.yml
+++ b/.github/workflows/geoip.yml
@@ -14,6 +14,7 @@
 # the database.
 name: GeoIP
 on:
+  workflow_dispatch:
   schedule:
     # Minute (1), Hour (0), day of the month (1), month (any), day of the week (any)
     # https://crontab.guru/
@@ -28,12 +29,12 @@ jobs:
         id: get-date
         shell: bash
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m")"
+          echo "::set-output name=date::$(/bin/date -u '+%Y%m')"
 
       - name: 'Download GeoIP database'
         env:
           GEOIP_OUTPUT_DIR: ${{ github.workspace }}/build/geoip/
         run: |
-          mkdir ${GEOIP_OUTPUT_DIR}
+          mkdir -p ${GEOIP_OUTPUT_DIR}
           wget --no-verbose -O  ${GEOIP_OUTPUT_DIR}/geoip.city.tar.gz 'https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${{ secrets.GEOIP_SECRET }}&suffix=tar.gz'
           tar -xzvf ${GEOIP_OUTPUT_DIR}/geoip.city.tar.gz --directory ${GEOIP_OUTPUT_DIR} --strip-components 1


### PR DESCRIPTION
The main fix is to use '-p' as the parent directory (build) does not exists.
We also change the quotations as they left the string actually unquoted.
Finally, adding 'on: workflow_dispatch' ensures we can trigger it manually too.