### PR TITLE
Trivial: Forward file/line in Flash's printLogs

### DIFF
--- a/source/agora/test/Flash.d
+++ b/source/agora/test/Flash.d
@@ -435,7 +435,7 @@ public class FlashNodeFactory : TestAPIManager
 
     public override void printLogs (string file = __FILE__, int line = __LINE__)
     {
-        super.printLogs();
+        super.printLogs(file, line);
         synchronized  // make sure logging output is not interleaved
         {
             writeln("---------------------------- START OF FLASH LOGS ----------------------------");


### PR DESCRIPTION
I had a failure where the logs were not fully printed, and it simply
pointed to the 'super' call instead of something helpful.