### PR TITLE
Test: Fix registry network config

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2276,7 +2276,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
         .map!(en => validatorAddress(en.index, en.value)).array;
 
     auto full_node_addresses = test_conf.full_nodes.iota.map!(
-        idx => fullNodeAddress(idx)).array ~ [Address("http://name.registry")];
+        idx => fullNodeAddress(idx)).array;
 
     // full nodes and enrolled validators will connect to other enrolled validators
     // and other full nodes (but not to outsider nodes)
@@ -2320,7 +2320,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
       node : makeNodeConfig(),
       interfaces: [ makeInterfaceConfig("name.registry") ],
       consensus: makeConsensusConfig(),
-      network : net.nodes.map!(pair => Address("http://"~pair.address)).array.idup,
+      network : connect_addresses.array.idup,
       logging: test_conf.logging,
       event_handlers : test_conf.event_handlers,
       registry: {

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -34,7 +34,7 @@ unittest
     foreach (key, node; network.nodes)
     {
         auto addresses = node.client.getNodeInfo().addresses.keys.map!(addr => addr.host).array;
-        const expectedCount = network.nodes.count + 1; // include name registry
+        const expectedCount = network.nodes.count;
         assert(addresses.sort.uniq.count == expectedCount,
             format("Node %s has %d peers but expected %d: %s",
                 key, addresses.length, expectedCount, addresses));


### PR DESCRIPTION
```
It depended on manager's node list, which is now populated
after the registry is created.
```

See https://github.com/bosagora/agora/commit/209ad7a225d7e57afaf280cbe2c0fa44c8ba03bc