### PR TITLE
Stats: Make address configurable

### DIFF
--- a/devel/config-fullnode.yaml
+++ b/devel/config-fullnode.yaml
@@ -13,13 +13,14 @@ node:
   realm: "testnet.bosagora.io"
   testing: true
   data_dir: .fullnode/data/
-  # Can be used with curl or just a browser
-  stats_listening_port: 9111
 
 interfaces:
   - type:    http
     address: 0.0.0.0
     port:    2826
+  - type: stats
+    address: 0.0.0.0
+    port: 9111
 
 consensus:
   block_interval:

--- a/devel/config-single.yaml
+++ b/devel/config-single.yaml
@@ -14,13 +14,14 @@ node:
   testing: true
   limit_test_validators: 1
   data_dir: .single/data/
-  # Can be used with curl or just a browser
-  stats_listening_port: 9111
 
 interfaces:
   - type:    http
     address: 0.0.0.0
     port:    2826
+  - type: stats
+    address: 0.0.0.0
+    port: 9111
 
 consensus:
   block_interval:

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -31,10 +31,6 @@ node:
     msecs: 5000
   # Path to the data directory (if the path doesn't exist it will be created)
   data_dir: data
-  # The local address where the stats server (currently Prometheus)
-  # is going to connect to, for example: http://0.0.0.0:8008
-  # It can also be set to -1 do disable listening (default is -1)
-  stats_listening_port: 9110
   # The duration between requests for doing periodic network discovery
   network_discovery_interval:
     seconds: 5
@@ -77,6 +73,9 @@ interfaces:
     address: 0.0.0.0 # Any node can bind - default value
     # Port on which we bind
     port:    2826    # 0xB0A, default value
+  - type: stats
+    address: 0.0.0.0
+    port: 9110
 
 # Proxy to be used for outgoing Agora connections
 proxy:

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -30,7 +30,7 @@ import agora.utils.Log;
 import vibe.inet.url;
 
 import std.algorithm.iteration : splitter;
-import std.algorithm.searching : all;
+import std.algorithm.searching : all, count;
 import std.exception;
 import std.getopt;
 import std.traits : hasUnsharedAliasing;
@@ -141,6 +141,8 @@ public struct Config
 
         if (this.consensus.quorum_threshold < 1 || this.consensus.quorum_threshold > 100)
             throw new Exception("consensus.quorum_threshold is a percentage and must be between 1 and 100, included");
+        if (this.interfaces.count!(intf => intf.type == InterfaceConfig.Type.stats) > 1)
+            throw new Exception("Can only configure a single stats interface");
     }
 }
 
@@ -160,6 +162,7 @@ public struct InterfaceConfig
         http = 0,
         https = 1,
         tcp = 2,
+        stats = 3,
     }
 
     /// Ditto
@@ -204,11 +207,6 @@ public struct NodeConfig
 
     /// Maximum number of listeners to connect to
     public size_t max_listeners = 10;
-
-    /// The local address where the stats server (currently Prometheus)
-    /// is going to connect to, for example: http://0.0.0.0:8008
-    /// It can also be set to 0 do disable listening
-    public @Optional ushort stats_listening_port;
 
     /// Time to wait between request retries
     public Duration retry_delay = 3.seconds;

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -444,8 +444,7 @@ public class FullNode : API
                     }));
         }
 
-        if (config.node.stats_listening_port != 0)
-            this.stats_server = this.makeStatsServer();
+        this.stats_server = this.makeStatsServer();
         this.transaction_relayer.start();
 
         // Special case
@@ -716,7 +715,10 @@ public class FullNode : API
     /// Returns a newly constructed StatsServer
     protected StatsServer makeStatsServer ()
     {
-        return new StatsServer(this.config.node.stats_listening_port);
+        auto stat_intf = this.config.interfaces.find!(intf => intf.type == InterfaceConfig.Type.stats);
+        if (stat_intf.empty)
+            return null;
+        return new StatsServer(stat_intf.front.address, stat_intf.front.port);
     }
 
     /// Returns: The Logger to use for this class

--- a/source/agora/stats/Server.d
+++ b/source/agora/stats/Server.d
@@ -34,15 +34,12 @@ public class StatsServer
 
     ***************************************************************************/
 
-    public this (ushort port)
+    public this (string address, ushort port)
     {
         auto router = new URLRouter;
         router.get("/metrics", &handle_metrics);
 
-        auto settings = new HTTPServerSettings;
-        // Vibe.d uses both IPv6 and IPv4 all-interfaces at once, which causes
-        // problems on Linux because of dual stack (the second listen fails)
-        settings.bindAddresses = [ "::" ];
+        auto settings = new HTTPServerSettings(address);
         settings.port = port;
         // The following correspond to your scraping interval in Prometheus
         // The default value for Prometheus is 1 minute:


### PR DESCRIPTION
Before, it was listening on all interfaces. With native binaries
in production we should have a way to select the interface, docker
used to do that.