### PR TITLE
NetMan: Clean up and simplify bookkeeping of apis and addresses

### DIFF
--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -104,7 +104,7 @@ public class NetworkClient
         No,
 
         ///
-        Yes
+        Yes,
     }
 
     /// Address of the node we're interacting with (for logging)

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -1239,7 +1239,7 @@ public class NetworkManager
 
     ***************************************************************************/
 
-    public NetworkClient getNetworkClient (ITaskManager taskman,
+    protected NetworkClient getNetworkClient (ITaskManager taskman,
         BanManager banman, Address address, agora.api.Validator.API api,
         Duration retry, size_t max_retries)
     {


### PR DESCRIPTION
While working on the DNS client, I inevitably ended up in the registry.
One thing that stood up, when trying to find the best fit for the client, was the bookkeeping around apis and addresses, which is the result of years of iterative design. It was very obvious in things like `attemptRequest` when it took the `API[]` by argument, despite it being reachable via the class reference, but still used the class reference to access the addresses.