### PR TITLE
Bump serialization and fix memory corruption in URI deserialization

### DIFF
--- a/source/agora/common/DNS.d
+++ b/source/agora/common/DNS.d
@@ -805,7 +805,9 @@ public struct ResourceRecord
                     tmp_data.uri = URIRDATA(
                         deserializeFull!(typeof(URIRDATA.priority))(&ctx.read, ctx.options),
                         deserializeFull!(typeof(URIRDATA.weight))(&ctx.read, ctx.options),
-                        Address(cast(string) ctx.read(rdlength - (URIRDATA.priority.sizeof + URIRDATA.weight.sizeof)))
+                        Address(deserializeArray!(string)(
+                            rdlength - (URIRDATA.priority.sizeof + URIRDATA.weight.sizeof),
+                            &ctx.read, ctx.options))
                     );
                     break;
                 default:


### PR DESCRIPTION
The previous code was retaining a reference to the stack,
because it did not dup the result like the serializer would.
It also failed to properly validate the string before passing
it to Address's constructor, which could trigger assert or
other logic errors. serialization was changed to introduce
deserializeArray as a simple way to handle this case.