### PR TITLE
Move config for registry_address from validator to node section

### DIFF
--- a/devel/config-fullnode.yaml
+++ b/devel/config-fullnode.yaml
@@ -13,6 +13,7 @@ node:
   realm: "testnet.bosagora.io"
   testing: true
   data_dir: .fullnode/data/
+  registry_address: https://ns1.bosagora.io/
 
 interfaces:
   - type:    http
@@ -26,10 +27,6 @@ consensus:
   block_interval:
     seconds: 20
   validator_cycle: 20
-
-validator:
-  enabled: false
-  registry_address: https://ns1.bosagora.io/
 
 registry:
   enabled: true

--- a/devel/config-single.yaml
+++ b/devel/config-single.yaml
@@ -14,6 +14,7 @@ node:
   testing: true
   test_validators: 1
   data_dir: .single/data/
+  registry_address: http://127.0.0.1:2826/
 
 interfaces:
   - type:    http
@@ -32,7 +33,6 @@ validator:
   enabled: true
   # We use first of Genesis Block enrollments: val5: boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8
   seed: SAZO4WA5SXUN3J6XBXZCFPXJJZ62IQAJYAG2KBVWF2QZKTU2WK3QTNMV
-  registry_address: http://127.0.0.1:2826/
   addresses_to_register:
     - http://127.0.0.1:2826/
 

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -63,6 +63,8 @@ node:
   # Do not change this unless you intend to maintain your own DNS servers,
   # or want to join an alternative network.
   realm: 'coinnet.bosagora.io'
+  # Address of the name registry
+  registry_address: http://127.0.0.1:3003
 
 # Each entry in this array is an interface Agora will listen to, allowing to
 # expose the same node on more than one network interface or with different
@@ -103,8 +105,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xpvald2ydpxzl9aat978kv78y5g24jxy46mcnl7munf4jyhd0zjrc5x62kn
   seed: SAUHVPR7O7F2QGLDVXG3DQTVHXESE3ZAWHIIGKT35LCHIPLZBZTAFXJA
-  # Address of the name registry
-  registry_address: http://127.0.0.1:3003
   # Network addresses that will be registered with the public key (Validator only)
   # If left empty, all public network addresses of the node will be registered
   addresses_to_register:

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -514,11 +514,11 @@ public class NetworkManager
     public ITimer startPeriodicNameRegistration ()
     {
         // No configured registry, nothing to do
-        if (this.config.validator.registry_address.length == 0)
+        if (this.config.node.registry_address.length == 0)
             return null;
 
         this.registry_client = this.getRegistryClient(
-            this.config.validator.registry_address);
+            this.config.node.registry_address);
 
         this.onRegisterName();  // avoid delay
         // We re-register at regular interval in order to cope with the situation below

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -125,10 +125,10 @@ public struct Config
     {
         if (this.validator.enabled)
             enforce(this.network.length || this.registry.enabled ||
-                    this.validator.registry_address != string.init ||
+                    this.node.registry_address != string.init ||
                     // Allow single-network validator (assume this is NODE6)
                     this.node.test_validators == 1,
-                    "Either the network section must not be empty, or 'validator.registry_address' must be set " ~
+                    "Either the network section must not be empty, or 'node.registry_address' must be set " ~
                     ", or registry must be enabled");
         else
             enforce(this.network.length || this.registry.enabled,
@@ -278,6 +278,9 @@ public struct NodeConfig
     /// The realm to which this node belongs (a domain name)
     public immutable(Domain) realm = Domain.fromSafeString("coinnet.bosagora.io.");
 
+    // Registry address
+    public @Optional string registry_address;
+
     /// Validate this struct
     public void validate () const scope @safe
     {
@@ -322,9 +325,6 @@ public struct ValidatorConfig
 
     // Network addresses that will be registered with the public key
     public @Optional immutable Address[] addresses_to_register;
-
-    // Registry address
-    public @Optional string registry_address;
 
     // If the enrollments will be renewed or not at the end of the cycle
     public bool recurring_enrollment = true;
@@ -620,9 +620,10 @@ validator:
     // Missing 'network' section for a validator node with name registry
     {
         immutable conf_str = `
+node:
+  registry_address: http://127.0.0.1:3003
 validator:
   enabled: true
-  registry_address: http://127.0.0.1:3003
   seed:    SDV3GLVZ6W7R7UFB2EMMY4BBFJWNCQB5FTCXUMD5ZCFTDEVZZ3RQ2BZI
   recurring_enrollment: true
   preimage_reveal_interval:
@@ -703,10 +704,11 @@ unittest
 {
     {
         immutable conf_example = `
+node:
+  registry_address: http://127.0.0.1:3003
 validator:
   enabled: true
   seed: SDV3GLVZ6W7R7UFB2EMMY4BBFJWNCQB5FTCXUMD5ZCFTDEVZZ3RQ2BZI
-  registry_address: http://127.0.0.1:3003
   recurring_enrollment : false
   preimage_reveal_interval:
     seconds: 99

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2180,6 +2180,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
     {
         NodeConfig conf = test_conf.node;
         conf.testing = true;
+        conf.registry_address = "dns://10.8.8.8";
         const selfCount = 1;
         if (conf.min_listeners == size_t.max)
             conf.min_listeners = (test_conf.node.test_validators + test_conf.full_nodes) - selfCount;
@@ -2222,7 +2223,6 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             enabled : true,
             key_pair : key_pair,
             addresses_to_register : [ self_address ],
-            registry_address : "dns://10.8.8.8",
             recurring_enrollment : test_conf.recurring_enrollment,
             name_registration_interval : 10.seconds,
             preimage_reveal_interval : test_conf.preimage_reveal_interval,

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -22,6 +22,7 @@ node:
   relay_tx_cache_exp:
     seconds : 1200
   realm: "integration.bosagora.io"
+  registry_address: http://node-0:1826
 
 interfaces:
   - type: http
@@ -53,8 +54,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xzval2a3cdxv28n6slr62wlczslk3juvk7cu05qt3z55ty2rlfqfc6egsh2
   seed: SAQXRDHTWME4GUIVNYCKPN433VJ4BJP2L2T7UWHGSSW47VFC67EQFY3S
-  # Address of the name registry
-  registry_address: http://node-0:1826
   # Network addresses that will be registered with the public key (Validator only)
   # If left empty, all public network addresses of the node will be registered
   addresses_to_register:

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -22,6 +22,7 @@ node:
   relay_tx_cache_exp:
     seconds : 1200
   realm: "integration.bosagora.io"
+  registry_address: http://node-0:1826
 
 interfaces:
   - type: http
@@ -53,8 +54,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xzval3ah8z7ewhuzx6mywveyr79f24w49rdypwgurhjkr8z2ke2mycftv9n
   seed: SC3H3ADGT3YGLMDWCLKZ2GILDHDTC4WDE7M3G4URQPWJZZM43TTAM2QG
-  # Address of the name registry
-  registry_address: http://node-0:1826
   # Network addresses that will be registered with the public key (Validator only)
   # If left empty, all public network addresses of the node will be registered
   addresses_to_register:

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -22,6 +22,7 @@ node:
   relay_tx_cache_exp:
     seconds : 1200
   realm: "integration.bosagora.io"
+  registry_address: http://node-0:1826
 
 interfaces:
   - type: http
@@ -53,8 +54,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xzval4nvru2ej9m0rptq7hatukkavemryvct4f8smyy3ky9ct5u0s8w6gfy
   seed: SBIJAVYYCSRV5RNO2WVTT25H6VZTEV3YSE7U7WT7UQUNSVBUGB6QNBWG
-  # Address of the name registry
-  registry_address: http://node-0:1826
   # Network addresses that will be registered with the public key (Validator only)
   # If left empty, all public network addresses of the node will be registered
   addresses_to_register:

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -22,6 +22,7 @@ node:
   relay_tx_cache_exp:
     seconds : 1200
   realm: "integration.bosagora.io"
+  registry_address: http://node-0:1826
 
 interfaces:
   - type: http
@@ -53,8 +54,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8
   seed: SAZO4WA5SXUN3J6XBXZCFPXJJZ62IQAJYAG2KBVWF2QZKTU2WK3QTNMV
-  # Address of the name registry
-  registry_address: http://node-0:1826
   # Network addresses that will be registered with the public key (Validator only)
   # If left empty, all public network addresses of the node will be registered
   addresses_to_register:

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -22,6 +22,7 @@ node:
   relay_tx_cache_exp:
     seconds : 1200
   realm: "integration.bosagora.io"
+  registry_address: http://node-0:1826
 
 interfaces:
   - type: http
@@ -53,8 +54,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xrval6hd8szdektyz69fnqjwqfejhu4rvrpwlahh9rhaazzpvs5g6lh34l5
   seed: SAFIQC7HRZPVPEG47ZHS3OBBCYDREHNC4DEKM3QODM7WKPZPU7VQXCPI
-  # Address of the name registry
-  registry_address: http://node-0:1826
   # Network addresses that will be registered with the public key (Validator only)
   # If left empty, all public network addresses of the node will be registered
   addresses_to_register:

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -22,6 +22,7 @@ node:
   relay_tx_cache_exp:
     seconds : 1200
   realm: "integration.bosagora.io"
+  registry_address: http://node-0:1826
 
 interfaces:
   - type: http
@@ -53,8 +54,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xrval7gwhjz4k9raqukcnv2n4rl4fxt74m2y9eay6l5mqdf4gntnzhhscrh
   seed: SAWI3JZWDDSQR6AX4DRG2OMS26Y6XY4X2WA3FK6D5UW4WTU74GUQXRZP
-  # Address of the name registry
-  registry_address: http://node-0:1826
   # Network addresses that will be registered with the public key (Validator only)
   # If left empty, all public network addresses of the node will be registered
   addresses_to_register:


### PR DESCRIPTION
In 'validator', it won't even be parsed if the section is not enabled.
Since all nodes rely on a validator, having it in node makes much more sense.