### PR TITLE
Test: Filter UTXOs by lock type in getSpendables

### DIFF
--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -40,7 +40,8 @@ unittest
     void createAndExpectNewBlock (Height new_height)
     {
         // create tx for a single block
-        auto utxo_pairs = node_1.getSpendables(100.coins, OutputType.Payment);
+        auto utxo_pairs = node_1.getSpendables(100.coins, OutputType.Payment,
+            agora.script.Lock.LockType.Key);
 
         // create and send tx to all nodes
         network.postAndEnsureTxInPool(
@@ -184,7 +185,8 @@ unittest
     void createAndExpectNewBlock (Height new_height)
     {
         // create tx for a single block
-        auto utxo_pairs = valid_nodes.front.getSpendables(100.coins, OutputType.Payment);
+        auto utxo_pairs = valid_nodes.front.getSpendables(100.coins, OutputType.Payment,
+            agora.script.Lock.LockType.Key);
 
         // create and send tx to all nodes
         network.postAndEnsureTxInPool(


### PR DESCRIPTION
```
Should fix crashes in Flash where TxBuilder tries to sign a
non-LockType.Key output
```

cc @linked0 