### PR TITLE
Registry: Add start routine to registry and zones

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -448,6 +448,8 @@ public class FullNode : API
         this.stats_server = this.makeStatsServer();
         this.transaction_relayer.start();
 
+        this.registry.start();
+
         // Special case
         // Block externalized handler is set and push for Genesis block.
         if (this.block_handlers.length > 0 && this.ledger.height() == 0)

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -161,7 +161,7 @@ public Listeners runNode (Config config)
             assert(false, e.msg);
     };
 
-    setTimer(0.seconds, &result.node.start, Periodic.No);  // asynchronous
+    result.node.start();
 
     string tls_user_help;
     auto tls_ctx = getTLSContext(tls_user_help);

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -143,6 +143,15 @@ public Listeners runNode (Config config)
             //dnstask.interrupt();
         }
 
+    bool delegate (in NetworkAddress address) @safe nothrow isBannedDg = (in address) @safe nothrow {
+        try
+            return result.node.getBanManager().isBanned(Address("agora://" ~ address.toAddressString()));
+        catch (Exception e)
+            assert(false, e.msg);
+    };
+
+    result.node.start();
+
     if (config.registry.enabled)
     {
         auto reg = result.node.getRegistry();
@@ -153,15 +162,6 @@ public Listeners runNode (Config config)
         result.tcp ~= listenTCP(config.registry.port, (conn) => conn.runTCPDNSServer(reg),
                 config.registry.address);
     }
-
-    bool delegate (in NetworkAddress address) @safe nothrow isBannedDg = (in address) @safe nothrow {
-        try
-            return result.node.getBanManager().isBanned(Address("agora://" ~ address.toAddressString()));
-        catch (Exception e)
-            assert(false, e.msg);
-    };
-
-    result.node.start();
 
     string tls_user_help;
     auto tls_ctx = getTLSContext(tls_user_help);


### PR DESCRIPTION
It was starting immediately during construction which is incompatible
with general structure of LocalRest and Agora. Registry and zones will be
started during `FullNode` start.

Towards #2933 since `getRegistryClient` requires a task context for `LocalRest`.