### PR TITLE
Fix Integration test for mac os

### DIFF
--- a/ci/system_integration_test.d
+++ b/ci/system_integration_test.d
@@ -52,7 +52,7 @@ immutable Cleanup = [ "rm", "-rf", IntegrationPath.buildPath("node/0/.cache/"),
                       IntegrationPath.buildPath("node/6/.cache/"),
                       IntegrationPath.buildPath("node/7/.cache/"),
 ];
-auto SetGenesisTimestamp = ["sed", "-i",
+auto SetGenesisTimestamp = ["sed", "-i''",
     "s/genesis_timestamp: [0-9]\\+/genesis_timestamp: curr_time/g",
     IntegrationPath.buildPath("node/0/config.yaml"),
     IntegrationPath.buildPath("node/2/config.yaml"),

--- a/tests/system/node/faucet/config.yaml
+++ b/tests/system/node/faucet/config.yaml
@@ -3,13 +3,13 @@
 ################################################################################
 tx_generator:
   # How frequently we run our periodic task in seconds
-  send_interval: 2
+  send_interval: 4
 
   # Between how many addresses we split a transaction by
   split_count: 8
 
   # Maximum number of utxo before merging instead of splitting
-  merge_threshold: 50
+  merge_threshold: 100
 
   # Addresses to send transactions
   addresses:


### PR DESCRIPTION
`sed` command required updating as if run locally on a Mac the following error was preventing it running:-
```
sed: 1: "/Users/chrishewison/COD ...": command c expects \ followed by text
object.Exception@ci/system_integration_test.d(135): Command failed: ["sed", "-i", "s/genesis_timestamp: [0-9]\\+/genesis_timestamp: 1647398943/g", "/Users/chrishewison/CODE/agora/tests/system/node/0/config.yaml", "/Users/chrishewison/CODE/agora/tests/system/node/2/config.yaml", "/Users/chrishewison/CODE/agora/tests/system/node/3/config.yaml", "/Users/chrishewison/CODE/agora/tests/system/node/4/config.yaml", "/Users/chrishewison/CODE/agora/tests/system/node/5/config.yaml", "/Users/chrishewison/CODE/agora/tests/system/node/6/config.yaml", "/Users/chrishewison/CODE/agora/tests/system/node/7/config.yaml", "/Users/chrishewison/CODE/agora/tests/system/node/faucet/config.yaml"]
```