### PR TITLE
Ensure: Gather latest trace info

### DIFF
--- a/source/agora/common/Ensure.d
+++ b/source/agora/common/Ensure.d
@@ -105,6 +105,10 @@ public void ensure (Args...) (bool exp, string fmt, lazy Args args,
     if (!exp)
     {
         auto res = instance.buffer.snformat(fmt, args);
+        // Instance info is filled on first throw and runtime doesn't update info
+        // when throwing same instance again
+        // https://issues.dlang.org/show_bug.cgi?id=22774
+        instance.info = null;
         instance.end = res.length;
         instance.file = file;
         instance.line = line;


### PR DESCRIPTION
D Runtime doesn't update trace info when same instance is used when
throw. This will workaround that and latest trace info will always be
gathered but this will cause allocation since gathering trace info
causes allocation which single instance throwable implementation avoided.

Fixes #2864 