### PR TITLE
Ledger: Gradually move pool / validation related utilities from `Ledger` to `NodeLedger`

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -584,17 +584,6 @@ public class Ledger
         return this.params.SlashPenaltyAmount;
     }
 
-    /// Error message describing the reason of validation failure
-    public static enum InvalidConsensusDataReason : string
-    {
-        NotEnoughValidators = "Enrollment: Insufficient number of active validators",
-        MayBeValid = "May be valid",
-        TooManyMPVs = "More MPVs than active enrollments",
-        NoUTXO = "Couldn't find UTXO for one or more Enrollment",
-        NotInPool = "Transaction is not in the pool",
-
-    }
-
     /***************************************************************************
 
         Check whether the block is valid.
@@ -1005,6 +994,16 @@ public class Ledger
 /// The Ledger class held by a node
 public class NodeLedger : Ledger
 {
+    /// Error message describing the reason of validation failure
+    public static enum InvalidConsensusDataReason : string
+    {
+        NotEnoughValidators = "Enrollment: Insufficient number of active validators",
+        MayBeValid = "May be valid",
+        TooManyMPVs = "More MPVs than active enrollments",
+        NoUTXO = "Couldn't find UTXO for one or more Enrollment",
+        NotInPool = "Transaction is not in the pool",
+    }
+
     /// A delegate to be called when a block was externalized (unless `null`)
     protected void delegate (in Block, bool) @safe onAcceptedBlock;
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1255,7 +1255,7 @@ extern(D):
                 {
                     Amount rate;
                     auto errormsg = this.ledger.getTxFeeRate(tx_hash, rate);
-                    if (errormsg == Ledger.InvalidConsensusDataReason.NotInPool)
+                    if (errormsg == NodeLedger.InvalidConsensusDataReason.NotInPool)
                         continue; // most likely a CoinBase Transaction
                     else if (errormsg)
                         assert(0);

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -993,7 +993,7 @@ public class NetworkManager
 
     ***************************************************************************/
 
-    public void getUnknownTXs (Ledger ledger) @safe nothrow
+    public void getUnknownTXs (NodeLedger ledger) @safe nothrow
     {
         auto unknown_txs = ledger.getUnknownTXHashes();
         log.trace("getUnknownTXs: detected {} unknown txs", unknown_txs.length);
@@ -1016,7 +1016,7 @@ public class NetworkManager
     }
 
     // Add the chunk of txs fetched from the other node
-    private size_t addTxs (Ledger ledger, Transaction[] txs) @safe nothrow
+    private size_t addTxs (NodeLedger ledger, Transaction[] txs) @safe nothrow
     {
         auto accepted = 0;
         txs.each!((tx)

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -121,7 +121,7 @@ public class FullNode : API
     protected TransactionPool pool;
 
     /// The Ledger is the main class driving consensus
-    protected Ledger ledger;
+    protected NodeLedger ledger;
 
     /// Enrollment manager
     protected EnrollmentManager enroll_man;
@@ -945,7 +945,7 @@ public class FullNode : API
 
     ***************************************************************************/
 
-    protected Ledger makeLedger ()
+    protected NodeLedger makeLedger ()
     {
         return new NodeLedger(params, this.engine, this.utxo_set, this.storage,
             this.enroll_man, this.pool, this.fee_man, &this.onAcceptedBlock);

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -69,7 +69,7 @@ public class NameRegistry: NameRegistryAPI
     private Domain flash;
 
     ///
-    private Ledger ledger;
+    private NodeLedger ledger;
 
     ///
     private Height validator_info_height;
@@ -83,7 +83,7 @@ public class NameRegistry: NameRegistryAPI
     ];
 
     ///
-    public this (string realm, RegistryConfig config, Ledger ledger,
+    public this (string realm, RegistryConfig config, NodeLedger ledger,
         ManagedDatabase cache_db)
     {
         assert(realm.length > 0, "No 'realm' provided");

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -715,7 +715,7 @@ public class Validator : FullNode, API
     {
         // Network needs Validators, see if we can enroll
         if (this.config.validator.recurring_enrollment &&
-            msg == Ledger.InvalidConsensusDataReason.NotEnoughValidators)
+            msg == NodeLedger.InvalidConsensusDataReason.NotEnoughValidators)
             this.checkAndEnroll(this.ledger.getBlockHeight());
     }
 }

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -280,7 +280,7 @@ unittest
         {
             // Unlike the regular validator, dont check the config. BatValidator
             // always answers a cry for help.
-            if (msg == Ledger.InvalidConsensusDataReason.NotEnoughValidators)
+            if (msg == NodeLedger.InvalidConsensusDataReason.NotEnoughValidators)
                 this.checkAndEnroll(this.ledger.getBlockHeight());
         }
     }


### PR DESCRIPTION
This is the main refactoring that comes from https://github.com/bosagora/agora/pull/2804
Each commit moves a specific set of functionalities to `NodeLedger`. First the transaction pool, then the enrollment pool (which the `EnrollmentManager` acts as a proxy for), and finally some misc functions / types.
The result is a "clean" `Ledger`, which we will be able to isolate in its own module, and will not require an EM / key to instantiate.