### PR TITLE
Do not throw away commit envelopes when missing tx

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -1245,7 +1245,7 @@ public class Ledger
             local_unknown_txs.byKey.each!(tx => this.unknown_txs.put(tx));
             log.warn("getValidTXSet: local_unknown_txs.length={}, unknown_txs.length={}",
                 local_unknown_txs.length, this.unknown_txs.length);
-            return InvalidConsensusDataReason.MayBeValid;
+            return InvalidConsensusDataReason.NotInPool;
         }
 
         return null;


### PR DESCRIPTION
When the node has missing `tx` that are included in a `tx set` received from another node it will now return `ValidationLevel.kMaybeValidValue` in the `validateValue` which means the node has missing context to fully validate.