### PR TITLE
Registry: Remove table drop in case of type change

### DIFF
--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -929,32 +929,6 @@ private struct ZoneData
             "FOREIGN KEY(pubkey) REFERENCES registry_%s_utxo(pubkey) ON DELETE CASCADE, " ~
             "PRIMARY KEY(pubkey, address))", zone_name, zone_name);
 
-        string query_prev_type = format("SELECT * FROM registry_%s_utxo " ~
-            "WHERE utxo = ?", zone_name);
-
-        bool was_primary;
-
-        try
-            was_primary = this.db.execute(query_prev_type, Hash.init).empty;
-        catch (Exception)
-            was_primary = false;
-
-        if (this.type == ZoneType.primary && !was_primary)
-        {
-            this.db.execute(
-                format("DROP TABLE IF EXISTS registry_%s_addresses", zone_name));
-            this.db.execute(
-                format("DROP TABLE IF EXISTS registry_%s_utxo", zone_name));
-        }
-        else if ((this.type == ZoneType.secondary
-                || this.type == ZoneType.caching) && was_primary)
-        {
-            this.db.execute(
-                format("DROP TABLE IF EXISTS registry_%s_utxo", zone_name));
-            this.db.execute(
-                format("DROP TABLE IF EXISTS registry_%s_addresses", zone_name));
-        }
-
         // Initialize common fields
         this.db.execute(query_sig_create);
         this.db.execute(query_addr_create);


### PR DESCRIPTION
This piece of code was dropping the registry tables iff the type of the registry
was changed between two runs. There's apparently no technical reason to do so,
as all types use the same table format.
This code created problems because it consistently prints 3 error messages when a node
starts, which can be startling to users. This could be avoided by checking for the
table existence before actually doing the SELECT, however, when considering the logic,
it stood out as no other node has that behavior (e.g. switching between full node and validator).
In this case, I think it is better to simply not do this and let the operator
wipe the table clean (by removing cacheDB) if that behavior is desired.