### PR TITLE
Centralize all TestNet specialization behind a switch

### DIFF
--- a/devel/testnet/README.md
+++ b/devel/testnet/README.md
@@ -43,7 +43,7 @@ and cannot be used to run a node.
 
 ## Running a full node under Docker
 
-Open a terminal and use the command `docker run bosagora/agora -c /dev/null`.
+Open a terminal and use the command `docker run bosagora/agora --testnet`.
 
 The node should start, and print a bunch of messages to the screen. It should start synchronizing
 with the network about a few seconds, downloading the current state of the chain.
@@ -59,7 +59,7 @@ will completely wipe out the state: the next time you start the node, it will re
 A simple way to avoid re-downloading the blockchain is to "mount" the current directory inside Docker
 with the following command:
 ```shell
-docker run -v $(pwd):/agora/ bosagora/agora -c /dev/null
+docker run -v $(pwd):/agora/ bosagora/agora --testnet
 ```
 
 As long as you use this command to start Agora, you will not have to always re-download the chain.
@@ -69,7 +69,7 @@ As long as you use this command to start Agora, you will not have to always re-d
 Agora can be extensively configured via the use of a configuration file.
 By default, Agora will look for `config.yaml` in the directory it is started in, but using the `-c`
 command line option, you can give Agora any configuration file.
-Using `-c /dev/null` is a special way to make Agora start without a configuration file.
+Using `--testnet` is a special way to make Agora start without a configuration file.
 
 You can find a [simple configuration file in this directory](./config.yaml), which you may modify to suit your own needs,
 using the directives listed in the [example configuration file](/doc/config.example.yaml)

--- a/devel/testnet/config.yaml
+++ b/devel/testnet/config.yaml
@@ -13,7 +13,7 @@
 node:
   realm: "testnet.bosagora.io"
   testing: true
-  data_dir: .fullnode/data/
+  data_dir: data/
   registry_address: http://ns1.bosagora.io/
 
 consensus:

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -61,21 +61,6 @@ import std.range;
 import core.stdc.time;
 import core.time;
 
-/// Work around issue #3030 and allow internal testing
-private immutable Address[] TestNetNodes;
-
-shared static this ()
-{
-    TestNetNodes = [
-        Address("http://boa1xzval2a3cdxv28n6slr62wlczslk3juvk7cu05qt3z55ty2rlfqfc6egsh2.validators.testnet.bosagora.io/"),
-        Address("http://boa1xzval3ah8z7ewhuzx6mywveyr79f24w49rdypwgurhjkr8z2ke2mycftv9n.validators.testnet.bosagora.io/"),
-        Address("http://boa1xzval4nvru2ej9m0rptq7hatukkavemryvct4f8smyy3ky9ct5u0s8w6gfy.validators.testnet.bosagora.io/"),
-        Address("http://boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8.validators.testnet.bosagora.io/"),
-        Address("http://boa1xrval6hd8szdektyz69fnqjwqfejhu4rvrpwlahh9rhaazzpvs5g6lh34l5.validators.testnet.bosagora.io/"),
-        Address("http://boa1xrval7gwhjz4k9raqukcnv2n4rl4fxt74m2y9eay6l5mqdf4gntnzhhscrh.validators.testnet.bosagora.io/"),
-    ];
-}
-
 /// Ditto
 public class NetworkManager
 {
@@ -288,11 +273,6 @@ public class NetworkManager
 
         // add the IP seeds
         this.addAddresses(Set!Address.from(config.network));
-        // Workaround #3030
-        import agora.common.DNS;
-        if (config.network.length == 0 && config.node.testing && !config.validator.enabled &&
-            config.node.realm == Domain.fromSafeString("testnet.bosagora.io."))
-            this.addAddresses(Set!Address.from(TestNetNodes));
 
         // add the DNS seeds
         if (config.dns_seeds.length > 0)

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -220,7 +220,7 @@ public struct NodeConfig
     public Duration timeout = 5000.msecs;
 
     /// Path to the data directory to store metadata and blockchain data
-    public string data_dir = ".cache";
+    public string data_dir = "data";
 
     /// The duration between requests for doing periodic network discovery
     public Duration network_discovery_interval = 5.seconds;

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -50,6 +50,9 @@ public struct AgoraCLIArgs
     ///
     public alias base this;
 
+    /// Special mode to run a TestNet full node
+    public bool testnet = false;
+
     /// If non-`null`, what address to bind the setup interface to
     public string initialize;
 
@@ -194,7 +197,7 @@ public struct NodeConfig
     /// If set to true will run in testing mode and use different
     /// genesis block (agora.consensus.data.genesis.Test)
     /// and TODO: addresses should be different prefix (e.g. TN... for TestNet)
-    public bool testing = true;
+    public bool testing;
 
     /// Should only be set if `test` is set, can be set to the number of desired
     /// enrollment in the test Genesis block (1 - 6)
@@ -408,6 +411,9 @@ public GetoptResult parseCommandLine (ref AgoraCLIArgs cmdline, string[] args)
 
     return getopt(
         args,
+        "testnet",
+            "Run the mode in standalone TestNet mode",
+           &cmdline.testnet,
         "initialize",
             "The address at which to offer a web-based configuration interface",
             &cmdline.initialize,

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -23,6 +23,7 @@ version (unittest) {}
 else:
 
 import agora.common.FileBasedLock;
+import agora.common.Types;
 import agora.node.admin.Setup;
 import agora.node.Config;
 import agora.node.FullNode;
@@ -135,6 +136,27 @@ private int main (string[] args)
 
     Nullable!Config configN = ()
     {
+        if (cmdln.testnet)
+        {
+            import agora.common.DNS;
+            import core.time;
+
+            Config defaultConfig = {
+                node: {
+                    testing: true,
+                    realm: Domain.fromSafeString("testnet.bosagora.io."),
+                    registry_address: Address("http://ns1.bosagora.io"),
+                },
+                network: TestNetNodes,
+                consensus: {
+                    validator_cycle: 20,
+                    block_interval: 1.minutes,
+                    genesis_timestamp: 1640995200,
+                },
+            };
+            return Nullable!Config(defaultConfig);
+        }
+
         if (cmdln.config_path == "/dev/null")
             return Nullable!Config(Config.init);
         return cmdln.parseConfigFileSimple!Config();
@@ -284,3 +306,18 @@ private void handleAssertion (string file, size_t line, string msg) nothrow
 
 /// A statically allocated instance to avoid invalid memory errors in destructors
 private AssertError stAssertError;
+
+/// Work around issue #3030 and allow internal testing
+private immutable Address[] TestNetNodes;
+
+shared static this ()
+{
+    TestNetNodes = [
+        Address("http://boa1xzval2a3cdxv28n6slr62wlczslk3juvk7cu05qt3z55ty2rlfqfc6egsh2.validators.testnet.bosagora.io/"),
+        Address("http://boa1xzval3ah8z7ewhuzx6mywveyr79f24w49rdypwgurhjkr8z2ke2mycftv9n.validators.testnet.bosagora.io/"),
+        Address("http://boa1xzval4nvru2ej9m0rptq7hatukkavemryvct4f8smyy3ky9ct5u0s8w6gfy.validators.testnet.bosagora.io/"),
+        Address("http://boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8.validators.testnet.bosagora.io/"),
+        Address("http://boa1xrval6hd8szdektyz69fnqjwqfejhu4rvrpwlahh9rhaazzpvs5g6lh34l5.validators.testnet.bosagora.io/"),
+        Address("http://boa1xrval7gwhjz4k9raqukcnv2n4rl4fxt74m2y9eay6l5mqdf4gntnzhhscrh.validators.testnet.bosagora.io/"),
+    ];
+}


### PR DESCRIPTION
```
This should have been done this way in the first place.
The realm in Config was left to TestNet but could be changed back anytime.
```

CC @mkykadir 