### PR TITLE
CI: Extend config file check to devel files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,10 @@ jobs:
 
     - name: Test example configuration file
       if: matrix.run_extra_checks && runner.os != 'Windows'
-      run: ./build/agora -c doc/config.example.yaml --config-check
+      run: |
+        ./build/agora -c doc/config.example.yaml --config-check
+        ./build/agora -c devel/config-fullnode.yaml --config-check
+        ./build/agora -c devel/config-single.yaml --config-check
 
     - name: Check vtable offset
       if: matrix.run_extra_checks && runner.os != 'Windows'

--- a/devel/config-fullnode.yaml
+++ b/devel/config-fullnode.yaml
@@ -28,23 +28,10 @@ consensus:
 
 validator:
   enabled: false
-  registry_address: https://v0.bosagora.io/
+  registry_address: https://ns1.bosagora.io/
 
 registry:
   enabled: true
-  flash:
-    email: github@bosagora.io
-  validators:
-    email: github@bosagora.io
-
-# Note: You may want to comment some of those to selectively test
-network:
-  - https://v2.bosagora.io/
-  - https://v3.bosagora.io/
-  - https://v4.bosagora.io/
-  - https://v5.bosagora.io/
-  - https://v6.bosagora.io/
-  - https://v7.bosagora.io/
 
 logging:
   root:


### PR DESCRIPTION
```
Those files are easy to break when a change happens in Agora.
Although they are in devel (and hence, subject to laxer rules),
we can easily avoid any breakage by adding this check to the CI,
as the check is extremely cheap.
```

As discussed with @hewison-chris yesterday.