### PR TITLE
Nominator: Use hasMajoritySignature instead of inlining it

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -477,17 +477,12 @@ extern(D):
             return;
         }
 
-        if (slot_idx > 1) // Genesis block is not signed
+        if (!this.ledger.hasMajoritySignature(this.ledger.getBlockHeight()))
         {
-            auto last_block = this.ledger.getLastBlock();
-            auto signed = last_block.header.validators;
-            if (signed.setCount <= signed.count() / 2)
-            {
-                this.log.trace(
-                    "checkNominate(): Require more than half signed last block, signed={}",
-                    signed);
-                return;
-            }
+            this.log.trace(
+                "checkNominate(): Last block ({}) doesn't have majority signatures, signed={}",
+                this.ledger.getBlockHeight(), this.ledger.getLastBlock().header.validators);
+            return;
         }
 
         ConsensusData data;


### PR DESCRIPTION
I saw an assert getting triggered in the tests:
<img width="1258" alt="Screen Shot 2022-01-06 at 9 33 57" src="https://user-images.githubusercontent.com/2180215/148315392-2764c0d6-fd8d-44c3-bd3a-2c9842e26f77.png">

Since this should never happen, the first step was to look at the code and notice the duplication. I'm not sure that it will solve the issue, but it's a step forward.
