### PR TITLE
Only fetch blocks with majority signed

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -153,6 +153,18 @@ public interface API
 
     /***************************************************************************
 
+        Returns:
+            the highest height in this node's ledger with majority signatures
+
+        API:
+            GET /signed_height
+
+    ***************************************************************************/
+
+    public ulong getSignedHeight ();
+
+    /***************************************************************************
+
         Expose blocks as a REST collection
 
         API:

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -142,6 +142,9 @@ public extern (C++) class Nominator : SCPDriver
     /// Delegate called when a block is to be externalized
     public extern (D) string delegate (in Block) @safe acceptBlock;
 
+    /// Delegate called when a block header is to be updated with signatures
+    public extern (D) void delegate (const(BlockHeader)) @safe acceptHeader;
+
     /// The missing validators at the start of the nomination round
     protected uint[] initial_missing_validators;
 
@@ -171,6 +174,7 @@ extern(D):
             data_dir = path to the data directory
             nomination_interval = How often to trigger `checkNominate`
             externalize = delegate called when a block is to be externalized
+            acceptHeader = delegate called when header is updated
 
     ***************************************************************************/
 
@@ -178,7 +182,8 @@ extern(D):
         Clock clock, NetworkManager network, ValidatingLedger ledger,
         EnrollmentManager enroll_man, ITaskManager taskman, ManagedDatabase cacheDB,
         Duration nomination_interval,
-        string delegate (in Block) @safe externalize)
+        string delegate (in Block) @safe externalize,
+        void delegate(const(BlockHeader)) @safe acceptHeader)
     {
         assert(externalize !is null);
 
@@ -204,6 +209,7 @@ extern(D):
         this.restoreSCPState();
         this.nomination_interval = nomination_interval;
         this.acceptBlock = externalize;
+        this.acceptHeader = acceptHeader;
     }
 
     /// Shut down the envelope processing timer
@@ -484,6 +490,7 @@ extern(D):
             this.log.trace(
                 "checkNominate(): Last block ({}) doesn't have majority signatures, signed={}",
                 this.ledger.height(), this.ledger.lastBlock().header.validators);
+            this.network.getMissingBlockSigs(this.ledger, this.acceptHeader);
             return;
         }
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -901,6 +901,7 @@ extern(D):
             if (fail_reason == this.ledger.InvalidConsensusDataReason.NotInPool)
             {
                 log.trace("validateValue(): This node can not yet fully validate this value: {}. Data: {}", fail_reason, data.prettify);
+                this.network.getUnknownTXs(this.ledger);
                 return ValidationLevel.kMaybeValidValue;
             }
             else

--- a/source/agora/consensus/state/Ledger.d
+++ b/source/agora/consensus/state/Ledger.d
@@ -211,6 +211,23 @@ public class Ledger
 
     /***************************************************************************
 
+        Returns the height with majority signatures for this `Ledger`
+
+        Returns:
+            The highest block height known to this Ledger with more then half
+            active validator's signatures
+
+    ***************************************************************************/
+
+    public Height majorityHeight () @safe nothrow
+    {
+        // If the latest block does not have majority of signatures then return the previous height
+        const height = this.last_block.header.height;
+        return this.hasMajoritySignature(height) ? height : Height(height - 1);
+    }
+
+    /***************************************************************************
+
         Expose the list of validators at a given height
 
         The `ValidatorInfo` struct contains the validator's UTXO hash, address,

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -405,6 +405,22 @@ public class NetworkClient
 
     /***************************************************************************
 
+        Returns:
+            the heightest block with majority signed in the node's ledger,
+            or ulong.max if the request failed
+
+        Throws:
+            Exception if the request failed.
+
+    ***************************************************************************/
+
+    public ulong getSignedHeight ()
+    {
+        return this.attemptRequest!(API.getSignedHeight, Throw.Yes)();
+    }
+
+    /***************************************************************************
+
         Get the array of blocks starting from the provided block height.
         The block at height is included in the array.
 

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -795,11 +795,11 @@ public class NetworkManager
         node_pairs.length = 0;
         assumeSafeAppend(node_pairs);
 
-        // return ulong.max if getBlockHeight() fails
+        // return ulong.max if getSignedHeight() fails
         Height getHeight (NetworkClient node)
         {
             try
-                return Height(node.getBlockHeight());
+                return Height(node.getSignedHeight());
             catch (Exception ex)
                 return Height(ulong.max);
         }

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -302,6 +302,7 @@ public class NetworkManager
 
     // Protect against running multiple times simultaneously
     private bool isGettingMissingBlockSigs = false;
+    private bool isGettingUnknownTXs = false;
 
     /// Ctor
     public this (in Config config, ManagedDatabase cache, ITaskManager taskman, Clock clock, agora.api.FullNode.API owner_node)
@@ -853,6 +854,11 @@ public class NetworkManager
 
     public void getUnknownTXs (NodeLedger ledger) @safe nothrow
     {
+        // Protect against running multiple times simultaneously
+        if (this.isGettingUnknownTXs)
+            return;
+        this.isGettingUnknownTXs = true;
+
         auto unknown_txs = ledger.getUnknownTXHashes();
         log.trace("getUnknownTXs: detected {} unknown txs", unknown_txs.length);
 
@@ -871,6 +877,7 @@ public class NetworkManager
             log.trace("getUnknownTXs: Added {} txs to tx pool", added);
             unknown_txs = ledger.getUnknownTXHashes();
         }
+        this.isGettingUnknownTXs = false;
     }
 
     // Add the chunk of txs fetched from the other node

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -300,6 +300,9 @@ public class NetworkManager
 
     protected agora.api.FullNode.API owner_node;
 
+    // Protect against running multiple times simultaneously
+    private bool isGettingMissingBlockSigs = false;
+
     /// Ctor
     public this (in Config config, ManagedDatabase cache, ITaskManager taskman, Clock clock, agora.api.FullNode.API owner_node)
     {
@@ -905,6 +908,11 @@ public class NetworkManager
         import std.range;
         import std.typecons;
 
+        // Protect against running multiple times simultaneously
+        if (this.isGettingMissingBlockSigs)
+            return;
+        this.isGettingMissingBlockSigs = true;
+
         size_t[Height] signed_validators;
 
         try
@@ -967,6 +975,7 @@ public class NetworkManager
         {
             log.error("getMissingBlockSigs: Exception thrown : {}", e.msg);
         }
+        this.isGettingMissingBlockSigs = false;
     }
 
     /// Shut down timers & dump the metadata

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -963,6 +963,13 @@ public class FullNode : API
         return this.ledger.height();
     }
 
+    /// GET: /signed_height
+    public override ulong getSignedHeight ()
+    {
+        this.recordReq("signed_height");
+        return this.ledger.majorityHeight();
+    }
+
     /// GET: /blocks_from
     public override const(Block)[] getBlocksFrom (ulong height,
         uint max_blocks)  @safe

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -481,7 +481,7 @@ public class Validator : FullNode, API
         return new Nominator(
             this.params, this.config.validator.key_pair, clock, network, ledger,
             enroll_man, taskman, this.cacheDB,
-            this.config.validator.nomination_interval, &this.acceptBlock);
+            this.config.validator.nomination_interval, &this.acceptBlock, &this.acceptHeader);
     }
 
     /***************************************************************************

--- a/source/agora/test/BlockRewards.d
+++ b/source/agora/test/BlockRewards.d
@@ -276,7 +276,7 @@ private class EvenBlockHeightSignerNode () : TestValidatorNode
         return new EvenBlockHeightSignerNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock);
+            &this.acceptBlock, &this.acceptHeader);
     }
 }
 

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -89,7 +89,7 @@ class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new ByzantineNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, reason);
+            &this.acceptBlock, &this.acceptHeader, reason);
     }
 }
 
@@ -149,7 +149,7 @@ private class SpyingValidator : TestValidatorNode
         return new SpyNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.envelope_type_counts);
+            &this.acceptBlock, &this.acceptHeader, this.envelope_type_counts);
     }
 }
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -181,7 +181,7 @@ unittest
             return new BadNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock, this.runCount);
+                &this.acceptBlock, &this.acceptHeader, this.runCount);
         }
     }
 

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -78,7 +78,7 @@ private class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new BadBlockSigningNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, reason);
+            &this.acceptBlock, &this.acceptHeader, reason);
     }
 }
 

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -82,7 +82,7 @@ private class BadNominatingVN : TestValidatorNode
         return new BadNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock);
+            &this.acceptBlock, &this.acceptHeader);
     }
 }
 

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -63,7 +63,7 @@ unittest
             return new CustomNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock);
+                &this.acceptBlock, &this.acceptHeader);
         }
     }
 

--- a/source/agora/test/NominatingCatchup.d
+++ b/source/agora/test/NominatingCatchup.d
@@ -51,7 +51,7 @@ private class CustomValidator : TestValidatorNode
         return new CustomNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock);
+            &this.acceptBlock, &this.acceptHeader);
     }
 }
 

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -77,7 +77,7 @@ private class TestNode () : TestValidatorNode
         return new DoesNotExternalizeBlockNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock);
+            &this.acceptBlock, &this.acceptHeader);
     }
 }
 

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -66,7 +66,7 @@ unittest
             return new ReNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock);
+                &this.acceptBlock, &this.acceptHeader);
         }
     }
 

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -109,7 +109,7 @@ unittest
             return new SocialDistancingNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock);
+                &this.acceptBlock, &this.acceptHeader);
         }
 
     }


### PR DESCRIPTION
When checking the height available from other nodes we only want to know the height of blocks with a majority of signatures.