### PR TITLE
Validator: Reveal preimages according to expected height

### DIFF
--- a/ci/system_integration_test.d
+++ b/ci/system_integration_test.d
@@ -4,8 +4,11 @@ module system_integration_test;
 private:
 
 import std.algorithm;
+import std.array;
+import std.conv;
 import std.file;
 import std.format;
+import std.datetime;
 import std.path;
 import std.process;
 import std.stdio;
@@ -49,6 +52,17 @@ immutable Cleanup = [ "rm", "-rf", IntegrationPath.buildPath("node/0/.cache/"),
                       IntegrationPath.buildPath("node/6/.cache/"),
                       IntegrationPath.buildPath("node/7/.cache/"),
 ];
+auto SetGenesisTimestamp = ["sed", "-i",
+    "s/genesis_timestamp: [0-9]\\+/genesis_timestamp: curr_time/g",
+    IntegrationPath.buildPath("node/0/config.yaml"),
+    IntegrationPath.buildPath("node/2/config.yaml"),
+    IntegrationPath.buildPath("node/3/config.yaml"),
+    IntegrationPath.buildPath("node/4/config.yaml"),
+    IntegrationPath.buildPath("node/5/config.yaml"),
+    IntegrationPath.buildPath("node/6/config.yaml"),
+    IntegrationPath.buildPath("node/7/config.yaml"),
+    IntegrationPath.buildPath("node/faucet/config.yaml"),
+];
 
 private int main (string[] args)
 {
@@ -67,6 +81,10 @@ private int main (string[] args)
     // First make sure that there we start from a clean slate,
     // as the docker-compose bind volumes
     runCmd(Cleanup);
+
+    auto now = (Clock.currTime(UTC()).toUnixTime + 10).to!string;
+    // Update genesis timestamps
+    runCmd(SetGenesisTimestamp.map!(str => str.replace("curr_time", now)).array);
 
     // We need to have a "foreground" process to use `--abort-on-container-exit`
     // This option allows us to detect when the node stops / crash even before

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -685,7 +685,7 @@ public class Validator : FullNode, API
     {
         PreImageInfo preimage;
         if (this.enroll_man.getNextPreimage(preimage,
-            this.ledger.height()))
+            max(this.ledger.height(), this.ledger.expectedHeight(this.clock.utcTime()))))
         {
             this.ledger.addPreimage(preimage);
             this.network.peers.each!(p => p.sendPreimage(preimage));

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -36,6 +36,7 @@ consensus:
   block_interval:
     seconds: 5
   validator_cycle: 20
+  genesis_timestamp: 1640995200
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -36,6 +36,7 @@ consensus:
   block_interval:
     seconds: 5
   validator_cycle: 20
+  genesis_timestamp: 1640995200
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -36,6 +36,7 @@ consensus:
   block_interval:
     seconds: 5
   validator_cycle: 20
+  genesis_timestamp: 1640995200
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -36,6 +36,7 @@ consensus:
   block_interval:
     seconds: 5
   validator_cycle: 20
+  genesis_timestamp: 1640995200
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -36,6 +36,7 @@ consensus:
   block_interval:
     seconds: 5
   validator_cycle: 20
+  genesis_timestamp: 1640995200
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -36,6 +36,7 @@ consensus:
   block_interval:
     seconds: 5
   validator_cycle: 20
+  genesis_timestamp: 1640995200
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -36,6 +36,7 @@ consensus:
   block_interval:
     seconds: 5
   validator_cycle: 20
+  genesis_timestamp: 1640995200
 
 ################################################################################
 ##                             Validator configuration                        ##

--- a/tests/system/node/faucet/config.yaml
+++ b/tests/system/node/faucet/config.yaml
@@ -59,3 +59,4 @@ consensus:
   block_interval:
     seconds: 5
   validator_cycle: 20
+  genesis_timestamp: 1640995200


### PR DESCRIPTION
When network falls behind on blocks, it creates a lot of blocks
in a short span and this results in some nodes to be slashed in the
process. If we reveal the preimage of the expected height instead
of the ledger height, we should decrease the chance of us getting
slashed in this scenario.