### PR TITLE
Signature catchup if mis-matching `Coinbase`

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -70,6 +70,8 @@ public class NodeLedger : Ledger
         TooManyMPVs = "More MPVs than active enrollments",
         NoUTXO = "Couldn't find UTXO for one or more Enrollment",
         NotInPool = "Transaction is not in the pool",
+        MissingCoinbase = "Missing Coinbase transaction",
+        MisMatchingCoinbase = "Missing matching Coinbase transaction",
     }
 
     /// A delegate to be called when a block was externalized (unless `null`)
@@ -335,9 +337,12 @@ public class NodeLedger : Ledger
             // Because CB TXs are never in the pool, they will always end up in
             // local_unknown_txs.
             if (local_unknown_txs.length == 0)
-                return "Missing Coinbase transaction";
+                return InvalidConsensusDataReason.MissingCoinbase;
             if (!local_unknown_txs.remove(coinbase_tx_hash))
-                return "Missing matching Coinbase transaction"; // Coinbase tx is missing or different
+            {
+                this.cached_coinbase = CachedCoinbase.init; // Clear cached value
+                return InvalidConsensusDataReason.MisMatchingCoinbase;
+            }
             tx_set ~= coinbase_tx;
         }
         if (local_unknown_txs.length > 0)

--- a/source/agora/consensus/Reward.d
+++ b/source/agora/consensus/Reward.d
@@ -153,7 +153,7 @@ public class Reward
         assert(height > 0, "We can not payout in Genesis block");
 
         auto validator_allocated = allocatedValRewards(height);
-        auto validator = reducedValRewards(validator_allocated, percent_signed);
+        auto validator = reducedValRewards(validator_allocated, percent_signed, height);
 
         // First initialize penalty as allocated and then subtract what is validator actual rewards
         auto penalty = validator_allocated;
@@ -254,7 +254,7 @@ public class Reward
 
     ***************************************************************************/
 
-    private Amount reducedValRewards (in Amount total_allocated, ubyte percent_signed) nothrow @safe
+    private Amount reducedValRewards (in Amount total_allocated, ubyte percent_signed, in Height height) nothrow @safe
     {
         assert(percent_signed >= 0 && percent_signed <= 100);
         if (percent_signed < 50)
@@ -271,7 +271,7 @@ public class Reward
             if (!actual.percentage(cast(ubyte) payout_percent))
                 assert(0, format!"Failed to get percentage %s of Amount %s"(payout_percent, actual));
 
-            log.info("Reduced validator reward is: {} as only {}% signed this block", actual, percent_signed);
+            log.info("Reduced validator reward is: {} as only {}% signed block #{}", actual, percent_signed, height);
             assert(actual.isValid());
         }
 
@@ -364,28 +364,28 @@ unittest
     auto reward = new Reward(144, 60.seconds);
 
     // 100% of the validators sign then full reward is paid to Validators
-    assert(reward.reducedValRewards(1_200.coins, 100) == 1_200.coins);
+    assert(reward.reducedValRewards(1_200.coins, 100, Height(1)) == 1_200.coins);
 
     // 1% missing then penalty is 2%
-    assert(reward.reducedValRewards(1_200.coins, 99) == 1_176.coins);
+    assert(reward.reducedValRewards(1_200.coins, 99, Height(1)) == 1_176.coins);
 
     // 2% missing then penalty is 4%
-    assert(reward.reducedValRewards(1_200.coins, 98) == 1_152.coins);
+    assert(reward.reducedValRewards(1_200.coins, 98, Height(1)) == 1_152.coins);
 
     // 10% missing then penalty is 20%
-    assert(reward.reducedValRewards(1_200.coins, 90) == 960.coins);
+    assert(reward.reducedValRewards(1_200.coins, 90, Height(1)) == 960.coins);
 
     // 25% missing then penalty is 50%
-    assert(reward.reducedValRewards(1_200.coins, 75) == 600.coins);
+    assert(reward.reducedValRewards(1_200.coins, 75, Height(1)) == 600.coins);
 
     // 49% missing then penalty is 98%
-    assert(reward.reducedValRewards(1_200.coins, 51) == 24.coins);
+    assert(reward.reducedValRewards(1_200.coins, 51, Height(1)) == 24.coins);
 
     // 50 percent signed then no reward is paid to Validators
-    assert(reward.reducedValRewards(1_200.coins, 50) == 0.coins);
+    assert(reward.reducedValRewards(1_200.coins, 50, Height(1)) == 0.coins);
 
     // less than half sign also no reward is paid to Validators
-    assert(reward.reducedValRewards(1_200.coins, 49) == 0.coins);
+    assert(reward.reducedValRewards(1_200.coins, 49, Height(1)) == 0.coins);
 }
 
 /// Testing Block Rewards payout to validators and Commons Budget

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -270,6 +270,9 @@ public class NetworkManager
 
     protected agora.api.FullNode.API owner_node;
 
+    // Protect against running multiple times simultaneously
+    private bool isGettingMissingBlockSigs = false;
+
     /// Ctor
     public this (in Config config, ManagedDatabase cache, ITaskManager taskman, Clock clock, agora.api.FullNode.API owner_node)
     {
@@ -902,6 +905,11 @@ public class NetworkManager
         import std.range;
         import std.typecons;
 
+        // Protect against running multiple times simultaneously
+        if (this.isGettingMissingBlockSigs)
+            return;
+        this.isGettingMissingBlockSigs = true;
+
         size_t[Height] signed_validators;
 
         try
@@ -964,6 +972,7 @@ public class NetworkManager
         {
             log.error("getMissingBlockSigs: Exception thrown : {}", e.msg);
         }
+        this.isGettingMissingBlockSigs = false;
     }
 
     /// Shut down timers & dump the metadata

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -481,7 +481,7 @@ public class Validator : FullNode, API
         return new Nominator(
             this.params, this.config.validator.key_pair, clock, network, ledger,
             enroll_man, taskman, this.cacheDB,
-            this.config.validator.nomination_interval, &this.acceptBlock);
+            this.config.validator.nomination_interval, &this.acceptBlock, &this.acceptHeader);
     }
 
     /***************************************************************************

--- a/source/agora/test/BlockRewards.d
+++ b/source/agora/test/BlockRewards.d
@@ -276,7 +276,7 @@ private class EvenBlockHeightSignerNode () : TestValidatorNode
         return new EvenBlockHeightSignerNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock);
+            &this.acceptBlock, &this.acceptHeader);
     }
 }
 

--- a/source/agora/test/Byzantine.d
+++ b/source/agora/test/Byzantine.d
@@ -89,7 +89,7 @@ class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new ByzantineNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, reason);
+            &this.acceptBlock, &this.acceptHeader, reason);
     }
 }
 
@@ -149,7 +149,7 @@ private class SpyingValidator : TestValidatorNode
         return new SpyNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, this.envelope_type_counts);
+            &this.acceptBlock, &this.acceptHeader, this.envelope_type_counts);
     }
 }
 

--- a/source/agora/test/EnrollmentManager.d
+++ b/source/agora/test/EnrollmentManager.d
@@ -181,7 +181,7 @@ unittest
             return new BadNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock, this.runCount);
+                &this.acceptBlock, &this.acceptHeader, this.runCount);
         }
     }
 

--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -78,7 +78,7 @@ private class ByzantineNode (ByzantineReason reason) : TestValidatorNode
         return new BadBlockSigningNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock, reason);
+            &this.acceptBlock, &this.acceptHeader, reason);
     }
 }
 

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -82,7 +82,7 @@ private class BadNominatingVN : TestValidatorNode
         return new BadNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock);
+            &this.acceptBlock, &this.acceptHeader);
     }
 }
 

--- a/source/agora/test/MultiRoundConsensus.d
+++ b/source/agora/test/MultiRoundConsensus.d
@@ -63,7 +63,7 @@ unittest
             return new CustomNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock);
+                &this.acceptBlock, &this.acceptHeader);
         }
     }
 

--- a/source/agora/test/NominatingCatchup.d
+++ b/source/agora/test/NominatingCatchup.d
@@ -51,7 +51,7 @@ private class CustomValidator : TestValidatorNode
         return new CustomNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock);
+            &this.acceptBlock, &this.acceptHeader);
     }
 }
 

--- a/source/agora/test/PeriodicCatchup.d
+++ b/source/agora/test/PeriodicCatchup.d
@@ -77,7 +77,7 @@ private class TestNode () : TestValidatorNode
         return new DoesNotExternalizeBlockNominator(
             this.params, this.config.validator.key_pair, args,
             this.cacheDB, this.config.validator.nomination_interval,
-            &this.acceptBlock);
+            &this.acceptBlock, &this.acceptHeader);
     }
 }
 

--- a/source/agora/test/RestoreSCPState.d
+++ b/source/agora/test/RestoreSCPState.d
@@ -66,7 +66,7 @@ unittest
             return new ReNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock);
+                &this.acceptBlock, &this.acceptHeader);
         }
     }
 

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -109,7 +109,7 @@ unittest
             return new SocialDistancingNominator(
                 this.params, this.config.validator.key_pair, args,
                 this.cacheDB, this.config.validator.nomination_interval,
-                &this.acceptBlock);
+                &this.acceptBlock, &this.acceptHeader);
         }
 
     }


### PR DESCRIPTION
The validator reward payouts are reduced for blocks where the signature count is less than 100%. This means that if nodes have a different number of signatures for those blocks then the `Coinbase` payouts will be different. To help recover from this we can trigger signature catchup when this happens.