### PR TITLE
NetClient: Remove address/api from ctor, use merge

### DIFF
--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -156,27 +156,23 @@ public class NetworkClient
         Params:
             taskman = used for creating new tasks
             banman = ban manager
-            address = used for logging and querying by external code
-            api = the API to issue the requests with
             retry = the amout to wait between retrying failed requests
             max_retries = max number of times a failed request should be retried
 
     ***************************************************************************/
 
-    public this (ITaskManager taskman, BanManager banman, Address address,
-        API api, Duration retry, size_t max_retries)
+    public this (ITaskManager taskman, BanManager banman,
+                 Duration retry, size_t max_retries)
     {
         // By default, use the module, but if we can identify a validator,
         // this logger will be replaced with a more specialized one.
         this.log = Log.lookup(__MODULE__);
         this.taskman = taskman;
         this.banman = banman;
-        this.connections ~= ConnectionInfo(address, api);
         this.retry_delay = retry;
         this.max_retries = max_retries;
         this.exception = new Exception(
-            format("Request failure to %s after %s attempts", address,
-                max_retries));
+            format("Request failure after %s attempts", max_retries));
         // Create and stop timer immediately
         this.gossip_timer = this.taskman.setTimer(GossipDelay, &this.gossipTask, Periodic.No);
         this.gossip_timer.stop();
@@ -607,7 +603,7 @@ public class NetworkClient
         if (this.tryMergeRPC(address, api))
             return true;
 
-        if (address != Address.init)
+        if (address != Address.init || this.connections.length == 0)
         {
             this.connections ~= ConnectionInfo(address, api);
             return true;

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -243,9 +243,10 @@ public class NetworkManager
             }
 
             auto client = new NetworkClient(this.outer.taskman,
-                this.outer.banman, this.address, this.api,
-                this.outer.node_config.retry_delay,
+                this.outer.banman, this.outer.node_config.retry_delay,
                 this.outer.node_config.max_retries);
+            if (!client.merge(this.address, this.api))
+                assert(0);
             if (is_validator)
                 client.setIdentity(key);
 


### PR DESCRIPTION
```
We want to move to supporting connection-less NetworkClient,
e.g. so that we can have objects to represent missing nodes,
hence we need to first remove the dependency on an existing
connection from the constructor.
```

Part of https://github.com/bosagora/agora/pull/2845