### PR TITLE
Simplify updating the signature in block header

### DIFF
--- a/source/agora/consensus/BlockStorage.d
+++ b/source/agora/consensus/BlockStorage.d
@@ -1054,13 +1054,13 @@ private void testStorage (IBlockStorage storage)
             txs = last_txs.length ? last_txs.map!(tx => TxBuilder(tx).sign()).array()
                 : genesisSpendable().map!(txb => txb.sign()).array();
             last_block = makeNewTestBlock(blocks[$ - 1], txs);
-            auto signed_block = last_block.updateSignature(
+            last_block.updateSignature(
                 Signature.fromString("0x0000000000000000000000000000000000000000000000000000000000000001" ~
                     "0000000000000000000000000000000000000000000000000000000000000002"), signed);
             last_txs = txs;
-            blocks ~= signed_block;
-            block_hashes ~= hashFull(signed_block.header);
-            storage.saveBlock(signed_block);
+            blocks ~= last_block;
+            block_hashes ~= hashFull(last_block.header);
+            storage.saveBlock(last_block);
         }
     }
 
@@ -1082,11 +1082,11 @@ private void testStorage (IBlockStorage storage)
         format!"validator bit %s should be set"(i)));
     assert(!block.header.validators[5], "validator bit 5 should not be set");
     signed[5] = true; // Last validator signs
-    Block signed_block = block.updateSignature(
+    block.updateSignature(
         Signature.fromString("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1" ~
             "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1"), signed);
-    storage.updateBlockSig(signed_block.header.height, signed_block.hashFull(),
-        signed_block.header.signature, signed_block.header.validators);
+    storage.updateBlockSig(block.header.height, block.hashFull(),
+        block.header.signature, block.header.validators);
     block = storage.readBlock(Height(BlockCount - 1));
     iota(0, 6).each!(i => assert(block.header.validators[i],
         format!"validator bit %s should be set after update"(i)));

--- a/source/agora/consensus/data/Block.d
+++ b/source/agora/consensus/data/Block.d
@@ -133,21 +133,17 @@ public struct BlockHeader
 
     /***************************************************************************
 
-        Returns:
-            this block header with an updated signature and validators bitmask
-
         Params:
             signature = new signature
             validators = mask to indicate who has signed
 
     ***************************************************************************/
 
-    public BlockHeader updateSignature (in Signature signature,
-        BitMask validators) @safe
+    public void updateSignature (in Signature signature,
+        BitMask validators) @safe pure nothrow @nogc
     {
         this.signature = signature;
         this.validators = validators;
-        return this;
     }
 
     /***************************************************************************
@@ -256,20 +252,16 @@ public struct Block
 
     /***************************************************************************
 
-        Returns:
-            this block with updated header
-
         Params:
             signature = new signature
             validators = mask to indicate who has signed
 
     ***************************************************************************/
 
-    public Block updateSignature (in Signature signature, BitMask validators)
-        @safe
+    public void updateSignature (in Signature signature, BitMask validators)
+        @safe pure nothrow @nogc
     {
         this.header.updateSignature(signature, validators);
-        return this;
     }
 
     /***************************************************************************
@@ -635,8 +627,8 @@ version (unittest)
                     sigs ~= block.header.sign(k.secret, pre_images[i]);
                 }
             });
-            auto signed_block = block.updateSignature(multiSigCombine(sigs), validators);
-            return signed_block;
+            block.updateSignature(multiSigCombine(sigs), validators);
+            return block;
         }
         catch (Exception e)
         {
@@ -646,7 +638,6 @@ version (unittest)
                 assert(0, format!"makeNewTestBlock exception thrown during test: %s"(e));
             }();
         }
-        return Block.init;
     }
 }
 

--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -591,7 +591,7 @@ Outputs (1): boa1xzgenes5...gm67(59,499,999.9,920,9)<Payment>
         return Unlock.init;
     }
 
-    const Block second_block = makeNewBlock(GenesisBlock,
+    Block second_block = makeNewBlock(GenesisBlock,
         genesisSpendable().take(2).map!(txb => txb.unlockSigner(&unlocker).sign()),
         WK.PreImages.at(GenesisBlock.header.height + 1, genesis_validator_keys));
 
@@ -600,8 +600,8 @@ Outputs (1): boa1xzgenes5...gm67(59,499,999.9,920,9)<Payment>
     const signature = Signature.fromString("0x000000000000000000016f605ea9638d7bff58d2c0c" ~
                               "c2467c18e38b36367be78000000000000000000016f60" ~
                               "5ea9638d7bff58d2c0cc2467c18e38b36367be78");
-    const block2 = second_block.clone().updateSignature(signature, validators);
-    const(Block)[] blocks = [GenesisBlock, block2];
+    second_block.updateSignature(signature, validators);
+    const(Block)[] blocks = [GenesisBlock, second_block];
     const actual = format("%s", prettify(blocks));
     assert(ResultStr == actual);
 }


### PR DESCRIPTION
As the `BlockHeader` is now mutable we can update the `signature` and `validators` bitmask without the need to return `this`. This is also the case for the `Block.updateSignature`. Also added some missing attributes to the `BlockHeader.updateSignature`.