### PR TITLE
Clock: Use UTC time everywhere

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -440,11 +440,10 @@ public class BanManager
 
     ***************************************************************************/
 
-    protected TimePoint getCurTime () @safe nothrow @nogc
+    protected TimePoint getCurTime () @safe nothrow
     {
-        return this.clock.localTime();
+        return this.clock.utcTime();
     }
-
 }
 
 ///

--- a/source/agora/consensus/state/Ledger.d
+++ b/source/agora/consensus/state/Ledger.d
@@ -1057,9 +1057,6 @@ public class Ledger
     {
         return this.utxo_set.getUTXOFinder();
     }
-
-    version (unittest):
-
 }
 
 /// This is the last block height that has had fees and rewards paid before the current block

--- a/source/agora/network/Clock.d
+++ b/source/agora/network/Clock.d
@@ -51,7 +51,8 @@ module agora.network.Clock;
 import agora.common.Types : TimePoint;
 import agora.utils.Log;
 
-import core.stdc.time;
+import std.datetime.systime : StdClock = Clock;
+import std.datetime.timezone : UTC;
 import core.time;
 
 /// Delegate used to calculate the time offset to apply in `networkTime`
@@ -107,7 +108,7 @@ public class Clock
 
     public TimePoint networkTime () @safe nothrow
     {
-        return this.localTime() + this.net_time_offset.total!"seconds";
+        return this.utcTime() + this.net_time_offset.total!"seconds";
     }
 
     /***************************************************************************
@@ -117,9 +118,11 @@ public class Clock
 
     ***************************************************************************/
 
-    public TimePoint localTime () @safe nothrow @nogc
+    public TimePoint utcTime () @safe nothrow
     {
-        return .time(null);
+        auto ut = StdClock.currTime(UTC()).toUnixTime;
+        assert(ut > 0);
+        return TimePoint(ut);
     }
 
     /***************************************************************************
@@ -174,7 +177,7 @@ public class MockClock : Clock
     public override TimePoint networkTime () @safe nothrow { return time;}
 
     /// returns time set by constructor
-    public override TimePoint localTime () @safe nothrow @nogc { return time;}
+    public override TimePoint utcTime () @safe nothrow @nogc { return time;}
 
     /// do nothing
     public override void startSyncing () @safe nothrow {}

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -467,19 +467,19 @@ public class NetworkManager
         () @trusted { assumeSafeAppend(offsets); }();
         // must include our own assumed clock drift (zero)
         offsets ~= TimeInfo(this.config.validator.key_pair.address,
-            this.clock.localTime());
+            this.clock.utcTime());
 
         foreach (node; this.validators())
         {
             if (node.identity.utxo !in this.quorum_set_keys)
                 continue;
 
-            const req_start = this.clock.localTime();
+            const req_start = this.clock.utcTime();
             const node_time = node.getLocalTime();
             if (node_time == 0)
                 continue;  // request failed
 
-            const req_delay = this.clock.localTime() - req_start;
+            const req_delay = this.clock.utcTime() - req_start;
             const dist_delay = req_delay / 2;  // divide evently
             const offset = (node_time - dist_delay) - req_start;
             offsets ~= TimeInfo(node.identity.key, node_time, req_delay, offset.seconds);

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -1131,7 +1131,7 @@ public class FullNode : API
     public override TimePoint getLocalTime () @safe nothrow
     {
         this.recordReq("local_time");
-        return this.clock.localTime();
+        return this.clock.utcTime();
     }
 
     /***************************************************************************

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1823,7 +1823,7 @@ public class TestClock : Clock
     }
 
     ///
-    public override TimePoint localTime ()
+    public override TimePoint utcTime ()
     {
         return atomicLoad(*this.cur_time);
     }


### PR DESCRIPTION
I was actually working on using the `Ledger.height` vs expected height (last commit) when I noticed our call to `time`, which doesn't handle timezone, meaning people joining the network would see massive offsets.