### PR TITLE
Update and improve instructions for testnet

### DIFF
--- a/devel/testnet/README.md
+++ b/devel/testnet/README.md
@@ -130,6 +130,9 @@ interfaces:
     port: 3000
 ```
 
+If docker is being used, it also needs to be instructed to expose the port.
+This is done with the `-p` option, e.g. `docker run -p 2826 [...]`.
+
 Once you start the node, and wait up to a few minutes, it should enroll by itself
 and start validating. You can also make sure your node is accessible by checking
 that `boa1xrwuel4csj4acdfdr5c6xufewa7r5l5g83cp5uax2lyxaakkhwc27aghk7m.validators.testnet.bosagora.io`

--- a/devel/testnet/config.yaml
+++ b/devel/testnet/config.yaml
@@ -13,10 +13,17 @@
 node:
   realm: "testnet.bosagora.io"
   testing: true
-  registry_address: http://ns1.bosagora.io/
+  registry_address: https://ns1.bosagora.io/
 
 registry:
   public: true
+
+# If you want to be a validator, use the following:
+# validator:
+#   enabled: true
+#   seed: YOUR_SEED_HERE
+#   addresses_to_register:
+#     - "agora://my-address.example.com"
 
 logging:
   root:


### PR DESCRIPTION
Use https as http gives a 301, mention that -p should be used for Docker,
and provide a template to make it even easier to become a validator.