### PR TITLE
Increase SCP slot timeout

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1543,7 +1543,7 @@ extern(D):
 
     ***************************************************************************/
 
-    protected override milliseconds computeTimeout(uint32_t roundNumber)
+    protected override milliseconds computeTimeout (uint32_t roundNumber)
     {
         auto base = min(this.nomination_interval, 5.seconds);
         // double the timeout every 8 validators

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1546,8 +1546,8 @@ extern(D):
     protected override milliseconds computeTimeout(uint32_t roundNumber)
     {
         auto base = min(this.nomination_interval, 1.seconds);
-        // double the timeout every 16 validators
-        auto val_multipler = 1 + this.ledger.validatorCount(this.ledger.height()) / 16;
+        // double the timeout every 8 validators
+        auto val_multipler = 1 + this.ledger.validatorCount(this.ledger.height()) / 8;
         this.round_timeout = base * val_multipler * roundNumber;
         const timeout = milliseconds(round_timeout.total!"msecs".to!long);
         log.dbg("{}: roundNumber {} timeout = {} msecs", __FUNCTION__, roundNumber, timeout);

--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1545,7 +1545,7 @@ extern(D):
 
     protected override milliseconds computeTimeout(uint32_t roundNumber)
     {
-        auto base = min(this.nomination_interval, 1.seconds);
+        auto base = min(this.nomination_interval, 5.seconds);
         // double the timeout every 8 validators
         auto val_multipler = 1 + this.ledger.validatorCount(this.ledger.height()) / 8;
         this.round_timeout = base * val_multipler * roundNumber;


### PR DESCRIPTION
Our timeouts were a bit agressive for a globally distributed arbitrarily large network. Let's see if this will help decrease our externalization time for the current state of the production.