### PR TITLE
UnlockAge test: use 2 test validators

### DIFF
--- a/source/agora/test/UnlockAge.d
+++ b/source/agora/test/UnlockAge.d
@@ -22,6 +22,7 @@ unittest
 {
     import std.conv;
     TestConf conf = TestConf.init;
+    conf.node.test_validators = 2;
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();


### PR DESCRIPTION
No need to test with more than two as we are verifying the transaction
input unlock not consensus. It could even be just one but that would
require a bit more test refactorring as currently it fails to set up
test network in unit tests if only a single validator is used.