### PR TITLE
Use URI records in Manager

### DIFF
--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -38,6 +38,17 @@ consensus:
   validator_cycle: 20
   genesis_timestamp: 1640995200
 
+registry:
+  realm:
+    query_servers:
+      - node-0:8053
+  validators:
+    query_servers:
+      - node-0:8053
+  flash:
+    query_servers:
+      - node-0:8053
+
 ################################################################################
 ##                             Validator configuration                        ##
 ## The server can operate in two modes: full node and validator node.         ##

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -38,6 +38,17 @@ consensus:
   validator_cycle: 20
   genesis_timestamp: 1640995200
 
+registry:
+  realm:
+    query_servers:
+      - node-0:8053
+  validators:
+    query_servers:
+      - node-0:8053
+  flash:
+    query_servers:
+      - node-0:8053
+
 ################################################################################
 ##                             Validator configuration                        ##
 ## The server can operate in two modes: full node and validator node.         ##

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -38,6 +38,17 @@ consensus:
   validator_cycle: 20
   genesis_timestamp: 1640995200
 
+registry:
+  realm:
+    query_servers:
+      - node-0:8053
+  validators:
+    query_servers:
+      - node-0:8053
+  flash:
+    query_servers:
+      - node-0:8053
+
 ################################################################################
 ##                             Validator configuration                        ##
 ## The server can operate in two modes: full node and validator node.         ##

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -38,6 +38,17 @@ consensus:
   validator_cycle: 20
   genesis_timestamp: 1640995200
 
+registry:
+  realm:
+    query_servers:
+      - node-0:8053
+  validators:
+    query_servers:
+      - node-0:8053
+  flash:
+    query_servers:
+      - node-0:8053
+
 ################################################################################
 ##                             Validator configuration                        ##
 ## The server can operate in two modes: full node and validator node.         ##

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -38,6 +38,17 @@ consensus:
   validator_cycle: 20
   genesis_timestamp: 1640995200
 
+registry:
+  realm:
+    query_servers:
+      - node-0:8053
+  validators:
+    query_servers:
+      - node-0:8053
+  flash:
+    query_servers:
+      - node-0:8053
+
 ################################################################################
 ##                             Validator configuration                        ##
 ## The server can operate in two modes: full node and validator node.         ##

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -38,6 +38,17 @@ consensus:
   validator_cycle: 20
   genesis_timestamp: 1640995200
 
+registry:
+  realm:
+    query_servers:
+      - node-0:8053
+  validators:
+    query_servers:
+      - node-0:8053
+  flash:
+    query_servers:
+      - node-0:8053
+
 ################################################################################
 ##                             Validator configuration                        ##
 ## The server can operate in two modes: full node and validator node.         ##


### PR DESCRIPTION
Utilize Registry DNS interface and get URI records for connecting peers

This changeset will reduce load on a primary Registry node, each node will cache the query results in their own Registry.

Depends on #3009