### PR TITLE
Clock: Remove some special casing, simplify API

### DIFF
--- a/source/agora/network/Clock.d
+++ b/source/agora/network/Clock.d
@@ -81,7 +81,7 @@ public class Clock
 
         Instantiate the clock.
 
-        The startSyncing() routine must be called when the task manager is
+        The `start` routine must be called when the task manager is
         ready to set up timers.
 
         Params:
@@ -134,7 +134,7 @@ public class Clock
 
     ***************************************************************************/
 
-    public void startSyncing () @safe nothrow
+    public void start () @safe nothrow
     {
         this.synchronize();
         this.setPeriodicTimerDg(ClockSyncInterval, &this.synchronize);
@@ -180,7 +180,7 @@ public class MockClock : Clock
     public override TimePoint utcTime () @safe nothrow @nogc { return time;}
 
     /// do nothing
-    public override void startSyncing () @safe nothrow {}
+    public override void start () @safe nothrow {}
 
     /// do nothing
     public override void synchronize () @safe nothrow {}

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -461,6 +461,7 @@ public class FullNode : API
                     }));
         }
 
+        this.timers[TimersIdx.ClockTick] = this.clock.start(this.taskman);
         this.stats_server = this.makeStatsServer();
         this.transaction_relayer.start();
 
@@ -677,8 +678,7 @@ public class FullNode : API
 
         // Shut down our timers (discovery, catchup)
         foreach (timer; this.timers)
-            if (timer !is null) // Clock timer is `null` in FullNode
-                timer.stop();
+            timer.stop();
         this.timers = null;
 
         // The handlers are just arrays on which we iterate,

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -677,7 +677,8 @@ public class FullNode : API
 
         // Shut down our timers (discovery, catchup)
         foreach (timer; this.timers)
-            timer.stop();
+            if (timer !is null) // Clock timer is `null` in FullNode
+                timer.stop();
         this.timers = null;
 
         // The handlers are just arrays on which we iterate,
@@ -829,10 +830,7 @@ public class FullNode : API
     protected Clock makeClock ()
     {
         // non-synchronizing clock (for now)
-        return new Clock(
-            (out Duration time_offset) { return true; },
-            (Duration duration, void delegate() cb) nothrow @trusted
-                { this.timers[TimersIdx.ClockTick] = this.taskman.setTimer(duration, cb, Periodic.Yes); });
+        return new Clock((out Duration time_offset) { return true; });
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -242,7 +242,7 @@ public class Validator : FullNode, API
             this.network.startPeriodicNameRegistration();
         super.start();
 
-        this.clock.startSyncing();
+        this.clock.start();
         this.timers[TimersIdx.PreImageReveal] = this.taskman.setTimer(
             this.config.validator.preimage_reveal_interval,
             &this.onPreImageRevealTimer, Periodic.Yes);

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -242,7 +242,6 @@ public class Validator : FullNode, API
             this.network.startPeriodicNameRegistration();
         super.start();
 
-        this.timers[TimersIdx.ClockTick] = this.clock.start(this.taskman);
         this.timers[TimersIdx.PreImageReveal] = this.taskman.setTimer(
             this.config.validator.preimage_reveal_interval,
             &this.onPreImageRevealTimer, Periodic.Yes);

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -242,7 +242,7 @@ public class Validator : FullNode, API
             this.network.startPeriodicNameRegistration();
         super.start();
 
-        this.clock.start();
+        this.timers[TimersIdx.ClockTick] = this.clock.start(this.taskman);
         this.timers[TimersIdx.PreImageReveal] = this.taskman.setTimer(
             this.config.validator.preimage_reveal_interval,
             &this.onPreImageRevealTimer, Periodic.Yes);
@@ -568,9 +568,7 @@ public class Validator : FullNode, API
             {
                 return this.network.getNetTimeOffset(this.qc.threshold,
                     time_offset);
-            },
-            (Duration duration, void delegate() cb) nothrow @trusted
-                { this.timers[TimersIdx.ClockTick] = this.taskman.setTimer(duration, cb, Periodic.Yes); });
+            });
     }
 
     /***************************************************************************

--- a/source/agora/node/admin/AdminInterface.d
+++ b/source/agora/node/admin/AdminInterface.d
@@ -365,7 +365,7 @@ unittest
     struct S { int a = 1; }
     S x;
     const KeyPair kp = KeyPair.random();
-    auto clock = new Clock(null, null);
+    auto clock = new MockClock(TimePoint.init);
     auto qRCodeInterface = new AdminInterface(kp, clock, null);
     string qr_svg = qRCodeInterface.createQRcode(x);
     string sample_svg =

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1824,12 +1824,6 @@ public class TestClock : Clock
     {
         return atomicLoad(*this.cur_time);
     }
-
-    /// we manually sync the clocks in the tests, not using the timer
-    public override ITimer start (ITaskManager taskman) @safe nothrow
-    {
-        return null;
-    }
 }
 
 /// A FullNode which also implements test routines in TestAPI

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1829,7 +1829,7 @@ public class TestClock : Clock
     }
 
     /// we manually sync the clocks in the tests, not using the timer
-    public override void startSyncing () @safe nothrow
+    public override void start () @safe nothrow
     {
 
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1813,12 +1813,9 @@ public class TestClock : Clock
     private shared(TimePoint)* cur_time;
 
     ///
-    public this (ITaskManager taskman, GetNetTimeOffset getNetTimeOffset,
-        shared(TimePoint)* cur_time)
+    public this (GetNetTimeOffset getNetTimeOffset, shared(TimePoint)* cur_time)
     {
-        super(getNetTimeOffset,
-            (Duration duration, void delegate() cb) nothrow @trusted
-                { taskman.setTimer(duration, cb, Periodic.Yes); });
+        super(getNetTimeOffset);
         this.cur_time = cur_time;
     }
 
@@ -1829,9 +1826,9 @@ public class TestClock : Clock
     }
 
     /// we manually sync the clocks in the tests, not using the timer
-    public override void start () @safe nothrow
+    public override ITimer start (ITaskManager taskman) @safe nothrow
     {
-
+        return null;
     }
 }
 
@@ -1863,7 +1860,7 @@ public class TestFullNode : FullNode, TestAPI
     /// Provides a unittest-adjusted clock source for the node
     protected override TestClock makeClock ()
     {
-        return new TestClock(this.taskman,
+        return new TestClock(
             (out Duration time_offset) { return true; }, this.cur_time);
     }
 
@@ -1951,7 +1948,7 @@ public class TestValidatorNode : Validator, TestAPI
     /// Provides a unittest-adjusted clock source for the node
     protected override TestClock makeClock ()
     {
-        return new TestClock(this.taskman,
+        return new TestClock(
             (out Duration time_offset)
             {
                 return this.network.getNetTimeOffset(this.qc.threshold,


### PR DESCRIPTION
This should pave the way for the Clock to be usable in FullNode, and for the unittests to behave more like the live system.