### PR TITLE
Issue2653 stop nominating once confirmed

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -1245,7 +1245,7 @@ public class Ledger
             local_unknown_txs.byKey.each!(tx => this.unknown_txs.put(tx));
             log.warn("getValidTXSet: local_unknown_txs.length={}, unknown_txs.length={}",
                 local_unknown_txs.length, this.unknown_txs.length);
-            return InvalidConsensusDataReason.MayBeValid;
+            return InvalidConsensusDataReason.NotInPool;
         }
 
         return null;

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1102,6 +1102,14 @@ extern(D):
 
     public override void emitEnvelope (ref const(SCPEnvelope) envelope) nothrow
     {
+
+        // Per SCP rules, once we CONFIRM a NOMINATE; we can't
+        // nominate new values. Keep track of the biggest slot_idx we confirmed
+        // a NOMINATE on
+        if (envelope.statement.slotIndex > this.last_confirmed_height &&
+            envelope.statement.pledges.type_ == SCPStatementType.SCP_ST_CONFIRM)
+            this.last_confirmed_height = Height(envelope.statement.slotIndex);
+
         SCPEnvelope env = cast()envelope;
         log.trace("Emitting envelope: {}", scpPrettify(&envelope, &this.getQSet));
 
@@ -1117,13 +1125,6 @@ extern(D):
         }
 
         this.network.validators().each!(v => v.client.sendEnvelope(env));
-
-        // Per SCP rules, once we CONFIRM a NOMINATE; we can't
-        // nominate new values. Keep track of the biggest slot_idx we confirmed
-        // a NOMINATE on
-        if (envelope.statement.slotIndex > this.last_confirmed_height &&
-            envelope.statement.pledges.type_ == SCPStatementType.SCP_ST_CONFIRM)
-            this.last_confirmed_height = Height(envelope.statement.slotIndex);
     }
 
     /***************************************************************************

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -343,7 +343,7 @@ public class NetworkManager
             while (1)
             {
                 scope (success)
-                    this.outer.taskman.wait(this.outer.node_config.retry_delay);
+                    this.outer.taskman.wait(this.outer.node_config.network_discovery_interval);
 
                 if (this.clients.empty())
                     continue;

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -222,7 +222,7 @@ public class Validator : FullNode, API
             &this.onPreImageRevealTimer, Periodic.Yes);
 
         this.timers ~= this.taskman.setTimer(
-            this.config.validator.preimage_reveal_interval,
+            this.config.validator.preimage_catchup_interval,
             &this.preImageCatchupTask, Periodic.Yes);
 
         if (this.enroll_man.isEnrolled(this.ledger.getBlockHeight() + 1, &this.utxo_set.peekUTXO))

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1976,7 +1976,7 @@ public struct TestConf
     /// How often the validator should try to catchup for the preimages for the
     /// next block
     /// Matches the eponymous field in the `validator` section.
-    public Duration preimage_catchup_interval = 100.seconds;
+    public Duration preimage_catchup_interval = 1.seconds;
 
     /// max failed requests before a node is banned
     /// Matches the eponymous field in the `banman` section.
@@ -2141,7 +2141,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             registry_address : "http://name.registry",
             recurring_enrollment : test_conf.recurring_enrollment,
             name_registration_interval : 10.seconds,
-            preimage_reveal_interval : 1.seconds,  // check revealing frequently
+            preimage_reveal_interval : 500.msecs,  // check revealing frequently
             nomination_interval: 100.msecs,
             preimage_catchup_interval: test_conf.preimage_catchup_interval,
             cycle_seed : cycle_seed,

--- a/source/agora/test/ManyTransactions.d
+++ b/source/agora/test/ManyTransactions.d
@@ -1,0 +1,48 @@
+/*******************************************************************************
+
+    Run via:
+    $ dtest=agora.test.ManyTransactions dub test
+
+    Copyright:
+        Copyright (c) 2019-2021 BOSAGORA Foundation
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.ManyTransactions;
+
+version (unittest):
+
+import agora.test.Base;
+import agora.utils.Log;
+import agora.utils.PrettyPrinter;
+
+mixin AddLogger!();
+
+unittest
+{
+    TestConf conf;
+    conf.consensus.quorum_threshold = 100;
+    auto network = makeTestNetwork!TestAPIManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+
+    auto nodes = network.clients;
+    auto node_1 = nodes[0];
+
+    foreach (idx; 0 .. 2)
+    {
+        auto last_block = node_1.getBlock(node_1.getBlockHeight());
+        log.trace("\nExternalized {} TXs at height {}", last_block.txs.length, last_block.header.height);
+        auto txs = last_block.spendable().map!(txb => txb.split(WK.Keys.byRange.take(3).map!(kp => kp.address)).sign());
+        txs.each!(tx => node_1.postTransaction(tx));
+        log.trace("Sending {} TXs", txs.walkLength);
+        network.expectHeight(Height(node_1.getBlockHeight() + 1), 10.seconds);
+    }
+    node_1.getBlocksFrom(1, 5).each!(b => log.trace("Block: {}", b.prettify));
+}

--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -473,9 +473,15 @@ public class AgoraLayout : Appender.Layout
     {
         switch (lvl)
         {
+            // White on Cyan
+        case LogLevel.Debug:
+            return "\u001b[46mDebug\u001b[0m";
             // Cyan
         case LogLevel.Trace:
             return "\u001b[36mTrace\u001b[0m";
+            // Blue
+        case LogLevel.Verbose:
+            return "\u001b[34mVerbose\u001b[0m";
             // Green
         case LogLevel.Info:
             return "\u001b[32mInfo\u001b[0m";
@@ -490,11 +496,11 @@ public class AgoraLayout : Appender.Layout
             return "\u001b[31mFatal\u001b[0m";
 
             // The following two should never be printed,
-            // so use red and make them noticeable
+            // so use white on red and make them noticeable
         case LogLevel.None:
-            return "\u001b[31mNone\u001b[0m";
+            return "\u001b[41mNone\u001b[0m";
         default:
-            return "\u001b[31mUnknown\u001b[0m";
+            return "\u001b[41mUnknown\u001b[0m";
         }
     }
 }


### PR DESCRIPTION
If the node waits till it has gossiped an envelope to all connected peers then it may well end up nominating new data sets when it should not.