### PR TITLE
Trivial: Remove unused test type DNSQuery

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2497,16 +2497,6 @@ package interface FullRegistryAPI : TestAPI, NameRegistryAPI
     public Message queryTCP (in Message query);
 }
 
-/// Mimics a DNS UDP Socket
-private struct DNSQuery
-{
-    /// DNS message
-    public Message msg;
-
-    /// A channel that the client will wait the response on
-    public Channel!Message response_chan;
-}
-
 /// A node that implements `FullRegistryAPI`
 public class RegistryNode : TestFullNode, FullRegistryAPI
 {


### PR DESCRIPTION
Its usage was removed in a previous commit, but the type was left behind.