### PR TITLE
Reduce the frequency of refreshing connections

### DIFF
--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -57,9 +57,8 @@ unittest
 /// test gossiping behavior for an outsider node
 unittest
 {
-    // node #7 is the outsider, so total foreign nodes may be 6
+    // node #7 is the fullnode
     TestConf conf = { full_nodes : 1 };
-    conf.node.max_listeners = 6;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();
@@ -71,10 +70,9 @@ unittest
 
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
 
-    auto send_txs = txs[0 .. $ - 1];  // 1 short of making a block (don't start consensus)
-    send_txs.each!(tx => node_1.postTransaction(tx));
+    txs.each!(tx => node_1.postTransaction(tx));
     nodes.each!(node =>
-       send_txs.each!(tx =>
+       txs.each!(tx =>
            node.hasTransactionHash(hashFull(tx)).retryFor(5.seconds)
     ));
 }

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -34,8 +34,10 @@ unittest
     foreach (key, node; network.nodes)
     {
         auto addresses = node.client.getNodeInfo().addresses.keys;
-        assert(addresses.sort.uniq.count >= GenesisValidators - 1,  // >= since it may connect to itself (#772)
-               format("Node %s has %d peers: %s", key, addresses.length, addresses));
+        const expectedCount = network.nodes.count + 1; // include name registry
+        assert(addresses.sort.uniq.count == expectedCount,
+            format("Node %s has %d peers but expected %d: %s",
+                key, addresses.length, expectedCount, addresses));
     }
 }
 
@@ -84,8 +86,10 @@ unittest
     foreach (key, node; network.nodes)
     {
         auto addresses = node.client.getNodeInfo().addresses.keys;
-        assert(addresses.sort.uniq.count >= GenesisValidators - 1,  // >= since it may connect to itself (#772)
-               format("Node %s has %d peers: %s", key, addresses.length, addresses));
+        const expectedCount = network.nodes.count + 1; // include name registry
+        assert(addresses.sort.uniq.count == expectedCount,
+               format("Node %s has %d peers but expected %d: %s",
+                key, addresses.length, expectedCount, addresses));
     }
 }
 

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -50,19 +50,19 @@ unittest
         full_nodes : 4,
     };
     conf.node.min_listeners = 9;
-    conf.node.network_discovery_interval = 2.seconds;
-    conf.node.retry_delay = 250.msecs;
+    conf.node.network_discovery_interval = 1.seconds;
     auto network = makeTestNetwork!TestAPIManager(conf);
 
     network.start();
     scope(exit) network.shutdown();
     scope(failure) network.printLogs();
-    network.waitForDiscovery();
+    network.waitForDiscovery;
 
     foreach (key, node; network.nodes)
     {
         auto addresses = node.client.getNodeInfo().addresses.keys;
-        assert(addresses.sort.uniq.count >= 9,  // >= since it may connect to itself (#772)
+        // It can connect to between min of 9 and max of 6 validators + 4 fullnode + registry
+        assert(addresses.sort.uniq.count >= 9 && addresses.sort.uniq.count <= 11,
                format("Node %s has %d peers: %s", key, addresses.length, addresses));
     }
 }


### PR DESCRIPTION
By using the `network_discovery_interval` duration which is usually set
to a larger duration than the `retry_delay`.