### PR TITLE
Trivial: Downgrade log level for not signed by majority

### DIFF
--- a/source/agora/consensus/state/Ledger.d
+++ b/source/agora/consensus/state/Ledger.d
@@ -882,8 +882,9 @@ public class Ledger
     protected string handleNotSignedByMajority (in BlockHeader header,
         in ValidatorInfo[] validators) @safe nothrow
     {
-        log.error("Block#{}: Signatures are not majority: {}/{}, signers: {}",
-            header.height, header.validators.setCount, header.validators.count, validators);
+        log.info("Block#{}: Signatures are not majority: {}/{}, signers: {}",
+            header.height, header.validators.setCount, header.validators.count,
+            validators.map!(v => v.address));
         return "The majority of validators hasn't signed this block";
     }
 


### PR DESCRIPTION
When blocks are fetched from other nodes during catchup it is often the
case that the last block has not yet received all the signatures. Also
only log the addresses of the validators.