### PR TITLE
RPC: Check if sending peer is banned

### DIFF
--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -223,10 +223,10 @@ public Listeners runNode (Config config)
         log.info("Node will be listening on TCP interface: {}:{}", interface_.address, interface_.port);
         if (auto fl = cast(agora.api.Validator.API) result.node)
             result.tcp ~= listenRPC!(agora.api.Validator.API)(fl, interface_.address, interface_.port, config.node.timeout,
-                &result.node.getNetworkManager().discoverFromClient);
+                &result.node.getNetworkManager().discoverFromClient, isBannedDg);
         else
             result.tcp ~= listenRPC!(agora.api.FullNode.API)(result.node, interface_.address, interface_.port, config.node.timeout,
-                &result.node.getNetworkManager().discoverFromClient);
+                &result.node.getNetworkManager().discoverFromClient, isBannedDg);
     }
 
     return result;


### PR DESCRIPTION
RPC node ban was only checked during sending phase, now also receivers
will be checking for the banned senders.