### PR TITLE
CPP: bind std::vector::reserve()

### DIFF
--- a/source/scpd/Cpp.d
+++ b/source/scpd/Cpp.d
@@ -367,6 +367,11 @@ extern(C++, (StdNamespace)) extern(C++, class) struct vector (T, Alloc = allocat
             return this._end - this._start;
         }
 
+        public size_t capacity () const @safe pure nothrow @nogc
+        {
+            return this._end_of_storage - this._start;
+        }
+
         public ConstIterator constIterator () const pure nothrow @nogc @safe
         {
             return ConstIterator(0, &this);
@@ -429,6 +434,7 @@ extern(C++, (StdNamespace)) extern(C++, class) struct vector (T, Alloc = allocat
         {
             auto array = src.deserializeWithPolicy!(JsonStringSerializer!string, SerPolicy, T[]);
             typeof(this) vec;
+            vec.reserve(array.length);
             foreach (ref item; array)
                 vec.push_back(item);
             return vec;
@@ -455,6 +461,7 @@ extern(C++, (StdNamespace)) extern(C++, class) struct vector (T, Alloc = allocat
             // `immutable` vector yet
             Unqual!(vector!(Unqual!(QT.ElementType))) ret;
             immutable len = deserializeLength(data, opts.maxLength);
+            ret.reserve(len);
             foreach (idx; 0 .. len)
             {
                 auto entry = deserializeFull!(QT.ElementType)(data, opts);
@@ -492,6 +499,9 @@ extern(C++, (StdNamespace)) extern(C++, class) struct vector (T, Alloc = allocat
             }
         }
     }
+
+    /// Set vector capacity
+    public void reserve (size_t new_cap) inout @trusted pure nothrow @nogc;
 }
 
 unittest
@@ -501,6 +511,8 @@ unittest
     import std.range : iota;
 
     vector!ubyte vec_ubyte;
+    vec_ubyte.reserve(1337);
+    assert(vec_ubyte.capacity() >= 1337);
     iota(5).each!((num) {ubyte b = cast(ubyte)num; vec_ubyte.push_back(b);});
     auto serialized = vec_ubyte.toString();
     assert(serialized == `"AAECAwQ="`, "actual serialized: " ~ serialized);

--- a/source/scpd/types/Utils.d
+++ b/source/scpd/types/Utils.d
@@ -32,6 +32,7 @@ public inout(opaque_vec!()) toVec (scope ref inout(Hash) data) nothrow @nogc
 public inout(opaque_vec!()) toVec (scope inout ubyte[] data) nothrow @nogc
 {
     inout opaque_vec!() ret;
+    ret.reserve(data.length);
     foreach (elem; data)
         ret.base.push_back(cast(ubyte) elem);
     return ret;

--- a/source/scpp/extra/DUtils.cpp
+++ b/source/scpp/extra/DUtils.cpp
@@ -147,14 +147,18 @@ CPPOBJECTINST(std::set<NodeID>);
 CPPOBJECTINST(std::set<SCPBallot>);
 CPPOBJECTINST(std::set<unsigned int>);
 
-CPPOBJECTINST(std::vector<unsigned char>);
-CPPOBJECTINST(std::vector<Value>);
-CPPOBJECTINST(std::vector<unsigned long>);
-CPPOBJECTINST(std::vector<unsigned long long>);
-CPPOBJECTINST(std::vector<SCPQuorumSet>);
-CPPOBJECTINST(std::vector<SCPEnvelope>);
-CPPOBJECTINST(std::vector<Slot::HistoricalStatement>);
 CPPOBJECTINST(stellar::SCPStatement::_pledges_t);
+
+#define CPPVECINST(T) template class T; \
+                      CPPOBJECTINST(T)
+
+CPPVECINST(std::vector<unsigned char>);
+CPPVECINST(std::vector<Value>);
+CPPVECINST(std::vector<unsigned long>);
+CPPVECINST(std::vector<unsigned long long>);
+CPPVECINST(std::vector<SCPQuorumSet>);
+CPPVECINST(std::vector<SCPEnvelope>);
+CPPVECINST(std::vector<Slot::HistoricalStatement>);
 
 #define CPPUNIQUEPTRINST(T) CPPDEFAULTCTORINST(std::unique_ptr<T>) \
                             CPPDTORINST(std::unique_ptr<T>)        \


### PR DESCRIPTION
So that we can have a single allocation when building vectors
on D side.