### PR TITLE
`checkExternalize`: return early if already externalized

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -837,6 +837,9 @@ extern(D):
     private void checkExternalize () @safe nothrow
     {
         const block = this.pending_block;
+        if (block.header.height == 0)
+            return; // pending block has been reset already
+
         try
         {
             if (block.header.height == this.ledger.height + 1)


### PR DESCRIPTION
It can be that several signatures are received at the same time and the
`updateMultiSignature` calls the `checkExternalize` multiple times to
check if we have a majority. If one of the checks passes then the
`pending_block` is reset to `Block.init` and subsequent calls to
`checkExternalize` should then be ignored.