### PR TITLE
Fix second test in ValidatorCleanRestart

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1349,6 +1349,7 @@ extern(D):
         const header = this.ledger.lastBlock().header;
         log.dbg("Nominator.computeHashNode: slot_idx={}, ledger height={}",
             slot_idx, header.height);
+        assert(header.height + 1 == slot_idx);
         const seed = header.hashFull();
         const Hash hash = hashMulti(slot_idx, prev[],
             is_priority ? hash_P : hash_N, round_num, node_id, seed);

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1346,7 +1346,10 @@ extern(D):
         const uint hash_N = 1;
         const uint hash_P = 2;
 
-        const seed = this.ledger.lastBlock().header.hashFull();
+        const header = this.ledger.lastBlock().header;
+        log.dbg("Nominator.computeHashNode: slot_idx={}, ledger height={}",
+            slot_idx, header.height);
+        const seed = header.hashFull();
         const Hash hash = hashMulti(slot_idx, prev[],
             is_priority ? hash_P : hash_N, round_num, node_id, seed);
 

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -128,7 +128,7 @@ unittest
     // Create a block from the Genesis block
     auto txs = genesisSpendable().map!(txb => txb.sign()).array();
     txs.each!(tx => node_1.postTransaction(tx));
-    network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(1));
 
     // node_1 restarts and becomes unresponsive
     network.restart(node_1);
@@ -137,12 +137,12 @@ unittest
     // Make 2 blocks
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
     txs.each!(tx => node_2.postTransaction(tx));
-    network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(2), network.blocks[0].header);
+    network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(2));
     network.expectHeight(iota(1, nodes.length), Height(2));
 
     txs = txs.map!(tx => TxBuilder(tx).sign()).array();
     txs.each!(tx => node_2.postTransaction(tx));
-    network.expectHeightAndPreImg(iota(1,nodes.length), Height(3), network.blocks[0].header);
+    network.expectHeightAndPreImg(iota(1,nodes.length), Height(3));
 
     // Wait for node_1 to wake up
     node_1.ctrl.withTimeout(10.seconds,
@@ -151,7 +151,7 @@ unittest
         }
     );
 
-    network.expectHeightAndPreImg(Height(3), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(3));
 
     // The node_2 restart and is disabled to respond, which means that
     // the node_2 will be slashed soon.
@@ -164,5 +164,5 @@ unittest
 
     // The new block has been inserted to the ledger with the approval
     // of the node_1, although node_2 was shutdown.
-    network.expectHeightAndPreImg(Height(4), network.blocks[0].header);
+    network.expectHeightAndPreImg(Height(4));
 }


### PR DESCRIPTION
Updating the test to focus on testing that a node can catch up after a clean restart and participate in consensus for the next block.