### PR TITLE
NetworkClient: Upgrade final message of client failure to 'warn'

### DIFF
--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -612,7 +612,7 @@ public class NetworkClient
                 this.taskman.wait(this.retry_delay);
             }
         }
-        log.info("Client.attemptRequest '{}' to addresses {} FAILED after {} attempts",
+        log.warn("Client.attemptRequest '{}' to addresses {} FAILED after {} attempts",
             name, this.connections.map!(c => c.address), this.max_retries);
 
         // request considered failed after max retries reached


### PR DESCRIPTION
Because when we look at the logs, it is drowned in a sea of other 'info' messages,
but can be quite useful for us to know why a test failed.