### PR TITLE
Ledger: Rename 'getBlockHeight' to just 'height' 

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -287,7 +287,7 @@ extern(D):
         // we stop the nomination and set the new quorum set.
         if(this.is_nominating)
         {
-            const height = this.ledger.getBlockHeight();
+            const height = this.ledger.height();
             try
             {
                 () @trusted {
@@ -431,7 +431,7 @@ extern(D):
     protected ulong getExpectedBlockTime () @safe @nogc nothrow pure
     {
         return this.params.GenesisTimestamp +
-            (ledger.getBlockHeight() + 1) * this.params.BlockInterval.total!"seconds";
+            (ledger.height() + 1) * this.params.BlockInterval.total!"seconds";
     }
 
     /***************************************************************************
@@ -449,7 +449,7 @@ extern(D):
 
     protected void checkNominate () @safe
     {
-        const slot_idx = this.ledger.getBlockHeight() + 1;
+        const slot_idx = this.ledger.height() + 1;
         // are we done nominating this round
         if (this.last_confirmed_height >= slot_idx)
         {
@@ -479,11 +479,11 @@ extern(D):
             return;
         }
 
-        if (!this.ledger.hasMajoritySignature(this.ledger.getBlockHeight()))
+        if (!this.ledger.hasMajoritySignature(this.ledger.height()))
         {
             this.log.trace(
                 "checkNominate(): Last block ({}) doesn't have majority signatures, signed={}",
-                this.ledger.getBlockHeight(), this.ledger.lastBlock().header.validators);
+                this.ledger.height(), this.ledger.lastBlock().header.validators);
             return;
         }
 
@@ -709,7 +709,7 @@ extern(D):
 
     public const(BlockHeader) receiveBlockSignature (in ValidatorBlockSig block_sig) @safe
     {
-        const cur_height = this.ledger.getBlockHeight();
+        const cur_height = this.ledger.height();
         log.trace("Received BLOCK SIG {} from node {} for block {}",
                     block_sig.signature, block_sig.utxo, block_sig.height);
         if (block_sig.height > cur_height)
@@ -903,7 +903,7 @@ extern(D):
             }
         }
 
-        const last_height = this.ledger.getBlockHeight();
+        const last_height = this.ledger.height();
         if (last_height + 1 == slot_idx) // Let's check last block is still one before this one
         {
             if (!this.ledger.hasMajoritySignature(last_height))
@@ -934,7 +934,7 @@ extern(D):
         ref const(Value) value) nothrow
     {
         Height height = Height(slot_idx);
-        const Height last_height = this.ledger.getBlockHeight();
+        const Height last_height = this.ledger.height();
         if (height != last_height + 1)
         {
             log.trace("valueExternalized: Will not externalize envelope with slot id {} as ledger is at height {}",

--- a/source/agora/consensus/state/Ledger.d
+++ b/source/agora/consensus/state/Ledger.d
@@ -204,7 +204,7 @@ public class Ledger
 
     ***************************************************************************/
 
-    public Height getBlockHeight () const scope @safe @nogc nothrow pure
+    public Height height () const scope @safe @nogc nothrow pure
     {
         return this.last_block.header.height;
     }
@@ -228,7 +228,7 @@ public class Ledger
         Params:
           height = Height at which to query the validator set.
                    Accurate results are only guaranteed for
-                   `height <= this.getBlockHeight() + 1`.
+                   `height <= this.height() + 1`.
           empty = Whether to allow an empty return value.
                   By default, this function will throw if there is no validators
                   at `height`. If `true` is passed, it will not.
@@ -268,7 +268,7 @@ public class Ledger
         Params:
           height = Height at which to query the validator set.
                    Accurate results are only guaranteed for
-                   `height <= this.getBlockHeight() + 1`.
+                   `height <= this.height() + 1`.
 
         Returns:
           Number of active validators at `height`.
@@ -351,7 +351,7 @@ public class Ledger
                 ? null
                 : "Trying to externalize a different block for the latest height";
 
-        if (!this.hasMajoritySignature(this.getBlockHeight()))
+        if (!this.hasMajoritySignature(this.height()))
             return "Previous height does not have majority signature";
 
         if (auto fail_reason = this.validateBlock(block))
@@ -916,7 +916,7 @@ public class Ledger
     /// Ditto
     public bool hasMajoritySignature (Height height) @safe nothrow
     {
-        if (height > this.getBlockHeight())
+        if (height > this.height())
             return false;
         else if (height == this.last_block.header.height) // most common case
             return this.hasMajoritySignature(this.last_block.header);
@@ -941,11 +941,11 @@ public class Ledger
 
     public auto getBlocksFrom (Height start_height) @safe nothrow
     {
-        start_height = min(start_height, this.getBlockHeight() + 1);
+        start_height = min(start_height, this.height() + 1);
 
         // Call to `Height.value` to work around
         // https://issues.dlang.org/show_bug.cgi?id=21583
-        return iota(start_height.value, this.getBlockHeight() + 1)
+        return iota(start_height.value, this.height() + 1)
             .map!(idx => this.storage.readBlock(Height(idx)));
     }
 
@@ -963,7 +963,7 @@ public class Ledger
 
         Returns:
           A newly created block based on the current block
-          (See `Ledger.lastBlock()` and `Ledger.getBlockHeight()`)
+          (See `Ledger.lastBlock()` and `Ledger.height()`)
 
     ***************************************************************************/
 
@@ -971,7 +971,7 @@ public class Ledger
         Enrollment[] enrollments, uint[] missing_validators)
         @safe
     {
-        const height = this.getBlockHeight() + 1;
+        const height = this.height() + 1;
         const validators = this.getValidators(height);
 
         Hash[] preimages = validators.enumerate.map!(
@@ -998,7 +998,7 @@ public class Ledger
     /// return the last paid out block before the current block
     public Height getLastPaidHeight () const scope @safe @nogc nothrow pure
     {
-        return lastPaidHeight(this.getBlockHeight, this.params.PayoutPeriod);
+        return lastPaidHeight(this.height, this.params.PayoutPeriod);
     }
 
     /***************************************************************************
@@ -1037,7 +1037,7 @@ public class Ledger
     /// Ditto
     public UTXO[Hash] getEnrolledUTXOs () @safe nothrow
     {
-        return this.getEnrolledUTXOs(this.getBlockHeight() + 1);
+        return this.getEnrolledUTXOs(this.height() + 1);
     }
 
     /***************************************************************************
@@ -1182,9 +1182,9 @@ public abstract class UTXOTracker
 unittest
 {
     scope ledger = new Ledger();
-    assert(ledger.getBlockHeight() == 0);
+    assert(ledger.height() == 0);
     // This used to throw because `validateBlock` would pass and the Ledger
     // was attempting to re-add the same block.
     assert(ledger.acceptBlock(ledger.lastBlock()) is null);
-    assert(ledger.getBlockHeight() == 0);
+    assert(ledger.height() == 0);
 }

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -450,7 +450,7 @@ public class FullNode : API
 
         // Special case
         // Block externalized handler is set and push for Genesis block.
-        if (this.block_handlers.length > 0 && this.getBlockHeight() == 0)
+        if (this.block_handlers.length > 0 && this.ledger.getBlockHeight() == 0)
             this.pushBlock(this.params.Genesis);
 
         this.timers ~= this.taskman.setTimer(

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -230,7 +230,7 @@ public class NameRegistry: NameRegistryAPI
             this.zones[ZoneIndex.Validator].get(registry_payload.data.public_key));
 
         // Last step is to check the state of the chain
-        auto last_height = this.ledger.getBlockHeight() + 1;
+        auto last_height = this.ledger.height() + 1;
         if (last_height > this.validator_info_height || this.validator_info.length == 0)
         {
             this.validator_info = this.ledger.getValidators(last_height);
@@ -1155,7 +1155,7 @@ unittest
         .array;
     txs.each!(tx => assert(ledger.acceptTransaction(tx) is null));
     ledger.forceCreateBlock();
-    assert(ledger.getBlockHeight() == 1);
+    assert(ledger.height() == 1);
 
     // Test a key that is not enrolled
     auto nep = makeTestPayload(WK.Keys[1]);
@@ -1172,7 +1172,7 @@ unittest
 
     // externalize enrollment
     ledger.forceCreateBlock();
-    assert(ledger.getBlockHeight() == 2);
+    assert(ledger.height() == 2);
 
     try
         registry.postValidator(payload);
@@ -1182,7 +1182,7 @@ unittest
     assert(RegistryPayload.init != registry.getValidator(WK.Keys[0].address));
 
     ledger.forceCreateBlock();
-    assert(ledger.getBlockHeight() == 3);
+    assert(ledger.height() == 3);
     // frozen UTXO is spent (slashed), entry should have been deleted
     assert(RegistryPayload.init == registry.getValidator(WK.Keys[0].address));
 }

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -100,12 +100,12 @@ public class Validator : FullNode, API
         // This is especially important on initialization, as replaying blocks
         // does not call `onAcceptedBlock`.
         PreImageInfo self;
-        if (this.enroll_man.getNextPreimage(self, this.ledger.getBlockHeight()))
+        if (this.enroll_man.getNextPreimage(self, this.ledger.height()))
             this.ledger.addPreimage(self);
 
         // currently we are not saving preimage info,
         // we only have the commitment in the genesis block
-        this.regenerateQuorums(this.ledger.getBlockHeight());
+        this.regenerateQuorums(this.ledger.height());
     }
 
     /***************************************************************************
@@ -122,7 +122,7 @@ public class Validator : FullNode, API
 
         Params:
             height = the height at which the validator set changed.
-                     Note that it may be different to 'ledger.getBlockHeight()'
+                     Note that it may be different to 'ledger.height()'
                      when the node is booting up for the first time as we
                      currently only have commitment info from GenesisBlock,
                      and lack preimages.
@@ -191,7 +191,7 @@ public class Validator : FullNode, API
         // In the fast path, this is called immediately after a block has been
         // externalized, so we can simply use the Ledger. Otherwise we need
         // to run from storage.
-        const rand_seed = this.ledger.getBlockHeight() == height ?
+        const rand_seed = this.ledger.height() == height ?
             this.ledger.lastBlock().header.randomSeed() :
             this.ledger.getBlocksFrom(height).front.header.randomSeed();
         foreach (utxo; utxos)
@@ -226,10 +226,10 @@ public class Validator : FullNode, API
             this.config.validator.preimage_catchup_interval,
             &this.preImageCatchupTask, Periodic.Yes);
 
-        if (this.enroll_man.isEnrolled(this.ledger.getBlockHeight() + 1, &this.ledger.peekUTXO))
+        if (this.enroll_man.isEnrolled(this.ledger.height() + 1, &this.ledger.peekUTXO))
             this.nominator.startNominatingTimer();
         if (this.config.validator.recurring_enrollment)
-            this.checkAndEnroll(this.ledger.getBlockHeight());
+            this.checkAndEnroll(this.ledger.height());
     }
 
     /// Ditto
@@ -259,7 +259,7 @@ public class Validator : FullNode, API
 
         // Only query pre-images if we need them, to avoid flooding peers
         // with queries
-        const next_height = this.ledger.getBlockHeight() + 1;
+        const next_height = this.ledger.height() + 1;
 
         if (!this.enroll_man.isEnrolled(next_height, &this.ledger.peekUTXO))
             return;
@@ -616,7 +616,7 @@ public class Validator : FullNode, API
     {
         PreImageInfo preimage;
         if (this.enroll_man.getNextPreimage(preimage,
-            this.ledger.getBlockHeight()))
+            this.ledger.height()))
         {
             this.ledger.addPreimage(preimage);
             this.network.peers.each!(p => p.client.sendPreimage(preimage));
@@ -723,6 +723,6 @@ public class Validator : FullNode, API
         // Network needs Validators, see if we can enroll
         if (this.config.validator.recurring_enrollment &&
             msg == NodeLedger.InvalidConsensusDataReason.NotEnoughValidators)
-            this.checkAndEnroll(this.ledger.getBlockHeight());
+            this.checkAndEnroll(this.ledger.height());
     }
 }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1880,7 +1880,7 @@ public class TestValidatorNode : Validator, TestAPI
     {
         this.config.validator.recurring_enrollment = doIt;
         if (this.config.validator.recurring_enrollment)
-            return this.checkAndEnroll(this.ledger.getBlockHeight());
+            return this.checkAndEnroll(this.ledger.height());
 
         return Enrollment.init;
     }
@@ -1911,7 +1911,7 @@ public class TestValidatorNode : Validator, TestAPI
         // We add one to height as we are interested in active validators in next block
         assert(this.enroll_man.getEnrolledUTXOs(height + 1, utxos) && utxos.length > 0);
         // See `Validator.rebuildQuorumConfig`
-        const rand_seed = this.ledger.getBlockHeight() == height ?
+        const rand_seed = this.ledger.height() == height ?
             this.ledger.lastBlock().header.randomSeed() :
             this.ledger.getBlocksFrom(height).front.header.randomSeed();
         QuorumConfig[] quorums;

--- a/source/agora/test/EnrollDifferentUTXO.d
+++ b/source/agora/test/EnrollDifferentUTXO.d
@@ -53,8 +53,8 @@ private class SameKeyValidator : TestValidatorNode
         assert(unused_utxo != Hash.init);
 
         const new_enroll =
-            this.enroll_man.createEnrollment(unused_utxo, this.ledger.getBlockHeight() + 1);
-        this.postEnrollment(new_enroll, this.ledger.getBlockHeight() + 1);
+            this.enroll_man.createEnrollment(unused_utxo, this.ledger.height() + 1);
+        this.postEnrollment(new_enroll, this.ledger.height() + 1);
 
         return new_enroll;
     }

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -214,7 +214,7 @@ unittest
             // Unlike the regular validator, dont check the config. BatValidator
             // always answers a cry for help.
             if (msg == NodeLedger.InvalidConsensusDataReason.NotEnoughValidators)
-                this.checkAndEnroll(this.ledger.getBlockHeight());
+                this.checkAndEnroll(this.ledger.height());
         }
     }
 


### PR DESCRIPTION
Got tired of the overly verbose name, and better to do it before `Faucet` depends on `Ledger.