### PR TITLE
Refactor timers in `Fullnode` and `Validator`

### DIFF
--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -61,6 +61,13 @@ import core.time;
 
 public class Validator : FullNode, API
 {
+    protected enum ValidatorTimers
+    {
+        NameRegistration = super.FullNodeTimers.max + 1,
+        PreImageReveal,
+        PreImageCatchup
+    }
+
     /// Nominator instance
     protected Nominator nominator;
 
@@ -224,15 +231,15 @@ public class Validator : FullNode, API
         // Note: Switching the next two lines leads to test failure
         // It should not, and this needs to be fixed eventually
         if (auto timer = this.network.startPeriodicNameRegistration())
-            this.timers ~= timer;
+            this.timers[ValidatorTimers.NameRegistration] = timer;
         super.start();
 
         this.clock.startSyncing();
-        this.timers ~= this.taskman.setTimer(
+        this.timers[ValidatorTimers.PreImageReveal] = this.taskman.setTimer(
             this.config.validator.preimage_reveal_interval,
             &this.onPreImageRevealTimer, Periodic.Yes);
 
-        this.timers ~= this.taskman.setTimer(
+        this.timers[ValidatorTimers.PreImageCatchup] = this.taskman.setTimer(
             this.config.validator.preimage_catchup_interval,
             &this.preImageCatchupTask, Periodic.Yes);
 
@@ -246,6 +253,7 @@ public class Validator : FullNode, API
     protected override void discoveryTask ()
     {
         this.network.discover(this.registry, this.ledger.getEnrolledUTXOs(), this.required_peer_utxos);
+        this.timers[FullNodeTimers.Discovery].rearm(this.config.node.network_discovery_interval, false);
     }
 
     ///
@@ -535,7 +543,7 @@ public class Validator : FullNode, API
                     time_offset);
             },
             (Duration duration, void delegate() cb) nothrow @trusted
-                { this.timers ~= this.taskman.setTimer(duration, cb, Periodic.Yes); });
+                { this.timers[FullNodeTimers.ClockTick] = this.taskman.setTimer(duration, cb, Periodic.Yes); });
     }
 
     /***************************************************************************

--- a/source/agora/test/FutureEnrollment.d
+++ b/source/agora/test/FutureEnrollment.d
@@ -49,6 +49,8 @@ unittest
         {
             if (atomicLoad(*this.enable_catchup))
                 super.catchupTask();
+            else
+                this.timers[FullNodeTimers.BlockCatchup].rearm(this.config.node.block_catchup_interval, false);
         }
     }
 


### PR DESCRIPTION
Rather than using a dynamic array to store the timers an AA is used with
the key an integer. The timers are then accessed using enums defined in
Fullnode and Validator to make sure the right timer is accessed.