### PR TITLE
Introduce NodeLedger as an intermediate Ledger type

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -947,7 +947,7 @@ public class FullNode : API
 
     protected Ledger makeLedger ()
     {
-        return new Ledger(params, this.engine, this.utxo_set, this.storage,
+        return new NodeLedger(params, this.engine, this.utxo_set, this.storage,
             this.enroll_man, this.pool, this.fee_man, &this.onAcceptedBlock);
     }
 


### PR DESCRIPTION
```
A NodeLedger is a more involved Ledger than the basic Ledger,
as the basic Ledger should be usable by a client without some of
the machinery present in the NodeLedger, most notably the two pools.

As a first step, and instant win to decouple things, we can move
`onValidatedBlock` to the `NodeLedger`, as a client would most likely
perform operations sequentially (call `acceptBlock` then check state).
```

Extracted from https://github.com/bosagora/agora/pull/2804