### PR TITLE
Trivial: Fix quotes around date in CI config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
       id: get-date
       shell: bash
       run: |
-        echo "::set-output name=date::$(/bin/date -u "+%Y%m")"
+        echo "::set-output name=date::$(/bin/date -u '+%Y%m')"
 
     - name: 'Load GeoIP from cache'
       id: cache-geoip


### PR DESCRIPTION
Editors don't like the look of this and colorize the whole file.