### PR TITLE
NetMan: Improve `getClient` / `getNameRegistryClient` API

### DIFF
--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -179,7 +179,7 @@ public class FlashNode : FlashControlAPI
     protected const(Block) delegate (ulong _height) @safe getBlock;
 
     ///
-    protected NameRegistryAPI delegate (string address, Duration timeout) getNameRegistryClient;
+    protected NameRegistryAPI delegate (string address) getNameRegistryClient;
 
     /***************************************************************************
 
@@ -201,7 +201,7 @@ public class FlashNode : FlashControlAPI
         Engine engine, ITaskManager taskman,
         TransactionResult delegate (in Transaction tx) postTransaction,
         const(Block) delegate (ulong _height) @safe getBlock,
-        NameRegistryAPI delegate (string address, Duration timeout) getNameRegistryClient)
+        NameRegistryAPI delegate (string address) getNameRegistryClient)
     {
         this.conf = conf;
         this.genesis_hash = genesis_hash;
@@ -271,7 +271,7 @@ public class FlashNode : FlashControlAPI
     {
         if (this.registry_client is null)  // try to get the client
             this.registry_client = this.getNameRegistryClient(
-                this.conf.registry_address, 10.seconds);
+                this.conf.registry_address);
 
         if (this.registry_client is null)
             return;  // failed, try again later

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -255,11 +255,14 @@ public class FlashNode : FlashControlAPI
         else  // avoid null checks & segfaults
             this.listener = new BlackHole!FlashListenerAPI();
 
+        assert(this.conf.registry_address.length);
+        this.registry_client = this.getRegistryClient(this.conf.registry_address);
+        this.onRegisterName();  // avoid delay
+
         this.gossip_timer = this.taskman.setTimer(100.msecs,
             &this.gossipTask, Periodic.Yes);
         this.open_chan_timer = this.taskman.setTimer(100.msecs,
             &this.channelOpenTask, Periodic.Yes);
-        this.onRegisterName();  // avoid delay
         this.periodic_timer = this.taskman.setTimer(2.minutes,
             &this.onRegisterName, Periodic.Yes);
         this.monitor_timer = this.taskman.setTimer(2.minutes,
@@ -269,13 +272,6 @@ public class FlashNode : FlashControlAPI
     /// register network addresses into the name registry
     private void onRegisterName ()
     {
-        if (this.registry_client is null)  // try to get the client
-            this.registry_client = this.getRegistryClient(
-                this.conf.registry_address);
-
-        if (this.registry_client is null)
-            return;  // failed, try again later
-
         foreach (pair; this.getManagedKeys())
         {
             RegistryPayload payload =

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -179,7 +179,7 @@ public class FlashNode : FlashControlAPI
     protected const(Block) delegate (ulong _height) @safe getBlock;
 
     ///
-    protected NameRegistryAPI delegate (string address) getNameRegistryClient;
+    protected NameRegistryAPI delegate (string address) getRegistryClient;
 
     /***************************************************************************
 
@@ -201,7 +201,7 @@ public class FlashNode : FlashControlAPI
         Engine engine, ITaskManager taskman,
         TransactionResult delegate (in Transaction tx) postTransaction,
         const(Block) delegate (ulong _height) @safe getBlock,
-        NameRegistryAPI delegate (string address) getNameRegistryClient)
+        NameRegistryAPI delegate (string address) getRegistryClient)
     {
         this.conf = conf;
         this.genesis_hash = genesis_hash;
@@ -213,7 +213,7 @@ public class FlashNode : FlashControlAPI
         this.db = this.getManagedDatabase(db_path);
         this.postTransaction = postTransaction;
         this.getBlock = getBlock;
-        this.getNameRegistryClient = getNameRegistryClient;
+        this.getRegistryClient = getRegistryClient;
 
         this.load();
 
@@ -270,7 +270,7 @@ public class FlashNode : FlashControlAPI
     private void onRegisterName ()
     {
         if (this.registry_client is null)  // try to get the client
-            this.registry_client = this.getNameRegistryClient(
+            this.registry_client = this.getRegistryClient(
                 this.conf.registry_address);
 
         if (this.registry_client is null)

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -512,10 +512,12 @@ public class NetworkManager
     /// Periodically registers network addresses
     public ITimer startPeriodicNameRegistration ()
     {
+        // No configured registry, nothing to do
+        if (this.config.validator.registry_address.length == 0)
+            return null;
+
         this.registry_client = this.getRegistryClient(
             this.config.validator.registry_address);
-        if (this.registry_client is null)
-            return null;
 
         this.onRegisterName();  // avoid delay
         // We re-register at regular interval in order to cope with the situation below
@@ -1056,8 +1058,6 @@ public class NetworkManager
 
     public NameRegistryAPI getRegistryClient (string address)
     {
-        if (address == string.init)
-            return null;
         auto settings = new RestInterfaceSettings();
         settings.baseURL = Address(address);
         settings.httpClientSettings = new HTTPClientSettings();

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -512,7 +512,7 @@ public class NetworkManager
     /// Periodically registers network addresses
     public ITimer startPeriodicNameRegistration ()
     {
-        this.registry_client = this.getNameRegistryClient(
+        this.registry_client = this.getRegistryClient(
             this.config.validator.registry_address);
         if (this.registry_client is null)
             return null;
@@ -1054,7 +1054,7 @@ public class NetworkManager
 
     ***************************************************************************/
 
-    public NameRegistryAPI getNameRegistryClient (string address)
+    public NameRegistryAPI getRegistryClient (string address)
     {
         if (address == string.init)
             return null;

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -183,8 +183,7 @@ public class NetworkManager
         private void connect_canthrow ()
         {
             if (this.api is null)
-                this.api = this.outer.getClient(
-                    this.address, this.outer.config.node.timeout);
+                this.api = this.outer.getClient(this.address);
 
             PublicKey key;
             Hash utxo;
@@ -514,7 +513,7 @@ public class NetworkManager
     public ITimer startPeriodicNameRegistration ()
     {
         this.registry_client = this.getNameRegistryClient(
-            this.config.validator.registry_address, 2.seconds);
+            this.config.validator.registry_address);
         if (this.registry_client is null)
             return null;
 
@@ -996,17 +995,17 @@ public class NetworkManager
 
         Params:
           address = The address (IPv4, IPv6, hostname) of this node
-          timeout = the timeout duration to use for requests
 
         Returns:
           An object to communicate with the node at `address`
 
     ***************************************************************************/
 
-    protected agora.api.Validator.API getClient (Address url, Duration timeout)
+    protected agora.api.Validator.API getClient (Address url)
     {
         import std.algorithm.searching;
 
+        const timeout = this.config.node.timeout;
         if (url.schema == "agora")
         {
             auto owner_validator = cast (agora.api.Validator.API) this.owner_node;
@@ -1049,22 +1048,21 @@ public class NetworkManager
 
         Params:
           address = The address of the name registry server
-          timeout = the timeout duration to use for requests
 
         Returns:
           An object to communicate with the name registry server
 
     ***************************************************************************/
 
-    public NameRegistryAPI getNameRegistryClient (string address, Duration timeout)
+    public NameRegistryAPI getNameRegistryClient (string address)
     {
         if (address == string.init)
             return null;
         auto settings = new RestInterfaceSettings();
         settings.baseURL = Address(address);
         settings.httpClientSettings = new HTTPClientSettings();
-        settings.httpClientSettings.connectTimeout = timeout;
-        settings.httpClientSettings.readTimeout = timeout;
+        settings.httpClientSettings.connectTimeout = this.config.node.timeout;
+        settings.httpClientSettings.readTimeout = this.config.node.timeout;
         settings.httpClientSettings.proxyURL = this.config.proxy.url;
 
         return new RestInterfaceClient!NameRegistryAPI(settings);

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -129,7 +129,7 @@ public Listeners runNode (Config config)
         auto flash = new FlashNode(config.flash,
             config.node.data_dir, params.Genesis.hashFull(), new Engine(),
             result.node.getTaskManager(), &result.node.postTransaction,
-            &result.node.getBlock, &result.node.getNetworkManager().getNameRegistryClient);
+            &result.node.getBlock, &result.node.getNetworkManager().getRegistryClient);
         router.registerRestInterface!FlashAPI(flash, settings);
         result.flash = flash;
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1342,24 +1342,23 @@ public class TestNetworkManager : NetworkManager
     }
 
     ///
-    protected final override TestAPI getClient (Address address,
-        Duration timeout)
+    protected final override TestAPI getClient (Address address)
     {
         auto tid = this.registry.locate!TestAPI(address.host);
         if (tid != typeof(tid).init)
-            return new RemoteAPI!TestAPI(tid, timeout);
+            return new RemoteAPI!TestAPI(tid, this.config.node.timeout);
         assert(0, format("Trying to access node at address '%s' from '%s' without first creating it",
                          address, this.address));
     }
 
     ///
-    public override RemoteAPI!NameRegistryAPI getNameRegistryClient (string address, Duration timeout)
+    public override RemoteAPI!NameRegistryAPI getNameRegistryClient (string address)
     {
         assert(address != string.init, "Requested address for registry is empty");
         const url = Address(address);
         auto tid = this.registry.locate!NameRegistryAPI(url.host);
         if (tid != typeof(tid).init)
-            return new RemoteAPI!NameRegistryAPI(tid, timeout);
+            return new RemoteAPI!NameRegistryAPI(tid, this.config.node.timeout);
         assert(0, "Trying to access name registry at address '" ~ address ~
                "' without first creating it");
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1352,7 +1352,7 @@ public class TestNetworkManager : NetworkManager
     }
 
     ///
-    public override RemoteAPI!NameRegistryAPI getNameRegistryClient (string address)
+    public override RemoteAPI!NameRegistryAPI getRegistryClient (string address)
     {
         assert(address != string.init, "Requested address for registry is empty");
         const url = Address(address);

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -146,7 +146,7 @@ public class TestFlashNode : FlashNode, TestFlashAPI
 
         this.agora_node = this.getAgoraClient(agora_address, timeout);
         super(conf, storage, genesis_hash, engine, new LocalRestTaskManager(),
-            &this.postTransaction, &agora_node.getBlock, &this.getNameRegistryClient);
+            &this.postTransaction, &agora_node.getBlock, &this.getRegistryClient);
     }
 
     /***************************************************************************
@@ -220,7 +220,7 @@ public class TestFlashNode : FlashNode, TestFlashAPI
     }
 
     ///
-    public NameRegistryAPI getNameRegistryClient (string address)
+    public NameRegistryAPI getRegistryClient (string address)
     {
         assert(address != string.init, "Empty address");
         const url = Address(address);

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -220,14 +220,14 @@ public class TestFlashNode : FlashNode, TestFlashAPI
     }
 
     ///
-    public NameRegistryAPI getNameRegistryClient (string address, Duration timeout)
+    public NameRegistryAPI getNameRegistryClient (string address)
     {
         assert(address != string.init, "Empty address");
         const url = Address(address);
         auto tid = this.registry.locate!NameRegistryAPI(url.host);
         assert(tid != typeof(tid).init, "Trying to access name registry at address '" ~ address ~
                "' without first creating it");
-        return new RemoteAPI!NameRegistryAPI(tid, timeout);
+        return new RemoteAPI!NameRegistryAPI(tid, this.conf.timeout);
     }
 
     ///


### PR DESCRIPTION
Had a discussion about it with @mkykadir and figured it could use a couple improvements.
Next (and last) step will be to use `Address` instead of `string` for `getRegistryClient` but that'll come after @mkykadir 's PR.