### PR TITLE
Enable UnlockNotify for d2sqlite3

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -178,7 +178,11 @@
         "bitblob":          { "version": "*", "dflags" : [ "-preview=in", "-revert=dtorfields" ] },
         "config":           { "version": "*", "dflags" : [ "-preview=in", "-revert=dtorfields" ] },
         "crypto":           { "version": "*", "dflags" : [ "-preview=in", "-revert=dtorfields" ] },
-        "d2sqlite3":        { "version": "*", "dflags" : [ "-preview=in", "-revert=dtorfields" ] },
+        "d2sqlite3":        { "version": "*",
+                              "dflags" : [ "-preview=in", "-revert=dtorfields" ],
+                              "dflags-linux" : [ "--d-version=SqliteEnableUnlockNotify" ],
+                              "dflags-osx" : [ "--d-version=SqliteFakeUnlockNotify" ]
+                            },
         "dyaml":            { "version": "*", "dflags" : [ "-preview=in", "-revert=dtorfields" ] },
         "libsodiumd":       { "version": "*", "dflags" : [ "-preview=in", "-revert=dtorfields" ] },
         "localrest":        { "version": "*", "dflags" : [ "-preview=in", "-revert=dtorfields" ] },


### PR DESCRIPTION
If our DB is locked by another process, we should gracefully wait
for it to be unlocked instead of erroring right away.

This will help NODE0 in production, DB of which is also accessed by
Grafana.

Homebrew sqlite has the native support disabled so we use the fake
UnlockNotify provided by the D bindings.