### PR TITLE
FullNode: Remove makeFeeManager

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -126,9 +126,6 @@ public class FullNode : API
     /// Enrollment manager
     protected EnrollmentManager enroll_man;
 
-    /// Fee manager
-    protected FeeManager fee_man;
-
     /// Set of unspent transaction outputs
     protected UTXOSet utxo_set;
 
@@ -293,7 +290,6 @@ public class FullNode : API
 
         this.stateDB = this.makeStateDB();
         this.cacheDB = this.makeCacheDB();
-        this.fee_man = this.makeFeeManager();
         this.taskman = this.makeTaskManager();
         this.clock = this.makeClock();
         this.network = this.makeNetworkManager(this.taskman, this.clock);
@@ -921,20 +917,6 @@ public class FullNode : API
 
     /***************************************************************************
 
-        Returns an instance of a FeeManager
-
-        Returns:
-            the fee manager
-
-    ***************************************************************************/
-
-    protected FeeManager makeFeeManager ()
-    {
-        return new FeeManager(this.stateDB, this.params);
-    }
-
-    /***************************************************************************
-
         Returns an instance of a Ledger to be used for a `Fullnode`.
 
         It is overridden in `Validator` and also Test-suites can inject
@@ -948,7 +930,8 @@ public class FullNode : API
     protected NodeLedger makeLedger ()
     {
         return new NodeLedger(params, this.engine, this.utxo_set, this.storage,
-            this.enroll_man, this.pool, this.fee_man, &this.onAcceptedBlock);
+            this.enroll_man, this.pool, new FeeManager(this.stateDB, this.params),
+            &this.onAcceptedBlock);
     }
 
     /*+*************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -25,6 +25,7 @@ import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.Transaction;
 import agora.consensus.data.ValidatorBlockSig;
 import agora.consensus.EnrollmentManager;
+import agora.consensus.Fee;
 import agora.consensus.protocol.Data;
 import agora.consensus.protocol.Nominator;
 import agora.consensus.Quorum;
@@ -482,7 +483,7 @@ public class Validator : FullNode, API
     {
         return new ValidatingLedger(this.params, this.engine,
             this.utxo_set, this.storage, this.enroll_man, this.pool,
-            this.fee_man, &this.onAcceptedBlock);
+            new FeeManager(this.stateDB, this.params), &this.onAcceptedBlock);
     }
 
     /***************************************************************************

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -111,7 +111,7 @@ unittest
             // Dont accept any incoming TXs
             log.info("Picky node ignoring TX {}", tx);
 
-            return TransactionResult(TransactionResult.Status.Accepted); 
+            return TransactionResult(TransactionResult.Status.Accepted);
         }
     }
 

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -18,6 +18,7 @@ version (unittest):
 
 import agora.crypto.Hash;
 import agora.common.Set;
+import agora.consensus.Fee;
 import agora.consensus.Ledger;
 import agora.test.Base;
 import agora.utils.Log;
@@ -102,7 +103,7 @@ unittest
         {
             return new PickyLedger(this.params, this.engine,
                 this.utxo_set, this.storage, this.enroll_man, this.pool,
-                this.fee_man, &this.onAcceptedBlock);
+                new FeeManager(this.stateDB, this.params), &this.onAcceptedBlock);
         }
 
         public override TransactionResult postTransaction (in Transaction tx) @safe


### PR DESCRIPTION
This was originally needed because we didn't have proper dependency injection:
we were passing a path around and each class was instantiating their own DB.
We now have a unified DB (stateDB) which we pass to classes,
so the need for makeFeeManager has disappeared.