### PR TITLE
Remove peer validation through Registry

### DIFF
--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -602,12 +602,6 @@ public class FlashNode : FlashControlAPI
                 return null;
             }
 
-            if (!payload.verifySignature(peer_pk))
-            {
-                log.warn("RegistryPayload signature is incorrect for {}", peer_pk);
-                return null;
-            }
-
             if (payload.data.addresses.length == 0)
                 return null;
 

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -736,11 +736,6 @@ public class NetworkManager
                             return false;
                         }
 
-                        if (!payload.verifySignature(ckey))
-                        {
-                            log.error("RegistryPayload signature is incorrect for {}: {}", ckey, payload);
-                            return false;
-                        }
                         foreach (addr; payload.data.addresses)
                             this.addAddress(addr);
                         return true;

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -657,13 +657,13 @@ private struct ZoneData
         this.query_registry_get = format("SELECT pubkey " ~
             "FROM registry_%s_signature", zone_name);
 
-        this.query_payload = format("SELECT signature, sequence, address, type, utxo " ~
+        this.query_payload = format("SELECT sequence, address, type, utxo " ~
             "FROM registry_%s_addresses l " ~
             "INNER JOIN registry_%s_signature r ON l.pubkey = r.pubkey " ~
             "WHERE l.pubkey = ?", zone_name, zone_name);
 
         this.query_signature_add = format("REPLACE INTO registry_%s_signature " ~
-            "(pubkey, signature, sequence, utxo) VALUES (?, ?, ?, ?)", zone_name);
+            "(pubkey, sequence, utxo) VALUES (?, ?, ?)", zone_name);
 
         this.query_addresses_add = format("REPLACE INTO registry_%s_addresses " ~
                     "(pubkey, address, type) VALUES (?, ?, ?)", zone_name);
@@ -675,7 +675,7 @@ private struct ZoneData
             "FROM registry_%s_addresses", zone_name);
 
         string query_sig_create = format("CREATE TABLE IF NOT EXISTS registry_%s_signature " ~
-            "(pubkey TEXT, signature TEXT NOT NULL, sequence INTEGER NOT NULL, " ~
+            "(pubkey TEXT, sequence INTEGER NOT NULL, " ~
             "utxo TEXT NOT NULL, PRIMARY KEY(pubkey))", zone_name);
 
         string query_addr_create = format("CREATE TABLE IF NOT EXISTS registry_%s_addresses " ~
@@ -882,7 +882,6 @@ private struct ZoneData
             return TypedPayload.init;
 
         const ulong sequence = results.front["sequence"].as!ulong;
-        const Signature signature = Signature.fromString(results.front["signature"].as!string);
         const Hash utxo = Hash.fromString(results.front["utxo"].as!string);
 
         const auto addresses = results.map!(r => Address(r["address"].as!string)).array;
@@ -895,7 +894,6 @@ private struct ZoneData
                 addresses : addresses,
                 seq : sequence,
             },
-            signature: signature,
         };
 
         // CNAME and A cannot exist at the same time for a node
@@ -965,7 +963,6 @@ private struct ZoneData
 
         db.execute(this.query_signature_add,
             payload.payload.data.public_key,
-            payload.payload.signature,
             payload.payload.data.seq,
             payload.utxo);
 


### PR DESCRIPTION
Current way of peer validation uses both registry and handshake for Validator nodes and just rely on registry (#2686) for Flash nodes. Relying on registry will not be achievable when we move to DNS from current GET interface and DNS has its own DNSSEC method for that. Registry itself will still validate registering nodes by signature.

Part of #2449 