### PR TITLE
Proxy protocol for RPC

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -76,6 +76,11 @@ interfaces:
   - type: stats
     address: 0.0.0.0
     port: 9110
+  - type: tcp
+    address: 0.0.0.0
+    port: 9220
+    # Enables proxy protocol v1 for the interface, only applicable for TCP
+    proxy_proto: true
 
 # Proxy to be used for outgoing Agora connections
 proxy:

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -174,6 +174,9 @@ public struct InterfaceConfig
     /// Bind port
     public ushort port;
 
+    /// Proxy Protocol V1
+    public bool proxy_proto;
+
     /// Default values when none is given in the config file
     private static immutable InterfaceConfig[Type.max] Default = [
         // Publicly enabled by default

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -222,11 +222,11 @@ public Listeners runNode (Config config)
     {
         log.info("Node will be listening on TCP interface: {}:{}", interface_.address, interface_.port);
         if (auto fl = cast(agora.api.Validator.API) result.node)
-            result.tcp ~= listenRPC!(agora.api.Validator.API)(fl, interface_.address, interface_.port, config.node.timeout,
-                &result.node.getNetworkManager().discoverFromClient, isBannedDg);
+            result.tcp ~= listenRPC!(agora.api.Validator.API)(fl, interface_.address, interface_.port, interface_.proxy_proto,
+                config.node.timeout, &result.node.getNetworkManager().discoverFromClient, isBannedDg);
         else
-            result.tcp ~= listenRPC!(agora.api.FullNode.API)(result.node, interface_.address, interface_.port, config.node.timeout,
-                &result.node.getNetworkManager().discoverFromClient, isBannedDg);
+            result.tcp ~= listenRPC!(agora.api.FullNode.API)(result.node, interface_.address, interface_.port, interface_.proxy_proto,
+                config.node.timeout, &result.node.getNetworkManager().discoverFromClient, isBannedDg);
     }
 
     return result;


### PR DESCRIPTION
Towards #1675 

[Proxy Protocol](http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) is a protocol that provides a way to access actual client's addresses over TCP streams when Agora is behind reverse proxy/load balancer. This allows us to properly ban manage peers.

The protocol should actually be part of Vibe.d's underlying stream implementation. Until then, this implementation can help us. The protocol actually has more recent version 2 but Nginx and most of the applications (like curl) doesn't support it yet. 

Needs testing, will try soon; let's have discussion on it.