### PR TITLE
Fixes Issue 3519: Log at trace level `No signatures in memory at height X`

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -915,7 +915,7 @@ extern(D):
 
         if (header.height !in this.slot_sigs)
         {
-            log.warn("No signatures in memory at height {}", header.height);
+            log.trace("No signatures in memory at height {}", header.height);
             return;
         }
         log.dbg("{}: Before updating block signature for block {}, mask: {}",


### PR DESCRIPTION
This can happen if catching up when previously not enrolled.