### PR TITLE
Fix #2875 : Check local NameRegistry before querying the remote

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -281,11 +281,11 @@ public class FullNode : API
         this.cacheDB = this.makeCacheDB();
         this.taskman = this.makeTaskManager();
         this.clock = this.makeClock();
-        this.network = this.makeNetworkManager(this.taskman, this.clock);
         this.storage = this.makeBlockStorage();
         this.pool = new TransactionPool(this.cacheDB, &getDoubleSpentSelector);
         this.enroll_man = this.makeEnrollmentManager();
         this.ledger = this.makeLedger();
+        this.network = this.makeNetworkManager(this.taskman, this.clock);
         // Note: Needs to be instantiated after `ledger` as it depends on it
         this.transaction_relayer = this.makeTransactionRelayer();
 
@@ -764,7 +764,8 @@ public class FullNode : API
 
     protected NetworkManager makeNetworkManager (ITaskManager taskman, Clock clock)
     {
-        return new NetworkManager(this.config, this.cacheDB, taskman, clock, this);
+        return new NetworkManager(this.config, this.cacheDB, taskman, clock,
+                                  this, this.registry);
     }
 
     protected TransactionRelayer makeTransactionRelayer ()

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1681,6 +1681,7 @@ private mixin template TestNodeMixin ()
         assert(taskman !is null);
         return new TestNetworkManager(
             this.config, this.cacheDB, taskman, clock, this,
+            this.registry,
             this.config.interfaces[0].address,
             this.nregistry);
     }


### PR DESCRIPTION
Only for validator, as for Flash, we don't have `KnownChannel` yet.
Will need to add test, and probably to move it somewhere else so it behaves the same in the unittests.