### PR TITLE
`InvalidBlockSigByzantine` test: add `assertSameSignatures`

### DIFF
--- a/source/agora/test/InvalidBlockSigByzantine.d
+++ b/source/agora/test/InvalidBlockSigByzantine.d
@@ -129,6 +129,7 @@ unittest
     network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(1));
     // Make sure the client we will check is in sync with others (except for byzantine)
     network.assertSameBlocks(iota(1, GenesisValidators), Height(1));
+    network.assertSameSignatures(iota(1, GenesisValidators), Height(1));
     nodes.drop(1).each!(node => assertValidatorsBitmask(node.getAllBlocks()[1]));
 }
 
@@ -153,6 +154,7 @@ unittest
     network.expectHeightAndPreImg(iota(1, GenesisValidators), Height(1));
     // Make sure the client we will check is in sync with others (except for byzantine)
     network.assertSameBlocks(iota(1, GenesisValidators), Height(1));
+    network.assertSameSignatures(iota(1, GenesisValidators), Height(1));
     nodes.drop(1).each!(node => assertValidatorsBitmask(node.getAllBlocks()[1]));
 }
 


### PR DESCRIPTION
This test checks the expected validator signatures are in the header of
each valid node. The test was sometimes failing because the nodes had
not all completed updating signatures from each other.