### PR TITLE
Simplify / Improve some Flash test, give an IP to the registry in unittests

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -892,7 +892,7 @@ public class TestAPIManager
 
         The name registry is a full node that exposes a more advanced interface.
         It is not part of the `nodes` array, but is reachable as a designed
-        address (currently "name.registry").
+        address (currently "10.8.8.8").
 
         Params:
           conf = The `FullNode` configuration to use.
@@ -2208,7 +2208,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             enabled : true,
             key_pair : key_pair,
             addresses_to_register : [ self_address ],
-            registry_address : "http://name.registry",
+            registry_address : "dns://10.8.8.8",
             recurring_enrollment : test_conf.recurring_enrollment,
             name_registration_interval : 10.seconds,
             preimage_reveal_interval : test_conf.preimage_reveal_interval,
@@ -2318,7 +2318,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
     Config registry_config = {
       banman : ban_conf,
       node : makeNodeConfig(),
-      interfaces: [ makeInterfaceConfig("name.registry") ],
+      interfaces: [ makeInterfaceConfig("10.8.8.8") ],
       consensus: makeConsensusConfig(),
       network : connect_addresses.array.idup,
       logging: test_conf.logging,

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -375,7 +375,7 @@ public class FlashNodeFactory : TestAPIManager
             max_retry_time : 4.seconds,
             max_retry_delay : 100.msecs,
             listener_address : ListenerAddress,
-            registry_address : "http://name.registry",
+            registry_address : "dns://10.8.8.8",
             addresses_to_register : [ Address("http://"~to!string(kp.address)) ],
             key_pair : kp,
         };

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -1715,20 +1715,7 @@ unittest
     scope (exit) network.shutdown();
     scope (failure) network.printLogs();
 
-    FlashConfig alice_conf = { enabled : true,
-        min_funding : Amount(1000),
-        max_funding : Amount(100_000_000),
-        min_settle_time : 0,
-        max_settle_time : 100,
-        listener_address : network.ListenerAddress,
-        max_retry_time : 4.seconds,
-        max_retry_delay : 10.msecs,
-        registry_address : "http://name.registry",
-        addresses_to_register : [ Address("http://"~to!string(WK.Keys.A.address)) ],
-        key_pair : WK.Keys.A
-    };
-
-    auto alice = network.createFlashNode(alice_conf);
+    auto alice = network.createFlashNode(WK.Keys.A);
     auto charlie = network.createFlashNode!RejectingFlashNode(WK.Keys.C);
     auto diego = network.createFlashNode(WK.Keys.D);
 
@@ -1813,20 +1800,7 @@ unittest
     scope (exit) network.shutdown();
     scope (failure) network.printLogs();
 
-    FlashConfig alice_conf = { enabled : true,
-        min_funding : Amount(1000),
-        max_funding : Amount(100_000_000),
-        min_settle_time : 0,
-        max_settle_time : 100,
-        listener_address : network.ListenerAddress,
-        max_retry_time : 4.seconds,
-        max_retry_delay : 10.msecs,
-        registry_address : "http://name.registry",
-        addresses_to_register : ["http://"~to!string(WK.Keys.A.address)],
-        key_pair : WK.Keys.A
-    };
-
-    auto alice = network.createFlashNode(alice_conf);
+    auto alice = network.createFlashNode(WK.Keys.A);
     auto charlie = network.createFlashNode(WK.Keys.C);
     auto diego = network.createFlashNode(WK.Keys.D);
 

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -380,12 +380,12 @@ public class FlashNodeFactory : TestAPIManager
             addresses_to_register : [ Address("http://"~to!string(kp.address)) ],
             key_pair : kp,
         };
-        return this.createFlashNode!FlashNodeImpl(kp, conf, storage, file, line);
+        return this.createFlashNode!FlashNodeImpl(conf, storage, file, line);
     }
 
     /// ditto
     public RemoteAPI!TestFlashAPI createFlashNode (FlashNodeImpl = TestFlashNode)
-        (const KeyPair kp, FlashConfig conf, DatabaseStorage storage = DatabaseStorage.Local,
+        (FlashConfig conf, DatabaseStorage storage = DatabaseStorage.Local,
         string file = __FILE__, int line = __LINE__)
     {
         import agora.api.Handlers;
@@ -394,10 +394,10 @@ public class FlashNodeFactory : TestAPIManager
             conf, &this.registry, this.nodes[0].address, storage,
             10.seconds, 10.seconds, file, line);  // timeout from main thread
 
-        this.addresses ~= kp.address;
+        this.addresses ~= conf.key_pair.address;
         this.flash_nodes ~= api;
-        this.registry.register(kp.address.to!string, api.listener());
-        api.registerKey(kp);
+        this.registry.register(conf.key_pair.address.to!string, api.listener());
+        api.registerKey(conf.key_pair);
 
         return api;
     }
@@ -1038,7 +1038,7 @@ unittest
         key_pair : WK.Keys.A
     };
 
-    auto alice = network.createFlashNode(WK.Keys.A, alice_conf);
+    auto alice = network.createFlashNode(alice_conf);
     auto charlie = network.createFlashNode(WK.Keys.C);
     auto diego = network.createFlashNode(WK.Keys.D);
 
@@ -1538,7 +1538,7 @@ unittest
         key_pair : WK.Keys.C
     };
     auto alice = network.createFlashNode(WK.Keys.A);
-    auto charlie = network.createFlashNode(WK.Keys.C, charlie_conf);
+    auto charlie = network.createFlashNode(charlie_conf);
 
     network.start();
     network.waitForDiscovery();
@@ -1741,7 +1741,7 @@ unittest
         key_pair : WK.Keys.A
     };
 
-    auto alice = network.createFlashNode(WK.Keys.A, alice_conf);
+    auto alice = network.createFlashNode(alice_conf);
     auto charlie = network.createFlashNode!RejectingFlashNode(WK.Keys.C);
     auto diego = network.createFlashNode(WK.Keys.D);
 
@@ -1839,7 +1839,7 @@ unittest
         key_pair : WK.Keys.A
     };
 
-    auto alice = network.createFlashNode(WK.Keys.A, alice_conf);
+    auto alice = network.createFlashNode(alice_conf);
     auto charlie = network.createFlashNode(WK.Keys.C);
     auto diego = network.createFlashNode(WK.Keys.D);
 

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -1025,20 +1025,7 @@ unittest
     scope (exit) network.shutdown();
     scope (failure) network.printLogs();
 
-    FlashConfig alice_conf = { enabled : true,
-        min_funding : Amount(1000),
-        max_funding : Amount(100_000_000),
-        min_settle_time : 0,
-        max_settle_time : 100,
-        listener_address : network.ListenerAddress,
-        max_retry_time : 4.seconds,
-        max_retry_delay : 100.msecs,
-        registry_address : "http://name.registry",
-        addresses_to_register : [ Address("http://"~to!string(WK.Keys.A.address)) ],
-        key_pair : WK.Keys.A
-    };
-
-    auto alice = network.createFlashNode(alice_conf);
+    auto alice = network.createFlashNode(WK.Keys.A);
     auto charlie = network.createFlashNode(WK.Keys.C);
     auto diego = network.createFlashNode(WK.Keys.D);
 


### PR DESCRIPTION
The end goal was to move all nodes to have an IP, the registry seemed like the best place to start.