### PR TITLE
RPC: ensure stream is connected before calling handle()

### DIFF
--- a/source/agora/network/RPC.d
+++ b/source/agora/network/RPC.d
@@ -455,7 +455,7 @@ private class RPCConnection
         }
         // Try to reuse the connection, if no requests arrive within a certain
         // period then handleThrow() will throw and handle() will return false
-        while (handle(impl, this, this.conn.readTimeout)) {}
+        while (this.conn.connected() && handle(impl, this, this.conn.readTimeout)) {}
     }
 }
 


### PR DESCRIPTION
Fixes a segfault where connection is closed and we call
readTimeout on it.