### PR TITLE
Report address of the object to be freed to Tracy

### DIFF
--- a/source/agora/utils/gc/GC.d
+++ b/source/agora/utils/gc/GC.d
@@ -4206,6 +4206,12 @@ debug (LOGGING)
         private void log_malloc(void *p, size_t size) nothrow
         {
             //debug(PRINTF) printf("+log_malloc(p = %p, size = %zd)\n", p, size);
+            if (OPFAIL != current.find(p))
+            {
+                debug(PRINTF) printf("Memory allocation without free'ing at %p\n", p);
+                return;
+            }
+
             Log log;
 
             log.p = p;

--- a/source/agora/utils/gc/GC.d
+++ b/source/agora/utils/gc/GC.d
@@ -2443,7 +2443,7 @@ struct Gcx
                         static foreach (w; 0 .. PageBits.length)
                             recoverPage = recoverPage && (~freebitsdata[w] == toFree[w]);
 
-                        bool hasFinalizer = false;
+                        bool hasFinalizer = true;
                         debug(COLLECT_PRINTF) // need output for each onject
                             hasFinalizer = true;
                         else debug(LOGGING)


### PR DESCRIPTION
Garbage sweeping works per-page basis but allocation is object based. Thus, object addresses is reported to Tracy and freeing also needs to report object address. Previously it was reporting page addresses to Tracy during sweeping. This is the reason why it was passing with `COLLECT_PRINTF` debug flag.

Fixes #2778 