### PR TITLE
Make clone() available to all agora code

### DIFF
--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -24,6 +24,13 @@ import vibe.inet.url;
 
 import geod24.bitblob;
 
+/// Clone any type via the serializer
+public T clone (T)(in T input)
+{
+    import agora.serialization.Serializer;
+    return input.serializeFull.deserializeFull!T;
+}
+
 shared static this ()
 {
     registerCommonInternetSchema("agora", 2826);

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -563,7 +563,7 @@ extern(D):
 
     public void receiveEnvelope (in SCPEnvelope envelope) @trusted
     {
-        auto copied = envelope.serializeFull.deserializeFull!SCPEnvelope;
+        auto copied = envelope.clone();
         this.queued_envelopes.insertBack(copied);
         this.envelope_timer.rearm(EnvTaskDelay, Periodic.No);
     }

--- a/source/agora/flash/Types.d
+++ b/source/agora/flash/Types.d
@@ -336,13 +336,6 @@ unittest
         flashPrettify(PublicKey(Scalar.fromString(s).toPoint())));
 }
 
-/// Clone any type via the serializer
-public T clone (T)(in T input)
-{
-    import agora.serialization.Serializer;
-    return input.serializeFull.deserializeFull!T;
-}
-
 /// Rudimentary support for serializing hashmaps
 public struct SerializeMap (Value : Value[Key], Key)
 {


### PR DESCRIPTION
This convenience function for cloning via the serializer was in the flash code.