### PR TITLE
Remove EnrollmentManager.getEnrollmentFinder()

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -709,17 +709,6 @@ public class EnrollmentManager
     {
         return this.enroll_pool.getEnrollment(enroll_hash);
     }
-
-    /***************************************************************************
-
-        Returns: A delegate to query past Enrollments
-
-    ***************************************************************************/
-
-    public EnrollmentFinder getEnrollmentFinder () @trusted nothrow
-    {
-        return &this.validator_set.findRecentEnrollment;
-    }
 }
 
 /// tests for member functions of EnrollmentManager
@@ -1131,7 +1120,7 @@ unittest
     auto utxos = utxo_set.getUTXOs(key_pair.address);
     Hash[] utxo_hashes = utxos.keys;
 
-    auto findEnrollment = man.getEnrollmentFinder();
+    auto findEnrollment = &man.validator_set.findRecentEnrollment;
 
     auto genesis_enroll = man.createEnrollment(utxo_hashes[0], Height(0));
     assert(man.addEnrollment(genesis_enroll, key_pair.address, Height(0),

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -689,7 +689,8 @@ public class Ledger
         if (!this.peekUTXO(utxo, utxo_val) || utxo_val.output.type != OutputType.Freeze)
             return 0.coins;
         EnrollmentState last_enrollment;
-        if (this.enroll_man.getEnrollmentFinder()(utxo, last_enrollment) && last_enrollment.slashed_height != 0)
+        if (this.enroll_man.validator_set.findRecentEnrollment(utxo, last_enrollment) &&
+            last_enrollment.slashed_height != 0)
             return 0.coins;
         return this.params.SlashPenaltyAmount;
     }
@@ -831,7 +832,7 @@ public class Ledger
                 this.last_block.header.hashFull,
                 this.utxo_set.getUTXOFinder(),
                 &this.fee_man.check,
-                this.enroll_man.getEnrollmentFinder(),
+                &this.enroll_man.validator_set.findRecentEnrollment,
                 &this.getPenaltyDeposit,
                 block.header.validators.count))
             return reason;


### PR DESCRIPTION
It's a trivial indirection which creates the impression that the Ledger
depends on the EnrollmentManager when it actually depends on the ValidatorSet.