### PR TITLE
Add check if shutting down before timer rearm

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -481,7 +481,7 @@ public class FullNode : API
         this.startTaskTimer(TimersIdx.BlockCatchup, this.config.node.block_catchup_interval);
     }
 
-    private void startTaskTimer (in TimersIdx timer_id, in Duration interval) @trusted nothrow
+    protected void startTaskTimer (in TimersIdx timer_id, in Duration interval) @trusted nothrow
     {
         log.dbg("{}: re-arm timer index {}", __FUNCTION__, timer_id);
         if (!this.is_shutting_down)

--- a/source/agora/node/Validator.d
+++ b/source/agora/node/Validator.d
@@ -275,7 +275,8 @@ public class Validator : FullNode, API
     protected override void discoveryTask ()
     {
         this.network.discover(this.required_peer_utxos);
-        this.timers[TimersIdx.Discovery].rearm(this.config.node.network_discovery_interval, false);
+        this.startTaskTimer(FullNode.TimersIdx.Discovery,
+            this.config.node.network_discovery_interval);
     }
 
     ///


### PR DESCRIPTION
The `Validator.discoveryTask` has been seen to cause `range violation`
in a test where the node is restarted. A check for if the node is
shutting down should prevent this.