### PR TITLE
Fix invalid block sig byzantine

### DIFF
--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -1,7 +1,7 @@
 /*******************************************************************************
 
-    Contains Byzantine node tests, which refuse to co-operate in the
-    SCP consensus protocol in various ways.
+    Test that when a node signs the block with an invalid signature that it is
+    not included in the block multisignature.
 
     Copyright:
         Copyright (c) 2019-2021 BOSAGORA Foundation


### PR DESCRIPTION
The unit test now follows this new scheme for signing which does not include use of the Enrollment commitment anymore.

<img width="970" alt="Screen Shot 2021-12-10 at 14 22 03" src="https://user-images.githubusercontent.com/11815575/145521665-fac17354-3839-4818-83e3-e714fcceb823.png">
