### PR TITLE
Registry: Compare record domains in case-insensitive manner

### DIFF
--- a/source/agora/common/DNS.d
+++ b/source/agora/common/DNS.d
@@ -920,6 +920,23 @@ public struct Domain
             this.value = cast(string) (v ~ '.');
     }
 
+    size_t toHash () const @safe pure nothrow
+    {
+        import std.ascii : toLower;
+        char[255] buffer;
+
+        foreach (ix, char c; this.value)
+            buffer[ix] = toLower(c);
+
+        return buffer.hashOf;
+    }
+
+    bool opEquals (in Domain other) const nothrow @safe
+    {
+        import std.uni : sicmp;
+        return (sicmp(other.value, value) == 0);
+    }
+
     /// Returns: A forward range allowing to iterate by label
     /// Iteration is done in reverse order from the string ordering,
     /// meaning for `bosagora.io.`, the initialized state is root (empty string)

--- a/source/agora/crypto/Bech32.d
+++ b/source/agora/crypto/Bech32.d
@@ -129,17 +129,12 @@ public DecodeResult decodeBech32 (in char[] str)
 {
     import std.conv;
 
-    bool lower = false, upper = false;
     for (size_t i = 0; i < str.length; ++i)
     {
         ubyte c = str[i];
-        if (c >= 'a' && c <= 'z') lower = true;
-        else if (c >= 'A' && c <= 'Z') upper = true;
-        else
-            ensure(c >= '!' && c <= '~',
-                    "Character '{X}' at pos {} is outside of valid char range", c, i);
+        ensure(c >= '!' && c <= '~',
+                "Character '{X}' at pos {} is outside of valid char range", c, i);
     }
-    ensure(lower ^ upper, "Bech32 does not allow mixed lower and upper cases");
 
     auto pos = lastIndexOf(str, '1');
     ensure(str.length <= 90 && pos != -1 && pos != 0 && pos + 7 <= str.length,

--- a/source/agora/crypto/Key.d
+++ b/source/agora/crypto/Key.d
@@ -196,8 +196,12 @@ public struct PublicKey
     unittest
     {
         immutable address = `boa1xrv266cegdthdc87uche9zvj8842shz3sdyvw0qecpgeykyv4ynssuz4lg0`;
+        immutable uAddress = `bOA1xrv266cegdthdc87uche9zvj8842shz3SDYvw0qecpgeykyv4ynssuz4lg0`;
         PublicKey pubkey = PublicKey.fromString(address);
+        PublicKey uPubkey = PublicKey.fromString(uAddress);
         assert(pubkey.toString() == address);
+        assert(uPubkey == pubkey);
+        assert(uPubkey.toString() == address);
         assertThrown(PublicKey.fromString(  // bad length
             "boa1xrv266cegdthdc87uche9zvj8842shz3sdyvw0qecpgeykyv4ynssuz4lg"));
         assertThrown(PublicKey.fromString(  // bad version byte


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.3

Fixes #2786 

Bech32 changeset is required to prevent disrupting secondary registry implementation (i.e. zone transferring)