### PR TITLE
Log success in `attemptRequest` only if it succeeds.

### DIFF
--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -548,7 +548,7 @@ public class NetworkClient
                 {
                     try
                     {
-                        this.log.format(log_level, "Client.attemptRequest '{}' to {}: {}/{} SUCCESS",
+                        scope (success) this.log.format(log_level, "Client.attemptRequest '{}' to {}: {}/{} SUCCESS",
                             name, conn.address, idx + 1, this.max_retries);
                         return __traits(getMember, conn.api, name)(args);
                     }


### PR DESCRIPTION
Use `scope (success)` to only log when it exits the scope without exception.
Currently it is misleading when debug logging is enabled as it show SUCCESS even when it fails:-
```
2022-01-04 01:24:05,429 Debug [agora.network.Client] - Client.attemptRequest 'handshake' to :: 1/10
2022-01-04 01:24:05,429 Trace [agora.network.Client] - Client.attemptRequest 'handshake' to :: 1/10 SUCCESS
2022-01-04 01:24:05,430 Trace [agora.network.Client] - Client.attemptRequest 'handshake' to :: 1/10 FAILED (Error writing data to socket.)
```