### PR TITLE
Fixes Issue2656: Add missing signatures if possible on fetched blocks and headers

### DIFF
--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -127,6 +127,31 @@ public struct BlockHeader
 
     /***************************************************************************
 
+        Returns:
+            a copy of this block header with a different signature and
+            validators bitmask
+
+        Params:
+            signature = new signature
+            validators = mask to indicate who has signed
+
+    ***************************************************************************/
+
+    public BlockHeader updateSignature (in Signature signature,
+        BitMask validators) const @safe
+    {
+        return BlockHeader(
+                this.prev_block,
+                this.merkle_root,
+                signature,
+                validators,
+                this.height,
+                this.preimages.dup,
+                this.enrollments.dup);
+    }
+
+    /***************************************************************************
+
         Verify that the provided signature is a valid signature for `pubkey`
 
         This function only checks that `sig` is valid for `pubkey`.
@@ -242,7 +267,8 @@ public struct Block
     /***************************************************************************
 
         Returns:
-            a copy of this block with a different signature and validators bitmask
+            a copy of this block with an updated header with different signature
+            and validators bitmask
 
         Params:
             signature = new signature
@@ -253,15 +279,25 @@ public struct Block
     public Block updateSignature (in Signature signature, BitMask validators)
         const @safe
     {
+        return updateHeader(this.header.updateSignature(signature, validators));
+    }
+
+    /***************************************************************************
+
+        Returns:
+            a copy of this block with an updated header
+
+        Params:
+            signature = new signature
+            validators = mask to indicate who has signed
+
+    ***************************************************************************/
+
+    public Block updateHeader (BlockHeader header)
+        const @safe
+    {
         return Block(
-            BlockHeader(
-                this.header.prev_block,
-                this.header.merkle_root,
-                signature,
-                validators,
-                this.header.height,
-                this.header.preimages.dup,
-                this.header.enrollments.dup),
+            header,
             // TODO: Optimize this by using dup for txs also
             this.txs.map!(tx =>
                 tx.serializeFull.deserializeFull!Transaction).array,

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -70,6 +70,12 @@ public struct BlockHeader
         return rng.empty ? Hash.init : rng.reduce!((a, b) => hashMulti(a, b));
     }
 
+    /// Create a mutable clone
+    public BlockHeader clone () const @safe
+    {
+        return this.serializeFull.deserializeFull!BlockHeader;
+    }
+
     /// Enrolled validators
     public Enrollment[] enrollments;
 
@@ -293,11 +299,11 @@ public struct Block
 
     ***************************************************************************/
 
-    public Block updateHeader (BlockHeader header)
+    public Block updateHeader (in BlockHeader header)
         const @safe
     {
         return Block(
-            header,
+            header.clone(),
             // TODO: Optimize this by using dup for txs also
             this.txs.map!(tx =>
                 tx.serializeFull.deserializeFull!Transaction).array,

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -763,7 +763,7 @@ extern(D):
 
     ***************************************************************************/
 
-    public Signature signBlock (in Block block) @safe nothrow
+    protected Signature signBlock (in Block block) @safe nothrow
     {
         return block.header.sign(this.kp.secret,
             this.enroll_man.getOurPreimage(block.header.height));

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -353,7 +353,7 @@ public class NetworkClient
 
     ***************************************************************************/
 
-    public void sendBlockSignature (ValidatorBlockSig block_sig) nothrow
+    public void sendBlockSignature (ValidatorBlockSig block_sig) @trusted nothrow
     {
         this.gossip_queue.insertBack(GossipEvent(block_sig));
         this.gossip_timer.rearm(GossipDelay, Periodic.No);

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -1023,7 +1023,8 @@ public class NetworkManager
 
     ***************************************************************************/
 
-    public BlockHeader[] getMissingBlockSigs (Ledger ledger) @safe nothrow
+    public void getMissingBlockSigs (Ledger ledger,
+        scope void delegate(const(BlockHeader)) @safe acceptHeader) @safe nothrow
     {
         import std.algorithm;
         import std.conv;
@@ -1031,8 +1032,6 @@ public class NetworkManager
         import std.typecons;
 
         size_t[Height] signed_validators;
-
-        BlockHeader[] headers_updated;
 
         try
         {
@@ -1071,8 +1070,7 @@ public class NetworkManager
                                 try
                                 {
                                     log.trace("getMissingBlockSigs: updating header signature: {} validators: {}", header.signature, header.validators);
-                                    ledger.updateBlockMultiSig(header);
-                                    headers_updated ~= header;
+                                    acceptHeader(header);
                                 }
                                 catch (Exception e)
                                 {
@@ -1095,7 +1093,6 @@ public class NetworkManager
         {
             log.error("getMissingBlockSigs: Exception thrown : {}", e.msg);
         }
-        return headers_updated;
     }
 
     /// Shut down timers & dump the metadata

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -1249,7 +1249,7 @@ public class NetworkManager
 
     ***************************************************************************/
 
-    public void gossipBlockSignature (ValidatorBlockSig block_sig) nothrow
+    public void gossipBlockSignature (ValidatorBlockSig block_sig) @safe nothrow
     {
         log.trace("Gossip block signature {} for height #{} node {}",
             block_sig.signature, block_sig.height , block_sig.utxo);

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -513,12 +513,29 @@ public class FullNode : API
         this.network.getUnknownTXs(this.ledger);
         try
         {
-            this.network.getMissingBlockSigs(this.ledger).each!(h => pushBlockHeader(h));
+            this.network.getMissingBlockSigs(this.ledger, &this.acceptHeader);
         }
         catch (Exception e)
         {
             log.error("Error sending updated block headers:{}", e);
         }
+    }
+
+    /***************************************************************************
+
+        Push the header to upstream servers.
+
+        For Validators this is overridden so that it also adds missing
+        signatures it has stored.
+
+        Params:
+            header = the block header to distribute
+
+    ***************************************************************************/
+
+    protected void acceptHeader (const(BlockHeader) header) @safe
+    {
+        this.pushBlockHeader(header);
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -390,14 +390,7 @@ public class Validator : FullNode, API
         auto sig = this.nominator.signBlock(block);
         assert(node_validator_index < block.header.validators.count,
             format!"The validator index %s is invalid"(node_validator_index));
-        if (signed_validators[node_validator_index])
-        {
-            log.trace("This node's signature is already in the block signature");
-            // Gossip this signature as it may have been only shared via ballot signing
-            this.network.gossipBlockSignature(
-                ValidatorBlockSig(block.header.height, this_utxo, sig.R));
-        }
-        else
+        if (!signed_validators[node_validator_index])
         {
             if (this.nominator.safeToSign(block.header.height))
             {

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -135,7 +135,7 @@ unittest
     auto txes = genesisSpendable().takeExactly(1).map!(txb => txb.sign()).array();
     txes.each!(tx => last_node.postTransaction(tx));
     // Trigger generation of block
-    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
+    network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(1));
     // Make sure the client we will check is in sync with others (except for byzantine)
     network.assertSameBlocks(iota(1, GenesisValidators), Height(1));
     assertValidatorsBitmask(last_node.getAllBlocks()[1]);
@@ -158,7 +158,7 @@ unittest
     auto txes = genesisSpendable().takeExactly(1).map!(txb => txb.sign()).array();
     txes.each!(tx => last_node.postTransaction(tx));
     // Trigger generation of block
-    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
+    network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(1));
     // Make sure the client we will check is in sync with others (except for byzantine)
     network.assertSameBlocks(iota(1, GenesisValidators), Height(1));
     assertValidatorsBitmask(last_node.getAllBlocks()[1]);

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -211,6 +211,7 @@ unittest
 {
     TestConf conf;
     conf.consensus.quorum_threshold = 66;
+    conf.node.max_retries = 2; // less retries as two are sleeping later
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();


### PR DESCRIPTION
When we fetch blocks or block headers from other nodes we can add any missing signatures we have stored. This will help to ensure that signatures are added more efficiently.