### PR TITLE
Issue2653 debug log

### DIFF
--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -541,10 +541,15 @@ public class NetworkClient
         foreach (idx; 0 .. this.max_retries)
         {
             foreach (conn; this.connections)
+            {
+                log.dbg("Client.attemptRequest '{}' to {}: {}/{}",
+                    name, conn.address, idx + 1, this.max_retries);
                 if (!this.banman.isBanned(conn.address))
                 {
                     try
                     {
+                        this.log.format(log_level, "Client.attemptRequest '{}' to {}: {}/{} SUCCESS",
+                            name, conn.address, idx + 1, this.max_retries);
                         return __traits(getMember, conn.api, name)(args);
                     }
                     catch (Exception ex)
@@ -560,8 +565,8 @@ public class NetworkClient
 
                         try
                         {
-                            this.log.format(log_level, "Request '{}' to {} failed: {}",
-                                name, conn.address, ex.message);
+                            this.log.format(log_level, "Client.attemptRequest '{}' to {}: {}/{} FAILED ({})",
+                                name, conn.address, idx +1, this.max_retries, ex.message);
                         }
                         catch (Exception ex)
                         {
@@ -570,9 +575,15 @@ public class NetworkClient
 
                     }
                 }
+            }
             if (idx + 1 < this.max_retries) // wait after each failure except last
+            {
+                log.dbg("Client.attemptRequest '{}' to all {} connections {}/{} FAILED - wait {} before retry",
+                    name, this.connections.length, idx + 1, this.max_retries, this.retry_delay);
                 this.taskman.wait(this.retry_delay);
+            }
         }
+        log.info("Client.attemptRequest '{}' to all {} connections FAILED after {} retries", name, this.connections.length, this.max_retries);
 
         // request considered failed after max retries reached
         foreach (const ref conn; this.connections)

--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -473,9 +473,15 @@ public class AgoraLayout : Appender.Layout
     {
         switch (lvl)
         {
+            // White on Cyan
+        case LogLevel.Debug:
+            return "\u001b[46mDebug\u001b[0m";
             // Cyan
         case LogLevel.Trace:
             return "\u001b[36mTrace\u001b[0m";
+            // Blue
+        case LogLevel.Verbose:
+            return "\u001b[34mVerbose\u001b[0m";
             // Green
         case LogLevel.Info:
             return "\u001b[32mInfo\u001b[0m";
@@ -490,11 +496,11 @@ public class AgoraLayout : Appender.Layout
             return "\u001b[31mFatal\u001b[0m";
 
             // The following two should never be printed,
-            // so use red and make them noticeable
+            // so use white on red and make them noticeable
         case LogLevel.None:
-            return "\u001b[31mNone\u001b[0m";
+            return "\u001b[41mNone\u001b[0m";
         default:
-            return "\u001b[31mUnknown\u001b[0m";
+            return "\u001b[41mUnknown\u001b[0m";
         }
     }
 }


### PR DESCRIPTION
Fix color ansi output for debug and verbose logging. Add some debug logging to `agora.network.Client.attemptRequest`.