### PR TITLE
Fix #2962: Use registry address as default DNS resolver

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -705,17 +705,20 @@ public class NetworkManager
         Returns an instance of a DNSResolver
 
         Params:
-            peer_addrs = Addresses of DNS servers that Resolver will send queries to
+            peers = Addresses of DNS servers that Resolver will send queries to
+                    If none / `null` is provided, default to the list of
+                    configured registries.
+
         Returns:
-            the dns resolver
+            A newly instantiated `DNSResolver` with the provided `peers`
 
     ***************************************************************************/
 
-    public DNSResolver makeDNSResolver (Address[] peer_addrs = null)
+    public DNSResolver makeDNSResolver (Address[] peers = null)
     {
-        return (peer_addrs !is null)
-            ? new VibeDNSResolver(peer_addrs)
-            : new VibeDNSResolver();
+        if (peers.length == 0)
+            peers = [ Address(this.config.node.registry_address) ];
+        return new VibeDNSResolver(peers);
     }
 
     /// register network addresses into the name registry

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1392,9 +1392,11 @@ public class TestNetworkManager : NetworkManager
     }
 
     /// Returns an instance of a DNSResolver
-    public override DNSResolver makeDNSResolver (Address[] peer_addrs = null)
+    public override DNSResolver makeDNSResolver (Address[] peers = null)
     {
-        return new LocalRestDNSResolver(peer_addrs, *this.registry);
+        if (peers.length == 0)
+            peers = [ Address(this.config.node.registry_address) ];
+        return new LocalRestDNSResolver(peers, *this.registry);
     }
 
     ///


### PR DESCRIPTION
The code previously was falling back to outside DNS servers,
which means the registry wasn't used when it should have been.