### PR TITLE
PeerRange: Fix calling popFront on empty range

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -1256,7 +1256,7 @@ public struct PeerRange
 
     public void popFront () nothrow @safe
     {
-        if (!this.checkIfInvalidated())
+        if (!this.empty())
             this.range.popFront();
     }
 


### PR DESCRIPTION
checkIfInvalidated() could cause range to be empty.