### PR TITLE
Reduce the pre-image flood

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -312,9 +312,12 @@ public interface API
         Params:
             preimage = a PreImageInfo object which contains a hash and a height
 
+        Returns:
+            the height of the pre-image that is currently stored
+
     ***************************************************************************/
 
-    public void postPreimage (in PreImageInfo preimage);
+    public Height postPreimage (in PreImageInfo preimage);
 
     /***************************************************************************
 

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -1102,7 +1102,7 @@ public class FullNode : API
     }
 
     /// POST /preimage
-    public override void postPreimage (in PreImageInfo preimage) @safe
+    public override Height postPreimage (in PreImageInfo preimage) @safe
     {
         this.recordReq("postPreimage");
         log.trace("Received Preimage: {}", prettify(preimage));
@@ -1113,6 +1113,8 @@ public class FullNode : API
             this.network.peers.each!(p => p.client.sendPreimage(preimage));
             this.pushPreImage(preimage);
         }
+
+        return this.enroll_man.getValidatorPreimage(preimage.utxo).height;
     }
 
     /// GET: /preimages

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2009,6 +2009,12 @@ public struct TestConf
     /// Matches the eponymous field in the `validator` section.
     public Duration preimage_catchup_interval = 1.seconds;
 
+    // How often we should check for pre-images to reveal
+    public Duration preimage_reveal_interval = 1.seconds;
+
+    // How far in the future (in unit of blocks) pre-images can be revealed
+    public size_t max_preimage_reveal = 6;
+
     /// max failed requests before a node is banned
     /// Matches the eponymous field in the `banman` section.
     public size_t max_failed_requests = 100;
@@ -2172,8 +2178,9 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             registry_address : "http://name.registry",
             recurring_enrollment : test_conf.recurring_enrollment,
             name_registration_interval : 10.seconds,
-            preimage_reveal_interval : 1.seconds,  // check revealing frequently
+            preimage_reveal_interval : test_conf.preimage_reveal_interval,
             nomination_interval: 100.msecs,
+            max_preimage_reveal: test_conf.max_preimage_reveal,
             preimage_catchup_interval: test_conf.preimage_catchup_interval,
             cycle_seed : cycle_seed,
             cycle_seed_height : cycle_seed_height,

--- a/source/agora/test/PreImageNoFlood.d
+++ b/source/agora/test/PreImageNoFlood.d
@@ -1,0 +1,124 @@
+/*******************************************************************************
+
+    Test for the flood of the posting pre-images not happening
+
+    Copyright:
+        Copyright (c) 2019-2022 BOSAGORA Foundation
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module agora.test.PreImageNoFlood;
+
+version (unittest):
+
+import agora.consensus.data.PreImageInfo;
+import agora.test.Base;
+
+import core.atomic;
+import core.thread;
+
+/// A validator should not receive the `postPreimage` calls after it has
+/// already received the same pre-images so that the flood of the posting
+/// pre-images does not happen.
+unittest
+{
+    static class CustomValidator : TestValidatorNode
+    {
+        mixin ForwardCtor!();
+
+        // The pointer to the number of the times the `postPreimage` is called
+        private shared int* post_preimage_count;
+
+        ///
+        public this (Parameters!(TestValidatorNode.__ctor) args,
+            shared(int)* count)
+        {
+            this.post_preimage_count = count;
+            super(args);
+        }
+
+        /// This overridden function counts the number to be called
+        public override Height postPreimage (in PreImageInfo preimage) @safe
+        {
+            atomicOp!("+=")(*this.post_preimage_count, 1);
+            return super.postPreimage(preimage);
+        }
+    }
+
+    static class CustomAPIManager : TestAPIManager
+    {
+        mixin ForwardCtor!();
+
+        // The number of times the `postPreimage` is called
+        public static shared int post_preimage_count;
+
+        /// set base class
+        public override void createNewNode (Config conf, string file, int line)
+        {
+            if (this.nodes.length == 0)
+                this.addNewNode!CustomValidator(conf, &post_preimage_count,
+                    file, line);
+            else
+                super.createNewNode(conf, file, line);
+        }
+    }
+
+    TestConf config;
+    auto network = makeTestNetwork!CustomAPIManager(config);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+    network.generateBlocks(Height(1));
+
+    // The count of calling `postPreimage` does not change after a while
+    Thread.sleep(config.preimage_reveal_interval);
+    auto prev_post_count = atomicLoad(CustomAPIManager.post_preimage_count);
+    Thread.sleep(config.preimage_reveal_interval * 2);
+    assert(atomicLoad(CustomAPIManager.post_preimage_count) ==
+        prev_post_count);
+}
+
+/// A validator should retrieve the pre-images even when the `postPreimage`
+/// does not work or the validator misses some pre-images. And the network
+/// must generate a block at the height of the `conf.max_preimage_reveal`
+/// plus one.
+unittest
+{
+    static class CustomValidator : TestValidatorNode
+    {
+        mixin ForwardCtor!();
+
+        /// It makes the situation where a node receives no pre-image
+        public override Height postPreimage (in PreImageInfo preimage) @safe
+        {
+            return preimage.height;
+        }
+    }
+
+    static class CustomAPIManager : TestAPIManager
+    {
+        mixin ForwardCtor!();
+
+        /// set base class
+        public override void createNewNode (Config conf, string file, int line)
+        {
+            if (this.nodes.length == 0)
+                this.addNewNode!CustomValidator(conf);
+            else
+                super.createNewNode(conf, file, line);
+        }
+    }
+
+    TestConf conf;
+    auto network = makeTestNetwork!CustomAPIManager(conf);
+    network.start();
+    scope(exit) network.shutdown();
+    scope(failure) network.printLogs();
+    network.waitForDiscovery();
+    network.generateBlocks(Height(conf.max_preimage_reveal + 1));
+}

--- a/source/agora/test/PreimageSharing.d
+++ b/source/agora/test/PreimageSharing.d
@@ -31,7 +31,10 @@ public class NoActivePINode : TestValidatorNode
 
     /// To be extra sure, we also disable receiving a pre-image
     /// so that the node may gossip them
-    public override void postPreimage (in PreImageInfo preimage) @safe {}
+    public override Height postPreimage (in PreImageInfo preimage) @safe
+    {
+        return preimage.height;
+    }
 }
 
 unittest


### PR DESCRIPTION
We previously took a rather aggressive approach to pre-image
propagation, which leads to a lot of unnecessary traffic. So
We check that the pre-images to be sent are already posted in
order to prevent the too heavy traffic.

Fixes #2356 