### PR TITLE
Registry: Accept staking nodes even if they are not enrolled

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -697,12 +697,10 @@ public class Validator : FullNode, API
     private Hash getFrozenUTXO () @safe nothrow
     {
         const pub_key = this.config.validator.key_pair.address;
-        foreach (utxo; this.ledger.utxos.getUTXOs(pub_key).byKeyValue)
+        foreach (tracked; this.ledger.getStakes())
         {
-            if (utxo.value.output.type == OutputType.Freeze &&
-                utxo.value.output.value.integral() >= Amount.MinFreezeAmount.integral() &&
-                this.ledger.getPenaltyDeposit(utxo.key) > 0.coins)
-                return utxo.key;
+            if (pub_key is tracked.output.address())
+                return tracked.hash;
         }
 
         return Hash.init;


### PR DESCRIPTION
One of the issue we are seeing live is that non-enrolled validators cannot yet register, leading to jumpy DNS.
In order to avoid this issue, we should rely on the stake being present, as it's much more long-lived.