### PR TITLE
Usability: Allow to start Agora with `-c /dev/null`

### DIFF
--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -135,6 +135,9 @@ private int main (string[] args)
 
     Nullable!Config config = ()
     {
+        if (cmdln.config_path == "/dev/null")
+            return Nullable!Config(Config.init);
+
         try
             return Nullable!Config(parseConfigFile!Config(cmdln));
         catch (ConfigException ex)


### PR DESCRIPTION
This is to allow a zeroconf Agora to "just work".
Obviously this usage is not the recommended one, as every restart
means re-syncing the whole chain, but for the foreseable future
it will be a welcome tool to have users test our chain.