### PR TITLE
Manager: Allow ConnectionTask to be spawned with just a PublicKey

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -913,7 +913,7 @@ public class FullNode : API
     }
 
     /// GET: /node_info
-    public override NodeInfo getNodeInfo () nothrow @safe
+    public override NodeInfo getNodeInfo () @safe
     {
         this.recordReq("node_info");
         return this.network.getNetworkInfo();

--- a/source/agora/test/NetworkDiscovery.d
+++ b/source/agora/test/NetworkDiscovery.d
@@ -34,7 +34,7 @@ unittest
     foreach (key, node; network.nodes)
     {
         auto addresses = node.client.getNodeInfo().addresses.keys.map!(addr => addr.host).array;
-        const expectedCount = network.nodes.count;
+        const expectedCount = network.nodes.count - 1; // minus node itself
         assert(addresses.sort.uniq.count == expectedCount,
             format("Node %s has %d peers but expected %d: %s",
                 key, addresses.length, expectedCount, addresses));


### PR DESCRIPTION
```
Which itself will do all the Registry/DNS queries
```

This will prevent overwhelming the registry