### PR TITLE
Move 'struct IP' to Types and re-use it

### DIFF
--- a/source/agora/common/DNS.d
+++ b/source/agora/common/DNS.d
@@ -20,7 +20,7 @@
 module agora.common.DNS;
 
 import agora.common.Ensure;
-import agora.common.Types : Address;
+import agora.common.Types : Address, IPv4;
 import agora.serialization.Serializer;
 
 import std.algorithm.iteration;
@@ -738,21 +738,6 @@ public struct ResourceRecord
     public void toString (scope void delegate(in char[]) @safe sink)
         const scope @trusted
     {
-        import core.sys.posix.arpa.inet : htonl;
-
-        static struct IP
-        {
-            public uint value;
-
-            public void toString (scope void delegate(in char[]) @safe sink)
-                const scope
-            {
-                formattedWrite!"%s.%s.%s.%s"(sink,
-                    this.value >> 24 & 0xFF, this.value >> 16 & 0xFF,
-                    this.value >>  8 & 0xFF, this.value >>  0 & 0xFF);
-            }
-        }
-
         switch (this.type)
         {
         case TYPE.OPT:
@@ -761,7 +746,7 @@ public struct ResourceRecord
             break;
         case TYPE.A:
             formattedWrite!"name: %s, TYPE: %s, RDATA: %s"(
-                sink, this.name, this.type, this.rdata.a.map!(v => IP(htonl(v))));
+                sink, this.name, this.type, this.rdata.a.map!(v => IPv4.fromHost(v)));
             break;
         case TYPE.CNAME, TYPE.NS:
             formattedWrite!"name: %s, TYPE: %s, RDATA: %s"(

--- a/source/agora/network/DNSResolver.d
+++ b/source/agora/network/DNSResolver.d
@@ -22,7 +22,6 @@ import agora.utils.Log;
 
 import std.array;
 import std.algorithm;
-import std.format;
 import std.random;
 static import std.socket;
 import core.time;
@@ -161,9 +160,7 @@ public abstract class DNSResolver
                 // Just pick the first record.
                 // TODO: What is expected when there's more than one record ?
                 // Should we use it as a fall back, round robin, something else?
-                const straddr = format("%d.%d.%d.%d",
-                    res.rdata.a[0] >> 24 & 0xFF, res.rdata.a[0] >> 16 & 0xFF,
-                    res.rdata.a[0] >>  8 & 0xFF, res.rdata.a[0] >>  0 & 0xFF);
+                const straddr = IPv4(res.rdata.a[0]).toString();
                 log.trace("Address '{}' resolved to A record '{}'", address, straddr);
                 address.host = straddr;
                 return address;


### PR DESCRIPTION
```
It's a handy tool to format a string, and might be useful in other places,
so just place it in Types as its dependency are minimal.
```

@mkykadir : I just spotted it while reviewing your PR, so if you want to wait until yours is merged LMK, since it's obviously going to conflict.