### PR TITLE
Tests: Print the address of nodes that are unreachable

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1010,13 +1010,13 @@ public class TestAPIManager
                 try
                     node.client.printLog();
                 catch (Exception ex)
-                    writefln("Could not print logs for node: %s", ex.message);
+                    writefln("Could not print logs for node %s: %s", node.address, ex.message);
             }
             writeln("Registry logs:");
             try
                 this.dns.printLog();
             catch (Exception ex)
-                writefln("Could not print registry logs: %s", ex.message);
+                writefln("Could not print registry logs (%s): %s", this.dns.address, ex.message);
         }
     }
 

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -435,7 +435,7 @@ public class FlashNodeFactory : TestAPIManager
         {
             writeln("---------------------------- START OF FLASH LOGS ----------------------------");
             writefln("%s(%s): Flash node logs:\n", file, line);
-            foreach (node; this.flash_nodes)
+            foreach (idx, node; this.flash_nodes)
             {
                 try
                 {
@@ -443,7 +443,7 @@ public class FlashNodeFactory : TestAPIManager
                 }
                 catch (Exception ex)
                 {
-                    writefln("Could not print logs for node: %s", ex.message);
+                    writefln("Could not print logs for node %s: %s", this.addresses[idx], ex.message);
                 }
             }
         }


### PR DESCRIPTION
```
Unreachable nodes have been observed in the tests, however since their address is not logged,
one has to guess which node it is (and can't grep for it).
```