### PR TITLE
Trivial: Rename Ledger.getLastBlock to lastBlock

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -179,7 +179,7 @@ public class Ledger
 
     ***************************************************************************/
 
-    public ref const(Block) getLastBlock () const scope @safe @nogc nothrow pure
+    public ref const(Block) lastBlock () const scope @safe @nogc nothrow pure
     {
         return this.last_block;
     }
@@ -1097,7 +1097,7 @@ public class Ledger
 
         Returns:
           A newly created block based on the current block
-          (See `Ledger.getLastBlock()` and `Ledger.getBlockHeight()`)
+          (See `Ledger.lastBlock()` and `Ledger.getBlockHeight()`)
 
     ***************************************************************************/
 
@@ -2546,7 +2546,7 @@ unittest
     assert(ledger.acceptTransaction(freeze_tx) is null);
     ledger.forceCreateBlock(1, false);
 
-    Block block = ledger.getLastBlock().clone();
+    Block block = ledger.lastBlock().clone();
     assert(block.header.height == 1);
     assert(block.header.validators.setCount < block.header.validators.count);
     assert(!ledger.hasMajoritySignature(block.header.height));

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -429,7 +429,7 @@ extern(D):
     protected ulong getExpectedBlockTime () @safe @nogc nothrow pure
     {
         return this.params.GenesisTimestamp +
-            (ledger.getLastBlock().header.height + 1) * this.params.BlockInterval.total!"seconds";
+            (ledger.getBlockHeight() + 1) * this.params.BlockInterval.total!"seconds";
     }
 
     /***************************************************************************
@@ -481,7 +481,7 @@ extern(D):
         {
             this.log.trace(
                 "checkNominate(): Last block ({}) doesn't have majority signatures, signed={}",
-                this.ledger.getBlockHeight(), this.ledger.getLastBlock().header.validators);
+                this.ledger.getBlockHeight(), this.ledger.lastBlock().header.validators);
             return;
         }
 
@@ -605,7 +605,7 @@ extern(D):
         if (this.nomination_timer is null)
             return;
 
-        const Block last_block = this.ledger.getLastBlock();
+        const Block last_block = this.ledger.lastBlock();
         // Don't use `height - tolerance` as it could underflow
         if (envelope.statement.slotIndex <= last_block.header.height)
         {
@@ -1339,7 +1339,7 @@ extern(D):
         const uint hash_N = 1;
         const uint hash_P = 2;
 
-        const seed = this.ledger.getLastBlock().header.hashFull();
+        const seed = this.ledger.lastBlock().header.hashFull();
         const Hash hash = hashMulti(slot_idx, prev[],
             is_priority ? hash_P : hash_N, round_num, node_id, seed);
 

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -191,7 +191,7 @@ public class Validator : FullNode, API
         // externalized, so we can simply use the Ledger. Otherwise we need
         // to run from storage.
         const rand_seed = this.ledger.getBlockHeight() == height ?
-            this.ledger.getLastBlock().header.randomSeed() :
+            this.ledger.lastBlock().header.randomSeed() :
             this.ledger.getBlocksFrom(height).front.header.randomSeed();
         foreach (utxo; utxos)
         {

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1912,7 +1912,7 @@ public class TestValidatorNode : Validator, TestAPI
         assert(this.enroll_man.getEnrolledUTXOs(height + 1, utxos) && utxos.length > 0);
         // See `Validator.rebuildQuorumConfig`
         const rand_seed = this.ledger.getBlockHeight() == height ?
-            this.ledger.getLastBlock().header.randomSeed() :
+            this.ledger.lastBlock().header.randomSeed() :
             this.ledger.getBlocksFrom(height).front.header.randomSeed();
         QuorumConfig[] quorums;
         foreach (idx, utxo; utxos)


### PR DESCRIPTION
Having a shorter name will be welcome, even thought the 'last block'
should be seldom used. Additionally, since 'lastBlock' returns by 'ref',
it is much more akin to a property function.