### PR TITLE
Part of Issue 2785: Unit test for many quorums

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -180,7 +180,7 @@ public class Validator : FullNode, API
 
     ***************************************************************************/
 
-    private void rebuildQuorumConfig (ref QuorumConfig[NodeID]quorums,
+    private void rebuildQuorumConfig (ref QuorumConfig[NodeID] quorums,
         in Hash[] utxos, Height height) @safe
     {
         import std.algorithm;

--- a/source/agora/test/ManyQuorums.d
+++ b/source/agora/test/ManyQuorums.d
@@ -1,0 +1,31 @@
+/*******************************************************************************
+
+    Contains test for multiple quorums
+
+    Run via:
+    $ dtest=agora.test.ManyQuorums dub test
+
+    Copyright:
+        Copyright (c) 2019-2022 BOSAGORA Foundation
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.ManyQuorums;
+
+version (unittest):
+
+import agora.test.Base;
+import agora.test.Simple: simpleTest;
+
+/// Simple test
+unittest
+{
+    TestConf conf;
+    conf.consensus.max_quorum_nodes = 3;
+    conf.consensus.payout_period = 10;
+    simpleTest(conf);
+}

--- a/source/agora/test/Simple.d
+++ b/source/agora/test/Simple.d
@@ -28,7 +28,11 @@ unittest
 {
     TestConf conf;
     conf.consensus.payout_period = 10;
+    simpleTest(conf);
+}
 
+public void simpleTest (TestConf conf)
+{
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();


### PR DESCRIPTION
This starts with max quorum size of 3 nodes.
More tests to be added with some outsider validators to create more quorums.