### PR TITLE
Revealing pre-images beyond the end of the enrollment cycle

### DIFF
--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -686,17 +686,6 @@ public class EnrollmentManager
         this.db.execute("REPLACE into node_enroll_data " ~
             "(key, val) VALUES (?, ?)", "utxo", enroll_key);
     }
-
-    /***************************************************************************
-
-        Reset all the information about an enrollment of this node
-
-    ***************************************************************************/
-
-    private void resetNodeEnrollment () @safe nothrow
-    {
-        this.enroll_key = Hash.init;
-    }
 }
 
 /// tests for member functions of EnrollmentManager

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -550,8 +550,7 @@ public class EnrollmentManager
     /// Returns: true if this validator is currently enrolled
     public bool isEnrolled (in Height height, scope UTXOFinder finder) nothrow @safe
     {
-        this.enroll_key = this.getEnrolledUTXO(height, finder);
-        return this.enroll_key != Hash.init;
+        return this.getEnrolledUTXO(height, finder) != Hash.init;
     }
 
     /// Returns: The UTXO hash that this Validator is enrolled with or Hash.init if not enrolled

--- a/source/agora/consensus/EnrollmentManager.d
+++ b/source/agora/consensus/EnrollmentManager.d
@@ -99,10 +99,6 @@ public class EnrollmentManager
     /// The final hash of the preimages at the beginning of the enrollment cycle
     private Hash commitment;
 
-    /// How far away in the future a pre-image should be revealed.
-    /// This is expressed in numbers of block
-    private size_t max_preimage_reveal;
-
     /// Validator set managing validators' information such as Enrollment object
     /// enrolled height, and preimages.
     public ValidatorSet validator_set;  // FIXME: Made public to ease transition to raise this to ledger
@@ -138,7 +134,6 @@ public class EnrollmentManager
         this.log = Logger(__MODULE__);
         this.params = params;
         this.key_pair = config.key_pair;
-        this.max_preimage_reveal = config.max_preimage_reveal;
 
         if (config.key_pair !is KeyPair.init)
         {
@@ -473,32 +468,16 @@ public class EnrollmentManager
         Get a pre-image for revelation
 
         Params:
-            preimage = will contain the PreImageInfo if exists
-            height = current block height
+            height = height of next preimage to reveal
 
         Returns:
-            true if the pre-image exists
+            PreImageInfo for given height
 
     ***************************************************************************/
 
-    public bool getNextPreimage (out PreImageInfo preimage, in Height height)
-        @safe
+    public PreImageInfo getPreimage (in Height height) @safe
     {
-        const enrolled = this.validator_set.getEnrolledHeight(height, this.enroll_key);
-        if (enrolled == ulong.max)
-            return false;
-
-        assert(height >= enrolled);
-        const next_reveal = min(height + this.max_preimage_reveal,
-                                enrolled + this.params.ValidatorCycle);
-
-        if (next_reveal <= height)
-            return false;
-
-        preimage.utxo = this.enroll_key;
-        preimage.height = Height(next_reveal);
-        preimage.hash = this.cycle[next_reveal];
-        return true;
+        return PreImageInfo(this.enroll_key, this.cycle[height], height);
     }
 
     /***************************************************************************
@@ -795,8 +774,8 @@ unittest
     PreImageInfo preimage;
     assert(man.addValidator(enroll, WK.Keys[0].address, Height(10),
             &utxo_set.peekUTXO, getPenaltyDeposit, utxos) is null);
-    assert(man.getNextPreimage(preimage, Height(10)));
-    assert(preimage.height >= Height(10));
+    preimage = man.getPreimage(Height(12));
+    assert(preimage.height == Height(12));
     assert(preimage.hash == man.cycle[preimage.height]);
 
     // test for getting validators' UTXO keys
@@ -1094,8 +1073,7 @@ unittest
     assert(state.preimage.hash == genesis_enroll.commitment);
     assert(state.preimage.height == 0);
 
-    PreImageInfo preimage;
-    assert(man.getNextPreimage(preimage, Height(params.ValidatorCycle / 2)));
+    PreImageInfo preimage = man.getPreimage(Height(params.ValidatorCycle / 2));
     assert(man.validator_set.addPreimage(preimage));
     assert(findEnrollment(genesis_enroll.utxo_key, state));
     assert(state.preimage.hash == preimage.hash);

--- a/source/agora/consensus/pool/Enrollment.d
+++ b/source/agora/consensus/pool/Enrollment.d
@@ -282,38 +282,6 @@ public class EnrollmentPool
 
     /***************************************************************************
 
-        Get the height when the enrollment will be available
-
-        Params:
-            enroll_hash = key for the available block height
-
-        Returns:
-            the available block height, or 0 if the enrollment isn't found
-
-    ***************************************************************************/
-
-    public Height getAvailableHeight (in Hash enroll_hash)
-        @trusted nothrow
-    {
-        try
-        {
-            auto results = this.db.execute("SELECT avail_height " ~
-                "FROM enrollment_pool WHERE key = ?", enroll_hash);
-            if (results.empty)
-                return Height(0);
-
-            return Height(results.oneValue!(size_t));
-        }
-        catch (Exception ex)
-        {
-            log.error("ManagedDatabase operation error: {}", ex.msg);
-            return Height(0);
-        }
-    }
-
-
-    /***************************************************************************
-
         Get the unregistered enrollments from the pool
         And this is arranged in ascending order with the utxo_key
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1523,7 +1523,9 @@ extern(D):
         auto base = 1.seconds;
         // double the timeout every 16 validators
         auto val_multipler = 1 + this.ledger.validatorCount(this.ledger.height()) / 16;
-        return milliseconds((base * val_multipler * roundNumber).total!"msecs".to!long);
+        const timeout = milliseconds((base * val_multipler * roundNumber).total!"msecs".to!long);
+        log.dbg("{}: roundNumber {} timeout = {} msecs", __FUNCTION__, roundNumber, timeout);
+        return timeout;
     }
 }
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -686,33 +686,33 @@ extern(D):
         Hash utxo = this.getNodeUTXO(envelope.statement.slotIndex, envelope.statement.nodeID);
         if (utxo == Hash.init)
         {
-            log.trace("No UTXO for the nodeID {} at the slot {}",
-                envelope.statement.nodeID, envelope.statement.slotIndex);
+            log.trace("{}: No UTXO for the nodeID {} at the slot {}",
+                __FUNCTION__, envelope.statement.nodeID, envelope.statement.slotIndex);
             return;
         }
 
         UTXO utxo_value;
         if (!this.ledger.peekUTXO(utxo, utxo_value))
         {
-            log.trace("Couldn't find UTXO {} at height {} to validate envelope's signature",
-                utxo, last_block.header.height);
+            log.trace("{}: Couldn't find UTXO {} at height {} to validate envelope's signature",
+                __FUNCTION__, utxo, last_block.header.height);
             return;
         }
         const PublicKey public_key = utxo_value.output.address;
         const Scalar challenge = SCPStatementHash(&envelope.statement).hashFull();
         if (!public_key.isValid())
         {
-            log.trace("Invalid point from public_key {}", public_key);
+            log.trace("{}: Invalid point from public_key {}", __FUNCTION__, public_key);
             return;
         }
         if (!verify(public_key, envelope.signature.toSignature(), challenge))
         {
             // If it fails signature verification, it might not originate from said key
-            log.trace("Envelope failed signature verification for {}", public_key);
+            log.trace("{}: Envelope failed signature verification for {}", __FUNCTION__, public_key);
             return;
         }
 
-        log.trace("Received signed envelope: {}", scpPrettify(&envelope, &this.getQSet));
+        log.trace("{}: Received signed envelope: {}", __FUNCTION__, scpPrettify(&envelope, &this.getQSet));
         if (envelope.statement.pledges.type_ == SCPStatementType.SCP_ST_NOMINATE)
         {
             // show some tolerance to early nominations
@@ -721,7 +721,7 @@ extern(D):
             // too early to nominate a new block
             if (this.clock.networkTime() + tolerance < this.getExpectedBlockTime())
             {
-                log.trace("Ignoring early nomination for height {}", envelope.statement.slotIndex);
+                log.trace("{}: Ignoring early nomination for height {}", __FUNCTION__, envelope.statement.slotIndex);
                 return;
             }
         }
@@ -750,7 +750,7 @@ extern(D):
             return;
 
         if (this.scp.receiveEnvelope(shared_env) != SCP.EnvelopeState.VALID)
-            log.trace("SCP indicated invalid envelope: {}", scpPrettify(&envelope, &this.getQSet));
+            log.trace("{}: SCP indicated invalid envelope: {}", __FUNCTION__, scpPrettify(&envelope, &this.getQSet));
         else
             this.emitEnvelope(shared_env.getEnvelope());
     }

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -379,8 +379,11 @@ extern(D):
     {
         if (!this.is_shutting_down)
         {
-            this.log.dbg("Re-arming timer {} for {}", timer_id, interval);
-            this.timers[timer_id].rearm(interval, false);
+            if (!this.timers[timer_id].pending())
+            {
+                this.log.dbg("Re-arming timer {} for {}", timer_id, interval);
+                this.timers[timer_id].rearm(interval, false);
+            }
         }
         else
             this.log.dbg("Not re-arming timer {} for {} because we are shutting down",
@@ -639,6 +642,7 @@ extern(D):
     public void receiveEnvelope (in SCPEnvelope envelope) @trusted
     {
         auto env_hash = envelope.hashFull();
+        log.dbg("{}: Received envelope with hash {}", __FUNCTION__, env_hash);
         if (env_hash !in this.seen_envs)
         {
             auto copied = envelope.clone();

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1257,7 +1257,7 @@ extern(D):
             copy = envelope.serializeFull.deserializeFull!SCPEnvelope();
         catch (Exception e)
             assert(0);
-        log.dbg("{}: peers are {}", __FUNCTION__, this.network.peers);
+        log.dbg("{}: peers are {}", __FUNCTION__, this.network.peers.map!(p => p.identity()));
         this.network.validators().each!(v => v.sendEnvelope(copy));
     }
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -606,6 +606,14 @@ extern(D):
         else
         {
             log.info("{}(): Tx set didn't trigger new nomination", __FUNCTION__);
+            const Height expected = this.ledger.expectedHeight(this.clock.utcTime());
+            if (expected > this.ledger.height)
+            {
+                log.info("{}(): Behind expected height so resend latest envleopes"
+                    , __FUNCTION__);
+                foreach (const ref env; this.scp.getLatestMessagesSend(slot_idx))
+                    this.emitEnvelope(env);
+            }
         }
     }
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -691,6 +691,12 @@ extern(D):
             return;
         }
 
+        if (utxo == this.enroll_man.getEnrollmentKey)
+        {
+            log.dbg("{}: Ignore this envelope as it is from this node", __FUNCTION__);
+            return;
+        }
+
         UTXO utxo_value;
         if (!this.ledger.peekUTXO(utxo, utxo_value))
         {

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1251,13 +1251,13 @@ extern(D):
 
     public override void emitEnvelope (ref const(SCPEnvelope) envelope) nothrow
     {
-        log.trace("Emitting envelope: {}", scpPrettify(&envelope, &this.getQSet));
         SCPEnvelope copy;
         try
             copy = envelope.serializeFull.deserializeFull!SCPEnvelope();
         catch (Exception e)
             assert(0);
-        log.dbg("{}: peers are {}", __FUNCTION__, this.network.peers.map!(p => p.identity()));
+        log.trace("{}: {} to peers {}", __FUNCTION__, scpPrettify(&copy, &this.getQSet),
+            this.network.validators().map!(p => p.identity().key));
         this.network.validators().each!(v => v.sendEnvelope(copy));
     }
 

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -675,8 +675,16 @@ extern(D):
             return;  // slot was already externalized
         }
 
-        // If the node is not enrolled at the height then return early
         const env_height = Height(envelope.statement.slotIndex);
+        // If the envelope is too early then trigger catchup task
+        if (env_height > last_block.header.height + 1)
+        {
+            log.dbg("{}: Envelope is for height {} but ledger is only at height {}.",
+                __FUNCTION__, env_height, last_block.header.height);
+            this.armTaskTimer(TimersIdx.Catchup, CatchupTaskDelay);
+        }
+
+        // If the node is not enrolled at the height then return early
         if (!this.enroll_man.isEnrolled(env_height, &this.ledger.peekUTXO))
         {
             log.dbg("{}: Skip this envelope as this node is not enrolled at height {}", __FUNCTION__, env_height);

--- a/source/agora/consensus/state/ValidatorSet.d
+++ b/source/agora/consensus/state/ValidatorSet.d
@@ -511,7 +511,7 @@ public class ValidatorSet
         if (prev_preimage == PreImageInfo.init)
         {
             log.info("Rejected pre-image for never-enrolled UTXO key: {}",
-                preimage.hash);
+                preimage.utxo);
             return false;
         }
 

--- a/source/agora/consensus/validation/Enrollment.d
+++ b/source/agora/consensus/validation/Enrollment.d
@@ -256,6 +256,10 @@ unittest
 
     assert(validator_set.countActive(Height(params.ValidatorCycle + 1)) == 0);
 
+    // Add initial enrollment first
+    enroll1.commitment = cycle[Height(0)];
+    enroll1.enroll_sig = sign(node_key_pair_1, signature_noise, hashMulti(Height(0), enroll1));
+    validator_set.add(Height(0), utxoPeek, getPenaltyDeposit, enroll1, key_pairs[0].address);
     // First 2 iterations should fail because commitment is wrong
     foreach (offset; [-1, +1, 0])
     {

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -146,7 +146,7 @@ public class Validator : FullNode, API
             return false;
 
         preimage = this.enroll_man.getPreimage(nextReveal);
-        return true;
+        return preimage.utxo != Hash.init;
     }
 
     /***************************************************************************

--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -89,7 +89,7 @@ unittest
         auto new_tx = genBlockTransactions(1);
         left_txs ~= new_tx;
         new_tx.each!(tx => nodes[0].postTransaction(tx));
-        network.expectHeightAndPreImg(iota(0, 4), Height(1 + block_idx + 1), network.blocks[0].header);
+        network.expectHeightAndPreImg(iota(0, 4), Height(1 + block_idx + 1));
         retryFor(nodes[full_node_idx].getBlockHeight() == 1, 1.seconds,
             format!"Expected Full node height of exactly 1 not %s"(nodes[full_node_idx].getBlockHeight()));
     }

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1026,6 +1026,27 @@ public class TestAPIManager
 
     /***************************************************************************
 
+        Clear the logs for each node
+
+    ***************************************************************************/
+
+    public void clearLogs (string file = __FILE__, int line = __LINE__)
+    {
+        synchronized // ,ake sure we complete the clearing of logs
+        {
+            writefln("%s(%s): Clear node logs:\n", file, line);
+            foreach (node; this.nodes)
+            {
+                try
+                    node.client.clearLog();
+                catch (Exception ex)
+                    writefln("Could not clear logs for node %s: %s", node.address, ex.message);
+            }
+        }
+    }
+
+    /***************************************************************************
+
         Print out the logs for each node
 
     ***************************************************************************/

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -716,8 +716,8 @@ public class TestAPIManager
         this.setTimeFor(height);
         foreach (idx; clients_idxs)
             retryFor(clients[idx].getBlockHeight() == height, timeout,
-                format("Node %s has block height %s. Expected: %s",
-                    idx, clients[idx].getBlockHeight(), height),
+                format("Node %s (%s) has block height %s. Expected: %s",
+                    idx, this.nodes[idx].address, clients[idx].getBlockHeight(), height),
                 file, line);
     }
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -756,7 +756,7 @@ public class TestAPIManager
         static assert (isInputRange!Idxs);
 
         assert(height > enroll_header.height);
-        this.waitForPreimages(clients_idxs, enroll_header.enrollments, height, timeout);
+        this.waitForPreimages(clients_idxs, enroll_header.enrollments, height, timeout, file, line);
         this.expectHeight(clients_idxs, height, timeout, file, line);
     }
 
@@ -776,15 +776,15 @@ public class TestAPIManager
     ***************************************************************************/
 
     public void waitForPreimages (const(Enrollment)[] enrolls, Height height,
-        Duration timeout = 10.seconds)
+        Duration timeout = 10.seconds, string file = __FILE__, int line = __LINE__)
     {
-        this.waitForPreimages(iota(this.test_conf.node.test_validators), enrolls, height, timeout);
+        this.waitForPreimages(iota(this.test_conf.node.test_validators), enrolls, height, timeout, file, line);
     }
 
     /// Ditto
     public void waitForPreimages (Idxs)(Idxs clients_idxs,
         const(Enrollment)[] enrolls, Height height,
-        Duration timeout = 10.seconds)
+        Duration timeout = 10.seconds, string file = __FILE__, int line = __LINE__)
     {
         static assert (isInputRange!Idxs);
         import std.algorithm.searching : any;

--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -192,8 +192,7 @@ unittest
             .attach(utxo_pairs.map!(p => tuple(p.utxo.output, p.hash)))
             .deduct(1.coins).sign());
 
-        network.expectHeightAndPreImg(iota(1, GenesisValidators),
-            new_height, blocks[0].header);
+        network.expectHeightAndPreImg(iota(1, GenesisValidators), new_height);
 
         // add next block
         blocks ~= valid_nodes.front.getBlocksFrom(new_height, 1);

--- a/source/agora/test/MissingPreImageDetection.d
+++ b/source/agora/test/MissingPreImageDetection.d
@@ -126,7 +126,8 @@ unittest
     // block 1
     txs.each!(tx => nodes[0].postTransaction(tx));
     // Exclude first node from the check as it is not sending pre-image
-    network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(1), network.blocks[0].header);
+    network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(1),
+        network.blocks[0].header.enrollments.dropExactly(1));
 }
 
 /// Situation: There is a validator does not reveal a pre-image for next
@@ -175,5 +176,7 @@ unittest
 
     // try to make block 1
     txs.each!(tx => nodes[0].postTransaction(tx));
-    network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(1), network.blocks[0].header);
+    // Exclude first node from the check as it is not sending pre-image
+    network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(1),
+        network.blocks[0].header.enrollments.dropExactly(1));
 }

--- a/source/agora/test/Quorum.d
+++ b/source/agora/test/Quorum.d
@@ -84,5 +84,5 @@ unittest
 
     // all nodes should have same block height now
     network.expectHeightAndPreImg(iota(nodes.length), Height(GenesisValidatorCycle + 1),
-        nodes[0].getAllBlocks()[GenesisValidatorCycle].header);
+        nodes[0].getAllBlocks()[GenesisValidatorCycle].header.enrollments);
 }

--- a/source/agora/test/SlashingMisbehavingValidator.d
+++ b/source/agora/test/SlashingMisbehavingValidator.d
@@ -65,7 +65,8 @@ unittest
     assert(nodes[0].getPenaltyDeposit(utxos[0].hash) != 0.coins);
     // block 1
     // Node index is 5 for bad node so we do not expect pre-image from it
-    network.expectHeightAndPreImg(iota(0, 5), Height(1), network.blocks[0].header);
+    network.expectHeightAndPreImg(iota(0, 5), Height(1),
+        network.blocks[0].header.enrollments.takeExactly(5));
 
     assert(utxos.length == 1);
     auto block1 = nodes[0].getBlocksFrom(1, 1)[0];
@@ -79,7 +80,10 @@ unittest
     assert(utxos[0] == refund[0]);
     assert(nodes[0].getPenaltyDeposit(utxos[0].hash) == 0.coins);
 
-    network.generateBlocks(iota(0, 5), Height(conf.consensus.payout_period * 3), true);
+    // Only check for first 5 nodes as sixth is byzantine
+    iota(2, Height(conf.consensus.payout_period * 3)).each!(h =>
+        network.expectHeightAndPreImg(iota(0, 5), Height(h),
+            network.blocks[0].header.enrollments.takeExactly(5)));
 }
 
 /// Situation: All the validators do not reveal their pre-images for

--- a/source/agora/test/ValidatorCleanRestart.d
+++ b/source/agora/test/ValidatorCleanRestart.d
@@ -98,7 +98,7 @@ unittest
     network.sendTransaction(set_b.front);
     const enroll_block = set_b.front.getBlock(Height(20));
     network.expectHeightAndPreImg(iota(GenesisValidators, allValidators), Height(GenesisValidatorCycle + 1),
-        enroll_block.header);
+        enroll_block.header.enrollments);
 
     // assert that all set_b have same block at height 21
     network.assertSameBlocks(iota(GenesisValidators, allValidators), Height(GenesisValidatorCycle + 1));

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -59,3 +59,6 @@ validator:
   # If left empty, all public network addresses of the node will be registered
   addresses_to_register:
     - "agora://node-2:2735"
+  # Block interval is only 5 seconds so we need to check to nominate more often
+  nomination_interval:
+    msecs: 500

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -59,3 +59,6 @@ validator:
   # If left empty, all public network addresses of the node will be registered
   addresses_to_register:
     - "agora://node-3:3735"
+  # Block interval is only 5 seconds so we need to check to nominate more often
+  nomination_interval:
+    msecs: 500

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -59,3 +59,6 @@ validator:
   # If left empty, all public network addresses of the node will be registered
   addresses_to_register:
     - "agora://node-4:4735"
+  # Block interval is only 5 seconds so we need to check to nominate more often
+  nomination_interval:
+    msecs: 500

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -59,3 +59,6 @@ validator:
   # If left empty, all public network addresses of the node will be registered
   addresses_to_register:
     - "agora://node-5:5735"
+  # Block interval is only 5 seconds so we need to check to nominate more often
+  nomination_interval:
+    msecs: 500

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -59,3 +59,6 @@ validator:
   # If left empty, all public network addresses of the node will be registered
   addresses_to_register:
     - "agora://node-6:6735"
+  # Block interval is only 5 seconds so we need to check to nominate more often
+  nomination_interval:
+    msecs: 500

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -59,3 +59,6 @@ validator:
   # If left empty, all public network addresses of the node will be registered
   addresses_to_register:
     - "agora://node-7:7735"
+  # Block interval is only 5 seconds so we need to check to nominate more often
+  nomination_interval:
+    msecs: 500


### PR DESCRIPTION
Now that the pre-images are based on height we can reveal them into the next cycle and thus reduce the risk of being slashed when the next cycle starts.
