### PR TITLE
Trigger signature catchup when needed

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -142,6 +142,9 @@ public extern (C++) class Nominator : SCPDriver
     /// Delegate called when a block is to be externalized
     public extern (D) string delegate (in Block) @safe acceptBlock;
 
+    /// Delegate called when a block header is to be updated with signatures
+    public extern (D) void delegate (const(BlockHeader)) @safe acceptHeader;
+
     /// The missing validators at the start of the nomination round
     protected uint[] initial_missing_validators;
 
@@ -171,6 +174,7 @@ extern(D):
             data_dir = path to the data directory
             nomination_interval = How often to trigger `checkNominate`
             externalize = delegate called when a block is to be externalized
+            acceptHeader = delegate called when header is updated
 
     ***************************************************************************/
 
@@ -178,7 +182,8 @@ extern(D):
         Clock clock, NetworkManager network, ValidatingLedger ledger,
         EnrollmentManager enroll_man, ITaskManager taskman, ManagedDatabase cacheDB,
         Duration nomination_interval,
-        string delegate (in Block) @safe externalize)
+        string delegate (in Block) @safe externalize,
+        void delegate(const(BlockHeader)) @safe acceptHeader)
     {
         assert(externalize !is null);
 
@@ -204,6 +209,7 @@ extern(D):
         this.restoreSCPState();
         this.nomination_interval = nomination_interval;
         this.acceptBlock = externalize;
+        this.acceptHeader = acceptHeader;
     }
 
     /// Shut down the envelope processing timer
@@ -484,6 +490,7 @@ extern(D):
             this.log.trace(
                 "checkNominate(): Last block ({}) doesn't have majority signatures, signed={}",
                 this.ledger.height(), this.ledger.lastBlock().header.validators);
+            this.network.getMissingBlockSigs(this.ledger, this.acceptHeader);
             return;
         }
 

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -300,6 +300,9 @@ public class NetworkManager
 
     protected agora.api.FullNode.API owner_node;
 
+    // Protect against running multiple times simultaneously
+    private bool isGettingMissingBlockSigs = false;
+
     /// Ctor
     public this (in Config config, ManagedDatabase cache, ITaskManager taskman, Clock clock, agora.api.FullNode.API owner_node)
     {
@@ -905,6 +908,11 @@ public class NetworkManager
         import std.range;
         import std.typecons;
 
+        // Protect against running multiple times simultaneously
+        if (this.isGettingMissingBlockSigs)
+            return;
+        this.isGettingMissingBlockSigs = true;
+
         size_t[Height] signed_validators;
 
         try
@@ -967,6 +975,7 @@ public class NetworkManager
         {
             log.error("getMissingBlockSigs: Exception thrown : {}", e.msg);
         }
+        this.isGettingMissingBlockSigs = false;
     }
 
     /// Shut down timers & dump the metadata

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -481,7 +481,7 @@ public class Validator : FullNode, API
         return new Nominator(
             this.params, this.config.validator.key_pair, clock, network, ledger,
             enroll_man, taskman, this.cacheDB,
-            this.config.validator.nomination_interval, &this.acceptBlock);
+            this.config.validator.nomination_interval, &this.acceptBlock, &this.acceptHeader);
     }
 
     /***************************************************************************

--- a/source/agora/test/BlockRewards.d
+++ b/source/agora/test/BlockRewards.d
@@ -276,7 +276,7 @@ private class EvenBlockHeightSignerNode () : TestValidatorNode
         return new EvenBlockHeightSignerNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock);
+            &this.acceptBlock, &this.acceptHeader);
     }
 }
 

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -89,7 +89,7 @@ class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new ByzantineNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, reason);
+            &this.acceptBlock, &this.acceptHeader, reason);
     }
 }
 
@@ -149,7 +149,7 @@ private class SpyingValidator : TestValidatorNode
         return new SpyNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.envelope_type_counts);
+            &this.acceptBlock, &this.acceptHeader, this.envelope_type_counts);
     }
 }
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -181,7 +181,7 @@ unittest
             return new BadNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock, this.runCount);
+                &this.acceptBlock, &this.acceptHeader, this.runCount);
         }
     }
 

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -78,7 +78,7 @@ private class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new BadBlockSigningNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, reason);
+            &this.acceptBlock, &this.acceptHeader, reason);
     }
 }
 

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -82,7 +82,7 @@ private class BadNominatingVN : TestValidatorNode
         return new BadNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock);
+            &this.acceptBlock, &this.acceptHeader);
     }
 }
 

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -63,7 +63,7 @@ unittest
             return new CustomNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock);
+                &this.acceptBlock, &this.acceptHeader);
         }
     }
 

--- a/source/agora/test/NominatingCatchup.d
+++ b/source/agora/test/NominatingCatchup.d
@@ -51,7 +51,7 @@ private class CustomValidator : TestValidatorNode
         return new CustomNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock);
+            &this.acceptBlock, &this.acceptHeader);
     }
 }
 

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -77,7 +77,7 @@ private class TestNode () : TestValidatorNode
         return new DoesNotExternalizeBlockNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock);
+            &this.acceptBlock, &this.acceptHeader);
     }
 }
 

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -66,7 +66,7 @@ unittest
             return new ReNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock);
+                &this.acceptBlock, &this.acceptHeader);
         }
     }
 

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -109,7 +109,7 @@ unittest
             return new SocialDistancingNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock);
+                &this.acceptBlock, &this.acceptHeader);
         }
 
     }


### PR DESCRIPTION
In the case where the previous block has less than majority signatures
but it is time to start nominations for the next block.