### PR TITLE
Tests: Compare block by hashes, not identity

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1238,7 +1238,7 @@ public class TestAPIManager
         // Compare blocks one at a time
         iota(from, to + 1).each!(h =>
             retryFor(client_idxs.map!(idx =>
-                this.clients[idx].getBlocksFrom(h, 1)).uniq().count() == 1, 5.seconds,
+                this.clients[idx].getBlocksFrom(h, 1).hashFull).uniq().count() == 1, 5.seconds,
                 format!"[%s:%s] Clients %s blocks are not all the same for block %s: %s"
                 (file, line, client_idxs, h, client_idxs.fold!((s, i) =>
                     s ~ format!"\n\n========== Client #%s (%s) ==========%s"


### PR DESCRIPTION
```
It's possible that some validators are behind / a bit slow,
and miss a signature or more, which is completely fine as
long as they have a majority of them.
```

Seen this one trigger in one of my PR.