### PR TITLE
Skip validation for enrollments in the pool

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -445,6 +445,10 @@ public class EnrollmentManager
         in PublicKey pubkey, in Height height, scope UTXOFinder findUTXO,
         scope GetPenaltyDeposit getPenaltyDeposit) @safe nothrow
     {
+        auto existing_enroll = this.enroll_pool.getEnrollment(enroll.utxo_key, height);
+        if (existing_enroll != Enrollment.init)
+            return existing_enroll == enroll ? null : "Enrollment: Differs from the pool";
+
         const Height enrolled = this.validator_set.getEnrolledHeight(height, enroll.utxo_key);
 
         if (enrolled == ulong.max)
@@ -459,6 +463,7 @@ public class EnrollmentManager
         if (auto fail_reason = enroll.isInvalidReason(findUTXO, height,
                                 &this.validator_set.findRecentEnrollment, getPenaltyDeposit))
             return fail_reason;
+        this.enroll_pool.addValidated(enroll, height);
 
         return null;
     }

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -235,6 +235,20 @@ public class EnrollmentManager
 
     /***************************************************************************
 
+        Remove all enrollments associated with a key from pool
+
+        Params:
+            enroll_key = the frozen UTXO hash
+
+    ***************************************************************************/
+
+    public void removeEnrollment (in Hash enroll_key) @safe
+    {
+        this.enroll_pool.remove(enroll_key);
+    }
+
+    /***************************************************************************
+
         Get the unregistered enrollments that can be validator in the next
         block based on the current block height.
 


### PR DESCRIPTION
```
and add new enrollments we encounter in nominations to the
pool
```

This should save us from a signature and commitment validation.