### PR TITLE
Fix Flash failure on CI test

### DIFF
--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -730,7 +730,7 @@ public class FlashNode : FlashControlAPI
         if (state == ChannelState.Open)  // todo: might not exist
             this.onChannelOpen(reg_pk, this.channels[chan_id].conf, height);
 
-        this.listener.onChannelNotify(reg_pk, chan_id, state, error);
+        this.listener.onChannelNotify(reg_pk, chan_id, state, error, height);
     }
 
     ///

--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -498,6 +498,7 @@ private class FlashListener : TestFlashListenerAPI
     {
         ChannelState state;
         ErrorCode error;
+        Height height;
     }
 
     State[PublicKey][Hash] channel_state;
@@ -565,12 +566,12 @@ private class FlashListener : TestFlashListenerAPI
     }
 
     public void onChannelNotify (PublicKey pk, Hash chan_id, ChannelState state,
-        ErrorCode error, Height = Height(0))
+        ErrorCode error, Height height = Height(0))
     {
         log.info("Channel event {}, id {}", state, chan_id.flashPrettify);
         if (chan_id !in this.channel_state)
             this.channel_state[chan_id] = typeof(this.channel_state[chan_id]).init;
-        this.channel_state[chan_id][pk] = State(state, error);
+        this.channel_state[chan_id][pk] = State(state, error, height);
     }
 
     public Result!ChannelUpdate onRequestedChannelOpen (PublicKey pk, ChannelConfig conf)


### PR DESCRIPTION
The unit tests in `agora.test.Flash` fail often on CI because there is
a timing issue. Unit tests expect `update_tx`s not to be sent as soon as
a block is externalized when the `allow_publish` is set to `false`. But
the `update_tx` is sent as soon as the `allow_publish` is to set `true`
by calling `setPublishEnable`, which is not to be supposed to be sent.

Fixes #2425 

The error log on CI was following,
`2022-01-28T02:49:34.7716990Z 2022-01-28 02:49:32,15 [32mInfo[0m [agora.flash.Channel] - Alice: Publishing update tx 4: 0x5fdc75. Result: { status: Status.Rejected, reason: "Double spend comes with a less-than-acceptable fee increase" }`

This was because a `charlie` node succeeded to send an `update` tx that has the same input as the above tx, but the tx should not be sent because `allow_publish` is thought to have a `false` value at the very moment.