### PR TITLE
Increase txs sent from Faucet in ci test

### DIFF
--- a/tests/system/node/faucet/config.yaml
+++ b/tests/system/node/faucet/config.yaml
@@ -3,10 +3,10 @@
 ################################################################################
 tx_generator:
   # How frequently we run our periodic task in seconds
-  send_interval: 4
+  send_interval: 2
 
   # Between how many addresses we split a transaction by
-  split_count: 4
+  split_count: 8
 
   # Maximum number of utxo before merging instead of splitting
   merge_threshold: 50


### PR DESCRIPTION
Sometimes we get more than 4 empty blocks which fails the test.