### PR TITLE
Add tests for secondary and caching registries

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2349,6 +2349,11 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
       event_handlers : test_conf.event_handlers,
       registry: {
           enabled: true,
+          realm: {
+              authoritative: SetInfo!bool(true, true),
+              primary: SetInfo!string("name.registry", true),
+              soa: { email: SetInfo!string("test@testnet", true), },
+          },
           validators: {
               authoritative: SetInfo!bool(true, true),
               primary: SetInfo!string("name.registry", true),


### PR DESCRIPTION
Fixes #2933 

Depends on #2947 , #2954 and https://github.com/bosagora/localrest/pull/1
after dependencies get merged, this will be rebased (which will reduce the number of commits)