### PR TITLE
NetworkManager: Remove `merge`, delay `NetworkClient` instantiation

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -49,13 +49,19 @@ public struct NodeInfo
 public struct Identity
 {
     /// Public Key of the node
-    PublicKey key;
+    public PublicKey key;
 
     /// UTXO that is used as collateral
-    Hash utxo;
+    public Hash utxo;
 
     /// MAC
-    ubyte[] mac;
+    public ubyte[] mac;
+
+    /// Whether or not this is in the `init` state (meaning a full node)
+    public bool opCast (T : bool) () const scope @safe pure nothrow @nogc
+    {
+        return this !is Identity.init;
+    }
 }
 
 /*******************************************************************************

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1099,7 +1099,7 @@ extern(D):
             assert(0, ex.to!string);
         }
 
-        this.network.validators().each!(v => v.client.sendEnvelope(env));
+        this.network.validators().each!(v => v.sendEnvelope(env));
     }
 
     /***************************************************************************

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -156,27 +156,23 @@ public class NetworkClient
         Params:
             taskman = used for creating new tasks
             banman = ban manager
-            address = used for logging and querying by external code
-            api = the API to issue the requests with
             retry = the amout to wait between retrying failed requests
             max_retries = max number of times a failed request should be retried
 
     ***************************************************************************/
 
-    public this (ITaskManager taskman, BanManager banman, Address address,
-        API api, Duration retry, size_t max_retries)
+    public this (ITaskManager taskman, BanManager banman,
+                 Duration retry, size_t max_retries)
     {
         // By default, use the module, but if we can identify a validator,
         // this logger will be replaced with a more specialized one.
         this.log = Log.lookup(__MODULE__);
         this.taskman = taskman;
         this.banman = banman;
-        this.connections ~= ConnectionInfo(address, api);
         this.retry_delay = retry;
         this.max_retries = max_retries;
         this.exception = new Exception(
-            format("Request failure to %s after %s attempts", address,
-                max_retries));
+            format("Request failure after %s attempts", max_retries));
         // Create and stop timer immediately
         this.gossip_timer = this.taskman.setTimer(GossipDelay, &this.gossipTask, Periodic.No);
         this.gossip_timer.stop();

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -146,6 +146,9 @@ public class NetworkClient
     /// Logger uniquely identifying this client
     private Logger log;
 
+    /// The identity associated with this node - may be empty
+    private Identity identity_;
+
     /// Gossip delay
     private enum GossipDelay = 10.msecs;
 
@@ -235,18 +238,34 @@ public class NetworkClient
 
     /***************************************************************************
 
-        Change this client's logger to make it easier to identify peers and
-        selectively enable or disable logging
+        Set/get the node's identity
+
+        The identity of a node can be accessed through the `identity` property.
+        Once an identity is set, it cannot be changed.
+        When the identity is set, the logger is also changed to make it easier
+        to identify peers and selectively enable or disable logging.
 
         Params:
-          key = Public key of this peer
+          utxo = UTXO used as collateral by this peer
+          key  = Public key of this peer
 
     ***************************************************************************/
 
-    public void setIdentity (in PublicKey key)
+    public void setIdentity (in Hash utxo, in PublicKey key)
     {
+        assert(!this.identity);
+        this.identity_ = Identity(key, utxo);
         this.log = Log.lookup(format("%s.%s", __MODULE__, key));
-        this.log.info("Peer identity established");
+        this.log.info("Peer identity established (UTXO: {})", utxo);
+    }
+
+    /// Get the identity of this node. Full nodes return `Identity.init`.
+    public Identity identity () const scope @safe pure nothrow @nogc
+    {
+        // Need to return a new instance as `MAC` is a dynamic array,
+        // hence it disables `const` to mutable conversion for `Identity`,
+        // but we never store `MAC`.
+        return Identity(this.identity_.key, this.identity_.utxo);
     }
 
     /***************************************************************************

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -114,7 +114,7 @@ public class NetworkClient
         public Address address;
 
         /// API client to the node
-        private API api;
+        public API api;
     }
 
     /// Caller's retry delay
@@ -600,31 +600,30 @@ public class NetworkClient
     }
 
     /// Merge connections of incoming client to this
-    public bool merge (scope ref NetworkClient incoming)
+    public bool merge (in Address address, API api)
     {
         import std.range;
-        assert(incoming.connections.length == 1);
 
-        if (this.tryMergeRPC(incoming))
+        if (this.tryMergeRPC(address, api))
             return true;
 
-        if (incoming.connections[0].address != Address.init)
+        if (address != Address.init)
         {
-            this.connections ~= incoming.connections[0];
+            this.connections ~= ConnectionInfo(address, api);
             return true;
         }
         return false;
     }
 
     /// Try to merge an incoming RPC connection to an existing one if possible
-    public bool tryMergeRPC (scope ref NetworkClient incoming)
+    public bool tryMergeRPC (in Address address, API api)
     {
         import std.typecons;
         import agora.network.RPC;
 
         alias ValidatorClient = RPCClient!(agora.api.Validator.API);
 
-        auto incoming_peer = cast(ValidatorClient) incoming.connections[0].api;
+        auto incoming_peer = cast(ValidatorClient) api;
         if (incoming_peer is null)
             return false;
 

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -161,15 +161,25 @@ public class NetworkClient
             banman = ban manager
             retry = the amout to wait between retrying failed requests
             max_retries = max number of times a failed request should be retried
+            utxo = The UTXO this client is to be bound to - key also needs to be
+                   provided if this field is.
+            key = The public key matching `utxo`.
 
     ***************************************************************************/
 
     public this (ITaskManager taskman, BanManager banman,
-                 Duration retry, size_t max_retries)
+                 Duration retry, size_t max_retries,
+                 in Hash utxo, in PublicKey key)
     {
-        // By default, use the module, but if we can identify a validator,
-        // this logger will be replaced with a more specialized one.
-        this.log = Log.lookup(__MODULE__);
+        assert((utxo is Hash.init) == (key is PublicKey.init),
+            "Both `utxo` and `key` or neither needs to be provided to NetworkClient");
+
+        this.identity_ = Identity(key, utxo);
+        if (identity)
+            this.log = Log.lookup(format("%s.%s", __MODULE__, key));
+        else // Might be replaced via a call to `setIdentity`
+            this.log = Log.lookup(__MODULE__);
+
         this.taskman = taskman;
         this.banman = banman;
         this.retry_delay = retry;

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -533,8 +533,9 @@ public class NetworkManager
         if (!node.isValidator() || existing_peers.empty())
             return false;
 
+        assert(node.client.connections.length == 1);
         existing_peers.front().utxo = node.utxo;
-        existing_peers.front().client.merge(node.client);
+        existing_peers.front().client.merge(node.client.connections[0].tupleof);
         return true;
     }
 

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -480,8 +480,8 @@ public class NetworkManager
             if (existing_peers.empty())
             {
                 client = new NetworkClient(this.taskman, this.banman,
-                    this.node_config.retry_delay, this.node_config.max_retries);
-                client.setIdentity(utxo, key);
+                    this.node_config.retry_delay, this.node_config.max_retries,
+                    utxo, key);
                 log.info("Found new Validator: {} (UTXO: {}, key: {})",
                          address, utxo, key);
                 this.required_peers.remove(utxo);
@@ -507,7 +507,8 @@ public class NetworkManager
                 return;
             }
             client = new NetworkClient(this.taskman, this.banman,
-                this.node_config.retry_delay, this.node_config.max_retries);
+                this.node_config.retry_delay, this.node_config.max_retries,
+                Hash.init, PublicKey.init);
             this.peers.insertBack(client);
             this.discovery_task.add(client);
         }

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -825,8 +825,7 @@ public class NetworkManager
         return !this.banman.isBanned(address) &&
             address !in this.connection_tasks &&
             address !in this.todo_addresses &&
-            (existing_peer.empty || // either does not exist or a validator with no stake
-                (existing_peer.front.isValidator() && existing_peer.front.utxo == Hash.init));
+            existing_peer.empty;
     }
 
     /// Received new set of addresses, put them in the todo address list

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -182,13 +182,9 @@ public class NetworkManager
         /// Ditto, just behind a trampoline to avoid function-wide try/catch
         private void connect_canthrow ()
         {
-            auto client = new NetworkClient(this.outer.taskman,
-                this.outer.banman, this.address,
-                this.api ? this.api :
-                this.outer.getClient(this.address,
-                    this.outer.node_config.timeout),
-                this.outer.node_config.retry_delay,
-                this.outer.node_config.max_retries);
+            if (this.api is null)
+                this.api = this.outer.getClient(
+                    this.address, this.outer.node_config.timeout);
 
             PublicKey key;
             Hash utxo;
@@ -200,7 +196,7 @@ public class NetworkManager
                     import libsodium.crypto_auth;
 
                     const ephemeral_kp = KeyPair.random();
-                    auto id = client.handshake(ephemeral_kp.address);
+                    auto id = this.api.handshake(ephemeral_kp.address);
 
                     // No identity, either a full node or not enrolled
                     if (id.key == PublicKey.init)
@@ -220,7 +216,6 @@ public class NetworkManager
 
                     utxo = id.utxo;
                     key = id.key;
-                    client.setIdentity(id.key);
                     break;
                 }
                 catch (Exception ex)
@@ -246,6 +241,13 @@ public class NetworkManager
                     return;
                 }
             }
+
+            auto client = new NetworkClient(this.outer.taskman,
+                this.outer.banman, this.address, this.api,
+                this.outer.node_config.retry_delay,
+                this.outer.node_config.max_retries);
+            if (is_validator)
+                client.setIdentity(key);
 
             NodeConnInfo node = {
                 key : key,

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -243,9 +243,10 @@ public class NetworkManager
             }
 
             auto client = new NetworkClient(this.outer.taskman,
-                this.outer.banman, this.address, this.api,
-                this.outer.node_config.retry_delay,
+                this.outer.banman, this.outer.node_config.retry_delay,
                 this.outer.node_config.max_retries);
+            if (!client.merge(this.address, this.api))
+                assert(0);
             if (is_validator)
                 client.setIdentity(key);
 

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -101,7 +101,9 @@ public class NetworkManager
 
         /// Called when we've connected and determined if this is
         /// a FullNode / Validator
-        private void delegate (scope ref NodeConnInfo) onHandshakeComplete;
+        public alias OnHandshakeComplete = void delegate (scope ref NodeConnInfo);
+        /// Ditto
+        private OnHandshakeComplete onHandshakeComplete;
 
         /// Called when a request to a node fails.
         /// The delegate should return true if we should continue trying
@@ -125,7 +127,7 @@ public class NetworkManager
         ***********************************************************************/
 
         public this (Address address,
-            void delegate (scope ref NodeConnInfo node) onHandshakeComplete,
+            OnHandshakeComplete onHandshakeComplete,
             bool delegate (in Address address) onFailedRequest)
             @safe pure nothrow @nogc
         {
@@ -133,7 +135,7 @@ public class NetworkManager
         }
 
         public this (Address address, agora.api.Validator.API api,
-            void delegate (scope ref NodeConnInfo node) onHandshakeComplete,
+            OnHandshakeComplete onHandshakeComplete,
             bool delegate (in Address address) onFailedRequest)
             @safe pure nothrow @nogc
         {

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -101,7 +101,8 @@ public class NetworkManager
 
         /// Called when we've connected and determined if this is
         /// a FullNode / Validator
-        public alias OnHandshakeComplete = void delegate (scope ref NodeConnInfo);
+        public alias OnHandshakeComplete = void delegate (
+            in Address, agora.api.Validator.API, in Hash, in PublicKey);
         /// Ditto
         private OnHandshakeComplete onHandshakeComplete;
 
@@ -242,21 +243,7 @@ public class NetworkManager
                 }
             }
 
-            auto client = new NetworkClient(this.outer.taskman,
-                this.outer.banman, this.outer.node_config.retry_delay,
-                this.outer.node_config.max_retries);
-            if (!client.merge(this.address, this.api))
-                assert(0);
-            if (is_validator)
-                client.setIdentity(key);
-
-            NodeConnInfo node = {
-                key : key,
-                utxo: utxo,
-                client : client
-            };
-
-            this.onHandshakeComplete(node);
+            this.onHandshakeComplete(this.address, this.api, utxo, key);
         }
     }
 
@@ -493,36 +480,51 @@ public class NetworkManager
     }
 
     /// Called after a node's handshake is complete
-    private void onHandshakeComplete (scope ref NodeConnInfo node)
+    private void onHandshakeComplete (
+        in Address address, agora.api.Validator.API api,
+        in Hash utxo, in PublicKey key)
     {
-        log.dbg("onHandshakeComplete: addresses: {}", node.client.addresses());
-        node.client.connections.each!(conn => this.connection_tasks.remove(conn.address));
+        auto client = new NetworkClient(this.taskman, this.banman,
+            this.node_config.retry_delay, this.node_config.max_retries);
+        if (!client.merge(address, api))
+            assert(0);
+        if (utxo !is Hash.init)
+            client.setIdentity(key);
+
+        NodeConnInfo node = {
+            key : key,
+            utxo: utxo,
+            client : client
+        };
+
+        log.dbg("onHandshakeComplete: addresses: {}", client.addresses());
+        client.connections.each!(conn => this.connection_tasks.remove(address));
         if (this.tryMerge(node))
         {
-            this.required_peers.remove(node.utxo);
+            this.required_peers.remove(utxo);
             return;
         }
         if (this.peerLimitReached())
             return;
 
-        if (!node.client.connections.any!(conn => conn.address == Address.init))
+        if (!client.connections.any!(conn => address == Address.init))
         {
             this.peers.insertBack(node);
-            this.discovery_task.add(node.client);
+            this.discovery_task.add(client);
 
             if (node.isValidator())
             {
                 log.info("Found new Validator: {} (UTXO: {}, key: {})",
-                         node.client.addresses(), node.utxo, node.key);
-                this.required_peers.remove(node.utxo);
+                         client.addresses(), utxo, key);
+                this.required_peers.remove(utxo);
             }
             else
-                log.info("Found new FullNode: {}", node.client.addresses());
+                log.info("Found new FullNode: {}", client.addresses());
         }
         else // unidentified connection that we can not merge, just use it for a single shot of address discovery
         {
             log.dbg("onHandshakeComplete: an unidentified connection was included");
-            auto node_info = node.client.getNodeInfo();
+            auto node_info = client.getNodeInfo();
             this.addAddresses(node_info.addresses);
         }
     }

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -73,10 +73,16 @@ public class NetworkManager
     public static struct NodeConnInfo
     {
         /// Hash of the output used as collateral, only set if the node is a Validator
-        Hash utxo;
+        public Hash utxo () const scope @safe pure nothrow @nogc
+        {
+            return this.client.identity.utxo;
+        }
 
         /// PublicKey of the node. TODO: Remove and just use utxo.
-        PublicKey key;
+        public PublicKey key () const scope @safe pure nothrow @nogc
+        {
+            return this.client.identity.key;
+        }
 
         /// Client
         NetworkClient client;
@@ -84,7 +90,7 @@ public class NetworkManager
         ///
         public bool isValidator () const scope @safe pure nothrow @nogc
         {
-            return this.key != PublicKey.init;
+            return !!this.client.identity;
         }
     }
 
@@ -489,11 +495,9 @@ public class NetworkManager
         if (!client.merge(address, api))
             assert(0);
         if (utxo !is Hash.init)
-            client.setIdentity(key);
+            client.setIdentity(utxo, key);
 
         NodeConnInfo node = {
-            key : key,
-            utxo: utxo,
             client : client
         };
 
@@ -537,7 +541,6 @@ public class NetworkManager
             return false;
 
         assert(node.client.connections.length == 1);
-        existing_peers.front().utxo = node.utxo;
         existing_peers.front().client.merge(node.client.connections[0].tupleof);
         return true;
     }

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -1122,7 +1122,7 @@ public class FullNode : API
             this.ledger.getBlockHeight() + 1, utxo_finder, getPenaltyDeposit))
         {
             log.info("Accepted enrollment: {}", prettify(enroll));
-            this.network.peers.each!(p => p.client.sendEnrollment(enroll));
+            this.network.peers.each!(p => p.sendEnrollment(enroll));
         }
     }
 
@@ -1142,7 +1142,7 @@ public class FullNode : API
         if (this.ledger.addPreimage(preimage))
         {
             log.info("Accepted preimage: {}", prettify(preimage));
-            this.network.peers.each!(p => p.client.sendPreimage(preimage));
+            this.network.peers.each!(p => p.sendPreimage(preimage));
             this.pushPreImage(preimage);
         }
     }

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -290,7 +290,7 @@ public class Validator : FullNode, API
                  next_height, missing);
 
         auto query = this.network.peers[]
-            .map!(peer => peer.client.getPreimages(missing));
+            .map!(peer => peer.getPreimages(missing));
 
         foreach (preimages; query)
         {
@@ -619,7 +619,7 @@ public class Validator : FullNode, API
             this.ledger.getBlockHeight()))
         {
             this.ledger.addPreimage(preimage);
-            this.network.peers.each!(p => p.client.sendPreimage(preimage));
+            this.network.peers.each!(p => p.sendPreimage(preimage));
             this.pushPreImage(preimage);
         }
     }
@@ -673,7 +673,7 @@ public class Validator : FullNode, API
         log.trace("Sending Enrollment for enrolling {} at height {} (to validate blocks {} to {})",
             this.enroll_man.getEnrollmentPublicKey(), avail_height, avail_height + 1, avail_height + this.params.ValidatorCycle);
         this.enroll_man.enroll_pool.addValidated(enrollment, avail_height);
-        this.network.peers.each!(p => p.client.sendEnrollment(enrollment));
+        this.network.peers.each!(p => p.sendEnrollment(enrollment));
         return enrollment;
     }
 


### PR DESCRIPTION
The goal here was to remove the notion of "merge", and instead rely on `NetworkClient` being added to.
In the process, `NetworkClient` gained a (sticky) identity and `NodeConnInfo` was removed.
I hope this makes the code simpler. The test currently fails on my machine (spuriously), so I'm going to break this down to make sure no commit introduce a regression.

Next steps are to:
- Allow for `peers` to contain `NetworkClient` with empty connection array;
- Eagerly instantiate `NetworkClient` on `required_peers`;
- Move what `ConnectionTask` is currently doing inside `NetworkClient` (somehow);
- Validate the incoming UTXO, creating four tiers: quorums, validators, nodes with a stake, full nodes;
- Rework the limits for the tiers above;
- Change the nominator to gossip only to our quorum;