### PR TITLE
Manager: Remove non-enrolled validators from peer list

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -268,6 +268,9 @@ public class NetworkManager
 
     protected agora.api.FullNode.API owner_node;
 
+    /// Most recent validator set
+    protected UTXO[Hash] last_known_validator_utxos;
+
     /// Ctor
     public this (in Config config, ManagedDatabase cache, ITaskManager taskman, Clock clock, agora.api.FullNode.API owner_node)
     {
@@ -535,11 +538,24 @@ public class NetworkManager
             &this.onRegisterName, Periodic.Yes);
     }
 
+    /// Called when validator set is changed
+    public void onValidatorSetChanged (UTXO[Hash] validator_utxos) @trusted
+    {
+        this.last_known_validator_utxos = validator_utxos;
+
+        foreach (val; this.validators())
+            if (val.identity.utxo !in this.last_known_validator_utxos)
+                if (this.peer_list.linearRemoveElement(val))
+                {
+                    this.peer_list_version++;
+                    val.shutdown();
+                }
+    }
+
     /// Discover the network, connect to all required peers
     /// Some nodes may want to connect to specific peers before
     /// discovery() is considered complete
-    public void discover (UTXO[Hash] last_known_validator_utxos,
-        UTXO[Hash] required_peer_utxos = null) nothrow
+    public void discover (UTXO[Hash] required_peer_utxos = null) nothrow
     {
         this.quorum_set_keys.from(Set!Hash.init);
         this.required_peers.from(Set!Hash.init);
@@ -553,9 +569,9 @@ public class NetworkManager
 
         log.trace(
             "Doing periodic network discovery: {} required peers requested, {} missing, known {}",
-            required_peer_utxos.length, this.required_peers.length, last_known_validator_utxos.length);
+            required_peer_utxos.length, this.required_peers.length, this.last_known_validator_utxos.length);
 
-        foreach (utxo; last_known_validator_utxos.byKeyValue)
+        foreach (utxo; this.last_known_validator_utxos.byKeyValue)
         {
             if (!this.peers.map!(ni => ni.identity.utxo).canFind(utxo.key))
             {

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -298,6 +298,8 @@ public class FullNode : API
         this.ledger = this.makeLedger();
 
         this.network = this.makeNetworkManager();
+        auto validator_set = this.ledger.getEnrolledUTXOs();
+        this.network.onValidatorSetChanged(validator_set);
         this.transaction_relayer = this.makeTransactionRelayer();
 
         Utils.getCollectorRegistry().addCollector(&this.collectAppStats);
@@ -525,7 +527,7 @@ public class FullNode : API
 
     protected void discoveryTask () nothrow
     {
-        this.network.discover(this.ledger.getEnrolledUTXOs());
+        this.network.discover();
         this.startTaskTimer(TimersIdx.Discovery, this.config.node.network_discovery_interval);
     }
 
@@ -1189,6 +1191,11 @@ public class FullNode : API
         log.dbg("{}: height {}", __PRETTY_FUNCTION__, block.header.height);
         this.pushBlock(block);
         this.registry.onAcceptedBlock(block, validators_changed);
+        if (validators_changed)
+        {
+            auto validator_set = this.ledger.getEnrolledUTXOs();
+            this.network.onValidatorSetChanged(validator_set);
+        }
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -257,7 +257,7 @@ public class Validator : FullNode, API
     /// Ditto
     protected override void discoveryTask ()
     {
-        this.network.discover(this.ledger.getEnrolledUTXOs(), this.required_peer_utxos);
+        this.network.discover(this.required_peer_utxos);
         this.timers[TimersIdx.Discovery].rearm(this.config.node.network_discovery_interval, false);
     }
 

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -27,7 +27,7 @@ unittest
     TestConf conf = { outsider_validators : 3,
         recurring_enrollment : false,
     };
-    conf.node.network_discovery_interval = 2.seconds;
+    conf.node.network_discovery_interval = 1.seconds;
     conf.node.retry_delay = 250.msecs;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();

--- a/source/agora/test/RestoreSlashingInfo.d
+++ b/source/agora/test/RestoreSlashingInfo.d
@@ -32,8 +32,9 @@ unittest
         recurring_enrollment : false
     };
     conf.node.timeout = 10.seconds;
-    conf.node.network_discovery_interval = 2.seconds;
+    conf.node.network_discovery_interval = 1.seconds;
     conf.node.retry_delay = 250.msecs;
+    conf.node.min_listeners = 4;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -116,6 +116,7 @@ unittest
 
     TestConf conf;
     conf.consensus.quorum_threshold = 100;
+    conf.node.network_discovery_interval = 1.seconds;
 
     auto network = makeTestNetwork!(TestNetwork!SocialDistancingValidator)(conf);
     network.start();


### PR DESCRIPTION
Will work both when a validator is no longer enrolled or changes
its stake.