### PR TITLE
Make TimePoint a struct instead of an alias

### DIFF
--- a/source/agora/common/BanManager.d
+++ b/source/agora/common/BanManager.d
@@ -254,7 +254,7 @@ public class BanManager
 
     public void banFor (Address address, Duration duration) @safe nothrow
     {
-        const ban_until = this.getCurTime() + duration.total!"seconds";
+        const ban_until = this.getCurTime() + duration;
         this.banUntil(address, ban_until);
     }
 
@@ -490,7 +490,7 @@ unittest
     assert(!banman.isBanned(node1));
 
     // banUntil
-    banman.banUntil(node1, 86500);
+    banman.banUntil(node1, TimePoint(86500));
     banman.time = 86499;
     assert(banman.isBanned(node1));
     banman.time = 86500;

--- a/source/agora/consensus/data/Params.d
+++ b/source/agora/consensus/data/Params.d
@@ -123,7 +123,8 @@ public struct ConsensusConfig
         Defaults to 2021-01-01:00:00:00 GMT.
 
     ***************************************************************************/
-    public TimePoint genesis_timestamp = 1609_459_200;
+
+    public TimePoint genesis_timestamp = TimePoint(1609_459_200);
 
     /// The cycle length for a validator
     public uint validator_cycle = 1008;

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -495,7 +495,7 @@ extern(D):
     protected TimePoint getExpectedBlockTime () @safe @nogc nothrow pure
     {
         return this.params.GenesisTimestamp +
-            (ledger.height() + 1) * this.params.BlockInterval.total!"seconds";
+            (ledger.height() + 1) * this.params.BlockInterval;
     }
 
     /***************************************************************************

--- a/source/agora/consensus/state/Ledger.d
+++ b/source/agora/consensus/state/Ledger.d
@@ -1055,9 +1055,8 @@ public class Ledger
     {
         if (utcTime <= this.params.GenesisTimestamp)
             return Height.init;
-        size_t offset = utcTime - this.params.GenesisTimestamp;
-        // TimePoint is a `ulong` consisting of a number of seconds
-        return Height(offset / this.params.BlockInterval.total!"seconds");
+        const offset = utcTime - this.params.GenesisTimestamp;
+        return Height(offset / this.params.BlockInterval);
     }
 }
 
@@ -1179,17 +1178,19 @@ unittest
 // Unittests for `Ledger.expectedHeight`
 unittest
 {
+    import core.time;
+
     scope ledger = new Ledger();
-    assert(ledger.expectedHeight(0) == Height(0));
+    assert(ledger.expectedHeight(TimePoint.init) == Height(0));
 
     const GTS = ledger.params.GenesisTimestamp;
-    const BIS = ledger.params.BlockInterval.total!"seconds";
-    assert(BIS >= 2);
+    const BIS = ledger.params.BlockInterval;
+    assert(BIS >= 2.seconds);
 
     assert(ledger.expectedHeight(GTS) == Height(0));
-    assert(ledger.expectedHeight(GTS + BIS - 1) == Height(0));
-    assert(ledger.expectedHeight(GTS + BIS    ) == Height(1));
-    assert(ledger.expectedHeight(GTS + BIS + 1) == Height(1));
+    assert(ledger.expectedHeight(GTS + BIS - 1.seconds) == Height(0));
+    assert(ledger.expectedHeight(GTS + BIS            ) == Height(1));
+    assert(ledger.expectedHeight(GTS + BIS + 1.seconds) == Height(1));
 
     assert(ledger.expectedHeight(GTS + (BIS * 200)) == Height(200));
 }

--- a/source/agora/network/Clock.d
+++ b/source/agora/network/Clock.d
@@ -98,7 +98,7 @@ public class Clock
 
     public TimePoint networkTime () @safe nothrow
     {
-        return this.utcTime() + this.net_time_offset.total!"seconds";
+        return this.utcTime() + this.net_time_offset;
     }
 
     /***************************************************************************

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -482,9 +482,9 @@ public class NetworkManager
             if (node_time == 0)
                 continue;  // request failed
 
-            const req_delay = (this.clock.utcTime() - req_start).seconds;
+            const req_delay = (this.clock.utcTime() - req_start);
             const dist_delay = req_delay / 2;  // divide evently
-            const offset = (node_time - req_start).seconds - dist_delay;
+            const offset = (node_time - req_start) - dist_delay;
             offsets ~= TimeInfo(node.identity.key, node_time, req_delay, offset);
         }
 

--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -461,7 +461,7 @@ public class NetworkManager
         {
             PublicKey key;
             TimePoint node_time;
-            long req_delay;
+            Duration req_delay;
             Duration offset;
         }
 
@@ -482,10 +482,10 @@ public class NetworkManager
             if (node_time == 0)
                 continue;  // request failed
 
-            const req_delay = this.clock.utcTime() - req_start;
+            const req_delay = (this.clock.utcTime() - req_start).seconds;
             const dist_delay = req_delay / 2;  // divide evently
-            const offset = (node_time - dist_delay) - req_start;
-            offsets ~= TimeInfo(node.identity.key, node_time, req_delay, offset.seconds);
+            const offset = (node_time - req_start).seconds - dist_delay;
+            offsets ~= TimeInfo(node.identity.key, node_time, req_delay, offset);
         }
 
         // we heard from at least one quorum slice

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -710,7 +710,7 @@ network:
     assert(config.consensus.tx_payload_fee_factor == 2100);
     assert(config.consensus.validator_tx_fee_cut == 69);
     assert(config.consensus.payout_period == 9999);
-    assert(config.consensus.genesis_timestamp == 424242);
+    assert(config.consensus.genesis_timestamp == TimePoint.fromString("424242"));
 }
 
 unittest

--- a/source/agora/node/TransactionRelayer.d
+++ b/source/agora/node/TransactionRelayer.d
@@ -265,7 +265,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
             return TransactionRelayError.TxFeeTooLow;
 
         this.txs.insert(TxHolder(rate, tx_hash,
-            this.clock.networkTime() + this.config.node.relay_tx_cache_exp.total!"seconds"));
+            this.clock.networkTime() + this.config.node.relay_tx_cache_exp));
         this.tx_hashes.put(tx_hash);
 
         return null;
@@ -378,7 +378,8 @@ public class TransactionRelayerFeeImp : TransactionRelayer
             return fee_man.getTxFeeRate(tx, &utxo_set.peekUTXO, getPenaltyDeposit, rate);
         };
 
-        this(new TransactionPool(cacheDB), config, toDelegate(noclients), null, new MockClock(0), wrapper, false);
+        this(new TransactionPool(cacheDB), config, toDelegate(noclients), null,
+             new MockClock(TimePoint.init), wrapper, false);
     }
 
     /***************************************************************************
@@ -470,7 +471,7 @@ public class TransactionRelayerFeeImp : TransactionRelayer
         assert(transaction_relayer.txs.length == 2);
 
         // clean up the relay queue after changing the clock
-        (cast(MockClock) transaction_relayer.clock).setTime(TimePoint.max - 1);
+        (cast(MockClock) transaction_relayer.clock).setTime(TimePoint.init + Duration.max);
         transaction_relayer.cleanRelayQueue();
         assert(transaction_relayer.tx_hashes.length == 0);
         assert(transaction_relayer.txs.length == 0);

--- a/source/agora/node/admin/AdminInterface.d
+++ b/source/agora/node/admin/AdminInterface.d
@@ -145,7 +145,7 @@ public class AdminInterface : NodeControlAPI
         KeyPair temp_kp = KeyPair.random();
 
         // A 'nonce' used to allow expiring (default: +90 days)
-        TimePoint expires = this.clock.utcTime() + (60 * 60 * 24 * 90);
+        TimePoint expires = this.clock.utcTime() + 90.days;
         LoginInfo login_info = LoginInfo(
             temp_kp.secret.toString(PrintMode.Clear),
             VoterCard(

--- a/source/agora/node/admin/AdminInterface.d
+++ b/source/agora/node/admin/AdminInterface.d
@@ -144,17 +144,14 @@ public class AdminInterface : NodeControlAPI
         // The randomly generated temporary KeyPair
         KeyPair temp_kp = KeyPair.random();
 
-        TimePoint current_time = this.clock.networkTime();
-        // A 'nonce' used to allow expiring
-        current_time += 60 * 60 * 24 * 90; // (default: +90 days)
-        SysTime expires_time = SysTime(unixTimeToStdTime(current_time), UTC());
-
+        // A 'nonce' used to allow expiring (default: +90 days)
+        TimePoint expires = this.clock.utcTime() + (60 * 60 * 24 * 90);
         LoginInfo login_info = LoginInfo(
             temp_kp.secret.toString(PrintMode.Clear),
             VoterCard(
                 this.key_pair.address,
                 temp_kp.address,
-                expires_time.toISOExtString()
+                SysTime(unixTimeToStdTime(expires), UTC()).toISOExtString(),
             )
         );
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -824,7 +824,7 @@ public class TestAPIManager
         static assert (isInputRange!Pairs);
 
         const exp_time = this.test_start_time +
-            this.test_conf.consensus.block_interval.total!"seconds" * height;
+            this.test_conf.consensus.block_interval * height;
         // We also need to set the registry time, because otherwise their Ledger
         // will reject new blocks as they exceed tolerance.
         // Note that this relies on the time moving forward only.

--- a/source/agora/test/TimeBlockInterval.d
+++ b/source/agora/test/TimeBlockInterval.d
@@ -38,5 +38,5 @@ unittest
             en.value.each!(tx => node_1.postTransaction(tx));
             network.expectHeightAndPreImg(Height(en.index + 1));
         });
-    assert(node_1.getNetworkTime() >= startTime + (4 * conf.consensus.block_interval.total!"seconds"));
+    assert(node_1.getNetworkTime() >= startTime + (4 * conf.consensus.block_interval));
 }

--- a/source/agora/test/TimeDrift.d
+++ b/source/agora/test/TimeDrift.d
@@ -39,8 +39,9 @@ unittest
     // Check the node local time
     void checkNodeLocalTime (ulong idx, ulong expected_height)
     {
-        retryFor(nodes[idx].getLocalTime() == expected_height +
-            network.test_start_time, 5.seconds,
+        retryFor(
+            nodes[idx].getLocalTime() == network.test_start_time + expected_height.seconds,
+            5.seconds,
             format!"Expected node #%s would have time of height %s not %s"
                 (idx, expected_height,
                     nodes[idx].getLocalTime() - network.test_start_time));
@@ -49,8 +50,9 @@ unittest
     // Check the node network time
     void checkNodeNetworkTime (ulong idx, ulong expected_height)
     {
-        retryFor(nodes[idx].getNetworkTime() == expected_height +
-            network.test_start_time, 5.seconds,
+        retryFor(
+            nodes[idx].getNetworkTime() == network.test_start_time + expected_height.seconds,
+            5.seconds,
             format!"Expected node #%s would have time of height %s not %s"
                 (idx, expected_height, nodes[idx].getNetworkTime() -
                     network.test_start_time));


### PR DESCRIPTION
Had this diff locally since forever. Ideally we'll make it contain a `DateTime` as well but there are a few obstacles to that.