### PR TITLE
Remove dead code in `Validator.acceptHeader`

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -385,17 +385,8 @@ public class Validator : FullNode, API
 {
         // Add any missing signatures we know
         const updated_header = this.nominator.updateMultiSignature(header);
-        if (updated_header == BlockHeader.init) // There were no signatures added
-        {
-            this.ledger.updateBlockMultiSig(header);
-            super.acceptHeader(header);
-
-        }
-        else
-        {
-            this.ledger.updateBlockMultiSig(updated_header);
-            super.acceptHeader(updated_header);
-        }
+        this.ledger.updateBlockMultiSig(updated_header);
+        super.acceptHeader(updated_header);
     }
 
     /***************************************************************************


### PR DESCRIPTION
The code in `updateMultiSignature` never returns `BlockHeader.init` so there is no need to check for it. It was using this at some point to indicate that no signatures were added, however, it is no longer the case.