### PR TITLE
Fix #2875 : Check local NameRegistry before querying the remote

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -318,6 +318,7 @@ public class FullNode : API
         this.registry = new NameRegistry(config.node.realm, config.registry,
                                          this.ledger, this.cacheDB, this.taskman,
                                          this.network);
+        this.network.setRegistry(this.registry);
 
         // Create timers
         this.timers[TimersIdx.Discovery] = this.taskman.createTimer(&this.discoveryTask);
@@ -513,7 +514,7 @@ public class FullNode : API
 
     protected void discoveryTask () nothrow
     {
-        this.network.discover(this.registry, this.ledger.getEnrolledUTXOs());
+        this.network.discover(this.ledger.getEnrolledUTXOs());
         this.timers[TimersIdx.Discovery].rearm(this.config.node.network_discovery_interval, false);
     }
 

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -260,7 +260,7 @@ public class Validator : FullNode, API
     /// Ditto
     protected override void discoveryTask ()
     {
-        this.network.discover(this.registry, this.ledger.getEnrolledUTXOs(), this.required_peer_utxos);
+        this.network.discover(this.ledger.getEnrolledUTXOs(), this.required_peer_utxos);
         this.timers[TimersIdx.Discovery].rearm(this.config.node.network_discovery_interval, false);
     }
 


### PR DESCRIPTION
Second attempt. I don't like the extra method, but it's a good temporary measure until we have negative caching.