### PR TITLE
Trivial update to log line

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1206,7 +1206,7 @@ extern(D):
             copy = envelope.serializeFull.deserializeFull!SCPEnvelope();
         catch (Exception e)
             assert(0);
-        log.dbg("{}: peers are {}", __PRETTY_FUNCTION__, this.network.peers);
+        log.dbg("{}: peers are {}", __FUNCTION__, this.network.peers);
         this.network.validators().each!(v => v.sendEnvelope(copy));
     }
 

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -1270,6 +1270,11 @@ public struct PeerRange
         return this.range.front();
     }
 
+    public auto save () nothrow @safe
+    {
+        return this;
+    }
+
     private bool checkIfInvalidated () nothrow @safe
     {
         if (*this.manager_version > this.range_version)
@@ -1281,3 +1286,4 @@ public struct PeerRange
         return false;
     }
 }
+static assert (isForwardRange!PeerRange);

--- a/source/agora/network/RPC.d
+++ b/source/agora/network/RPC.d
@@ -279,8 +279,8 @@ public class RPCClient (API) : API
                             if (size >= tmp.length)
                             {
                                 this.log.warn("{}: Read size {} is too large for buffer size {}, closing connection",
-                                         __PRETTY_FUNCTION__, size, tmp.length);
-                                ensure(0, "{}: Out of bound read: {} >= {}", __PRETTY_FUNCTION__, size, tmp.length);
+                                         __FUNCTION__, size, tmp.length);
+                                ensure(0, "{}: Out of bound read: {} >= {}", __FUNCTION__, size, tmp.length);
                             }
                             conn.read(tmp[0 .. size]);
                             return tmp[0 .. size];
@@ -299,7 +299,7 @@ public class RPCClient (API) : API
                         version (all)
                         {
                             auto retval = deserializeFull!(typeof(return))(dg);
-                            this.log.trace("[CLIENT] {}: Returning {}", __PRETTY_FUNCTION__, retval);
+                            this.log.trace("[CLIENT] {}: Returning {}", __FUNCTION__, retval);
                             return retval;
                         }
                         else

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -1186,7 +1186,7 @@ public class FullNode : API
     protected void onAcceptedBlock (in Block block, bool validators_changed)
         @safe
     {
-        log.dbg("{}: height {}", __PRETTY_FUNCTION__, block.header.height);
+        log.dbg("{}: height {}", __FUNCTION__, block.header.height);
         this.pushBlock(block);
         this.registry.onAcceptedBlock(block, validators_changed);
     }

--- a/source/agora/node/TransactionRelayer.d
+++ b/source/agora/node/TransactionRelayer.d
@@ -217,7 +217,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
     /// Sends an array of transactions ordered by fee to known network clients.
     public void relayTransactions () @safe nothrow
     {
-        log.dbg("{}: clients: {}", __PRETTY_FUNCTION__, this.clients().map!(v => v.identity.key));
+        log.dbg("{}: clients: {}", __FUNCTION__, this.clients().map!(v => v.identity.key));
         if (this.clients().canFind!(client => client.isAuthenticated()))
             this.getRelayTransactions().each!(tx => this.clients().each!(c => c.sendTransaction(tx)));
     }

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -610,7 +610,7 @@ public class Validator : FullNode, API
     protected override void onAcceptedBlock (in Block block,
         bool validators_changed) @safe
     {
-        log.dbg("{}: height {}", __PRETTY_FUNCTION__);
+        log.dbg("{}: height {}", __FUNCTION__);
         assert(block.header.height >= this.last_shuffle_height);
 
         // block received either via externalize or getBlocksFrom(),

--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -403,6 +403,11 @@ unittest
 
     // Make sure we don't trip on stray format specifiers
     assert(get_log_output("Thou shalt ignore random %s in the string") == " string");
+
+    // log a map over a range
+    import std.algorithm;
+    import std.range;
+    assert(get_log_output(format("{}", iota(2).map!(i => i + 1))) == "[1, 2]");
 }
 
 /// A file appender that uses Phobos


### PR DESCRIPTION
The client keys were not printed as the map was not being traversed. 
By converting to array it will be. 
Also using `__FUNCTION__` in place of `__PRETTY_FUNCTION__` as it is more concise.