### PR TITLE
Manager: Simplify removal of connection tasks

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -154,6 +154,7 @@ public class NetworkManager
             catch (Exception exc)
                 log.error("Unexpected exception while contacting {}: {}",
                           this.address, exc);
+            this.outer.connection_tasks.remove(this.address);
         }
 
         /// Ditto, just behind a trampoline to avoid function-wide try/catch
@@ -211,7 +212,6 @@ public class NetworkManager
                 {
                     // either we connected to ourself, or someone else is pretending
                     // to be us
-                    this.outer.connection_tasks.remove(address);
                     this.outer.banman.ban(address);
                     return;
                 }
@@ -305,7 +305,6 @@ public class NetworkManager
         in Hash utxo, in PublicKey key)
     {
         log.dbg("onHandshakeComplete: {} - (k: {}, utxo: {})", address, key, utxo);
-        this.connection_tasks.remove(address);
 
         // We have an authenticated client, maybe we already have a client for it
         if (key !is PublicKey.init)
@@ -598,13 +597,7 @@ public class NetworkManager
         /// else false if the address was banned
         bool onFailedRequest (in Address address) nothrow
         {
-            if (this.banman.isBanned(address))
-            {
-                this.connection_tasks.remove(address);
-                return false;
-            }
-
-            return true;
+            return !this.banman.isBanned(address);
         }
 
         try

--- a/source/agora/test/Timeout.d
+++ b/source/agora/test/Timeout.d
@@ -23,7 +23,6 @@ unittest
     TestConf conf = {
         max_failed_requests : 1000, // never ban
     };
-    conf.node.max_retries = 2;
     conf.node.retry_delay = 1.msecs;
     conf.node.timeout = 500.msecs;
 

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -96,7 +96,7 @@ unittest
 
     // give time for the outsiders to be added as validators before sending tx for next block
     // as catchup for missing txs only occurs after nomination has started
-    Thread.sleep(conf.node.network_discovery_interval);
+    Thread.sleep(1.seconds);
 
     // Block 21 with the new validators in the set B
     network.generateBlocks(iota(GenesisValidators, allValidators),


### PR DESCRIPTION
I have seen lingering connection tasks in production. We remove them
in various points and they are mostly guarded by a condition. This way
we ensure they get removed from the AA when they exit.