### PR TITLE
Local setup for either two or three validators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ log/
 
 # Agora single node data and log directory
 .single
+# Agora two-node data and log directory
+.two-nodes

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ log/
 .single
 # Agora two-node data and log directory
 .two-nodes
+.three-nodes

--- a/devel/three-nodes/config-v0.yaml
+++ b/devel/three-nodes/config-v0.yaml
@@ -1,0 +1,56 @@
+# three node + fullnode setup without docker
+#
+# Run from the root with:
+# dub run -- -c devel/three-nodes/config-v0.yaml
+
+node:
+  realm: "localhost"
+  testing: true
+  limit_test_validators: 3
+  data_dir: .three-nodes/0/data/
+  # Can be used with curl or just a browser
+  stats_listening_port: 4440
+  block_catchup_interval:
+    seconds: 2
+
+interfaces:
+  - type:    http
+    address: 0.0.0.0
+    port:    2220
+
+consensus:
+  block_interval:
+    seconds: 2
+  validator_cycle: 20
+  payout_period: 12
+
+validator:
+  enabled: false
+
+registry:
+  enabled: true
+  address: 127.0.0.1
+  # Use a non-priviledged port to avoid a clash with the system resolver
+  port: 5335
+  validators:
+    authoritative: true
+    primary: localhost
+    soa:
+      email: no@no.no
+  flash:
+    authoritative: true
+    primary: localhost
+    soa:
+      email: no@no.no
+
+logging:
+  root:
+    level: Info
+    console: true
+    file: .three-nodes/0/root.log
+  agora:
+    level: Trace
+    console: false
+    file: .three-nodes/0/agora.log
+  agora.node.registry:
+    console: true

--- a/devel/three-nodes/config-v3.yaml
+++ b/devel/three-nodes/config-v3.yaml
@@ -1,0 +1,57 @@
+# three node setup without docker
+#
+# Run from the root with:
+# dub run -- -c devel/three-nodes/config-v3.yaml
+
+node:
+  realm: "localhost"
+  testing: true
+  limit_test_validators: 3
+  data_dir: .three-nodes/3/data/
+  # Can be used with curl or just a browser
+  stats_listening_port: 4443
+  block_catchup_interval:
+    seconds: 2
+
+interfaces:
+  - type:    http
+    address: 0.0.0.0
+    port:    2223
+  - type:    tcp
+    address: 0.0.0.0
+    port:    5553
+
+consensus:
+  block_interval:
+    seconds: 2
+  validator_cycle: 20
+  payout_period: 12
+
+validator:
+  enabled: true
+  # val3: boa1xzval3ah8z7ewhuzx6mywveyr79f24w49rdypwgurhjkr8z2ke2mycftv9n
+  seed: SC3H3ADGT3YGLMDWCLKZ2GILDHDTC4WDE7M3G4URQPWJZZM43TTAM2QG
+  registry_address: http://127.0.0.1:2220/
+  addresses_to_register:
+    - tcp://127.0.0.1:5553
+
+registry:
+  enabled: false
+
+admin:
+  enabled: false
+
+network:
+  - tcp://127.0.0.1:5555
+  - tcp://127.0.0.1:5557
+
+logging:
+  root:
+    level: Info
+    console: true
+  agora:
+    level: Debug
+    console: false
+    file: .two-nodes/3/agora.log
+  agora.consensus.state.Ledger:
+    console: true

--- a/devel/three-nodes/config-v5.yaml
+++ b/devel/three-nodes/config-v5.yaml
@@ -1,0 +1,57 @@
+# two node setup without docker
+#
+# Run from the root with:
+# dub run -- -c devel/three-nodes/config-v5.yaml
+
+node:
+  realm: "localhost"
+  testing: true
+  limit_test_validators: 3
+  data_dir: .three-nodes/5/data/
+  # Can be used with curl or just a browser
+  stats_listening_port: 4445
+  block_catchup_interval:
+    seconds: 2
+
+interfaces:
+  - type:    http
+    address: 0.0.0.0
+    port:    2225
+  - type:    tcp
+    address: 0.0.0.0
+    port:    5555
+
+consensus:
+  block_interval:
+    seconds: 2
+  validator_cycle: 20
+  payout_period: 12
+
+validator:
+  enabled: true
+  # val5: boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8
+  seed: SAZO4WA5SXUN3J6XBXZCFPXJJZ62IQAJYAG2KBVWF2QZKTU2WK3QTNMV
+  registry_address: http://127.0.0.1:2220/
+  addresses_to_register:
+    - tcp://127.0.0.1:5555
+
+registry:
+  enabled: false
+
+admin:
+  enabled: false
+
+network:
+  - tcp://127.0.0.1:5553
+  - tcp://127.0.0.1:5557
+
+logging:
+  root:
+    level: Info
+    console: true
+  agora:
+    level: Debug
+    console: false
+    file: .two-nodes/5/agora.log
+  agora.consensus.state.Ledger:
+    console: true

--- a/devel/three-nodes/config-v7.yaml
+++ b/devel/three-nodes/config-v7.yaml
@@ -1,0 +1,57 @@
+# three node setup without docker
+#
+# Run from the root with:
+# dub run -- -c devel/three-nodes/config-v7.yaml
+
+node:
+  realm: "localhost"
+  testing: true
+  limit_test_validators: 3
+  data_dir: .three-nodes/7/data/
+  # Can be used with curl or just a browser
+  stats_listening_port: 4447
+  block_catchup_interval:
+    seconds: 2
+
+interfaces:
+  - type:    http
+    address: 0.0.0.0
+    port:    2227
+  - type:    tcp
+    address: 0.0.0.0
+    port:    5557
+
+consensus:
+  block_interval:
+    seconds: 2
+  validator_cycle: 20
+  payout_period: 12
+
+validator:
+  enabled: true
+  # val7: boa1xrval7gwhjz4k9raqukcnv2n4rl4fxt74m2y9eay6l5mqdf4gntnzhhscrh
+  seed: SAWI3JZWDDSQR6AX4DRG2OMS26Y6XY4X2WA3FK6D5UW4WTU74GUQXRZP
+  registry_address: http://127.0.0.1:2220/
+  addresses_to_register:
+    - tcp://127.0.0.1:5557
+
+registry:
+  enabled: false
+
+admin:
+  enabled: false
+
+network:
+  - tcp://127.0.0.1:5553
+  - tcp://127.0.0.1:5555
+
+logging:
+  root:
+    level: Info
+    console: true
+  agora:
+    level: Debug
+    console: false
+    file: .two-nodes/7/agora.log
+  agora.consensus.state.Ledger:
+    console: true

--- a/devel/two-nodes/config-v3.yaml
+++ b/devel/two-nodes/config-v3.yaml
@@ -1,0 +1,56 @@
+# two node setup without docker
+#
+# Run from the root with:
+# dub run -- -c devel/two-nodes/config-v3.yaml
+
+node:
+  realm: "localhost"
+  testing: true
+  limit_test_validators: 2
+  data_dir: .two-nodes/3/data/
+  # Can be used with curl or just a browser
+  stats_listening_port: 4443
+  block_catchup_interval:
+    seconds: 2
+
+interfaces:
+  - type:    http
+    address: 0.0.0.0
+    port:    2223
+  - type:    tcp
+    address: 0.0.0.0
+    port:    5553
+
+consensus:
+  block_interval:
+    seconds: 2
+  validator_cycle: 20
+  payout_period: 12
+
+validator:
+  enabled: true
+  # val3: boa1xzval3ah8z7ewhuzx6mywveyr79f24w49rdypwgurhjkr8z2ke2mycftv9n
+  seed: SC3H3ADGT3YGLMDWCLKZ2GILDHDTC4WDE7M3G4URQPWJZZM43TTAM2QG
+
+admin:
+  enabled: false
+  tls: false
+  address: 0.0.0.0
+  port:    3333
+  username: admin
+  pwd: s3cr3t
+
+network:
+  - tcp://127.0.0.1:5555
+
+logging:
+  root:
+    level: Info
+    console: true
+  agora.consensus.state.Ledger:
+    level: Info
+    console: true
+  agora:
+    level: Debug
+    console: false
+    file: .two-nodes/3/agora.log

--- a/devel/two-nodes/config-v5.yaml
+++ b/devel/two-nodes/config-v5.yaml
@@ -1,0 +1,56 @@
+# two node setup without docker
+#
+# Run from the root with:
+# dub run -- -c devel/two-nodes/config-v5.yaml
+
+node:
+  realm: "localhost"
+  testing: true
+  limit_test_validators: 2
+  data_dir: .two-nodes/5/data/
+  # Can be used with curl or just a browser
+  stats_listening_port: 4445
+  block_catchup_interval:
+    seconds: 2
+
+interfaces:
+  - type:    http
+    address: 0.0.0.0
+    port:    2225
+  - type:    tcp
+    address: 0.0.0.0
+    port:    5555
+
+consensus:
+  block_interval:
+    seconds: 2
+  validator_cycle: 20
+  payout_period: 12
+
+validator:
+  enabled: true
+  # val5: boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8
+  seed: SAZO4WA5SXUN3J6XBXZCFPXJJZ62IQAJYAG2KBVWF2QZKTU2WK3QTNMV
+
+admin:
+  enabled: false
+  tls: false
+  address: 0.0.0.0
+  port:    3335
+  username: admin
+  pwd: s3cr3t
+
+network:
+  - tcp://127.0.0.1:5553
+
+logging:
+  root:
+    level: Info
+    console: true
+  agora.consensus.state.Ledger:
+    level: Info
+    console: true
+  agora:
+    level: Debug
+    console: false
+    file: .two-nodes/5/agora.log


### PR DESCRIPTION
This enables running locally either a set of two nodes (see devel/two-nodes) or three `validators` and a `fullnode` / `registry` (see devel/three-nodes).