### PR TITLE
Extend timer interface

### DIFF
--- a/source/agora/common/Task.d
+++ b/source/agora/common/Task.d
@@ -140,4 +140,15 @@ public interface ITimer
     ***************************************************************************/
 
     void rearm (Duration timeout, bool periodic) nothrow;
+
+    /***************************************************************************
+
+        See_also: https://vibed.org/api/vibe.core.core/Timer.pending
+
+        Returns:
+            True if timer is armed and pending to fire
+
+    ***************************************************************************/
+
+    public bool pending () @safe nothrow;
 }

--- a/source/agora/common/Task.d
+++ b/source/agora/common/Task.d
@@ -91,6 +91,22 @@ public abstract class ITaskManager
 
     /***************************************************************************
 
+        Creates a new timer without arming it
+
+        See_Also: https://vibed.org/api/vibe.core.core/createTimer
+
+        Params:
+            dg = This delegate will be called when the timer fires
+
+        Returns:
+            An `ITimer` interface with the ability to control the timer
+
+    ***************************************************************************/
+
+    public ITimer createTimer (void delegate() nothrow @safe dg) nothrow;
+
+    /***************************************************************************
+
         Log out the request stats
 
     ***************************************************************************/

--- a/source/agora/common/VibeTask.d
+++ b/source/agora/common/VibeTask.d
@@ -86,4 +86,10 @@ private final class VibedTimer : ITimer
     {
         this.timer.rearm(timeout, periodic);
     }
+
+    /// Ditto
+    public override bool pending () @safe nothrow
+    {
+        return this.timer.pending();
+    }
 }

--- a/source/agora/common/VibeTask.d
+++ b/source/agora/common/VibeTask.d
@@ -51,6 +51,13 @@ public final class VibeTaskManager : ITaskManager
         assert(dg !is null, "Cannot call this delegate if null");
         return new VibedTimer(vibe.core.core.setTimer(timeout, dg, periodic));
     }
+
+    ///
+    public override ITimer createTimer (void delegate() nothrow @safe dg) nothrow
+    {
+        assert(dg !is null, "Cannot call this delegate if null");
+        return new VibedTimer(vibe.core.core.createTimer(dg));
+    }
 }
 
 /*******************************************************************************

--- a/source/agora/common/VibeTask.d
+++ b/source/agora/common/VibeTask.d
@@ -30,8 +30,10 @@ public final class VibeTaskManager : ITaskManager
         vibe.core.core.runTask(dg);
     }
 
+    @safe nothrow:
+
     ///
-    public override void wait (Duration dur) nothrow
+    public override void wait (Duration dur)
     {
         try
             vibe.core.core.sleep(dur);
@@ -44,8 +46,11 @@ public final class VibeTaskManager : ITaskManager
     }
 
     ///
-    public override ITimer setTimer (Duration timeout, void delegate() dg,
-        Periodic periodic = Periodic.No) nothrow
+    alias setTimer = typeof(super).setTimer;
+
+    ///
+    public override ITimer setTimer (Duration timeout, SafeTimerHandler dg,
+        Periodic periodic = Periodic.No)
     {
         this.tasks_started++;
         assert(dg !is null, "Cannot call this delegate if null");
@@ -53,7 +58,10 @@ public final class VibeTaskManager : ITaskManager
     }
 
     ///
-    public override ITimer createTimer (void delegate() nothrow @safe dg) nothrow
+    alias createTimer = typeof(super).createTimer;
+
+    ///
+    public override ITimer createTimer (SafeTimerHandler dg)
     {
         assert(dg !is null, "Cannot call this delegate if null");
         return new VibedTimer(vibe.core.core.createTimer(dg));
@@ -70,25 +78,27 @@ private final class VibedTimer : ITimer
 {
     private vibe.core.core.Timer timer;
 
-    public this (vibe.core.core.Timer timer) @safe nothrow
+    @safe nothrow:
+
+    public this (vibe.core.core.Timer timer)
     {
         this.timer = timer;
     }
 
     /// Ditto
-    public override void stop () @safe nothrow
+    public override void stop ()
     {
         this.timer.stop();
     }
 
     /// Ditto
-    public override void rearm (Duration timeout, bool periodic) nothrow
+    public override void rearm (Duration timeout, bool periodic)
     {
         this.timer.rearm(timeout, periodic);
     }
 
     /// Ditto
-    public override bool pending () @safe nothrow
+    public override bool pending ()
     {
         return this.timer.pending();
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -527,6 +527,12 @@ private final class LocalRestTimer : ITimer
     {
         this.timer.rearm(timeout, periodic);
     }
+
+    /// Ditto
+    public override bool pending () @safe nothrow
+    {
+        return this.timer.pending();
+    }
 }
 
 /// We use a pair of (key, client) rather than a hashmap client[key],

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -438,6 +438,7 @@ public class LocalRestTaskManager : ITaskManager
         geod24.LocalRest.runTask(dg);
     }
 
+    @safe nothrow:
     /***************************************************************************
 
         Suspend the current task for the given duration
@@ -447,7 +448,7 @@ public class LocalRestTaskManager : ITaskManager
 
     ***************************************************************************/
 
-    public override void wait (Duration dur) nothrow
+    public override void wait (Duration dur) @trusted
     {
         geod24.LocalRest.sleep(dur);
     }
@@ -470,9 +471,11 @@ public class LocalRestTaskManager : ITaskManager
            An `ITimer` interface with the ability to control the timer
 
     ***************************************************************************/
+    alias setTimer = typeof(super).setTimer;
 
-    public override ITimer setTimer (Duration timeout, void delegate() dg,
-        Periodic periodic = Periodic.No) nothrow
+    /// Ditto
+    public override ITimer setTimer (Duration timeout,
+        SafeTimerHandler dg, Periodic periodic = Periodic.No)
     {
         this.tasks_started++;
         return new LocalRestTimer(geod24.LocalRest.setTimer(timeout, dg,
@@ -492,8 +495,10 @@ public class LocalRestTaskManager : ITaskManager
             An `ITimer` interface with the ability to control the timer
 
     ***************************************************************************/
+    alias createTimer = typeof(super).createTimer;
 
-    public override ITimer createTimer (void delegate() nothrow @safe dg) nothrow
+    /// Ditto
+    public override ITimer createTimer (SafeTimerHandler dg)
     {
         return new LocalRestTimer(geod24.LocalRest.createTimer(dg));
     }
@@ -511,25 +516,26 @@ private final class LocalRestTimer : ITimer
 
     private LocalRest.Timer timer;
 
-    public this (LocalRest.Timer timer) @safe nothrow
+    @safe nothrow:
+    public this (LocalRest.Timer timer)
     {
         this.timer = timer;
     }
 
     /// Ditto
-    public override void stop () @safe nothrow
+    public override void stop ()
     {
         this.timer.stop();
     }
 
     /// Ditto
-    public override void rearm (Duration timeout, bool periodic) nothrow
+    public override void rearm (Duration timeout, bool periodic)
     {
         this.timer.rearm(timeout, periodic);
     }
 
     /// Ditto
-    public override bool pending () @safe nothrow
+    public override bool pending ()
     {
         return this.timer.pending();
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -478,6 +478,25 @@ public class LocalRestTaskManager : ITaskManager
         return new LocalRestTimer(geod24.LocalRest.setTimer(timeout, dg,
             periodic));
     }
+
+    /***************************************************************************
+
+        Creates a new timer without arming it
+
+        Works similarly to Vibe.d's `createTimer`.
+
+        Params:
+            dg = This delegate will be called when the timer fires
+
+        Returns:
+            An `ITimer` interface with the ability to control the timer
+
+    ***************************************************************************/
+
+    public override ITimer createTimer (void delegate() nothrow @safe dg) nothrow
+    {
+        return new LocalRestTimer(geod24.LocalRest.createTimer(dg));
+    }
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Include more (useful) interfaces from Vibe.d's timer

- `createTimer`: Creating timer without arming
- `pending`: State of the timer after arming (if waiting to be fired)

With this PR, also timer handlers are converted to `@safe nothrow` delegations. Since we didn't have those attributes previously, most of the handlers are unsafe and can throw exceptions in Agora. I've forced them to be `@safe nothrow` but it became a huge change set (300+ line changes and increasing) which led to still allowing current handler types in a `trusted` attribute and logging exceptions thrown in the handler.