### PR TITLE
Increase DNS compatibility of Registry storage

### DIFF
--- a/source/agora/api/Registry.d
+++ b/source/agora/api/Registry.d
@@ -34,8 +34,11 @@ public struct RegistryPayloadData
     /// monotonically increasing sequence number
     public ulong seq;
 
+    /// TTL of the registry record
+    public uint ttl;
+
     /// Compares payload data for equality, ignores `seq`
-    /// and permutations of `addresses` are considered as equal
+    /// and permutations of `addresses` are considered as equal, `ttl` is ignored
     bool opEquals (in RegistryPayloadData other) const nothrow @safe
     {
         return (this.public_key == other.public_key)


### PR DESCRIPTION
Secondary and caching zones will use DNS interface for registry communication. `TypedPayload` is Registry's data storage type and compatible with REST payload, this change set adds DNS payload compatibility and TTL (Time-to-Live) support for the data storage.

Part of #2449 