### PR TITLE
Add URI support to Registry

### DIFF
--- a/source/agora/test/DNS.d
+++ b/source/agora/test/DNS.d
@@ -58,14 +58,19 @@ unittest
     assert(result.length == 1);
     assert(result[0].type == TYPE.A);
 
+    // URI record
+    result = resolver.query("_agora._tcp." ~ node_addr ~ ".validators.unittest.bosagora.io.", QTYPE.URI);
+    assert(result.length == 1);
+    assert(result[0].type == TYPE.URI);
+
     // CNAME record
     result = resolver.query(node_addr ~ ".validators.unittest.bosagora.io.", QTYPE.CNAME);
     assert(result.length == 0);
 
     // AXFR zone transfer
     result = resolver.query("validators.unittest.bosagora.io.", QTYPE.AXFR);
-    // + 2 for starting and ending SOA records
-    assert(result.length == conf.node.test_validators + 2);
+    // * 2 for URI records and + 2 for starting and ending SOA records
+    assert(result.length == (conf.node.test_validators * 2) + 2);
     assert(result[0].type == TYPE.SOA);
     assert(result[$-1].type == TYPE.SOA);
 }
@@ -106,14 +111,19 @@ unittest
     assert(result.length == 1);
     assert(result[0].type == TYPE.A);
 
+    // URI record
+    result = resolver.query("_agora._tcp." ~ node_addr ~ ".validators.unittest.bosagora.io.", QTYPE.URI);
+    assert(result.length == 1);
+    assert(result[0].type == TYPE.URI);
+
     // CNAME record
     result = resolver.query(node_addr ~ ".validators.unittest.bosagora.io.", QTYPE.CNAME);
     assert(result.length == 0);
 
     // AXFR zone transfer
     result = resolver.query("validators.unittest.bosagora.io.", QTYPE.AXFR);
-    // + 2 for starting and ending SOA records
-    assert(result.length == conf.node.test_validators + 2);
+    // * 2 for URI records and + 2 for starting and ending SOA records
+    assert(result.length == (conf.node.test_validators * 2) + 2);
     assert(result[0].type == TYPE.SOA);
     assert(result[$-1].type == TYPE.SOA);
 }
@@ -153,6 +163,11 @@ unittest
     result = resolver.query(node_addr ~ ".validators.unittest.bosagora.io.", QTYPE.A);
     assert(result.length == 1);
     assert(result[0].type == TYPE.A);
+
+    // URI record
+    result = resolver.query("_agora._tcp." ~ node_addr ~ ".validators.unittest.bosagora.io.", QTYPE.URI);
+    assert(result.length == 1);
+    assert(result[0].type == TYPE.URI);
 
     // CNAME record
     result = resolver.query(node_addr ~ ".validators.unittest.bosagora.io.", QTYPE.CNAME);


### PR DESCRIPTION
Adds URI support to registry, second commit ended up with a big changeset but commit message tries to explain why, I can try to split it when requested

```
URI record creates a chicken-egg problem, thus several other changes
are happened within this commit. URI records store full address, thus
A and CNAME records are not needed to store full addresses. Some
architectural changes are needed to achieve URI support and continue
supporting REST interface.

- SQL Foreign Key relation between utxo and addresses tables are broken
- Only primary zones will have utxo table
- Persistent storage methods are using ResourceRecord instead of TypedPayload
- TypedPayload can only be constructed with URI records from Registry side
- REST/GET interface will only return URI record
```

Fixes #2869 