### PR TITLE
Nominator: Nominate until a deadline

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -470,11 +470,12 @@ extern(D):
         }
 
         const next_nomination = this.getExpectedBlockTime();
-        if (cur_time < next_nomination)
+        const nomination_deadline = next_nomination + this.params.BlockInterval.total!"seconds" / 2;
+        if (cur_time < next_nomination || (cur_time > nomination_deadline && this.is_nominating))
         {
             this.log.trace(
-                "checkNominate(): Too early to nominate (current: {}, next: {})",
-                cur_time, next_nomination);
+                "checkNominate(): Not in the nomination window (current: {}, window: {}-{})",
+                cur_time, next_nomination, nomination_deadline);
             return;
         }
 


### PR DESCRIPTION
Nominator will nominate new values only for the first half of the
block interval, to allocate rest of the interval for Ballot protocol
to terminate.

We also ensure that each node nominates atleast a single value for
each slot, regardless of the time.