### PR TITLE
Manager: Add a range to iterate over mutable peer list

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1166,7 +1166,7 @@ extern(D):
             copy = envelope.serializeFull.deserializeFull!SCPEnvelope();
         catch (Exception e)
             assert(0);
-        log.dbg("{}: peers are {}", __PRETTY_FUNCTION__, this.network.peers[]);
+        log.dbg("{}: peers are {}", __PRETTY_FUNCTION__, this.network.peers);
         this.network.validators().each!(v => v.sendEnvelope(copy));
     }
 

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -315,7 +315,7 @@ public class Validator : FullNode, API
         log.warn("Currently missing pre-images for next height ({}): {}",
                  next_height, missing);
 
-        auto query = this.network.peers[]
+        auto query = this.network.peers
             .map!(peer => peer.getPreimages(missing));
 
         foreach (preimages; query)


### PR DESCRIPTION
We used to be not able to remove from peer list since multiple
fibers could be iterating over it at any moment without any
synchronization between them. With PeerRange, NetworkManager
can remove/add to the peer_list and invalidate all ranges over the
list by incrementing the peer_list_version.

Ranges will start back from the beginning, so caller can iterate
over the same peers multiple times but that probably we a rare
occurrence and even if it did happen, not much would change.