### PR TITLE
Add `TransactionResult` struct for result of posting transaction

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -289,9 +289,12 @@ public interface API
         Params:
             tx = a Transaction being posted
 
+        Returns:
+            a TransactionResult object, the result of posting the transaction
+
     ***************************************************************************/
 
-    public void postTransaction (in Transaction tx);
+    public TransactionResult postTransaction (in Transaction tx);
 
     /***************************************************************************
 

--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -286,6 +286,9 @@ public interface API
         API:
             POST /transaction
 
+        Params:
+            tx = a Transaction being posted
+
     ***************************************************************************/
 
     public void postTransaction (in Transaction tx);

--- a/source/agora/cli/client/SendTxProcess.d
+++ b/source/agora/cli/client/SendTxProcess.d
@@ -204,7 +204,9 @@ public int sendTxProcess (string[] args, ref string[] outputs, APIMaker api_make
     auto node = api_maker(op.address);
 
     // send the transaction
-    node.postTransaction(tx);
+    auto result = node.postTransaction(tx);
+    if (result.status != TransactionResult.Status.Accepted)
+        return 1;
 
     return 0;
 }
@@ -221,9 +223,10 @@ unittest
         /// Contains the transaction cache
         private Transaction[Hash] tx_cache;
 
-        public override void postTransaction (in Transaction tx) @safe
+        public override TransactionResult postTransaction (in Transaction tx) @safe
         {
             this.tx_cache[hashFull(tx)] = tx.serializeFull().deserializeFull!Transaction;
+            return TransactionResult(TransactionResult.Status.Accepted);
         }
 
         /// GET: /hasTransactionHash

--- a/source/agora/cli/client/SendTxProcess.d
+++ b/source/agora/cli/client/SendTxProcess.d
@@ -122,6 +122,9 @@ public void printSendTxHelp (ref string[] outputs)
                   (1 line will be one entry)
         api_maker = A delegate that makes an API object based on the address
 
+    Result:
+        0 if successful, otherwise 1
+
 *******************************************************************************/
 
 public int sendTxProcess (string[] args, ref string[] outputs, APIMaker api_maker)

--- a/source/agora/consensus/data/Transaction.d
+++ b/source/agora/consensus/data/Transaction.d
@@ -377,6 +377,20 @@ unittest
     assert(expected2 == tx_freeze_hash, expected2.toString());
 }
 
+/// The information of the result of posting a transaction
+public struct TransactionResult
+{
+    public enum Status : uint
+    {
+        Accepted,
+        Duplicated,
+        Rejected,
+    }
+    
+    Status status;
+    string reason;
+}
+
 /*******************************************************************************
 
     Get sum of `Output`

--- a/source/agora/flash/Channel.d
+++ b/source/agora/flash/Channel.d
@@ -63,7 +63,7 @@ mixin AddLogger!();
 public class Channel
 {
     /// Used to publish funding / trigger / update / settlement txs to blockchain
-    public const void delegate (in Transaction) txPublisher;
+    public const TransactionResult delegate (in Transaction) txPublisher;
 
     /// Database
     private ManagedDatabase db;
@@ -151,7 +151,7 @@ public class Channel
     public this (FlashConfig flash_conf, ChannelConfig conf, in KeyPair kp,
         PrivateNonce priv_nonce, PublicNonce peer_nonce, FlashAPI peer,
         Engine engine, ITaskManager taskman,
-        void delegate (in Transaction) txPublisher,
+        TransactionResult delegate (in Transaction) txPublisher,
         PaymentRouter paymentRouter,
         OnChannelNotify onChannelNotify,
         OnPaymentComplete onPaymentComplete,
@@ -204,7 +204,7 @@ public class Channel
 
     public this (in PublicKey key, Hash chan_id, FlashConfig flash_conf, Engine engine,
         ITaskManager taskman,
-        void delegate (in Transaction) txPublisher,
+        TransactionResult delegate (in Transaction) txPublisher,
         PaymentRouter paymentRouter,
         OnChannelNotify onChannelNotify,
         OnPaymentComplete onPaymentComplete,
@@ -258,7 +258,7 @@ public class Channel
         FlashAPI delegate (in PublicKey peer_pk, Duration timeout,
             Address address = Address.init) getFlashClient,
         Engine engine, ITaskManager taskman,
-        void delegate (in Transaction) txPublisher, PaymentRouter paymentRouter,
+        TransactionResult delegate (in Transaction) txPublisher, PaymentRouter paymentRouter,
         OnChannelNotify onChannelNotify,
         OnPaymentComplete onPaymentComplete,
         OnUpdateComplete onUpdateComplete,

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -173,7 +173,7 @@ public class FlashNode : FlashControlAPI
     private ManagedDatabase db;
 
     /// Callback for sending transactions to the network
-    protected void delegate (in Transaction tx) postTransaction;
+    protected TransactionResult delegate (in Transaction tx) postTransaction;
 
     /// Callback for fetching a block
     protected const(Block) delegate (ulong _height) @safe getBlock;
@@ -198,7 +198,8 @@ public class FlashNode : FlashControlAPI
     ***************************************************************************/
 
     public this (FlashConfig conf, string db_path, Hash genesis_hash,
-        Engine engine, ITaskManager taskman, void delegate (in Transaction tx) postTransaction,
+        Engine engine, ITaskManager taskman,
+        TransactionResult delegate (in Transaction tx) postTransaction,
         const(Block) delegate (ulong _height) @safe getBlock,
         NameRegistryAPI delegate (string address, Duration timeout) getNameRegistryClient)
     {

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1644,13 +1644,15 @@ private mixin template TestNodeMixin ()
 
     ***************************************************************************/
 
-    public override void postTransaction (in Transaction tx) @safe
+    public override TransactionResult postTransaction (in Transaction tx) @safe
     {
-        super.postTransaction(tx);
+        auto result = super.postTransaction(tx);
         const tx_hash = tx.hashFull();
         if (tx_hash !in this.accepted_txs &&
             this.pool.hasTransactionHash(tx_hash))
             this.accepted_txs.put(tx_hash);
+
+        return result;
     }
 
     /***************************************************************************

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -312,12 +312,17 @@ public class TestFlashNode : FlashNode, TestFlashAPI
     }
 
     ///
-    private void postTransaction (in Transaction tx)
+    private TransactionResult postTransaction (in Transaction tx)
     {
         if (this.allow_publish)
-            this.agora_node.postTransaction(tx);
+        {
+            return this.agora_node.postTransaction(tx);
+        }
         else
+        {
             log.info("Skipping publishing {}", tx);
+            return TransactionResult(TransactionResult.Status.Accepted);
+        }
     }
 }
 

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -105,10 +105,12 @@ unittest
                 this.stateDB, &this.onAcceptedBlock);
         }
 
-        public override void postTransaction (in Transaction tx) @safe
+        public override TransactionResult postTransaction (in Transaction tx) @safe
         {
             // Dont accept any incoming TXs
             log.info("Picky node ignoring TX {}", tx);
+
+            return TransactionResult(TransactionResult.Status.Accepted); 
         }
     }
 

--- a/source/agora/test/PostTransactionResult.d
+++ b/source/agora/test/PostTransactionResult.d
@@ -1,0 +1,63 @@
+/*******************************************************************************
+
+    Contains tests for the result of posting transactions which can be one
+    of these status: `Accepted``, `Duplicated`, and `Rejected`.
+
+    Copyright:
+        Copyright (c) 2019-2021 BOSAGORA Foundation
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.PostTransactionResult;
+
+version (unittest):
+
+import agora.api.Validator;
+import agora.consensus.data.genesis.Test;
+import agora.crypto.Hash;
+import agora.crypto.Key;
+import agora.test.Base;
+import agora.utils.Test;
+
+import core.thread.osthread : Thread;
+import std.algorithm.searching;
+
+/// test for posting transactions, waiting for the various results
+unittest
+{
+    TestConf conf = TestConf.init;
+    auto network = makeTestNetwork!TestAPIManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto input_txs = GenesisBlock.txs.filter!(tx => tx.isPayment).array;
+    auto output_addr = WK.Keys.AA.address;
+
+    // create a transaction with the fee rate of 10000
+    auto tx = TxBuilder(input_txs[0], 0).feeRate(Amount(10_000))
+        .draw(Amount(100_000), [output_addr])
+        .sign();
+
+    // post the transaction, expect `Accepted`
+    auto result = nodes[0].postTransaction(tx);
+    assert(result == TransactionResult(TransactionResult.Status.Accepted));
+
+    // post the same transaction again, expect `Duplicated`
+    result = nodes[0].postTransaction(tx);
+    assert(result == TransactionResult(TransactionResult.Status.Duplicated));
+
+    // post a transaction with no fee, expect `Rejected`
+    tx = TxBuilder(input_txs[0], 1).feeRate(Amount(0))
+        .draw(Amount(100_000), [output_addr])
+        .sign();
+    result = nodes[0].postTransaction(tx);
+    assert(result.status == TransactionResult.status.Rejected);
+    assert(!result.reason.find("Fee rate is less than minimum").empty);
+}


### PR DESCRIPTION
We need to know the details about why the posting transaction has failed.
So we introduce a new structure for identifying whether the operation
succeeds and the reason when the operation fails.

Fixes #1082 