### PR TITLE
Validator clean restart test update

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1154,7 +1154,7 @@ public class TestAPIManager
             // Wait for tx gossipping before setting time for block
             foreach (idx; client_idxs)
                 retryFor(this.clients[idx].hasTransactionHash(tx.hashFull()),
-                    4.seconds, format!"Client #%s (%s) did not receive tx in expected time for height %s"
+                    10.seconds, format!"Client #%s (%s) did not receive tx in expected time for height %s"
                         (idx, this.nodes[idx].address, target_height), file, line);
         }
 

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -94,10 +94,6 @@ unittest
     // Make all the validators of the set A disable to respond
     set_a.each!(node => node.ctrl.shutdown);
 
-    // give time for the outsiders to be added as validators before sending tx for next block
-    // as catchup for missing txs only occurs after nomination has started
-    Thread.sleep(conf.node.network_discovery_interval);
-
     // Block 21 with the new validators in the set B
     network.generateBlocks(iota(GenesisValidators, allValidators),
         Height(GenesisValidatorCycle + 1));


### PR DESCRIPTION
The first test has been seen to fail during `base.d:add_block` when the tx is not gossiped within 4 seconds to all the nodes.
This PR removes a sleep in the test before generating blocks but allows more time for the gossip to occur.