### PR TITLE
Coinbase: reset cache if signature is added

### DIFF
--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -706,8 +706,7 @@ public class ValidatingLedger : NodeLedger
         data.enrolls = this.getCandidateEnrollments(next_height, utxo_finder);
         data.missing_validators = this.getCandidateMissingValidators(next_height, utxo_finder);
         data.tx_set = this.getCandidateTransactions(next_height, utxo_finder);
-        if (next_height >= 2 * this.params.PayoutPeriod
-            && next_height % this.params.PayoutPeriod == 0)   // This is a Coinbase payout block
+        if (this.isCoinbaseBlock(next_height))
             {
                 auto coinbase_tx = this.getCoinbaseTX(next_height);
                 auto coinbase_hash = coinbase_tx.hashFull();

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1201,6 +1201,7 @@ extern(D):
             {
                 log.error("validateValue(): Validation failed: {}. Will check for missing signatures", fail_reason);
                 this.armTaskTimer(TimersIdx.Catchup, CatchupTaskDelay);
+                return ValidationLevel.kMaybeValidValue;
             }
             else
             {

--- a/source/agora/consensus/state/Ledger.d
+++ b/source/agora/consensus/state/Ledger.d
@@ -475,8 +475,7 @@ public class Ledger
         }
 
         // if this was a block with fees payout
-        if (block.header.height >= 2 * this.params.PayoutPeriod
-            && block.header.height % this.params.PayoutPeriod == 0)
+        if (this.isCoinbaseBlock(block.header.height))
         {
             // Clear out paid fees
             this.fee_man.clearBlockFeesBefore(Height(block.header.height - this.params.PayoutPeriod));
@@ -614,8 +613,7 @@ public class Ledger
 
     protected Transaction getCoinbaseTX (in Height height) nothrow @safe
     {
-        if (height < 2 * this.params.PayoutPeriod
-            || height % this.params.PayoutPeriod != 0)   // not a Coinbase payout block
+        if (!this.isCoinbaseBlock(height))
             return Transaction.init;
 
         if (cached_coinbase.height == height)
@@ -795,8 +793,7 @@ public class Ledger
         auto incoming_cb_txs = block.txs.filter!(tx => tx.isCoinbase);
         const cbTxCount = incoming_cb_txs.count;
         // If it is a payout block then a single Coinbase transaction is included
-        if (block.header.height >= 2 * this.params.PayoutPeriod
-            && block.header.height % this.params.PayoutPeriod == 0)
+        if (this.isCoinbaseBlock(block.header.height))
         {
             if (cbTxCount == 0)
                 return "Missing expected Coinbase transaction in payout block";


### PR DESCRIPTION
It can happen that the nodes do not all have the same signatures in the
blocks for the payout period. In the case where a signature is added to
the block header of a block within the payout period we should reset the
cached version of the Coinbase so that it can be re-calculated later.