### PR TITLE
Ledger: Move FeeManager / UTXOCache instantiation in the Ledger

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1706,7 +1706,7 @@ private mixin template TestNodeMixin ()
     {
         UTXOPair[] result;
         Amount accumulated;
-        foreach (const ref Hash key, const ref UTXO value; this.utxo_set)
+        foreach (const ref Hash key, const ref UTXO value; this.ledger.utxos)
         {
             if (value.output.type == output_type && !this.pool.spending(key))
             {
@@ -1722,7 +1722,7 @@ private mixin template TestNodeMixin ()
     ///
     public override UTXOPair[] getUTXOs (PublicKey owner)
     {
-        return this.utxo_set.getUTXOs(owner).byKeyValue
+        return this.ledger.utxos.getUTXOs(owner).byKeyValue
             .map!((pair) => UTXOPair(pair.key, pair.value)).array;
     }
 
@@ -1730,7 +1730,7 @@ private mixin template TestNodeMixin ()
     public override UTXO getUTXO (Hash hash)
     {
         UTXO result;
-        if (!this.utxo_set.peekUTXO(hash, result))
+        if (!this.ledger.peekUTXO(hash, result))
             throw new Exception(format("UTXO not found: %s", hash));
         return result;
     }
@@ -1918,9 +1918,9 @@ public class TestValidatorNode : Validator, TestAPI
         foreach (idx, utxo; utxos)
         {
             UTXO utxo_value;
-            this.utxo_set.peekUTXO(utxo, utxo_value);
+            this.ledger.peekUTXO(utxo, utxo_value);
             quorums ~= buildQuorumConfig(idx, utxos,
-                this.utxo_set.getUTXOFinder(), rand_seed, this.quorum_params);
+                this.ledger.getUTXOFinder(), rand_seed, this.quorum_params);
         }
         return quorums;
     }

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -28,7 +28,7 @@ private class SameKeyValidator : TestValidatorNode
     public override Enrollment setRecurringEnrollment (bool doIt)
     {
         Hash[] utxo_hashes;
-        auto utxos = this.utxo_set.getUTXOs(
+        auto utxos = this.ledger.utxos.getUTXOs(
             this.config.validator.key_pair.address);
         foreach (key, utxo; utxos)
         {

--- a/source/agora/test/LocalTransactions.d
+++ b/source/agora/test/LocalTransactions.d
@@ -101,9 +101,8 @@ unittest
 
         protected override ValidatingLedger makeLedger ()
         {
-            return new PickyLedger(this.params, this.engine,
-                this.utxo_set, this.storage, this.enroll_man, this.pool,
-                new FeeManager(this.stateDB, this.params), &this.onAcceptedBlock);
+            return new PickyLedger(this.params, this.stateDB, this.storage,
+                this.engine, this.enroll_man, this.pool, &this.onAcceptedBlock);
         }
 
         public override TransactionResult postTransaction (in Transaction tx) @safe


### PR DESCRIPTION
```
The instantiation happening in the node is a leftover of the time
where dependency injection was done at the class level.
Now that we just pass a ManagedDatabase, there is no need for it.
If tests want to implement a specific behavior for one of those
classes, they can re-introduce the dependency injection in the Ledger.
```