### PR TITLE
Use and adjust for tests the pre-image catchup interval

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -222,7 +222,7 @@ public class Validator : FullNode, API
             &this.onPreImageRevealTimer, Periodic.Yes);
 
         this.timers ~= this.taskman.setTimer(
-            this.config.validator.preimage_reveal_interval,
+            this.config.validator.preimage_catchup_interval,
             &this.preImageCatchupTask, Periodic.Yes);
 
         if (this.enroll_man.isEnrolled(this.ledger.getBlockHeight() + 1, &this.utxo_set.peekUTXO))

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1976,7 +1976,7 @@ public struct TestConf
     /// How often the validator should try to catchup for the preimages for the
     /// next block
     /// Matches the eponymous field in the `validator` section.
-    public Duration preimage_catchup_interval = 100.seconds;
+    public Duration preimage_catchup_interval = 1.seconds;
 
     /// max failed requests before a node is banned
     /// Matches the eponymous field in the `banman` section.


### PR DESCRIPTION
The timer was incorrectly armed using the `preimage_reveal_interval`.