### PR TITLE
Registry API: Return the payload data directly

### DIFF
--- a/source/agora/api/Registry.d
+++ b/source/agora/api/Registry.d
@@ -149,7 +149,7 @@ public interface NameRegistryAPI
 
     ***************************************************************************/
 
-    public const(RegistryPayload) getValidator (PublicKey public_key);
+    public const(RegistryPayloadData) getValidator (PublicKey public_key);
 
     /***************************************************************************
 
@@ -187,7 +187,7 @@ public interface NameRegistryAPI
 
     ***************************************************************************/
 
-    public const(RegistryPayload) getFlashNode (PublicKey public_key);
+    public const(RegistryPayloadData) getFlashNode (PublicKey public_key);
 
     /***************************************************************************
 

--- a/source/agora/flash/Node.d
+++ b/source/agora/flash/Node.d
@@ -590,16 +590,16 @@ public class FlashNode : FlashControlAPI
         if (address == Address.init)
         {
             auto payload = this.registry_client.getFlashNode(peer_pk);
-            if (payload == RegistryPayload.init)
+            if (payload == RegistryPayloadData.init)
             {
                 log.warn("Could not find mapping in registry for key {}", peer_pk);
                 return null;
             }
 
-            if (payload.data.addresses.length == 0)
+            if (payload.addresses.length == 0)
                 return null;
 
-            address = payload.data.addresses[0];
+            address = payload.addresses[0];
         }
 
         auto peer = this.createFlashClient(address, timeout);

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -554,20 +554,20 @@ public class NetworkManager
                     retry!
                     ({
                         auto payload = this.registry_client.getValidator(ckey);
-                        if (payload == RegistryPayload.init)
+                        if (payload == RegistryPayloadData.init)
                         {
                             log.warn("Could not find mapping in registry for key {}", ckey);
                             return false;
                         }
 
-                        if (payload.data.public_key != ckey)
+                        if (payload.public_key != ckey)
                         {
                             log.error("Registry answered with the wrong key: {} => {}",
                                       ckey, payload);
                             return false;
                         }
 
-                        foreach (addr; payload.data.addresses)
+                        foreach (addr; payload.addresses)
                             this.addAddress(addr);
                         return true;
                     },

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2547,7 +2547,7 @@ public class RegistryNode : TestFullNode, FullRegistryAPI
     mixin ForwardCtor!();
 
     /// Forwards to the registry's methods
-    public const(RegistryPayload) getValidator (PublicKey public_key) @safe
+    public const(RegistryPayloadData) getValidator (PublicKey public_key) @safe
     {
         return this.registry.getValidator(public_key);
     }
@@ -2559,7 +2559,7 @@ public class RegistryNode : TestFullNode, FullRegistryAPI
     }
 
     /// Ditto
-    public const(RegistryPayload) getFlashNode(PublicKey public_key) @safe
+    public const(RegistryPayloadData) getFlashNode(PublicKey public_key) @safe
     {
         return this.registry.getFlashNode(public_key);
     }


### PR DESCRIPTION
Currently, we return a RegistryPayload where the signature is always init.
This was a necessary change from the original design as zone transfer over
DNS does not allow to send those custom records.
We can just return a RegistryPayloadData directly and save ourselve some trouble.