### PR TITLE
FullNode: Update ledger after accepting header

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -903,7 +903,7 @@ public class NetworkManager
 
     public void getMissingBlockSigs (Ledger ledger,
         scope ulong delegate(BlockHeader) @safe extra_sigs,
-        scope void delegate(BlockHeader) @safe acceptHeader) @safe nothrow
+        scope string delegate(BlockHeader) @safe acceptHeader) @safe nothrow
     {
         import std.algorithm;
         import std.conv;
@@ -949,8 +949,14 @@ public class NetworkManager
                             {
                                 try
                                 {
-                                    log.trace("getMissingBlockSigs: updating header signature: {} validators: {}", header.signature, header.validators);
-                                    acceptHeader(header);
+                                    if (auto res = acceptHeader(header))
+                                        log.dbg("getMissingBlockSigs: couldn't update header ({})", header.height);
+                                    else
+                                    {
+                                        log.trace("getMissingBlockSigs: updated header ({}) signature: {} validators: {}",
+                                            header.height, header.signature, header.validators);
+                                        missing_heights.remove(header.height);
+                                    }
                                 }
                                 catch (Exception e)
                                 {
@@ -958,7 +964,6 @@ public class NetworkManager
                                 }
                             }
                         }
-                        missing_heights = heightsMissingSigs();
                         if (missing_heights.empty)
                             break;
                     }

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -615,11 +615,24 @@ public class FullNode : API
         Params:
             header = the block header to distribute
 
+        Returns:
+            the error message if block validation failed, otherwise null
+
     ***************************************************************************/
 
-    protected void acceptHeader (BlockHeader header) @safe
+    protected string acceptHeader (BlockHeader header) @safe
     {
+        // First we must validate the header
+        if (auto err = this.ledger.validateBlockSignature(header))
+        {
+            log.trace("acceptHeader: Received header is not valid: {}", err);
+            return err;
+        }
+        // Add any missing signatures we know
+        this.ledger.updateBlockMultiSig(header);
         this.pushBlockHeader(header);
+
+        return null;
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -411,20 +411,19 @@ public class Validator : FullNode, API
         Params:
             block = block to be added to the Ledger
 
+        Returns:
+            the error message if block validation failed, otherwise null
+
     ***************************************************************************/
 
-    protected override void acceptHeader (BlockHeader header) @safe
+    protected override string acceptHeader (BlockHeader header) @safe
     {
-        // First we must validate the header
-        if (auto err = this.ledger.validateBlockSignature(header))
-        {
-            log.trace("acceptHeader: Recieved header is not valid: {}", err);
-            return;
-        }
+        if (auto err = super.acceptHeader(header))
+            return err;
+
         // Add any missing signatures we know
         this.nominator.updateMultiSignature(header);
-        this.ledger.updateBlockMultiSig(header);
-        super.acceptHeader(header);
+        return null;
     }
 
     /***************************************************************************

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -388,7 +388,8 @@ public class Validator : FullNode, API
         if (auto fail_msg = super.acceptBlock(block))
             return fail_msg;
 
-        acceptHeader(block.header.clone());
+        if (auto fail_msg = acceptHeader(block.header.clone()))
+            return fail_msg;
 
         // In the case where a validator is restarted and frozen utxo is not in Genesis
         if (this.identity.utxo == Hash.init)


### PR DESCRIPTION
Fixes #3164 and reduces GC operation in `doCatchUp`.

Following memory trace is from `v0.x.x` where `doCatchUp` always checks again for missing signatures between peers
![v0.x.x](https://user-images.githubusercontent.com/3192210/156723481-5c7a598f-6691-4c73-b9d4-1173ac6e7cb5.png)

Following memory trace is longer duration than the above one but GC impact is improved, accepted block headers are removed from AA between peers
![new](https://user-images.githubusercontent.com/3192210/156723848-98cb9679-a924-4b1c-8a6e-a200023f4e19.png)

