### PR TITLE
ValidatorCleanRestart test: Use 5 nodes in quorum

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -27,7 +27,10 @@ import d2sqlite3.results;
 import d2sqlite3.sqlite3;
 
 import std.algorithm;
+import std.datetime.systime : SysTime;
+import std.datetime.timezone : UTC;
 import std.file;
+import std.format;
 import std.socket : getAddressInfo, AddressFamily;
 import std.stdio;
 
@@ -254,6 +257,13 @@ public class BanManager
         this.banUntil(address, ban_until);
     }
 
+    private string unixDateTime(TimePoint unixtime) @safe nothrow
+    {
+        static import agora.utils.Utility;
+        return agora.utils.Utility.assumeNothrow(
+            format!"unixtime:%s (%s)"(unixtime, SysTime.fromUnixTime(unixtime, UTC()).toString));
+    }
+
     /***************************************************************************
 
         Manually ban an address, until the specified time.
@@ -269,9 +279,10 @@ public class BanManager
         if (address is Address.init || this.isWhitelisted(address))
             return; // no address or Whitelisted address
 
-        log.info("BanManager: Address {} banned until {}", address, banned_until);
         try
         {
+            log.info("BanManager: Address {} banned at {} until {}", address,
+                unixDateTime(this.getCurTime()), unixDateTime(banned_until));
             this.url_failures.require(address).banned_until = banned_until;
             this.storeBanned(address, banned_until);
         }
@@ -310,6 +321,7 @@ public class BanManager
 
         this.whitelisted.put(address);
         this.storeWhitelisted(address);
+        log.dbg("{}/{}: Whitelisted address {}", __FILE__, __LINE__, address);
     }
 
     private void storeWhitelisted (Address address) @trusted nothrow
@@ -339,6 +351,7 @@ public class BanManager
         this.whitelisted.remove(address);
         // remove from cache db
         this.deleteWhitelisted(address);
+        log.dbg("[{}:{}] {} No longer whitelisted at {}", __FILE__, __LINE__, address, unixDateTime(this.getCurTime()));
     }
 
     private void deleteWhitelisted (Address address) @trusted nothrow
@@ -374,15 +387,18 @@ public class BanManager
         // if the ban was set and has expired then remove it
         if (status.banned_until > 0 && this.getCurTime() > status.banned_until)
         {
+            log.dbg("[{}:{}] {} No longer banned at {}", __FILE__, __LINE__, address, unixDateTime(this.getCurTime()));
             // remove from AA
             this.url_failures.remove(address);
             // remove from cache db
             this.deleteBanned(address);
             return false;
         }
-
         // return if the ban is still active
-        return status.banned_until > this.getCurTime();
+        const stillBanned = status.banned_until > this.getCurTime();
+        if (stillBanned)
+            log.dbg("[{}:{}] {} Still banned at {} until {}", __FILE__, __LINE__, address, unixDateTime(this.getCurTime()), unixDateTime(status.banned_until));
+        return stillBanned;
     }
 
     private void deleteBanned (Address address) @trusted nothrow

--- a/source/agora/consensus/Quorum.d
+++ b/source/agora/consensus/Quorum.d
@@ -79,6 +79,8 @@ public QuorumConfig buildQuorumConfig (in NodeID key, in Hash[] utxo_keys,
     scope UTXOFinder finder, in Hash rand_seed, const ref QuorumParams params)
     @safe nothrow
 {
+    static import agora.utils.Utility;
+
     // special-case: only 1 validator is active
     if (utxo_keys.length == 1)
         return QuorumConfig(1, [key]);
@@ -94,18 +96,12 @@ public QuorumConfig buildQuorumConfig (in NodeID key, in Hash[] utxo_keys,
     auto RNG_gen = getGenerator(key, rand_seed);
     auto stake_amounts = stakes.map!(stake => stake.amount.integral);
 
-    static assumeNothrow (T)(lazy T exp) nothrow
-    {
-        try return exp();
-        catch (Exception ex) assert(0, ex.msg);
-    }
-
     // +1 as we already added ourself
     const MaxNodes = min(stakes.length + 1, params.MaxQuorumNodes);
     while (quorum.nodes.length < MaxNodes)
     {
         // dice() can only throw if the sum of stakes is zero
-        auto idx = assumeNothrow(dice(RNG_gen, stake_amounts));
+        auto idx = agora.utils.Utility.assumeNothrow(dice(RNG_gen, stake_amounts));
         if (added[idx])  // skip duplicate
             continue;
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -913,7 +913,11 @@ extern(D):
             }
         }
         else if (slot_idx > last_height + 1)   // Too early for us to check for signatures
+        {
+            log.dbg("Too early to check signatures of last block. slot_idx: {}, ledger height: {}",
+                slot_idx, last_height);
             return ValidationLevel.kMaybeValidValue;
+        }
 
         return ValidationLevel.kFullyValidatedValue;
     }
@@ -1246,6 +1250,7 @@ extern(D):
     public override ValueWrapperPtr combineCandidates (uint64_t slot_idx,
         ref const(ValueWrapperPtrSet) candidates)
     {
+        log.dbg("combineCandidates for slot i: {}", cast(ulong) slot_idx);
         try
         {
             CandidateHolder[] candidate_holders;
@@ -1281,7 +1286,7 @@ extern(D):
             }
 
             auto chosen_consensus_data = candidate_holders.sort().front;
-            log.trace("Chosen consensus data: {}", chosen_consensus_data.prettify);
+            log.trace("Chosen consensus data for slot i: {} : {}", cast(ulong) slot_idx, chosen_consensus_data.prettify);
 
             const Value val = chosen_consensus_data.serializeFull().toVec();
             auto dupe_val = duplicate_value(&val);

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -571,12 +571,15 @@ public class NetworkClient
         {
             foreach (conn; this.connections)
             {
-                log.dbg("Client.attemptRequest '{}' to {}: {}/{}",
-                    name, conn.address, idx, this.max_retries);
-                if (!this.banman.isBanned(conn.address))
+                if (this.banman.isBanned(conn.address))
+                {
+                    log.dbg("Client.attemptRequest '{}' skipped as {} is banned: {}/{}", name, conn.address, idx, this.max_retries);
+                }
+                else
                 {
                     try
                     {
+                        log.dbg("Client.attemptRequest '{}' to {}: {}/{}", name, conn.address, idx, this.max_retries);
                         scope (success) this.log.format(log_level, "Client.attemptRequest '{}' to {}: {}/{} SUCCESS",
                             name, conn.address, idx, this.max_retries);
                         return __traits(getMember, conn.api, name)(args);

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -692,7 +692,8 @@ public class FullNode : API
         immutable Genesis = () {
             if (!config.node.testing)
                 return COINNET.GenesisBlock;
-            if (!config.node.limit_test_validators)
+            if (!config.node.limit_test_validators
+                || config.node.limit_test_validators == TESTNET.GenesisBlock.header.enrollments.length)
                 return TESTNET.GenesisBlock;
 
             immutable Block result = {

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -519,8 +519,10 @@ public class FullNode : API
         if (this.network.peers.empty())  // no clients yet (discovery)
             return;
 
+        const nextHeight = Height(this.ledger.height() + 1);
+        log.dbg("catchupTask: getBlocksFrom height {}", nextHeight);
         this.network.getBlocksFrom(
-            Height(this.ledger.height() + 1),
+            nextHeight,
             &this.addBlocks);
         this.network.getUnknownTXs(this.ledger);
         try

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2046,6 +2046,10 @@ public struct TestConf
     /// Matches the eponymous field in the `banman` section.
     public size_t max_failed_requests = 100;
 
+    /// duration that the node is banned
+    /// Matches the eponymous field in the `banman` section.
+    public Duration ban_duration = 300.seconds;
+
     /// Base values for the `node` section
     public NodeConfig node = {
         /// Minimum number of clients to connect to
@@ -2173,7 +2177,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
     BanManager.Config ban_conf =
     {
         max_failed_requests : test_conf.max_failed_requests,
-        ban_duration: 300.seconds,
+        ban_duration: test_conf.ban_duration,
     };
 
     immutable(Address[]) makeNetworkConfig (size_t idx, Address[] addresses)

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1120,7 +1120,7 @@ public class TestAPIManager
             // Wait for tx gossipping before setting time for block
             client_idxs.each!(idx =>
                 retryFor(this.clients[idx].hasTransactionHash(tx.hashFull()),
-                    4.seconds, format!"[%s:%s] Client #%s did not receive tx in expected time for height %s"
+                    10.seconds, format!"[%s:%s] Client #%s did not receive tx in expected time for height %s"
                         (file, line, idx, target_height)));
         }
 

--- a/source/agora/test/Simple.d
+++ b/source/agora/test/Simple.d
@@ -28,7 +28,9 @@ unittest
 {
     TestConf conf;
     conf.consensus.payout_period = 10;
-
+    conf.node.limit_test_validators = 4;
+    conf.consensus.max_quorum_nodes = 4;
+    conf.consensus.quorum_threshold = 75;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -114,6 +114,7 @@ unittest
 {
     TestConf conf;
     conf.node.block_catchup_interval = 100.msecs; // speed up catchup
+    conf.consensus.max_quorum_nodes = 5;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();
@@ -125,7 +126,7 @@ unittest
     auto node_1 = nodes[1];
     auto node_2 = nodes[2];
 
-    assert(node_1.getQuorumConfig().threshold == 5);
+    assert(node_1.getQuorumConfig().threshold == 4);
 
     // Create a block after the Genesis block
     network.generateBlocks(Height(1));

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -113,8 +113,11 @@ version(none) unittest
 unittest
 {
     TestConf conf;
-    conf.node.block_catchup_interval = 100.msecs; // speed up catchup
-    conf.consensus.max_quorum_nodes = 5;
+    conf.node.block_catchup_interval = 250.msecs; // speed up catchup
+    conf.node.limit_test_validators = 4;
+    conf.consensus.max_quorum_nodes = 4;
+    conf.consensus.quorum_threshold = 75;
+    conf.node.max_retries = 3;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();
@@ -126,8 +129,6 @@ unittest
     auto node_1 = nodes[1];
     auto node_2 = nodes[2];
 
-    assert(node_1.getQuorumConfig().threshold == 4);
-
     // Create a block after the Genesis block
     network.generateBlocks(Height(1));
 
@@ -136,18 +137,18 @@ unittest
     node_2.ctrl.sleep(1.hours, true);
 
     // Make 2 blocks
-    network.generateBlocks(only(0, 1, 3, 4, 5), Height(3));
+    network.generateBlocks(only(0, 1, 3), Height(3));
 
     // Wake up node_2
     node_2.ctrl.sleep(0.seconds);
 
+    // wait till node_2 catches up
+    network.assertSameBlocks(only(0, 2, 3), Height(3));
+
     // node_1 is sleeping
     node_1.ctrl.sleep(1.hours, true);
 
-    // wait till node_2 catches up
-    network.assertSameBlocks(only(0, 2, 3, 4, 5), Height(3));
-
     // A new block is still inserted into the ledger with the approval
     // of node_2, although node_1 was sleeping.
-    network.generateBlocks(only(0, 2, 3, 4, 5), Height(4));
+    network.generateBlocks(only(0, 2, 3), Height(4));
 }

--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -55,7 +55,9 @@ public struct Logger
     /// See `ocean.util.log.Logger : Logger.dbg`
     public void dbg (Args...) (cstring fmt, Args args)
     {
-        this.format(LogLevel.Debug, fmt, args);
+        // For debug logging let's assume we do not throw
+        static import agora.utils.Utility;
+        agora.utils.Utility.assumeNothrow(this.format(LogLevel.Debug, fmt, args));
     }
 
     /// See `ocean.util.log.Logger : Logger.trace`

--- a/source/agora/utils/Utility.d
+++ b/source/agora/utils/Utility.d
@@ -28,6 +28,12 @@ import core.time;
 
 mixin AddLogger!();
 
+public static assumeNothrow (T)(lazy T exp) nothrow
+{
+    try return exp();
+    catch (Exception ex) assert(0, ex.msg);
+}
+
 /***************************************************************************
 
     Retry executing a given delegate at most X times and wait between


### PR DESCRIPTION
This is to follow the quorum size calculation using if `N = 3f +1` then
quorum size is `2f + 1` where N is total nodes and f is max faulty or
byzantine nodes with guaranteed safety. The quorum size was previously
6 which can result in less liveliness as it results in a single quorum
with all nodes as members.