### PR TITLE
Trivial: Ledger: Print the head block's signature when externalizing

### DIFF
--- a/source/agora/consensus/state/Ledger.d
+++ b/source/agora/consensus/state/Ledger.d
@@ -402,7 +402,8 @@ public class Ledger
 
     protected void addValidatedBlock (in Block block) @safe
     {
-        log.info("Beginning externalization of block #{}", block.header.height);
+        log.info("Beginning externalization of block #{} (previous block signatures: {})",
+                 block.header.height, this.last_block.header.validators);
         log.info("Transactions: {} - Enrollments: {}",
                  block.txs.length, block.header.enrollments.length);
         log.info("Validators: Active: {} - Signing: {} - Slashed: {}",


### PR DESCRIPTION
This will provide more insight into the state of the chain when reading the logs.