### PR TITLE
Temporarily set node.testing to true by default

### DIFF
--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -194,7 +194,7 @@ public struct NodeConfig
     /// If set to true will run in testing mode and use different
     /// genesis block (agora.consensus.data.genesis.Test)
     /// and TODO: addresses should be different prefix (e.g. TN... for TestNet)
-    public bool testing;
+    public bool testing = true;
 
     /// Should only be set if `test` is set, can be set to the number of desired
     /// enrollment in the test Genesis block (1 - 6)


### PR DESCRIPTION
As we are preparing the TestNet release, we still have a few usability
improvements needed for users to be able to run a node smoothly.
Anything in the configuration file will be off-putting, especially with Docker,
as a volume / mount is needed. Additionally, the CoinNet Genesis block is broken
anyways, and needs to be re-done, so for the time being, TestNet is the default.