### PR TITLE
Nominator: Remove validation in combineCandidates

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1275,16 +1275,6 @@ extern(D):
                 auto data = deserializeFull!ConsensusData(candidate[]);
                 log.trace("Consensus data: {}", data.prettify);
 
-                if (auto msg = this.ledger.validateConsensusData(data, this.initial_missing_validators))
-                {
-                    if (msg == this.ledger.InvalidConsensusDataReason.MisMatchingCoinbase)
-                    {
-                        log.error("combineCandidates(): Validation failed: {}. Will attempt catchup to get missing signatures", msg);
-                        this.catchup_timer.rearm(CatchupTaskDelay, false);
-                    }
-                    else
-                        assert(0, format!"combineCandidates: Invalid consensus data: %s"( msg));
-                }
                 Amount total_rate;
                 foreach (const ref tx_hash; data.tx_set)
                 {


### PR DESCRIPTION
SCP ensures that only validated values are fed to combineCandidates