### PR TITLE
Config: Rename `enabled` field to `public` for Registry

### DIFF
--- a/devel/config-single.yaml
+++ b/devel/config-single.yaml
@@ -37,7 +37,7 @@ validator:
     - http://127.0.0.1:2826/
 
 registry:
-  enabled: true
+  public: true
   address: 127.0.0.1
   # Use a non-priviledged port to avoid a clash with the system resolver
   port: 5335

--- a/devel/testnet/config.yaml
+++ b/devel/testnet/config.yaml
@@ -22,7 +22,7 @@ consensus:
   validator_cycle: 20
 
 registry:
-  enabled: true
+  public: true
 
 logging:
   root:

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -297,8 +297,8 @@ event_handlers:
 ## extra API for registration, and a DNS server (on port 53 by default).      ##
 ################################################################################
 registry:
-  # If this node should also act as a registry
-  enabled: true
+  # If this node should provide public registry interface
+  public: true
 
   # The address to bind the DNS server to (default: 0.0.0.0)
   # On Linux system with systemd, one might want to specify the local IP,

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -127,15 +127,15 @@ public struct Config
     public void validate () @safe const scope
     {
         if (this.validator.enabled)
-            enforce(this.network.length || this.registry.enabled ||
+            enforce(this.network.length || this.registry.public_interface ||
                     this.node.registry_address.set ||
                     // Allow single-network validator (assume this is NODE6)
                     this.node.test_validators == 1,
                     "Either the network section must not be empty, or 'node.registry_address' must be set " ~
-                    ", or registry must be enabled");
+                    ", or registry public interface must be enabled");
         else
-            enforce(this.network.length || this.registry.enabled,
-                    "Either the network section must not be empty, or registry must be enabled");
+            enforce(this.network.length || this.registry.public_interface,
+                    "Either the network section must not be empty, or registry public interface must be enabled");
 
         if (!this.node.testing && this.node.test_validators)
             throw new Exception("Cannot use 'node.test_validators' without 'node.testing' set to 'true'");
@@ -435,8 +435,9 @@ public GetoptResult parseCommandLine (ref AgoraCLIArgs cmdline, string[] args)
 /// Configuration for the name registry
 public struct RegistryConfig
 {
-    /// If this node should also act as a registry
-    public bool enabled;
+    /// If this node should provide registry interface to public
+    @Name("public")
+    public bool public_interface;
 
     /***************************************************************************
 

--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -135,7 +135,7 @@ public Listeners runNode (Config config)
     }
 
     scope (exit)
-        if (config.registry.enabled)
+        if (config.registry.public_interface)
         {
             // Here, we might need to interrupt the task to correctly shut down,
             // however this throws an exception in the task that needs to be explicitly
@@ -152,7 +152,7 @@ public Listeners runNode (Config config)
 
     result.node.start();
 
-    if (config.registry.enabled)
+    if (config.registry.public_interface)
     {
         auto reg = result.node.getRegistry();
         assert(reg !is null);

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2369,7 +2369,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
             logging: test_conf.logging,
             event_handlers : test_conf.event_handlers,
             registry: {
-                enabled: true,
+                public_interface: true,
                 realm: {
                     authoritative: setField(true),
                     primary: setField("name.registry"),

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -53,7 +53,7 @@ validator:
 ##                             Registry configuration                         ##
 ################################################################################
 registry:
-  enabled: true
+  public: true
   address: 0.0.0.0
   port: 8053
   realm:


### PR DESCRIPTION
Registry is always enabled for a node, but providing a public interface
is optional. `enabled` field name causes Configy to ignore other fields
when the field is set to `false`.

Related with #3047 