### PR TITLE
Limit `Address` type to only accept schemes supported by Agora

### DIFF
--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -14,6 +14,7 @@
 module agora.common.Types;
 
 import agora.common.Amount;
+import agora.common.Ensure : ensure;
 import agora.crypto.ECC;
 import agora.crypto.Key;
 import agora.crypto.Schnorr;
@@ -23,6 +24,8 @@ import agora.serialization.Serializer;
 import vibe.inet.url;
 
 import geod24.bitblob;
+
+import std.algorithm.comparison : among;
 
 /// Clone any type via the serializer
 public T clone (T)(in T input)
@@ -52,6 +55,9 @@ public struct Address
 
     public this (URL url)
     {
+        ensure(url.schema.among("agora", "http", "https", "dns") != 0,
+            "Address schema '{}' is not supported", url.schema);
+
         this.inner = url;
         this.inner.normalize(true);
     }

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -1183,7 +1183,7 @@ public class NetworkManager
     {
         import std.algorithm.searching;
 
-        if (url.schema == "tcp" || url.schema == "agora")
+        if (url.schema == "agora")
         {
             auto owner_validator = cast (agora.api.Validator.API) this.owner_node;
 

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -58,8 +58,8 @@ validator:
 network:
   # Supported value: IPv4, IPv6
   - http://node-2:2826
-  - tcp://node-3:3735
+  - agora://node-3:3735
   - http://node-4:4826
-  - tcp://node-5:5735
+  - agora://node-5:5735
   - http://node-6:6826
-  - tcp://node-7:7735
+  - agora://node-7:7735

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -64,7 +64,7 @@ network:
   # Supported value: IPv4, IPv6
   - http://node-0:1826
   - http://node-3:3826
-  - tcp://node-4:4735
+  - agora://node-4:4735
   - http://node-5:5826
-  - tcp://node-6:6735
+  - agora://node-6:6735
   - http://node-7:7826

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -62,9 +62,9 @@ validator:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - tcp://node-0:1735
+  - agora://node-0:1735
   - http://node-2:2826
   - http://node-4:4826
-  - tcp://node-5:5735
+  - agora://node-5:5735
   - http://node-6:6826
-  - tcp://node-7:7735
+  - agora://node-7:7735

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -63,8 +63,8 @@ validator:
 network:
   # Supported value: IPv4, IPv6
   - http://node-0:1826
-  - tcp://node-2:2735
+  - agora://node-2:2735
   - http://node-3:3826
   - http://node-5:5826
-  - tcp://node-6:6735
+  - agora://node-6:6735
   - http://node-7:7826

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -62,9 +62,9 @@ validator:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - tcp://node-0:1735
+  - agora://node-0:1735
   - http://node-2:2826
-  - tcp://node-3:3735
+  - agora://node-3:3735
   - http://node-4:4826
   - http://node-6:6826
-  - tcp://node-7:7735
+  - agora://node-7:7735

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -63,8 +63,8 @@ validator:
 network:
   # Supported value: IPv4, IPv6
   - http://node-0:1826
-  - tcp://node-2:2735
+  - agora://node-2:2735
   - http://node-3:3826
-  - tcp://node-4:4735
+  - agora://node-4:4735
   - http://node-5:5826
   - http://node-7:7826

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -62,9 +62,9 @@ validator:
 ################################################################################
 network:
   # Supported value: IPv4, IPv6
-  - tcp://node-0:1735
+  - agora://node-0:1735
   - http://node-2:2826
-  - tcp://node-3:3735
+  - agora://node-3:3735
   - http://node-4:4826
-  - tcp://node-5:5735
+  - agora://node-5:5735
   - http://node-6:6826


### PR DESCRIPTION
Fixes #2882 

Let's see if we have invalid scheme usages in tests first