### PR TITLE
Reveal Pre-images beyond the end of the enrollment cycle

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -664,17 +664,6 @@ public class EnrollmentManager
         this.db.execute("REPLACE into node_enroll_data " ~
             "(key, val) VALUES (?, ?)", "utxo", enroll_key);
     }
-
-    /***************************************************************************
-
-        Reset all the information about an enrollment of this node
-
-    ***************************************************************************/
-
-    private void resetNodeEnrollment () @safe nothrow
-    {
-        this.enroll_key = Hash.init;
-    }
 }
 
 /// tests for member functions of EnrollmentManager

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -549,8 +549,7 @@ public class EnrollmentManager
     /// Returns: true if this validator is currently enrolled
     public bool isEnrolled (in Height height, scope UTXOFinder finder) nothrow @safe
     {
-        this.enroll_key = this.getEnrolledUTXO(height, finder);
-        return this.enroll_key != Hash.init;
+        return this.getEnrolledUTXO(height, finder) != Hash.init;
     }
 
     /// Returns: The UTXO hash that this Validator is enrolled with or Hash.init if not enrolled

--- a/source/agora/consensus/pool/Enrollment.d
+++ b/source/agora/consensus/pool/Enrollment.d
@@ -278,38 +278,6 @@ public class EnrollmentPool
 
     /***************************************************************************
 
-        Get the height when the enrollment will be available
-
-        Params:
-            enroll_hash = key for the available block height
-
-        Returns:
-            the available block height, or 0 if the enrollment isn't found
-
-    ***************************************************************************/
-
-    public Height getAvailableHeight (in Hash enroll_hash)
-        @trusted nothrow
-    {
-        try
-        {
-            auto results = this.db.execute("SELECT avail_height " ~
-                "FROM enrollment_pool WHERE key = ?", enroll_hash);
-            if (results.empty)
-                return Height(0);
-
-            return Height(results.oneValue!(size_t));
-        }
-        catch (Exception ex)
-        {
-            log.error("ManagedDatabase operation error: {}", ex.msg);
-            return Height(0);
-        }
-    }
-
-
-    /***************************************************************************
-
         Get the unregistered enrollments from the pool
         And this is arranged in ascending order with the utxo_key
 

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -507,7 +507,7 @@ public class ValidatorSet
         if (prev_preimage == PreImageInfo.init)
         {
             log.info("Rejected pre-image for never-enrolled UTXO key: {}",
-                preimage.hash);
+                preimage.utxo);
             return false;
         }
 

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -118,7 +118,8 @@ public class Validator : FullNode, API
         // This is especially important on initialization, as replaying blocks
         // does not call `onAcceptedBlock`.
         PreImageInfo self;
-        if (this.enroll_man.getNextPreimage(self, this.ledger.height()))
+        if (this.enroll_man.getNextPreimage(self, this.ledger.height(),
+            this.ledger.expectedHeight(this.clock.utcTime())))
         {
             this.ledger.addPreimage(self);
             this.setIdentity(self.utxo);
@@ -688,8 +689,7 @@ public class Validator : FullNode, API
             __FUNCTION__, height, expected_height);
 
         PreImageInfo preimage;
-        if (this.enroll_man.getNextPreimage(preimage,
-            max(height, expected_height)))
+        if (this.enroll_man.getNextPreimage(preimage, height, expected_height))
         {
             this.ledger.addPreimage(preimage);
             this.network.peers.each!(p => p.sendPreimage(preimage));

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -682,9 +682,14 @@ public class Validator : FullNode, API
 
     protected void onPreImageRevealTimer () @safe
     {
+        const height = this.ledger.height();
+        const expected_height = this.ledger.expectedHeight(this.clock.utcTime());
+        log.dbg("{}: ledger height = {}, expected height = {} ",
+            __FUNCTION__, height, expected_height);
+
         PreImageInfo preimage;
         if (this.enroll_man.getNextPreimage(preimage,
-            max(this.ledger.height(), this.ledger.expectedHeight(this.clock.utcTime()))))
+            max(height, expected_height)))
         {
             this.ledger.addPreimage(preimage);
             this.network.peers.each!(p => p.sendPreimage(preimage));

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -796,8 +796,8 @@ public class TestAPIManager
                     scope node = this.nodes[idx];
                     retryFor(node.client.getPreimages(Set!Hash.from(enroll.utxo_key.only))
                         .any!(preimage => preimage.height >= height),
-                            timeout, format!"Client #%s (%s) has no preimage for client #%s (%s) at height %s"
-                                (idx, node.address, idx_enroll, this.nodes[idx_enroll].address, height));
+                            timeout, format!"Client #%s (%s) has no preimage for node enrolled with utxo %s at height %s"
+                                (idx, node.address, enroll.utxo_key, height));
                 }
     }
 

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -241,6 +241,13 @@ unittest
 
     // Even if configured to not re-enroll, BatValidator should enroll if there
     // are not enough validators
+    network.generateBlocks(Height(GenesisValidatorCycle), true);
+
+    // fetch last block and check they all enrolled
+    auto block = network.clients[0].getBlock(Height(GenesisValidatorCycle));
+    assert(block.header.enrollments.length == 1);
+
+    // Generate next block in new cycle
     network.generateBlocks(Height(GenesisValidatorCycle + 1), true);
 }
 

--- a/source/agora/test/ValidatorRecurringEnrollment.d
+++ b/source/agora/test/ValidatorRecurringEnrollment.d
@@ -131,7 +131,14 @@ unittest
     auto blocks = node_0.getBlocksFrom(0, 2);
     assert(blocks.length == 1);
 
+    network.generateBlocks(Height(GenesisValidatorCycle), true);
+
+    // This block has only half of the validators enrolled
+    network.generateBlocks(iota(3), Height(GenesisValidatorCycle + 1), true);
+
+    // Block with all validators again
     network.generateBlocks(Height(GenesisValidatorCycle + 2), true);
+
     blocks = node_0.getBlocksFrom(10, GenesisValidatorCycle + 3);
     assert(blocks[$ - 1].header.height == Height(GenesisValidatorCycle + 2));
     auto last_enrolls = blocks.retro.take(3).map!(block => block.header.enrollments.length);


### PR DESCRIPTION
Reveal pre-images beyond the current cycle. This will help reduce the risk of being slashed when the new cycle starts.