### PR TITLE
Add check unsigned to some columns

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -119,7 +119,8 @@ public class BanManager
         {
             // create banned if required
             this.db.execute("CREATE TABLE IF NOT EXISTS banned " ~
-                "(url TEXT PRIMARY KEY, until INTEGER NOT NULL)");
+                "(url TEXT PRIMARY KEY, until INTEGER NOT NULL, " ~
+                "CHECK (until >= 0))");
 
             // create whitelisted if required
             this.db.execute("CREATE TABLE IF NOT EXISTS whitelisted " ~

--- a/source/agora/consensus/Fee.d
+++ b/source/agora/consensus/Fee.d
@@ -212,7 +212,8 @@ public class FeeManager
     private void initialize ()
     {
         this.db.execute("CREATE TABLE IF NOT EXISTS block_fees " ~
-            "(height INTEGER, fee INTEGER, data_fee INTEGER)");
+            "(height INTEGER, fee INTEGER, data_fee INTEGER, " ~
+            "CHECK (height >= 0 AND fee >= 0 AND data_fee >=0))");
 
         auto results = this.db.execute("SELECT height, fee, data_fee FROM block_fees");
 

--- a/source/agora/consensus/pool/Enrollment.d
+++ b/source/agora/consensus/pool/Enrollment.d
@@ -62,7 +62,7 @@ public class EnrollmentPool
         // create the table for enrollment pool if it doesn't exist yet
         this.db.execute("CREATE TABLE IF NOT EXISTS enrollment_pool " ~
             "(key TEXT PRIMARY KEY, val BLOB NOT NULL, " ~
-            "avail_height INTEGER)");
+            "avail_height INTEGER, CHECK (avail_height >= 0))");
     }
 
     /***************************************************************************

--- a/source/agora/consensus/pool/Transaction.d
+++ b/source/agora/consensus/pool/Transaction.d
@@ -108,7 +108,8 @@ public class TransactionPool
 
         // create the table if it doesn't exist yet
         this.db.execute("CREATE TABLE IF NOT EXISTS tx_pool " ~
-            "(key TEXT PRIMARY KEY, val BLOB NOT NULL, fee INTEGER NOT NULL)");
+            "(key TEXT PRIMARY KEY, val BLOB NOT NULL, fee INTEGER NOT NULL, " ~
+            "CHECK (fee >= 0))");
 
         // populate the input set from the tx'es in the DB
         foreach (const ref Transaction tx; this)

--- a/source/agora/consensus/state/UTXODB.d
+++ b/source/agora/consensus/state/UTXODB.d
@@ -50,7 +50,8 @@ package class UTXODB
         this.db.execute("CREATE TABLE IF NOT EXISTS utxo " ~
             "(hash TEXT NOT NULL PRIMARY KEY, unlock_height INTEGER NOT NULL, " ~
             "type INTEGER NOT NULL, amount INTEGER NOT NULL, " ~
-            "locktype INTEGER NOT NULL, lock BLOB NOT NULL)");
+            "locktype INTEGER NOT NULL, lock BLOB NOT NULL, " ~
+            "CHECK (unlock_height >= 0 AND amount >= 0))");
     }
 
     /***************************************************************************

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -90,12 +90,13 @@ public class ValidatorSet
             "(key TEXT, public_key TEXT, " ~
             "enrolled_height INTEGER, " ~
             "nonce TEXT, slashed_height INTEGER, stake INTEGER,
-            PRIMARY KEY (key, enrolled_height))");
+            PRIMARY KEY (key, enrolled_height), " ~
+            "CHECK (enrolled_height >= 0 AND slashed_height >= 0 AND stake >=0))");
 
         // create the table for preimages if it doesn't exist yet
         this.db.execute("CREATE TABLE IF NOT EXISTS preimages " ~
             "(key TEXT, height INTEGER, preimage TEXT,
-            PRIMARY KEY (key))");
+            PRIMARY KEY (key), CHECK (height >= 0))");
     }
 
     /***************************************************************************


### PR DESCRIPTION
Fixes #830 
Sqlite does not have unsigned data types so it is better to ensure that negative values can never be stored in columns that Agora uses to store unsigned values.