### PR TITLE
DNS: Add AAAA record to the list of accepted types

### DIFF
--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -79,7 +79,7 @@ public class NameRegistry: NameRegistryAPI
 
     /// Supported DNS query types
     private immutable QTYPE[] supported_query_types = [
-        QTYPE.A, QTYPE.CNAME, QTYPE.AXFR, QTYPE.ALL, QTYPE.SOA, QTYPE.NS,
+        QTYPE.A, QTYPE.AAAA, QTYPE.CNAME, QTYPE.AXFR, QTYPE.ALL, QTYPE.SOA, QTYPE.NS,
     ];
 
     ///


### PR DESCRIPTION
While we don't store them at the moment, this allow to remove
the warning that shows up quite a bit in the logs due to recursion.