### PR TITLE
DNS: Remove CNAME limitation from resolver

### DIFF
--- a/source/agora/network/DNSResolver.d
+++ b/source/agora/network/DNSResolver.d
@@ -71,10 +71,6 @@ public final class VibeDNSResolver : DNSResolver
         // underlying address.
         foreach (idx, ref res; this.resolvers)
         {
-            assert(peers[idx].host.guessAddressType != TYPE.CNAME,
-                   "Address '" ~ peers[idx].host ~
-                   "' is not an IP address and can't be used for DNS resolution");
-
             res.address = resolveHost(peers[idx].host);
             res.address.port = peers[idx].port;
         }


### PR DESCRIPTION
`resolveHost` is capable of resolving address of a name and this limitation
prevents users from providing name server names (i.e. `ns1.bosagora.io`)
in `query_servers` field.