### PR TITLE
Ledger: Only check for double spending when building TX sets

### DIFF
--- a/source/agora/consensus/pool/Transaction.d
+++ b/source/agora/consensus/pool/Transaction.d
@@ -217,6 +217,15 @@ public class TransactionPool
         }
     }
 
+    /// Remove all TXs that spend the `utxo_hash`
+    public void removeSpenders (in Hash utxo_hash) @trusted
+    {
+        if (auto spender_set = utxo_hash in this.spenders)
+            foreach (tx_hash; *spender_set)
+                this.remove(tx_hash, false);
+        this.spenders.remove(utxo_hash);
+    }
+
     /***************************************************************************
 
         Add the given TX to `spenders` list


### PR DESCRIPTION
TXs are validated before being added to the pool. So we can skip
validating it again after fetching it from the pool. We only need
to make sure that TX set is not double spending.

Our TX validation routine depends on 3 inputs;

1) TX itself, which is static.
2) UTXO set
	If a UTXO gets spent, we remove all the TXs that spend it from
	the pool. So any TX in pool is guaranteed to still have its inputs
	in the UTXO set.

	We may lock a Freeze output, if it is used for an enrollment.
	If a melting TX comes before the enrollment and makes it to the pool,
	it would still be in the pool after the enrollment. So we need to remove
	any TXs that spend that Frozen stake from the pool, when we update its
	lock height
3) Penalty deposit
	A stake could be slashed and lose its penalty deposit, but since
	that stake should be actively enrolled for it to be slashed and we lock
	the stake for the duration of the enrollment, no TX that spends a enrolled
	stake can be in the pool.