### PR TITLE
Add  TCP support to `DNSResolver` and improve UDP

### DIFF
--- a/source/agora/network/DNSResolver.d
+++ b/source/agora/network/DNSResolver.d
@@ -110,6 +110,9 @@ public final class VibeDNSResolver : DNSResolver
                 continue;
             }
         }
+
+        log.trace("None of the {} peers had an answer for message: {}",
+            this.resolvers.length, msg);
         return Message.init;
     }
 
@@ -160,7 +163,11 @@ public final class VibeDNSResolver : DNSResolver
                     conn.read(buffer[0 .. size]);
                     conn.close();
 
-                    return deserializeFull!Message(buffer[0 .. size]);
+                    auto answer = deserializeFull!Message(buffer[0 .. size]);
+                    log.trace("Got response from '{}' for '{}' : {}",
+                          peer.address, msg, answer);
+
+                    return answer;
                 }
                 catch (Exception exc)
                 {
@@ -171,7 +178,8 @@ public final class VibeDNSResolver : DNSResolver
                 break;
             }
         }
-
+        log.trace("None of the {} peers had an answer for message: {}",
+            this.resolvers.length, msg);
         return Message.init;
     }
 }

--- a/source/agora/network/DNSResolver.d
+++ b/source/agora/network/DNSResolver.d
@@ -237,7 +237,8 @@ public abstract class DNSResolver
     /// Ditto
     public ResourceRecord[] query (const(char)[] name, QTYPE type = QTYPE.ALL) @safe
     {
-        return this.query(this.buildQuery(name, type));
+        // RFC 5936 recommends AXFR over TCP
+        return this.query(this.buildQuery(name, type), type == QTYPE.AXFR);
     }
 
     /// Returns: DNS message for querying a record of `type` for `name'

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2637,17 +2637,16 @@ public final class LocalRestDNSResolver : DNSResolver
 
     ***************************************************************************/
 
-    private ResourceRecord[] queryInner (Message msg, bool tcp = false) @trusted
+    private Message queryInner (Message msg, bool tcp = false) @trusted
     {
         foreach (p; this.peers)
         {
             auto answer = !tcp ? p.queryUDP(msg) : p.queryTCP(msg);
             log.trace("Got response from for '{}' : {}", msg, answer);
-            if (answer.header.RCODE == Header.RCode.NoError)
-                return answer.answers;
+            return answer;
         }
         log.trace("None of the {} peers had an answer for message: {}", this.peers.length, msg);
-        return null;
+        return Message.init;
     }
 
     /***************************************************************************
@@ -2659,7 +2658,7 @@ public final class LocalRestDNSResolver : DNSResolver
 
     ***************************************************************************/
 
-    public override ResourceRecord[] queryUDP (Message msg) @trusted
+    public override Message queryUDP (Message msg) @trusted
     {
         return this.queryInner(msg, false);
     }
@@ -2673,7 +2672,7 @@ public final class LocalRestDNSResolver : DNSResolver
 
     ***************************************************************************/
 
-    public override ResourceRecord[] queryTCP (Message msg) @trusted
+    public override Message queryTCP (Message msg) @trusted
     {
         return this.queryInner(msg, true);
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2633,12 +2633,12 @@ public final class LocalRestDNSResolver : DNSResolver
 
         Params:
             msg = DNS message
+            tcp = Use TCP for query, default is UDP
 
     ***************************************************************************/
 
-    public override ResourceRecord[] query (Message msg) @trusted
+    private ResourceRecord[] queryInner (Message msg, bool tcp = false) @trusted
     {
-        const tcp = msg.questions.length > 0 && msg.questions[0].qtype == QTYPE.AXFR;
         foreach (p; this.peers)
         {
             auto answer = !tcp ? p.queryUDP(msg) : p.queryTCP(msg);
@@ -2648,5 +2648,33 @@ public final class LocalRestDNSResolver : DNSResolver
         }
         log.trace("None of the {} peers had an answer for message: {}", this.peers.length, msg);
         return null;
+    }
+
+    /***************************************************************************
+
+        Query the server over UDP with given `msg` and return the response
+
+        Params:
+            msg = DNS message
+
+    ***************************************************************************/
+
+    public override ResourceRecord[] queryUDP (Message msg) @trusted
+    {
+        return this.queryInner(msg, false);
+    }
+
+    /***************************************************************************
+
+        Query the server over TCP with given `msg` and return the response
+
+        Params:
+            msg = DNS message
+
+    ***************************************************************************/
+
+    public override ResourceRecord[] queryTCP (Message msg) @trusted
+    {
+        return this.queryInner(msg, true);
     }
 }


### PR DESCRIPTION
See each commit for details

- Adds TCP support to DNS resolver
- AXFR zone transfer over TCP
- Retries through TCP when UDP returns with truncation

Depends on #2979 

Fixes #2945 