### PR TITLE
Improve TestNet configuration and allow dynamic ConsensusParams

### DIFF
--- a/devel/testnet/config.yaml
+++ b/devel/testnet/config.yaml
@@ -16,11 +16,6 @@ node:
   data_dir: data/
   registry_address: http://ns1.bosagora.io/
 
-consensus:
-  block_interval:
-    seconds: 20
-  validator_cycle: 20
-
 registry:
   enabled: true
 

--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -19,6 +19,7 @@ import agora.common.Types;
 import agora.common.Set;
 import agora.consensus.data.Block;
 import agora.consensus.data.Enrollment;
+import agora.consensus.data.Params;
 import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.Transaction;
 import agora.consensus.data.ValidatorInfo;
@@ -411,4 +412,21 @@ public interface API
 
     @method(HTTPMethod.GET)
     public Enrollment getEnrollment (in Hash enroll_hash);
+
+    /***************************************************************************
+
+        Get the node's consensus parameter
+
+        This endpoint is not used for consensus, but to allow a smoother
+        experience for test networks that need frequents updates.
+
+        API:
+            GET /consensus_params
+
+        Returns:
+            The `ConsensusParams` for this node
+
+    ***************************************************************************/
+
+    public WrappedConsensusParams getConsensusParams ();
 }

--- a/source/agora/common/Types.d
+++ b/source/agora/common/Types.d
@@ -27,6 +27,8 @@ import geod24.bitblob;
 
 import std.algorithm.comparison : among;
 
+import core.time;
+
 /// Clone any type via the serializer
 public T clone (T)(in T input)
 {
@@ -256,3 +258,33 @@ unittest
 
 /// Delegate type to query the penalty deposit of a utxo
 public alias GetPenaltyDeposit = Amount delegate (Hash utxo) @safe nothrow;
+
+/// Wraps `core.time : Duration` but can be used with the serializer
+public struct SerializableDuration
+{
+    ///
+    public alias data this;
+
+    ///
+    public Duration data;
+
+
+    /// Support for network (de)serialization
+    public void serialize (scope SerializeDg dg) const @safe
+    {
+        serializePart(this.data.total!"hnsecs", dg);
+    }
+
+    /// Ditto
+    public static QT fromBinary (QT) (
+        scope DeserializeDg dg, in DeserializerOptions opts) @safe
+    {
+        return QT(deserializeFull!long(dg, opts).hnsecs);
+    }
+}
+
+unittest
+{
+    checkFromBinary!SerializableDuration();
+    testSymmetry!SerializableDuration();
+}

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -1384,4 +1384,10 @@ public class FullNode : API
     {
         return this.getValidators(this.ledger.height() + 1);
     }
+
+    ///
+    public override WrappedConsensusParams getConsensusParams ()
+    {
+        return WrappedConsensusParams(this.params);
+    }
 }


### PR DESCRIPTION
This fixes two major issues with the current TestNet setting:
- A network reset requires a new release and users to manually upgrade;
- Using '--testnet' does not work when a one wants to run a validator;

We fix both issues by first adding a new endpoint to the API, which returns the ConsensusParams.
The current approach is not ideal as ConsensusParams and ConsensusConfig are slightly different,
but it will cover our immediate need. The second issue is fixed by only overriding the consensus
section whenever we detect there is a configuration file we can read.
The realm, the registry address, and node.testing still need to be set correctly,
but the sample config file does this and people are likely to start off of it.