### PR TITLE
Nominator: Skip externalization if missing sigs for previous height

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -932,6 +932,13 @@ extern(D):
                 height, last_height);
             return;  // slot was already externalized or envelope is too new
         }
+        else if (!this.ledger.hasMajoritySignature(last_height))
+        {
+            log.trace("valueExternalized: Will not externalize envelope with slot id {} as we are " ~
+                "missing signagures for height {}", height, last_height);
+            return;
+        }
+
         ConsensusData data = void;
         try
             data = deserializeFull!ConsensusData(value[]);


### PR DESCRIPTION
```
Let the catchup process handle it
```

Root cause of the issue PR #2793 was trying to address, as explained [here](https://github.com/bosagora/agora/pull/2793#issuecomment-1006342118)