### PR TITLE
Registry: Allow configuration of multiple NS records

### DIFF
--- a/devel/config-single.yaml
+++ b/devel/config-single.yaml
@@ -43,12 +43,14 @@ registry:
   port: 5335
   validators:
     authoritative: true
-    primary: localhost
+    nameservers:
+      - localhost
     soa:
       email: no@no.no
   flash:
     authoritative: true
-    primary: localhost
+    nameservers:
+      - localhost
     soa:
       email: no@no.no
 

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -329,7 +329,9 @@ registry:
     # should have `authoritative` unset or set to `true`, and `primary` and `email` set.
     authoritative: true
 
-    # The *hostname* (not IP address) of the primary name server for this zone
+    # The *hostname* (not IP address) of authoritative name servers for this zone
+    # The first entry will be used as primary name server
+    # for the zone (MNAME field of the SOA record)
     #
     # If this is set, `email` must be set too. If this isn't set, `email` must be unset.
     #
@@ -337,7 +339,8 @@ registry:
     # For example, if the node that read this configuration will be reachable via
     # `agora.example.com`, then this string can be used.
     # However, the typical naming convention would be to use `ns1.example.com`.
-    primary: ns1.bosagora.io
+    nameservers:
+      - ns1.bosagora.io
 
     # Whitelist for AXFR zone transfers
     #

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2427,12 +2427,12 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
                 public_interface: true,
                 realm: {
                     authoritative: setField(true),
-                    primary: setField("name.registry"),
+                    nameservers: ["name.registry"],
                     soa: { email: setField("test@testnet"), },
                 },
                 validators: {
                     authoritative: setField(authoritative),
-                    primary: setField("name.registry"),
+                    nameservers: ["name.registry"],
                     allow_transfer: [ZoneConfig.IPAddress("127.0.0.127")],
                     query_servers: ["10.8.8.8"],
                     redirect_register: "http://10.8.8.8",
@@ -2441,7 +2441,7 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
                 },
                 flash: {
                     authoritative: setField(true),
-                    primary: setField("name.registry"),
+                    nameservers: ["name.registry"],
                     soa: { email: setField("test@testnet"), },
                 },
             },

--- a/tests/system/node/0/config.yaml
+++ b/tests/system/node/0/config.yaml
@@ -59,16 +59,19 @@ registry:
   port: 8053
   realm:
     authoritative: true
-    primary: node-0.
+    nameservers:
+      - node-0.
     soa:
       email: dev@bosagora.io
   validators:
     authoritative: true
-    primary: node-0.
+    nameservers:
+      - node-0.
     soa:
       email: dev@bosagora.io
   flash:
     authoritative: true
-    primary: node-0.
+    nameservers:
+      - node-0.
     soa:
       email: dev@bosagora.io


### PR DESCRIPTION
NS record indicates authoritative DNS servers for a zone; since Agora
allows multiple distributed authoritative servers for zones it should
also allow multiple NS records to be configured.

Fixes #3102 and Fixes #3103