### PR TITLE
Move nodes identity in `NetworkClient` and remove `NodeConnInfo`

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1133,7 +1133,7 @@ extern(D):
         }
 
         log.dbg("{}: peers are {}", __PRETTY_FUNCTION__, this.network.peers[]);
-        this.network.validators().each!(v => v.client.sendEnvelope(env));
+        this.network.validators().each!(c => c.sendEnvelope(env));
     }
 
     /***************************************************************************

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -314,6 +314,12 @@ public class NetworkClient
         return Identity(this.identity_.key, this.identity_.utxo);
     }
 
+    ///
+    public bool isAuthenticated () const scope @safe pure nothrow @nogc
+    {
+        return this.identity.key != PublicKey.init;
+    }
+
     /***************************************************************************
 
         Params:

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -74,10 +74,16 @@ public class NetworkManager
     public static struct NodeConnInfo
     {
         /// Hash of the output used as collateral, only set if the node is a Validator
-        Hash utxo;
+        public Hash utxo () const scope @safe pure nothrow @nogc
+        {
+            return this.client.identity.utxo;
+        }
 
         /// PublicKey of the node. TODO: Remove and just use utxo.
-        PublicKey key;
+        public PublicKey key () const scope @safe pure nothrow @nogc
+        {
+            return this.client.identity.key;
+        }
 
         /// Client
         NetworkClient client;
@@ -325,8 +331,6 @@ public class NetworkManager
             assert(0);
 
         NodeConnInfo node = {
-            key : key,
-            utxo: utxo,
             client : client
         };
 
@@ -344,12 +348,12 @@ public class NetworkManager
         {
             this.peers.insertBack(node);
 
-            if (node.isAuthenticated())
+            if (key !is PublicKey.init)
             {
                 log.info("Found new Validator: {} (UTXO: {}, key: {})",
                          client.addresses(), utxo, key);
                 this.required_peers.remove(utxo);
-                client.setIdentity(key);
+                client.setIdentity(utxo, key);
             }
             else
                 log.info("Found new FullNode: {}", client.addresses());
@@ -370,7 +374,7 @@ public class NetworkManager
             return false;
 
         assert(node.client.connections.length == 1);
-        existing_peers.front().utxo = node.utxo;
+        existing_peers.front().client.setIdentity(node.utxo, node.key);
         existing_peers.front().client.merge(node.client.connections[0].tupleof);
         return true;
     }

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -83,7 +83,7 @@ public class NetworkManager
         NetworkClient client;
 
         ///
-        public bool isValidator () const scope @safe pure nothrow @nogc
+        public bool isAuthenticated () const scope @safe pure nothrow @nogc
         {
             return this.key != PublicKey.init;
         }
@@ -344,7 +344,7 @@ public class NetworkManager
         {
             this.peers.insertBack(node);
 
-            if (node.isValidator())
+            if (node.isAuthenticated())
             {
                 log.info("Found new Validator: {} (UTXO: {}, key: {})",
                          client.addresses(), utxo, key);
@@ -366,7 +366,7 @@ public class NetworkManager
     private bool tryMerge (scope ref NodeConnInfo node)
     {
         auto existing_peers = this.peers[].find!(p => p.key == node.key);
-        if (!node.isValidator() || existing_peers.empty())
+        if (!node.isAuthenticated() || existing_peers.empty())
             return false;
 
         assert(node.client.connections.length == 1);
@@ -655,7 +655,7 @@ public class NetworkManager
             address !in this.connection_tasks &&
             address !in this.todo_addresses &&
             (existing_peer.empty || // either does not exist or a validator with no stake
-                (existing_peer.front.isValidator() && existing_peer.front.utxo == Hash.init));
+                (existing_peer.front.isAuthenticated() && existing_peer.front.utxo == Hash.init));
     }
 
     /// Received new set of addresses, put them in the todo address list
@@ -767,7 +767,7 @@ public class NetworkManager
 
     public auto validators () return @safe nothrow pure
     {
-        return this.peers[].filter!(p => p.isValidator());
+        return this.peers[].filter!(p => p.isAuthenticated());
     }
 
     /***************************************************************************

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -987,10 +987,19 @@ public class NetworkManager
     {
         log.dbg("minPeersConnected: missing = {}, peers = {}, min = {}",
             this.required_peers.length, this.peers[].walkLength, this.config.node.min_listeners);
-        return this.required_peers.length == 0 &&
-            this.peers[].walkLength >= this.config.node.min_listeners &&
-            this.validators().filter!(node =>
-                !node.client.addresses.all!(addr => this.banman.isBanned(addr))).count != 0;
+
+        // We need to establish connections to all peers we were explicitly asked for
+        if (this.required_peers.length)
+            return false;
+
+        // We need to establish a minimum number of connections
+        if (this.peers[].walkLength < this.config.node.min_listeners)
+            return false;
+
+        // We don't have an authenticated peer where all the addresses are banned
+        return this.validators().filter!(
+            node => !node.client.addresses.all!(addr => this.banman.isBanned(addr)))
+            .count != 0;
     }
 
     private bool peerLimitReached ()  nothrow @safe

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -454,6 +454,7 @@ public class NetworkManager
         time offset will be correct.
 
         Params:
+            threshold = The threshold of responses to expect (see `Returns`)
             time_offest = will contain the offset that should be applied to the
                           clock's local time to get the median clock time of the
                           node's quorum nodes (zero if return value is false)

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -1040,7 +1040,7 @@ public class FullNode : API
             avail_height, utxo_finder, getPenaltyDeposit))
         {
             log.info("Accepted enrollment: {}", prettify(enroll));
-            this.network.peers.each!(p => p.client.sendEnrollment(enroll, avail_height));
+            this.network.peers.each!(p => p.sendEnrollment(enroll, avail_height));
         }
     }
 
@@ -1060,7 +1060,7 @@ public class FullNode : API
         if (this.ledger.addPreimage(preimage))
         {
             log.info("Accepted preimage: {}", prettify(preimage));
-            this.network.peers.each!(p => p.client.sendPreimage(preimage));
+            this.network.peers.each!(p => p.sendPreimage(preimage));
             this.pushPreImage(preimage);
         }
 

--- a/source/agora/node/TransactionRelayer.d
+++ b/source/agora/node/TransactionRelayer.d
@@ -220,7 +220,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
     public void relayTransactions () @safe nothrow
     {
         log.dbg("{}: clients: {}", __PRETTY_FUNCTION__, (*this.clients)[].map!(v => v.key));
-        if ((*this.clients)[].canFind!(client => client.isValidator()))
+        if ((*this.clients)[].canFind!(client => client.isAuthenticated()))
             this.getRelayTransactions().each!(tx => (*this.clients).each!(node_info => node_info.client.sendTransaction(tx)));
     }
 

--- a/source/agora/node/TransactionRelayer.d
+++ b/source/agora/node/TransactionRelayer.d
@@ -55,8 +55,6 @@ import core.time;
 private alias SinkT = void delegate(scope const(char)[] v);
 ///
 private alias SafeSinkT = void delegate(scope const(char)[] v) @safe;
-///
-private alias NodeConnInfo = NetworkManager.NodeConnInfo;
 
 /// Returns the fee rate for a transaction (total fees / tx size)
 public alias GetFeeRateDg = string delegate(in Transaction tx, out Amount rate) @safe nothrow;
@@ -99,7 +97,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
     private immutable Config config;
 
     ///
-    private DList!NodeConnInfo* clients;
+    private DList!NetworkClient* clients;
 
     ///
     private ITaskManager taskman;
@@ -146,7 +144,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
 
     ***************************************************************************/
 
-    public this (TransactionPool pool, immutable Config config, DList!NodeConnInfo* clients,
+    public this (TransactionPool pool, immutable Config config, DList!NetworkClient* clients,
           ITaskManager taskman, Clock clock, GetFeeRateDg getTxFeeRate, bool start_timers = true)
     {
         this.pool = pool;
@@ -219,9 +217,9 @@ public class TransactionRelayerFeeImp : TransactionRelayer
     /// Sends an array of transactions ordered by fee to known network clients.
     public void relayTransactions () @safe nothrow
     {
-        log.dbg("{}: clients: {}", __PRETTY_FUNCTION__, (*this.clients)[].map!(v => v.key));
+        log.dbg("{}: clients: {}", __PRETTY_FUNCTION__, (*this.clients)[].map!(v => v.identity.key));
         if ((*this.clients)[].canFind!(client => client.isAuthenticated()))
-            this.getRelayTransactions().each!(tx => (*this.clients).each!(node_info => node_info.client.sendTransaction(tx)));
+            this.getRelayTransactions().each!(tx => (*this.clients).each!(c => c.sendTransaction(tx)));
     }
 
     /// Cleans expired entries from the internal datastructures.
@@ -373,7 +371,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
         auto cacheDB = new ManagedDatabase(":memory:");
         immutable params = new immutable(ConsensusParams)();
         auto fee_man = new FeeManager(stateDB, params);
-        auto noclients = new DList!NodeConnInfo();
+        auto noclients = new DList!NetworkClient();
         GetFeeRateDg wrapper = (in Transaction tx, out Amount rate)
         {
             return fee_man.getTxFeeRate(tx, &utxo_set.peekUTXO, getPenaltyDeposit, rate);

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -298,7 +298,7 @@ public class Validator : FullNode, API
                  next_height, missing);
 
         auto query = this.network.peers[]
-            .map!(peer => peer.client.getPreimages(missing));
+            .map!(peer => peer.getPreimages(missing));
 
         foreach (preimages; query)
         {
@@ -635,7 +635,7 @@ public class Validator : FullNode, API
             this.ledger.height()))
         {
             this.ledger.addPreimage(preimage);
-            this.network.peers.each!(p => p.client.sendPreimage(preimage));
+            this.network.peers.each!(p => p.sendPreimage(preimage));
             this.pushPreImage(preimage);
         }
     }
@@ -711,7 +711,7 @@ public class Validator : FullNode, API
         log.trace("checkAndEnroll: Sending Enrollment for enrolling {} at height {} (to validate blocks {} to {})",
             this.enroll_man.getEnrollmentPublicKey(), avail_height, avail_height + 1, avail_height + this.params.ValidatorCycle);
         this.enroll_man.enroll_pool.addValidated(enrollment, avail_height);
-        this.network.peers.each!(p => p.client.sendEnrollment(enrollment, avail_height));
+        this.network.peers.each!(p => p.sendEnrollment(enrollment, avail_height));
         return enrollment;
     }
 


### PR DESCRIPTION
The idea is that, eventually, we will have the `NetworkClient` responsible for anything related to a peer.
Currently it handles the gossip queue, and store all the connections, but there are some relics which make us instantiate `NetworkClient` too early, and we're almost to the point where we can remove them.
Another thing I'd like to do is more some of `ConnectionTask` to the `NetworkClient`, as often we want to connect to a certain validator, and we know beforehand what key we expect.