### PR TITLE
Delay forcing catchup till end of block time

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -607,9 +607,9 @@ extern(D):
         {
             log.info("{}(): Tx set didn't trigger new nomination", __FUNCTION__);
             const Height expected = this.ledger.expectedHeight(this.clock.utcTime());
-            if (expected > this.ledger.height)
+            if (expected > this.ledger.height + 1) // We are one block late
             {
-                log.info("{}(): Behind expected height - Resending latest envelopes"
+                log.info("{}(): Full block span behind expected height - Resending latest envelopes"
                     , __FUNCTION__);
                 foreach (const ref env; this.scp.getLatestMessagesSend(slot_idx))
                     this.emitEnvelope(env);

--- a/tests/system/node/faucet/config.yaml
+++ b/tests/system/node/faucet/config.yaml
@@ -3,13 +3,13 @@
 ################################################################################
 tx_generator:
   # How frequently we run our periodic task in seconds
-  send_interval: 2
+  send_interval: 4
 
   # Between how many addresses we split a transaction by
   split_count: 8
 
   # Maximum number of utxo before merging instead of splitting
-  merge_threshold: 50
+  merge_threshold: 100
 
   # Addresses to send transactions
   addresses:


### PR DESCRIPTION
To help prevent the blockchain flat lining a check was added to
`nominate` function to resend latest envelopes and kick off catchup task
after 10 msecs. This is better left till the time has been reached for
the next block start rather than the current. Otherwise catchup will
keep the node busy whilst others are nominating.