### PR TITLE
Rework timer message to be driven by catchup

### DIFF
--- a/source/agora/consensus/state/Ledger.d
+++ b/source/agora/consensus/state/Ledger.d
@@ -1071,7 +1071,8 @@ public class Ledger
 
     ***************************************************************************/
 
-    public Height expectedHeight (in TimePoint utcTime)
+    public Height expectedHeight (in TimePoint utcTime) const scope
+        @safe pure nothrow @nogc
     {
         if (utcTime <= this.params.GenesisTimestamp)
             return Height.init;

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -551,7 +551,7 @@ public class NetworkManager
                 this.required_peers.put(peer.key);
         }
 
-        log.info(
+        log.trace(
             "Doing periodic network discovery: {} required peers requested, {} missing, known {}",
             required_peer_utxos.length, this.required_peers.length, last_known_validator_utxos.length);
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1263,7 +1263,7 @@ public class TestAPIManager
 
         foreach (idx; client_idxs)
         {
-            retryFor(Height(this.clients[idx].getBlockHeight()) == to, 5.seconds,
+            retryFor(Height(this.clients[idx].getBlockHeight()) == to, 15.seconds,
                 format!"Expected height %s for client #%s (%s) not %s"
                      (to, idx, this.nodes[idx].address,  this.clients[idx].getBlockHeight()),
                 file, line);

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -165,8 +165,7 @@ unittest
     last_txs = txs;
 
     // the validator node has 2 blocks, but bad node pretends to have 3
-    assert(node_validators[0].getBlockHeight() == 2,
-        node_validators[0].getBlockHeight().to!string);
+    assert(node_validators[0].getBlockHeight() == 2);
     assert(node_bad.getBlockHeight() == 3);
     assert(node_test.getBlockHeight() == 0);  // only genesis
 


### PR DESCRIPTION
That should make running a full node much better. We still get a flood of message at startup, but not during continous operation.

However, it also shows one issue with our timers:
```
2022-02-17 15:10:21,463 Info [agora.consensus.state.Ledger] - Completed externalization of block #1650
2022-02-17 15:10:58,37 Info [agora.node.FullNode] - Ledger has fell behind, missing 465 blocks (current height: 1650)
2022-02-17 15:12:05,340 Info [agora.node.FullNode] - Ledger has fell behind, missing 467 blocks (current height: 1650)
2022-02-17 15:13:12,264 Info [agora.node.FullNode] - Ledger has fell behind, missing 468 blocks (current height: 1650)
2022-02-17 15:14:21,539 Info [agora.node.FullNode] - Ledger has fell behind, missing 469 blocks (current height: 1650)
```

Look at the timing. I'm using the default config, so it should trigger every 20 seconds.