### PR TITLE
Compare potential sig count in catchup

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -900,7 +900,8 @@ public class NetworkManager
     ***************************************************************************/
 
     public void getMissingBlockSigs (Ledger ledger,
-        scope void delegate (BlockHeader) @safe acceptHeader) @safe nothrow
+        scope ulong delegate(BlockHeader) @safe extra_sigs,
+        scope void delegate(BlockHeader) @safe acceptHeader) @safe nothrow
     {
         import std.algorithm;
         import std.conv;
@@ -939,9 +940,10 @@ public class NetworkManager
                     {
                         foreach (header; peer.getBlockHeaders(missing_heights))
                         {
-                            auto sig_signed_validators = iota(enrolled_validators[header.height]).filter!(i =>
-                                header.validators[i] || header.preimages[i] is Hash.init).count();
-                            if (sig_signed_validators > signed_validators[header.height])
+                            auto potential_sig_count = iota(enrolled_validators[header.height]).filter!(i =>
+                                header.validators[i] || header.preimages[i] is Hash.init).count()
+                                + extra_sigs(header);
+                            if (potential_sig_count > signed_validators[header.height])
                             {
                                 try
                                 {

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -556,7 +556,7 @@ public class FullNode : API
 
         try
         {
-            this.network.getMissingBlockSigs(this.ledger, &this.acceptHeader);
+            this.network.getMissingBlockSigs(this.ledger, &this.extra_sigs, &this.acceptHeader);
         }
         catch (Exception e)
         {
@@ -580,6 +580,27 @@ public class FullNode : API
         // Otherwise we don't print a message, as the Ledger is up to date.
 
         this.network.getUnknownTXs(this.ledger);
+    }
+
+    /***************************************************************************
+
+        Count extra signatures that could be added to the provided header.
+
+        For Validators this is overridden as it stores signatures and could add
+        them to the header if missing.
+
+        Params:
+            header = the block header fetched from another node
+
+        Returns:
+            The number of signatures that could be added to the given header,
+            FullNode does not store signatures so will return 0
+
+    ***************************************************************************/
+
+    protected ulong extra_sigs (BlockHeader header) @safe
+    {
+        return 0;
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -430,6 +430,25 @@ public class Validator : FullNode, API
 
     /***************************************************************************
 
+        Count extra signatures that could be added to the provided header.
+
+        Params:
+            header = the block header fetched from another node
+
+        Returns:
+            The number of signatures that could be added to the given header
+
+    ***************************************************************************/
+
+    protected override ulong extra_sigs (BlockHeader header) @safe
+    {
+        const currentCount = header.validators.setCount;
+        this.nominator.updateMultiSignature(header);
+        return header.validators.setCount - currentCount;
+    }
+
+    /***************************************************************************
+
         Receive an SCP envelope.
 
         API:


### PR DESCRIPTION
During catchup if we fetch a header we should check if more signatures would result in adding ones in memory that are not in the header already.