### PR TITLE
SingleNode: Update to first validator in Genesis

### DIFF
--- a/devel/config-single.yaml
+++ b/devel/config-single.yaml
@@ -29,8 +29,8 @@ consensus:
 
 validator:
   enabled: true
-  # We use first of Genesis Block enrollments: val7: boa1xrval7gwhjz4k9raqukcnv2n4rl4fxt74m2y9eay6l5mqdf4gntnzhhscrh
-  seed: SAWI3JZWDDSQR6AX4DRG2OMS26Y6XY4X2WA3FK6D5UW4WTU74GUQXRZP
+  # We use first of Genesis Block enrollments: val5: boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8
+  seed: SAZO4WA5SXUN3J6XBXZCFPXJJZ62IQAJYAG2KBVWF2QZKTU2WK3QTNMV
   registry_address: http://127.0.0.1:2826/
   addresses_to_register:
     - http://127.0.0.1:2826/


### PR DESCRIPTION
This special configuration for running a single node locally for testing
requires that the node uses the seed from the first validator in the
Genesis block. Recently this was updated but this file was out of sync.