### PR TITLE
NetworkManager: Store nodes identity directly in `NetworkClient`

### DIFF
--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -261,7 +261,10 @@ public class NetworkClient
 
     public void setIdentity (in Hash utxo, in PublicKey key)
     {
-        assert(!this.identity);
+        assert(!this.identity, "Cannot `setIdentity` twice");
+        assert(utxo !is Hash.init);
+        assert(key.isValid());
+
         this.identity_ = Identity(key, utxo);
         this.log = Log.lookup(format("%s.%s", __MODULE__, key));
         this.log.info("Peer identity established (UTXO: {})", utxo);

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -825,8 +825,7 @@ public class NetworkManager
         return !this.banman.isBanned(address) &&
             address !in this.connection_tasks &&
             address !in this.todo_addresses &&
-            (existing_peer.empty || // either does not exist or a validator with no stake
-                (existing_peer.front.isValidator() && existing_peer.front.utxo == Hash.init));
+            existing_peer.empty;
     }
 
     /// Received new set of addresses, put them in the todo address list

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -101,7 +101,8 @@ public class NetworkManager
 
         /// Called when we've connected and determined if this is
         /// a FullNode / Validator
-        public alias OnHandshakeComplete = void delegate (scope ref NodeConnInfo);
+        public alias OnHandshakeComplete = void delegate (
+            in Address, agora.api.Validator.API, in Hash, in PublicKey);
         /// Ditto
         private OnHandshakeComplete onHandshakeComplete;
 
@@ -242,21 +243,7 @@ public class NetworkManager
                 }
             }
 
-            auto client = new NetworkClient(this.outer.taskman,
-                this.outer.banman, this.outer.node_config.retry_delay,
-                this.outer.node_config.max_retries);
-            if (!client.merge(this.address, this.api))
-                assert(0);
-            if (is_validator)
-                client.setIdentity(key);
-
-            NodeConnInfo node = {
-                key : key,
-                utxo: utxo,
-                client : client
-            };
-
-            this.onHandshakeComplete(node);
+            this.onHandshakeComplete(this.address, this.api, utxo, key);
         }
     }
 
@@ -493,36 +480,51 @@ public class NetworkManager
     }
 
     /// Called after a node's handshake is complete
-    private void onHandshakeComplete (scope ref NodeConnInfo node)
+    private void onHandshakeComplete (
+        in Address address, agora.api.Validator.API api,
+        in Hash utxo, in PublicKey key)
     {
-        log.dbg("onHandshakeComplete: addresses: {}", node.client.addresses());
-        node.client.connections.each!(conn => this.connection_tasks.remove(conn.address));
+        auto client = new NetworkClient(this.taskman, this.banman,
+            this.node_config.retry_delay, this.node_config.max_retries);
+        if (!client.merge(address, api))
+            assert(0);
+        if (utxo !is Hash.init)
+            client.setIdentity(key);
+
+        NodeConnInfo node = {
+            key : key,
+            utxo: utxo,
+            client : client
+        };
+
+        log.dbg("onHandshakeComplete: addresses: {}", client.addresses());
+        client.connections.each!(conn => this.connection_tasks.remove(address));
         if (this.tryMerge(node))
         {
-            this.required_peers.remove(node.utxo);
+            this.required_peers.remove(utxo);
             return;
         }
         if (this.peerLimitReached())
             return;
 
-        if (!node.client.connections.any!(conn => conn.address == Address.init))
+        if (!client.connections.any!(conn => address == Address.init))
         {
             this.peers.insertBack(node);
-            this.discovery_task.add(node.client);
+            this.discovery_task.add(client);
 
             if (node.isValidator())
             {
                 log.info("Found new Validator: {} (UTXO: {}, key: {})",
-                         node.client.addresses(), node.utxo, node.key);
-                this.required_peers.remove(node.utxo);
+                         client.addresses(), utxo, key);
+                this.required_peers.remove(utxo);
             }
             else
-                log.info("Found new FullNode: {}", node.client.addresses());
+                log.info("Found new FullNode: {}", client.addresses());
         }
         else // unidentified connection that we can not merge, just use it for a single shot of address discovery
         {
             log.dbg("onHandshakeComplete: an unidentified connection was included");
-            auto node_info = node.client.getNodeInfo();
+            auto node_info = client.getNodeInfo();
             this.addAddresses(node_info.addresses);
         }
     }

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -825,7 +825,8 @@ public class NetworkManager
         return !this.banman.isBanned(address) &&
             address !in this.connection_tasks &&
             address !in this.todo_addresses &&
-            existing_peer.empty;
+            (existing_peer.empty || // either does not exist or a validator with no stake
+                (existing_peer.front.isValidator() && existing_peer.front.utxo == Hash.init));
     }
 
     /// Received new set of addresses, put them in the todo address list

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -73,10 +73,16 @@ public class NetworkManager
     public static struct NodeConnInfo
     {
         /// Hash of the output used as collateral, only set if the node is a Validator
-        Hash utxo;
+        public Hash utxo () const scope @safe pure nothrow @nogc
+        {
+            return this.client.identity.utxo;
+        }
 
         /// PublicKey of the node. TODO: Remove and just use utxo.
-        PublicKey key;
+        public PublicKey key () const scope @safe pure nothrow @nogc
+        {
+            return this.client.identity.key;
+        }
 
         /// Client
         NetworkClient client;
@@ -84,7 +90,7 @@ public class NetworkManager
         ///
         public bool isValidator () const scope @safe pure nothrow @nogc
         {
-            return this.key != PublicKey.init;
+            return !!this.client.identity;
         }
     }
 
@@ -489,11 +495,9 @@ public class NetworkManager
         if (!client.merge(address, api))
             assert(0);
         if (utxo !is Hash.init)
-            client.setIdentity(key);
+            client.setIdentity(utxo, key);
 
         NodeConnInfo node = {
-            key : key,
-            utxo: utxo,
             client : client
         };
 
@@ -537,7 +541,6 @@ public class NetworkManager
             return false;
 
         assert(node.client.connections.length == 1);
-        existing_peers.front().utxo = node.utxo;
         existing_peers.front().client.merge(node.client.connections[0].tupleof);
         return true;
     }


### PR DESCRIPTION
One step towards eliminating `NodeConnInfo`.
Part of https://github.com/bosagora/agora/pull/2845