### PR TITLE
ValidatorCleanRestart: Raise the timeout from 10 to 30 seconds

### DIFF
--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -421,7 +421,8 @@ private void runTCPDNSServer_canThrow (TCPConnection conn, NameRegistry registry
         auto query = deserializeFull!Message(buffer[0 .. size]);
         registry.answerQuestions(
             query,
-            (in Message msg) @safe => msg.serializePart(writer, CompactMode.No));
+            (in Message msg) @safe => msg.serializePart(writer, CompactMode.No),
+            true);
 
         // Write the length at the begining
         assert(length >= 2);

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -164,5 +164,5 @@ unittest
 
     // The new block has been inserted to the ledger with the approval
     // of the node_1, although node_2 was shutdown.
-    network.expectHeightAndPreImg(Height(4), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(4), network.blocks[0].header, 30.seconds);
 }

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -25,8 +25,13 @@ import agora.consensus.protocol.Nominator;
 import agora.crypto.Hash;
 import agora.consensus.Ledger;
 
+import std.stdio;
+
 unittest
 {
+    writeln("+First unittest"); stdout.flush();
+    scope (exit) { writeln("-First unittest"); stdout.flush(); }
+
     TestConf conf;
     conf.consensus.quorum_threshold = 100;
     auto network = makeTestNetwork!TestAPIManager(conf);
@@ -77,6 +82,9 @@ unittest
 // They should not be able to enroll and no new block should be created.
 unittest
 {
+    writeln("+Second unittest"); stdout.flush();
+    scope (exit) { writeln("-Second unittest"); stdout.flush(); }
+
     import std.exception;
     import core.exception : AssertError;
 
@@ -151,7 +159,11 @@ unittest
 // create another enrollment request for the next block
 unittest
 {
+    writeln("+Third unittest"); stdout.flush();
+    scope (exit) { writeln("-Third unittest"); stdout.flush(); }
+
     import std.algorithm.mutation : reverse;
+
     static class SocialDistancingNominator : Nominator
     {
         mixin ForwardCtor!();
@@ -209,6 +221,9 @@ unittest
 // still manage to enroll when they are back online
 unittest
 {
+    writeln("+Fourth unittest"); stdout.flush();
+    scope (exit) { writeln("-Fourth unittest"); stdout.flush(); }
+
     TestConf conf;
     conf.consensus.quorum_threshold = 66;
     conf.node.max_retries = 2; // less retries as two are sleeping later
@@ -271,6 +286,9 @@ unittest
 // No validator will willingly re-enroll until the network is stuck
 unittest
 {
+    writeln("+Fifth unittest"); stdout.flush();
+    scope (exit) { writeln("-Fifth unittest"); stdout.flush(); }
+
     static class BatValidator : TestValidatorNode
     {
         mixin ForwardCtor!();
@@ -304,6 +322,9 @@ unittest
 // Make a validator recur enrollment in the middle of generating blocks
 unittest
 {
+    writeln("+Sixth unittest"); stdout.flush();
+    scope (exit) { writeln("-Sixth unittest"); stdout.flush(); }
+
     TestConf conf = {
         recurring_enrollment : false,
     };


### PR DESCRIPTION
This test often errors out, possibly because it runs too slowly.
This is an attempt at finding out if that is the case or if there
is another cause for the frequent failures.