### PR TITLE
Registry: Extract public key from domain with new function

### DIFF
--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -593,10 +593,9 @@ private struct TypedPayload
 
     ***************************************************************************/
 
-    public static TypedPayload make (ResourceRecord rr,
-        PublicKey delegate(in char[]) const scope @safe pubKeyParser)
+    public static TypedPayload make (ResourceRecord rr)
     {
-        auto public_key = pubKeyParser(rr.name.value);
+        auto public_key = rr.name.value.extractPublicKey();
         assert(public_key != PublicKey.init,
             "PublicKey cannot be extracted from domain");
 


### PR DESCRIPTION
PR #2788 updated the way `PublicKey` parsed from `Domain`

This update is needed for #2703 