### PR TITLE
Dockerfile: Temporarily use alpine 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN if [ -z ${AGORA_STANDALONE+x} ]; then dub build --skip-registry=all --compil
 # Runner
 # Uses edge as we need the same `ldc-runtime` as the LDC that compiled Agora,
 # and `bosagora/agora-builder:latest` uses edge.
-FROM alpine:edge
+FROM alpine:3.15
 # The following makes debugging Agora much easier on server
 # Since it's a tiny configuration file read by GDB at init, it won't affect release build
 COPY devel/dotgdbinit /root/.gdbinit


### PR DESCRIPTION
The reason we use edge is to match 'docker-agora-builder'.
However, upstream has broken the LDC package and we are currently
waiting on them to merge the fix.
Luckily, the last Alpine release was 2021-11-24,
and no LDC update has happened since.