### PR TITLE
Fix #3048, #3030: Set 'registry_address' as explicitly set in TestNet

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -554,31 +554,32 @@ public class NetworkManager
                 if (key == this.config.validator.key_pair.address)
                     continue;
 
-                taskman.runTask
-                ({
+                taskman.runTask(
+                () nothrow {
                     // https://github.com/bosagora/agora/issues/2197
                     const ckey = key;
-                    retry!
-                    ({
+                    try
+                    {
                         auto payload = this.registry.getValidatorInternal(ckey);
                         if (payload == RegistryPayloadData.init)
                         {
                             log.warn("Could not find mapping in registry for key {}", ckey);
-                            return false;
+                            return;
                         }
 
                         if (payload.public_key != ckey)
                         {
                             log.error("Registry answered with the wrong key: {} => {}",
                                       ckey, payload);
-                            return false;
+                            return;
                         }
 
                         foreach (addr; payload.addresses)
                             this.addAddress(addr);
-                        return true;
-                    },
-                    )(taskman, 3, 2.seconds, "Exception happened while trying to get validator addresses");
+                    }
+                    catch (Exception exc)
+                        log.error("Exception happened while looking up address for {}: {}",
+                                  ckey, exc);
                 });
             }
         }

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -641,7 +641,7 @@ public class NetworkManager
 
     ***************************************************************************/
 
-    private bool shouldEstablishConnection (Address address) @safe
+    private bool shouldEstablishConnection (Address address) @safe nothrow
     {
         auto existing_peer = this.peers[].find!(p => p.addresses.canFind(address));
         return !this.banman.isBanned(address) &&
@@ -652,14 +652,14 @@ public class NetworkManager
     }
 
     /// Received new set of addresses, put them in the todo address list
-    private void addAddresses (AddressSet) (AddressSet addresses) @safe
+    private void addAddresses (AddressSet) (AddressSet addresses) @safe nothrow
     {
         foreach (address; addresses)
             this.addAddress(address);
     }
 
     /// Ditto
-    private void addAddress (Address address) @safe
+    private void addAddress (Address address) @safe nothrow
     {
         if (this.shouldEstablishConnection(address))
             this.todo_addresses.put(address);

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -354,7 +354,7 @@ private Nullable!Config makeTestNetConfig (AgoraCLIArgs cmdln)
         node: {
             testing: true,
             realm: Domain.fromSafeString("testnet.bosagora.io."),
-            registry_address: Address("http://ns1.bosagora.io"),
+            registry_address: SetInfo!Address(Address("http://ns1.bosagora.io"), true),
         },
         network: TestNetNodes,
         consensus: params.data.config,

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -338,7 +338,7 @@ private Nullable!Config makeTestNetConfig (AgoraCLIArgs cmdln)
             flash: config.flash,
             admin: config.admin,
             registry: config.registry,
-            network: config.network.length ? config.network : TestNetNodes,
+            network: config.network,
             dns_seeds: config.dns_seeds,
             logging: config.logging,
             event_handlers: config.event_handlers,
@@ -356,7 +356,6 @@ private Nullable!Config makeTestNetConfig (AgoraCLIArgs cmdln)
             realm: Domain.fromSafeString("testnet.bosagora.io."),
             registry_address: SetInfo!Address(Address("http://ns1.bosagora.io"), true),
         },
-        network: TestNetNodes,
         consensus: params.data.config,
     };
     return Nullable!Config(defaultConfig);


### PR DESCRIPTION
I think it's time to fix configy. In the meantime, this fixes Agora. Packed a few improvements along the way.