### PR TITLE
Validate header signature when fetching blocks

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -891,7 +891,7 @@ public class Ledger
             return "Found Coinbase transaction in a non payout block";
 
         // Finally, validate the signatures
-        return this.validateBlockSignature(block);
+        return this.validateBlockSignature(block.header);
     }
 
     /***************************************************************************
@@ -936,16 +936,16 @@ public class Ledger
 
     ***************************************************************************/
 
-    private string validateBlockSignature (in Block block) @safe nothrow
+    public string validateBlockSignature (in BlockHeader header) @safe nothrow
     {
         import agora.crypto.ECC;
 
         Point sum_K;
         Scalar sum_s;
-        const Scalar challenge = hashFull(block);
+        const Scalar challenge = hashFull(header);
         ValidatorInfo[] validators;
         try
-            validators = this.getValidators(block.header.height);
+            validators = this.getValidators(header.height);
         catch (Exception exc)
         {
             this.log.error("Exception thrown by getActiveValidatorPublicKey while externalizing valid block: {}", exc);
@@ -953,25 +953,25 @@ public class Ledger
         }
 
         // Check that more than half have signed
-        if (!this.hasMajoritySignature(block.header))
-            if (auto fail_msg = this.handleNotSignedByMajority(block.header, validators))
+        if (!this.hasMajoritySignature(header))
+            if (auto fail_msg = this.handleNotSignedByMajority(header, validators))
                 return fail_msg;
 
-        log.trace("Checking signature, participants: {}/{}", block.header.validators.setCount, validators.length);
+        log.trace("Checking signature, participants: {}/{}", header.validators.setCount, validators.length);
         foreach (idx, validator; validators)
         {
             const K = validator.address;
             assert(K != PublicKey.init, "Could not find the public key associated with a validator");
 
-            if (!block.header.validators[idx])
+            if (!header.validators[idx])
             {
                 // This is not an error, we might just receive the signature later
                 log.trace("Block#{}: Validator {} (idx: {}) has not yet signed",
-                          block.header.height, K, idx);
+                          header.height, K, idx);
                 continue;
             }
 
-            const pi = block.header.preimages[idx];
+            const pi = header.preimages[idx];
             // TODO: Currently we consider that validators slashed at this height
             // can sign the block (e.g. they have a space in the bit field),
             // however without their pre-image they can't sign the block.
@@ -985,16 +985,16 @@ public class Ledger
         assert(sum_K != Point.init, "Block has validators but no signature");
 
         // If this doesn't match, the block is not self-consistent
-        if (sum_s != block.header.signature.s)
+        if (sum_s != header.signature.s)
         {
             log.error("Block#{}: Signature's `s` mismatch: Expected {}, got {}",
-                      block.header.height, sum_s, block.header.signature.s);
+                      header.height, sum_s, header.signature.s);
             return "Block: Invalid schnorr signature (s)";
         }
-        if (!BlockHeader.verify(sum_K, sum_s, block.header.signature.R, challenge))
+        if (!BlockHeader.verify(sum_K, sum_s, header.signature.R, challenge))
         {
-            log.error("Block#{}: Invalid signature: {}", block.header.height,
-                      block.header.signature);
+            log.error("Block#{}: Invalid signature: {}", header.height,
+                      header.signature);
             return "Block: Invalid signature";
         }
 

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -383,6 +383,12 @@ public class Validator : FullNode, API
 
     protected override void acceptHeader (const(BlockHeader) header) @safe
     {
+        // First we must validate the header
+        if (auto err = this.ledger.validateBlockSignature(header))
+        {
+            log.trace("acceptHeader: Recieved header is not valid: {}", err);
+            return;
+        }
         // Add any missing signatures we know
         const updated_header = this.nominator.updateMultiSignature(header);
         this.ledger.updateBlockMultiSig(updated_header);

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -113,6 +113,7 @@ private class ByzantineManager (ByzantineReason reason) : TestAPIManager
 unittest
 {
     TestConf conf;
+    conf.node.block_catchup_interval = 100.msecs; // force catchup
     conf.consensus.quorum_threshold = 83;
     auto network = makeTestNetwork!(ByzantineManager!(ByzantineReason.BadPreimage))(conf);
     network.start();
@@ -128,7 +129,7 @@ unittest
     network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(1));
     // Make sure the client we will check is in sync with others (except for byzantine)
     network.assertSameBlocks(iota(1, GenesisValidators), Height(1));
-    assertValidatorsBitmask(last_node.getAllBlocks()[1]);
+    nodes.drop(1).each!(node => assertValidatorsBitmask(node.getAllBlocks()[1]));
 }
 
 /// MultiSig test: One node signs with an invalid secretkey.
@@ -136,6 +137,7 @@ unittest
 unittest
 {
     TestConf conf;
+    conf.node.block_catchup_interval = 100.msecs; // force catchup
     conf.consensus.quorum_threshold = 83;
     auto network = makeTestNetwork!(ByzantineManager!(ByzantineReason.BadSecretKey))(conf);
     network.start();
@@ -151,7 +153,7 @@ unittest
     network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(1));
     // Make sure the client we will check is in sync with others (except for byzantine)
     network.assertSameBlocks(iota(1, GenesisValidators), Height(1));
-    assertValidatorsBitmask(last_node.getAllBlocks()[1]);
+    nodes.drop(1).each!(node => assertValidatorsBitmask(node.getAllBlocks()[1]));
 }
 
 private void assertValidatorsBitmask (const Block block)


### PR DESCRIPTION
If a block is fetched from another node during catchup then the header signature should be validated.