### PR TITLE
Internalize Prometheus dependencies

### DIFF
--- a/source/agora/node/admin/AdminInterface.d
+++ b/source/agora/node/admin/AdminInterface.d
@@ -32,8 +32,6 @@ import vibe.data.json;
 import vibe.http.router;
 import vibe.http.server;
 
-import Ocean = ocean.util.log.Logger;
-
 import barcode;
 
 import std.datetime : SysTime, unixTimeToStdTime, UTC;

--- a/source/agora/script/Signature.d
+++ b/source/agora/script/Signature.d
@@ -306,7 +306,6 @@ unittest
     import agora.crypto.Key;
     import agora.common.Amount;
     import agora.utils.Test;
-    import ocean.core.Test;
 
     // SigHash.All
     {

--- a/source/agora/stats/Collector.d
+++ b/source/agora/stats/Collector.d
@@ -1,0 +1,295 @@
+/*******************************************************************************
+
+    Contains methods that collect stats from primitive data members of structs
+    or classes to respond to Prometheus queries with.
+
+    The metric designs specified by Prometheus
+    (`https://prometheus.io/docs/concepts/metric_types/`) have not been
+    implemented yet. So, as of now, this collector can process only primitive
+    data-type members from a struct or a class. However, the current Prometheus
+    stat collection framework could be enhanced to support metrics with a very
+    little effort.
+
+    In Prometheus' data model, the stats that are measured are called Metrics,
+    and the dimensions along which stats are measured are called Labels.
+
+    Metrics can be any measurable value, e.g., CPU or memory consumption.
+
+    Labels resemble key-value pairs, where the key is referred to as a label's
+    name, and the value as a label's value. A label name would refer to the name
+    of a dimension across which we want to measure stats. Correspondingly, a
+    label value would refer to a point along the said dimension. A stat can have
+    more than one label, if it is intended to be measured across multiple
+    dimensions.
+
+    Stats with labels look like the following example
+    `
+    promhttp_metric_handler_requests_total{code="200"} 3
+    promhttp_metric_handler_requests_total{code="500"} 0
+    promhttp_metric_handler_requests_total{code="503"} 0
+    `
+    Here `promhttp_metric_handler_requests_total` is the metric, `code` is
+    the label name, `"200"`, `"500"` and `"503"` are the label values, and `3`,
+    `0` and `0` are the respective metric values.
+
+    On the data visualization side of Prometheus, fetching stats using queries
+    is analogous to calling functions. A metric name is analogous to a function
+    name, and a label is analogous to a function parameter. Continuing with the
+    above example, the following query will return `3`:
+    `
+    promhttp_metric_handler_requests_total {code="200"}
+    `
+
+    (For detailed information about Prometheus-specific terminology, e.g.,
+    Metrics and Labels, please refer to
+    `https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels`.)
+
+    This module contains a class which can be used to collect metrics as well as
+    labels from composite-type values, and format them in a way acceptable for
+    Prometheus.
+
+    Copyright:
+        Copyright (c) 2019 dunnhumby Germany GmbH.
+        All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module agora.stats.Collector;
+
+import ocean.util.prometheus.collector.StatFormatter;
+
+/*******************************************************************************
+
+    This class provides methods to collect metrics with no label, one label, or
+    multiple labels, using overloaded definitions of the `collect` method.
+
+    Once the desired stats have been collected, the accumulated response
+    string can be collected using the `getCollection` method.
+
+    Additionally, the `reset` method can be used to reset stat
+    collection, when the desired stats have been collected from a Collector
+    instance.
+
+*******************************************************************************/
+
+public class Collector
+{
+    /// A buffer used for storing collected stats. Is cleared when the `reset`
+    /// method is called.
+    private char[] collect_buf;
+
+    /***************************************************************************
+
+        Returns:
+            The stats collected since the last call to the `reset` method, in a
+            textual respresentation that can be readily added to a response
+            message body.
+            The specifications of the format of the collected stats can be found
+            at `https://prometheus.io/docs/instrumenting/exposition_formats/`.
+
+    ***************************************************************************/
+
+    public const(char)[] getCollection ( )
+    {
+        return this.collect_buf;
+    }
+
+    /// Reset the length of the stat collection buffer to 0.
+    public void reset ( )
+    {
+        this.collect_buf.length = 0;
+        assumeSafeAppend(this.collect_buf);
+    }
+
+    /***************************************************************************
+
+        Collect stats from the data members of a struct or a class and prepare
+        them to be fetched upon the next call to `getCollection`. The
+        specifications of the format of the collected stats can be found at
+        `https://prometheus.io/docs/instrumenting/exposition_formats/`.
+
+        Params:
+            ValuesT = The struct or class type to fetch the stat names from.
+            values  = The struct or class to fetch stat values from.
+
+    ***************************************************************************/
+
+    public void collect ( ValuesT ) ( ValuesT values )
+    {
+        static assert (is(ValuesT == struct) || is(ValuesT == class),
+            "'values' parameter must be a struct or a class.");
+
+        formatStats(values, this.collect_buf);
+    }
+
+    /***************************************************************************
+
+        Collect stats from the data members of a struct or a class, annotate
+        them with a given label name and value, and prepare them to be fetched
+        upon the next call to `getCollection`.
+        The specifications of the format of the collected stats can be found
+        at `https://prometheus.io/docs/instrumenting/exposition_formats/`.
+
+        Params:
+            LabelName = The name of the label to annotate the stats with.
+            ValuesT   = The struct or class type to fetch the stat names from.
+            LabelT    = The type of the label's value.
+            values    = The struct or class to fetch stat values from.
+            label_val = The label value to annotate the stats with.
+
+    ***************************************************************************/
+
+    public void collect ( string LabelName, ValuesT, LabelT ) (
+        ValuesT values, LabelT label_val )
+    {
+        static assert (is(ValuesT == struct) || is(ValuesT == class),
+            "'values' parameter must be a struct or a class.");
+
+        formatStats!(LabelName)(values, label_val, this.collect_buf);
+    }
+
+    /***************************************************************************
+
+        Collect stats from the data members of a struct or a class, annotate
+        them with labels from the data members of another struct or class, and
+        prepare them to be fetched upon the next call to `getCollection`.
+        The specifications of the format of the collected stats can be found
+        at `https://prometheus.io/docs/instrumenting/exposition_formats/`.
+
+        Params:
+            ValuesT = The struct or class type to fetch the stat names from.
+            LabelsT = The struct or class type to fetch the label names from.
+            values  = The struct or class to fetch stat values from.
+            labels  = The struct or class holding the label values to annotate
+                      the stats with.
+
+    ***************************************************************************/
+
+    public void collect ( ValuesT, LabelsT ) ( ValuesT values, LabelsT labels )
+    {
+        static assert (is(ValuesT == struct) || is(ValuesT == class),
+            "'values' parameter must be a struct or a class.");
+        static assert (is(LabelsT == struct) || is(LabelsT == class),
+            "'labels' parameter must be a struct or a class.");
+
+        formatStats(values, labels, this.collect_buf);
+    }
+}
+
+/// Test collecting populated stats, but without any label.
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect(Statistics(3600, 347, 3.14, 6.023, 0.43));
+
+    assert(test_collector.getCollection() ==
+        "up_time_s 3600\ncount 347\nratio 3.14\nfraction 6.023\n" ~
+        "very_real 0.43\n");
+}
+
+/// Test collecting populated stats with one label
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect!("id")(
+        Statistics(3600, 347, 3.14, 6.023, 0.43), 123.034);
+
+    assert(test_collector.getCollection() ==
+        "up_time_s {id=\"123.034\"} 3600\ncount {id=\"123.034\"} 347\n" ~
+        "ratio {id=\"123.034\"} 3.14\nfraction {id=\"123.034\"} 6.023\n" ~
+        "very_real {id=\"123.034\"} 0.43\n");
+}
+
+/// Test collecting stats having initial values with multiple labels
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect(Statistics(3600, 347, 3.14, 6.023, 0.43),
+        Labels(1_235_813, "ocean", 3.14159));
+
+    assert(test_collector.getCollection() ==
+        "up_time_s {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3600\n" ~
+        "count {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 347\n" ~
+        "ratio {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3.14\n" ~
+        "fraction {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 6.023\n" ~
+        "very_real {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 0.43\n");
+}
+
+/// Test resetting collected stats
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect!("id")(Statistics.init, 123);
+
+    assert(test_collector.getCollection() ==
+        "up_time_s {id=\"123\"} 0\ncount {id=\"123\"} 0\n" ~
+        "ratio {id=\"123\"} 0\nfraction {id=\"123\"} 0\n" ~
+        "very_real {id=\"123\"} 0\n");
+
+    test_collector.reset();
+
+    assert(test_collector.getCollection() == "");
+}
+
+// Test collecting stats having initial values, but without any label.
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect(Statistics.init);
+
+    assert(test_collector.getCollection() ==
+        "up_time_s 0\ncount 0\nratio 0\nfraction 0\nvery_real 0\n");
+}
+
+// Test collecting stats having initial values with one label
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect!("id")(Statistics.init, 123);
+
+    assert(test_collector.getCollection() ==
+        "up_time_s {id=\"123\"} 0\ncount {id=\"123\"} 0\n" ~
+        "ratio {id=\"123\"} 0\nfraction {id=\"123\"} 0\n" ~
+        "very_real {id=\"123\"} 0\n");
+}
+
+// Test collecting stats having initial values with multiple labels
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect(Statistics.init, Labels.init);
+
+    assert(test_collector.getCollection() ==
+        "up_time_s {id=\"0\",job=\"\",perf=\"0\"} 0\n" ~
+        "count {id=\"0\",job=\"\",perf=\"0\"} 0\n" ~
+        "ratio {id=\"0\",job=\"\",perf=\"0\"} 0\n" ~
+        "fraction {id=\"0\",job=\"\",perf=\"0\"} 0\n" ~
+        "very_real {id=\"0\",job=\"\",perf=\"0\"} 0\n");
+}
+
+// Test accumulation of collected stats
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect!("id")(Statistics.init, 123);
+
+    assert(test_collector.getCollection() ==
+        "up_time_s {id=\"123\"} 0\ncount {id=\"123\"} 0\n" ~
+        "ratio {id=\"123\"} 0\nfraction {id=\"123\"} 0\n" ~
+        "very_real {id=\"123\"} 0\n");
+
+    test_collector.collect!("id")(
+        Statistics(3600, 347, 3.14, 6.023, 0.43), 123.034);
+
+    assert(test_collector.getCollection() ==
+        "up_time_s {id=\"123\"} 0\ncount {id=\"123\"} 0\n" ~
+        "ratio {id=\"123\"} 0\nfraction {id=\"123\"} 0\n" ~
+        "very_real {id=\"123\"} 0\n" ~
+
+        "up_time_s {id=\"123.034\"} 3600\ncount {id=\"123.034\"} 347\n" ~
+        "ratio {id=\"123.034\"} 3.14\nfraction {id=\"123.034\"} 6.023\n" ~
+        "very_real {id=\"123.034\"} 0.43\n");
+}

--- a/source/agora/stats/CollectorRegistry.d
+++ b/source/agora/stats/CollectorRegistry.d
@@ -1,0 +1,193 @@
+/*******************************************************************************
+
+    Contains a collection of prometheus stat collectors that acts as an
+    interface between the response handler, and stat collectors from every
+    individual metric and label set.
+
+    Copyright:
+        Copyright (c) 2019 dunnhumby Germany GmbH.
+        All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module agora.stats.CollectorRegistry;
+
+import agora.stats.Collector : Collector;
+
+/// ditto
+public class CollectorRegistry
+{
+    /// An alias for the type of delegates that are called for stat collection
+    public alias void delegate ( Collector ) CollectionDg;
+
+    /// An array of delegates that are called for stat collection
+    private CollectionDg[] collector_callbacks;
+
+    /// The collector to use for stat collection. This acts as the actual
+    /// parameter for the delegates in `collector_callbacks`.
+    private Collector collector;
+
+    /***************************************************************************
+
+        Constructor, that accepts an array of stat collection callbacks.
+
+        Params:
+            callbacks = An array of delegates to be called for stat collection.
+
+    ***************************************************************************/
+
+    public this ( scope CollectionDg[] callbacks )
+    {
+        this.collector = new Collector();
+        this.collector_callbacks = callbacks;
+    }
+
+    /***************************************************************************
+
+        Appends a stat collector callback to the list of existing ones.
+        May result in a re-allocation of the entire buffer storing the
+        callbacks.
+
+        Params:
+            collector = The stat collector to append.
+
+    ***************************************************************************/
+
+    public void addCollector ( scope CollectionDg collector )
+    {
+        this.collector_callbacks ~= collector;
+    }
+
+    /***************************************************************************
+
+        Collects stats by calling all delegates specified for stat collection,
+        formats them using `ocean.util.prometheus.collector.StatFormatter`
+        eventually, and finally returns the accumulated result. The
+        specifications of the format can be found at
+        `https://prometheus.io/docs/instrumenting/exposition_formats/`.
+
+        Returns:
+            The stats accumulated since last time this method was called.
+
+    ***************************************************************************/
+
+    public const(char)[] collect ( )
+    {
+        this.collector.reset();
+
+        try
+        {
+            foreach (ref callback; this.collector_callbacks)
+            {
+                callback(this.collector);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw ex;
+        }
+
+        return this.collector.getCollection();
+    }
+}
+
+version (unittest)
+{
+    import agora.stats.Collector;
+
+    import agora.stats.StatFormatter : Labels, Statistics;
+
+    private class ExampleStats
+    {
+        Statistics test_stats;
+        Labels test_labels;
+
+        ///
+        public void setTestStats ( Statistics stats )
+        {
+            test_stats = stats;
+        }
+
+        ///
+        public void setTestLabels ( Labels labels )
+        {
+            test_labels = labels;
+        }
+
+        ///
+        public void collectDg1 ( Collector collector )
+        {
+            collector.collect!("id")(test_stats, 123.034);
+        }
+
+        ///
+        public void collectDg2 ( Collector collector )
+        {
+            collector.collect(test_stats, test_labels);
+        }
+    }
+}
+
+/// Test collection from a single delegate
+unittest
+{
+    auto stats = new ExampleStats();
+    auto registry = new CollectorRegistry([&stats.collectDg1]);
+
+    stats.setTestStats(Statistics(3600, 347, 3.14, 6.023, 0.43));
+
+    assert(registry.collect() ==
+        "up_time_s {id=\"123.034\"} 3600\ncount {id=\"123.034\"} 347\n" ~
+        "ratio {id=\"123.034\"} 3.14\nfraction {id=\"123.034\"} 6.023\n" ~
+        "very_real {id=\"123.034\"} 0.43\n");
+}
+
+/// Test collection from more than one delegates
+unittest
+{
+    auto stats = new ExampleStats();
+    auto registry = new CollectorRegistry([&stats.collectDg1]);
+    registry.addCollector(&stats.collectDg2);
+
+    stats.setTestStats(Statistics(3600, 347, 3.14, 6.023, 0.43));
+    stats.setTestLabels(Labels(1_235_813, "ocean", 3.14159));
+
+    assert(registry.collect() ==
+        "up_time_s {id=\"123.034\"} 3600\ncount {id=\"123.034\"} 347\n" ~
+        "ratio {id=\"123.034\"} 3.14\nfraction {id=\"123.034\"} 6.023\n" ~
+        "very_real {id=\"123.034\"} 0.43\n" ~
+
+        "up_time_s {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3600\n" ~
+        "count {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 347\n" ~
+        "ratio {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3.14\n" ~
+        "fraction {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 6.023\n" ~
+        "very_real {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 0.43\n");
+}
+
+/// Test that the collections are not accumulated upon more than one call to
+/// the `collect` method.
+unittest
+{
+    auto stats = new ExampleStats();
+    auto registry = new CollectorRegistry([&stats.collectDg2]);
+
+    stats.setTestStats(Statistics(3600, 347, 3.14, 6.023, 0.43));
+    stats.setTestLabels(Labels(1_235_813, "ocean", 3.14159));
+
+    auto collected = registry.collect();
+
+    // Update the stats
+    stats.setTestStats(Statistics(4200, 257, 2.345, 1.098, 0.56));
+
+    // A 2nd call to `collect` should return the updated stats, without the
+    // previous values anywhere in it.
+    assert(registry.collect(),
+        "up_time_s {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 4200\n" ~
+        "count {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 257\n" ~
+        "ratio {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 2.345\n" ~
+        "fraction {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 1.098\n" ~
+        "very_real {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 0.56\n");
+}

--- a/source/agora/stats/Server.d
+++ b/source/agora/stats/Server.d
@@ -13,9 +13,9 @@
 
 module agora.stats.Server;
 
+import agora.stats.CollectorRegistry;
 import agora.stats.Utils;
 
-import ocean.util.prometheus.collector.CollectorRegistry;
 import vibe.http.server;
 import vibe.http.router;
 

--- a/source/agora/stats/StatFormatter.d
+++ b/source/agora/stats/StatFormatter.d
@@ -1,0 +1,359 @@
+/*******************************************************************************
+
+    Contains methods that format primitive data members from structs or classes
+    into strings that can be exported as responses to prometheus queries.
+
+    Copyright:
+        Copyright (c) 2019 dunnhumby Germany GmbH.
+        All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module agora.stats.StatFormatter;
+
+import std.math.traits : isNaN, isInfinity;
+import std.traits : isBasicType, isFloatingPoint;
+import ocean.text.convert.Formatter;
+
+/*******************************************************************************
+
+    Format data members from a struct or a class into a string that can be
+    added to a stat collection buffer for exporting to prometheus.
+
+    The names and values of the members of the given struct are formatted as
+    stat names and values, respectively.
+
+    Params:
+        ValuesT = The struct or class type to fetch the stat names from.
+        values  = The struct or class to fetch stat values from.
+        buffer  = The buffer to add the formatted stats to.
+
+*******************************************************************************/
+
+public static void formatStats ( ValuesT ) (
+    ValuesT values, ref char[] buffer )
+{
+    static assert (is(ValuesT == struct) || is(ValuesT == class),
+        "'values' parameter must be a struct or a class.");
+
+    foreach (i, ValMemberT; typeof(ValuesT.tupleof))
+    {
+        static if (isBasicType!(ValMemberT))
+        {
+            sformat(buffer, "{}", __traits(identifier, ValuesT.tupleof[i]));
+            appendValue(values.tupleof[i], buffer);
+        }
+    }
+}
+
+/*******************************************************************************
+
+    Format data members from a struct or a class, with a additional label name
+    and value, into a string that can be added to a stat collection buffer for
+    exporting to prometheus.
+
+    Params:
+        LabelName = The name of the label to annotate the stats with.
+        ValuesT   = The struct or class type to fetch the stat names from.
+        LabelT    = The type of the label's value.
+        values    = The struct or class to fetch stat values from.
+        label_val = The label value to annotate the stats with.
+        buffer    = The buffer to add the formatted stats to.
+
+*******************************************************************************/
+
+public static void formatStats ( string LabelName, ValuesT, LabelT ) (
+    ValuesT values, LabelT label_val, ref char[] buffer )
+{
+    static assert (is(ValuesT == struct) || is(ValuesT == class),
+        "'values' parameter must be a struct or a class.");
+
+    foreach (i, ValMemberT; typeof(ValuesT.tupleof))
+    {
+        static if (isBasicType!(ValMemberT))
+        {
+            sformat(buffer, "{} {{", __traits(identifier, ValuesT.tupleof[i]));
+
+            appendLabel!(LabelName)(label_val, buffer);
+
+            sformat(buffer, "}");
+            appendValue(values.tupleof[i], buffer);
+        }
+    }
+}
+
+
+/*******************************************************************************
+
+    Format data members from a struct or a class, with an additional struct or
+    class to fetch label names and values from, into a string that can be added
+    to a stat collection buffer for exporting to prometheus.
+
+    Params:
+        ValuesT = The struct or class type to fetch the stat names from.
+        LabelsT = The struct or class type to fetch the label names from.
+        values  = The struct or class to fetch stat values from.
+        labels  = The struct or class holding the label values to annotate
+                    the stats with.
+        buffer  = The buffer to add the formatted stats to.
+
+*******************************************************************************/
+
+public static void formatStats ( ValuesT, LabelsT ) ( ValuesT values,
+    LabelsT labels, ref char[] buffer )
+{
+    static assert (is(ValuesT == struct) || is(ValuesT == class),
+        "'values' parameter must be a struct or a class.");
+    static assert (is(LabelsT == struct) || is(LabelsT == class),
+        "'labels' parameter must be a struct or a class.");
+
+    foreach (i, ValMemberT; typeof(ValuesT.tupleof))
+    {
+        static if (isBasicType!(ValMemberT))
+        {
+            sformat(buffer, "{} {{", __traits(identifier, ValuesT.tupleof[i]));
+
+            bool first_label = true;
+
+            foreach (j, LabelMemberT; typeof(LabelsT.tupleof))
+            {
+                if (first_label)
+                {
+                    first_label = false;
+                }
+                else
+                {
+                    sformat(buffer, ",");
+                }
+
+                appendLabel!(__traits(identifier, LabelsT.tupleof[j]))(
+                    labels.tupleof[j], buffer);
+            }
+
+            sformat(buffer, "}");
+            appendValue(values.tupleof[i], buffer);
+        }
+    }
+}
+
+/*******************************************************************************
+
+    Appends a label name and value to a given buffer. If the value is of a
+    floating-point type, then appends it with a precision upto 6 decimal places.
+
+    Params:
+        LabelName = The name of the label to annotate the stats with.
+        LabelT    = The type of the label's value.
+        label_val = The label value to annotate the stats with.
+        buffer    = The buffer to append the label to.
+
+*******************************************************************************/
+
+private static void appendLabel ( string LabelName, LabelT ) (
+    LabelT label_val, ref char[] buffer )
+{
+    static if (isFloatingPoint!(LabelT))
+    {
+        sformat(buffer, "{}=\"{:6.}\"", LabelName,
+            getSanitized(label_val));
+    }
+    else
+    {
+        sformat(buffer, "{}=\"{}\"", LabelName, label_val);
+    }
+}
+
+// Test appending a label with a value of type string
+unittest
+{
+    char[] buffer;
+    appendLabel!("labelname")("labelval", buffer);
+    assert(buffer == "labelname=\"labelval\"");
+}
+
+// Test appending a label with an integer type value
+unittest
+{
+    char[] buffer;
+    appendLabel!("labelname")(2345678UL, buffer);
+    assert(buffer == "labelname=\"2345678\"");
+}
+
+// Test appending a label with a floting point type value
+unittest
+{
+    char[] buffer;
+    appendLabel!("labelname")(3.1415926, buffer);
+    assert(buffer == "labelname=\"3.141593\"");
+}
+
+/*******************************************************************************
+
+    Appends a stat value to a given buffer. If the value is of a floating-point
+    type, then appends it with a precision of upto 6 decimal places.
+
+    Params:
+        T      = The datatype of the value.
+        value  = The value to append to the buffer.
+        buffer = The buffer to which the stat value will be appended.
+
+*******************************************************************************/
+
+private static void appendValue ( T ) ( T value, ref char[] buffer )
+{
+    static if (isFloatingPoint!(T))
+    {
+        sformat(buffer, " {:6.}\n", getSanitized(value));
+    }
+    else
+    {
+        sformat(buffer, " {}\n", value);
+    }
+}
+
+// Test appending a non-floating-point values
+unittest
+{
+    char[] buffer;
+    appendValue(32768UL, buffer);
+    assert(buffer == " 32768\n");
+}
+
+// Test appending a floating-point value having less than 6 decimal places
+unittest
+{
+    char[] buffer;
+    appendValue(3.14159, buffer);
+    assert(buffer == " 3.14159\n");
+}
+
+// Test appending a floating-point value having more than 6 decimal places
+unittest
+{
+    char[] buffer;
+    appendValue(3.1415926, buffer);
+    assert(buffer == " 3.141593\n");
+}
+
+/*******************************************************************************
+
+    Sanitizes floating-point type values.
+
+    If the datatype of the value is a floating-point type, then returns 0.0
+    for NaN and the datatype's maximum value for +/-Inf.
+    If the datatype of the value is not a floating-point type, then returns
+    the given value without any modification.
+
+    Params:
+        T      = The datatype of the value.
+        value  = The value to append to sanitize.
+
+    Returns:
+        The sanitized value, if the input is of a floating-point type,
+        otherwise the given value itself.
+
+*******************************************************************************/
+
+private static T getSanitized ( T ) ( T val )
+{
+    static if (isFloatingPoint!(T))
+    {
+        if (isNaN(val))
+        {
+            return 0.0;
+        }
+        else if (isInfinity(val))
+        {
+            return T.max;
+        }
+    }
+
+    return val;
+}
+
+// Test sanitization of a floating type value as NaN
+unittest
+{
+    assert(getSanitized(double.init) == 0.0);
+}
+
+// Test sanitization of a floating point value as infinity
+unittest
+{
+    assert(getSanitized(double.infinity) == double.max);
+}
+
+// Test that sanitization does not alter any floating point value that is
+// not NaN or Inf.
+unittest
+{
+    double pi = 3.141592;
+    assert(getSanitized(pi) == 3.141592);
+}
+
+
+version (unittest)
+{
+    package struct Statistics
+    {
+        ulong up_time_s;
+        size_t count;
+        float ratio;
+        double fraction;
+        real very_real;
+    }
+
+    package struct Labels
+    {
+        hash_t id;
+        const(char)[] job;
+        float perf;
+    }
+}
+
+/// Test collecting populated stats, but without any label.
+unittest
+{
+    auto expected = "up_time_s 3600\ncount 347\nratio 3.14\nfraction 6.023\n" ~
+        "very_real 0.43\n";
+
+    char[] actual;
+    formatStats(Statistics(3600, 347, 3.14, 6.023, 0.43), actual);
+
+    assert(actual == expected);
+}
+
+/// Test collecting populated stats with one label
+unittest
+{
+    auto expected =
+        "up_time_s {id=\"123.034\"} 3600\ncount {id=\"123.034\"} 347\n" ~
+        "ratio {id=\"123.034\"} 3.14\nfraction {id=\"123.034\"} 6.023\n" ~
+        "very_real {id=\"123.034\"} 0.43\n";
+
+    char[] actual;
+    formatStats!("id")(
+        Statistics(3600, 347, 3.14, 6.023, 0.43), 123.034, actual);
+
+    assert(actual == expected);
+}
+
+/// Test collecting stats having initial values with multiple labels
+unittest
+{
+    auto expected =
+        "up_time_s {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3600\n" ~
+        "count {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 347\n" ~
+        "ratio {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3.14\n" ~
+        "fraction {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 6.023\n" ~
+        "very_real {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 0.43\n";
+
+    char[] actual;
+    formatStats(Statistics(3600, 347, 3.14, 6.023, 0.43),
+        Labels(1_235_813, "ocean", 3.14159), actual);
+
+    assert(actual == expected);
+}

--- a/source/agora/stats/Stats.d
+++ b/source/agora/stats/Stats.d
@@ -135,10 +135,9 @@ public struct NoLabel {}
 
 version (unittest)
 {
+    import agora.stats.Collector;
+    import agora.stats.CollectorRegistry;
     import agora.stats.Utils;
-
-    import ocean.util.prometheus.collector.CollectorRegistry;
-    import ocean.util.prometheus.collector.Collector;
 
     public struct TestStatsWithLabelT
     {

--- a/source/agora/stats/Utils.d
+++ b/source/agora/stats/Utils.d
@@ -13,8 +13,8 @@
 
 module agora.stats.Utils;
 
-public import ocean.util.prometheus.collector.Collector;
-import ocean.util.prometheus.collector.CollectorRegistry;
+public import agora.stats.Collector;
+import agora.stats.CollectorRegistry;
 
 /*******************************************************************************
 

--- a/source/agora/stats/Utils.d
+++ b/source/agora/stats/Utils.d
@@ -16,8 +16,6 @@ module agora.stats.Utils;
 public import ocean.util.prometheus.collector.Collector;
 import ocean.util.prometheus.collector.CollectorRegistry;
 
-import std.stdio;
-
 /*******************************************************************************
 
     Utility method to generate a collector delegate for a particular `Stats`

--- a/source/agora/utils/SCPPrettyPrinter.d
+++ b/source/agora/utils/SCPPrettyPrinter.d
@@ -38,8 +38,6 @@ import scpd.Cpp;
 import scpd.types.Stellar_SCP;
 import scpd.types.Stellar_types : StellarHash = Hash, NodeID;
 
-import Ocean = ocean.text.convert.Formatter;
-
 import std.algorithm;
 import std.format;
 import std.range;
@@ -403,6 +401,7 @@ version (unittest)
     private void testAssert (T) (string expected, in T toFmt, int line = __LINE__)
     {
         import std.stdio;
+        import Ocean = ocean.text.convert.Formatter;
 
         auto phobosResult = format("%s", toFmt);
         auto oceanResult = Ocean.format("{}", toFmt);


### PR DESCRIPTION
As mentioned recently, I am attempting to drop our Ocean dependency, and besides the formatter / logger, Prometheus is the only thing we use from it.