### PR TITLE
Network Unit tests with subset of Genesis validators

### DIFF
--- a/devel/config-single.yaml
+++ b/devel/config-single.yaml
@@ -12,7 +12,7 @@
 node:
   realm: "localhost"
   testing: true
-  limit_test_validators: 1
+  test_validators: 1
   data_dir: .single/data/
 
 interfaces:

--- a/source/agora/consensus/state/Ledger.d
+++ b/source/agora/consensus/state/Ledger.d
@@ -143,7 +143,7 @@ public class Ledger
                  this.last_block.header.hashFull());
 
         Block gen_block = this.storage.readBlock(Height(0));
-        ensure(gen_block == params.Genesis,
+        ensure(gen_block.hashFull() == params.Genesis.hashFull(),
                 "Genesis block loaded from disk ({}) is different from the one in the config file ({})",
                 gen_block.hashFull(), params.Genesis.hashFull());
 

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -127,17 +127,17 @@ public struct Config
             enforce(this.network.length || this.registry.enabled ||
                     this.validator.registry_address != string.init ||
                     // Allow single-network validator (assume this is NODE6)
-                    this.node.limit_test_validators == 1,
+                    this.node.test_validators == 1,
                     "Either the network section must not be empty, or 'validator.registry_address' must be set " ~
                     ", or registry must be enabled");
         else
             enforce(this.network.length || this.registry.enabled,
                     "Either the network section must not be empty, or registry must be enabled");
 
-        if (!this.node.testing && this.node.limit_test_validators)
+        if (!this.node.testing && this.node.test_validators)
             throw new Exception("Cannot use 'node.limit_test_validator' without 'node.testing' set to 'true'");
-        if (this.node.limit_test_validators > 6)
-            throw new Exception("Value of 'node.limit_test_validators' must be between 0 and 6, inclusive");
+        if (this.node.test_validators > 6)
+            throw new Exception("Value of 'node.test_validators' must be between 0 and 6, inclusive");
 
         if (this.consensus.quorum_threshold < 1 || this.consensus.quorum_threshold > 100)
             throw new Exception("consensus.quorum_threshold is a percentage and must be between 1 and 100, included");
@@ -198,7 +198,7 @@ public struct NodeConfig
 
     /// Should only be set if `test` is set, can be set to the number of desired
     /// enrollment in the test Genesis block (1 - 6)
-    public @Optional ubyte limit_test_validators;
+    public @Optional ubyte test_validators;
 
     /// The minimum number of listeners to connect to
     /// before discovery is considered complete

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -692,14 +692,14 @@ public class FullNode : API
         immutable Genesis = () {
             if (!config.node.testing)
                 return COINNET.GenesisBlock;
-            if (!config.node.limit_test_validators)
+            if (!config.node.test_validators)
                 return TESTNET.GenesisBlock;
 
             immutable Block result = {
                 header: {
                     merkle_root: TESTNET.GenesisBlock.header.merkle_root,
-                    validators: typeof(BlockHeader.validators)(config.node.limit_test_validators),
-                    enrollments: TESTNET.GenesisBlock.header.enrollments[0 .. config.node.limit_test_validators],
+                    validators: typeof(BlockHeader.validators)(config.node.test_validators),
+                    enrollments: TESTNET.GenesisBlock.header.enrollments[0 .. config.node.test_validators],
                 },
                 merkle_tree: TESTNET.GenesisBlock.merkle_tree,
                 txs:         TESTNET.GenesisBlock.txs,

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -724,7 +724,7 @@ public class TestAPIManager
         Duration timeout = 10.seconds,
         string file = __FILE__, int line = __LINE__)
     {
-        this.expectHeightAndPreImg(iota(GenesisValidators), height, enroll_header,
+        this.expectHeightAndPreImg(iota(this.test_conf.node.test_validators), height, enroll_header,
             timeout, file, line);
     }
 
@@ -759,7 +759,7 @@ public class TestAPIManager
     public void waitForPreimages (const(Enrollment)[] enrolls, Height height,
         Duration timeout = 10.seconds)
     {
-        this.waitForPreimages(iota(GenesisValidators), enrolls, height, timeout);
+        this.waitForPreimages(iota(this.test_conf.node.test_validators), enrolls, height, timeout);
     }
 
     /// Ditto
@@ -1062,7 +1062,7 @@ public class TestAPIManager
     public void generateBlocks (Height height, bool no_txs = false,
         string file = __FILE__, int line = __LINE__)
     {
-        this.generateBlocks(iota(GenesisValidators), height, no_txs, file, line);
+        this.generateBlocks(iota(this.test_conf.node.test_validators), height, no_txs, file, line);
     }
 
     /// Ditto
@@ -1095,7 +1095,7 @@ public class TestAPIManager
     void addBlock (bool no_txs = false,
         string file = __FILE__, int line = __LINE__)
     {
-        this.addBlock(iota(0, GenesisValidators), no_txs, file, line);
+        this.addBlock(iota(0, this.test_conf.node.test_validators), no_txs, file, line);
     }
 
     /// Ditto
@@ -1182,7 +1182,7 @@ public class TestAPIManager
 
     void enroll (size_t client_idx)
     {
-        enroll(iota(GenesisValidators), client_idx);
+        enroll(iota(this.test_conf.node.test_validators), client_idx);
     }
 
     /// Ditto
@@ -1216,7 +1216,7 @@ public class TestAPIManager
     void assertSameBlocks (Height to, Height from = Height(0),
         string file = __FILE__, int line = __LINE__)
     {
-        assertSameBlocks(iota(GenesisValidators), to, from, file, line);
+        assertSameBlocks(iota(this.test_conf.node.test_validators), to, from, file, line);
     }
 
     /// Ditto
@@ -2066,6 +2066,10 @@ public struct TestConf
 
         // Always set to true, cannot be overriden, but also set here for clarity
         testing: true,
+
+        // As testing is set to True it is possible to use a subset of the validators in the GenesisBlock
+        test_validators: 6,
+
         // Unittest realm
         realm: Domain.fromSafeString("unittest.bosagora.io."),
     };
@@ -2139,7 +2143,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
     static import std.concurrency;
     std.concurrency.scheduler = null;
 
-    const TotalNodes = GenesisValidators + test_conf.full_nodes +
+    const TotalNodes = test_conf.node.test_validators + test_conf.full_nodes +
         test_conf.outsider_validators + /* Registry */ 1;
 
     ConsensusConfig makeConsensusConfig ()
@@ -2164,7 +2168,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
         NodeConfig conf = test_conf.node;
         conf.testing = true;
         if (conf.min_listeners == size_t.max)
-            conf.min_listeners = (GenesisValidators + test_conf.full_nodes) - 1;
+            conf.min_listeners = (test_conf.node.test_validators + test_conf.full_nodes) - 1;
         if (conf.max_listeners == size_t.max)
             conf.max_listeners = TotalNodes - 1;
         return conf;
@@ -2260,7 +2264,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
     auto outsider_validators_keys = WK.Keys.byRange()
         .takeExactly(test_conf.outsider_validators);
 
-    auto validator_keys = genesis_validator_keys ~ outsider_validators_keys.array;
+    auto validator_keys = genesis_validator_keys[0 .. test_conf.node.test_validators] ~ outsider_validators_keys.array;
 
     // all enrolled and un-enrolled validators
     auto validator_addresses = validator_keys.enumerate
@@ -2268,7 +2272,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
 
     // only enrolled validators
     auto enrolled_addresses = genesis_validator_keys.enumerate
-        .takeExactly(GenesisValidators)
+        .takeExactly(test_conf.node.test_validators)
         .map!(en => validatorAddress(en.index, en.value)).array;
 
     auto full_node_addresses = test_conf.full_nodes.iota.map!(
@@ -2296,8 +2300,17 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
 
     auto all_configs = validator_configs.chain(full_node_configs).array;
 
-    immutable(Block)[] blocks = generateExtraBlocks(GenesisBlock,
-        test_conf.extra_blocks);
+    immutable Block Genesis = {
+        header: {
+            merkle_root: GenesisBlock.header.merkle_root,
+            validators: typeof(BlockHeader.validators)(test_conf.node.test_validators),
+            enrollments: GenesisBlock.header.enrollments[0 .. test_conf.node.test_validators],
+        },
+        merkle_tree: GenesisBlock.merkle_tree,
+        txs:         GenesisBlock.txs,
+    };
+    immutable(Block)[] blocks;
+    blocks = generateExtraBlocks(Genesis, test_conf.extra_blocks);
 
     auto net = new APIManager(blocks, test_conf, validator_configs[0].consensus.genesis_timestamp, eArgs);
 

--- a/source/agora/test/Simple.d
+++ b/source/agora/test/Simple.d
@@ -23,12 +23,18 @@ version (unittest):
 
 import agora.test.Base;
 
-/// Simple test
+/// Simple test with 4 nodes
 unittest
 {
     TestConf conf;
-    conf.consensus.payout_period = 10;
+    conf.node.test_validators = 4;
+    conf.consensus.max_quorum_nodes = 3;
+    simpleTest(conf);
+}
 
+public void simpleTest (TestConf conf)
+{
+    conf.consensus.payout_period = 8;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();


### PR DESCRIPTION
This makes it possible to configure the number of validators used in a
test. This can sometimes help to debug a problem or make the test run
faster. The Simple test is updated to run with 4 nodes with quorum size
of 3. Some of the longer running tests can be sped up quite a bit.