### PR TITLE
DNS: More validation in Domain

### DIFF
--- a/source/agora/common/DNS.d
+++ b/source/agora/common/DNS.d
@@ -740,11 +740,12 @@ public struct ResourceRecord
             deserializeFull!(TYPE)(&ctx.read, ctx.options),
             deserializeFull!(CLASS)(&ctx.read, ctx.options),
             deserializeFull!(uint)(&ctx.read, ctx.options),
+            T.RDATA(null),
         );
 
         auto rdlength = deserializeFull!(ushort)(&ctx.read, ctx.options);
 
-        ResourceRecord.RDATA tmp_data;
+        ResourceRecord.RDATA tmp_data = null;
         () @trusted
         {
             switch (tmp.type)
@@ -894,7 +895,8 @@ public struct OPTRR
 
     ***************************************************************************/
 
-    public ResourceRecord record = ResourceRecord(Domain.init, TYPE.OPT, cast(CLASS) 4096);
+    public ResourceRecord record = ResourceRecord(
+        Domain.init, TYPE.OPT, cast(CLASS) 4096, 0, ResourceRecord.RDATA(null));
 
     /// Requestor's UDP payload size
     public ushort payloadSize () scope const

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -516,16 +516,16 @@ unittest
 /// Converts a `ZoneConfig` to an `SOA` record
 private SOA fromConfig (in ZoneConfig zone, Domain name, uint serial) @safe pure
 {
-    SOA soa;
-    soa.mname = Domain(zone.primary);
-    soa.rname = Domain(zone.soa.email.value.replace('@', '.'));
-    soa.serial = serial;
-    // Casts are safe as the values are validated during config parsing
-    soa.refresh = cast(int) zone.soa.refresh.total!"seconds";
-    soa.retry = cast(int) zone.soa.retry.total!"seconds";
-    soa.expire = cast(int) zone.soa.expire.total!"seconds";
-    soa.minimum = cast(uint) zone.soa.minimum.total!"seconds";
-    return soa;
+    return SOA(
+        // mname, rname
+        Domain(zone.primary), Domain(zone.soa.email.value.replace('@', '.')),
+        serial,
+        // Casts are safe as the values are validated during config parsing
+        cast(int) zone.soa.refresh.total!"seconds",
+        cast(int) zone.soa.retry.total!"seconds",
+        cast(int) zone.soa.expire.total!"seconds",
+        cast(uint) zone.soa.minimum.total!"seconds",
+    );
 }
 
 /// Internal registry data


### PR DESCRIPTION
```
Properly validate the domain name when creating an instance.
There are now two ways to create a Domain:
- `fromSafeString`: Will validate its argument and `Domain` will be
  a wrapper around it.
- `fromString`: Does what the constructor was previously doing,
  plus some extra validation. Will always duplicate the input.

The constructor has been disabled has it was too error prone.
```

@mkykadir : I am not too happy about how this looks, so suggestions are welcome.
The main idea is that we should have a way to instantiate a Domain from a pre-validated string without allocating.