### PR TITLE
Improve address registry UX

### DIFF
--- a/devel/config-single.yaml
+++ b/devel/config-single.yaml
@@ -34,8 +34,6 @@ validator:
   enabled: true
   # We use first of Genesis Block enrollments: val5: boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8
   seed: SAZO4WA5SXUN3J6XBXZCFPXJJZ62IQAJYAG2KBVWF2QZKTU2WK3QTNMV
-  addresses_to_register:
-    - http://127.0.0.1:2826/
 
 registry:
   public: true

--- a/devel/testnet/README.KR.md
+++ b/devel/testnet/README.KR.md
@@ -1,4 +1,4 @@
-# 노드 운영 방법 및 조건 
+# 노드 운영 방법 및 조건
 
 보스아고라 노드인 아고라(Agora)를 테스트 하는데 필요한 단계와 테스트 네트워크(‘TestNet’)에서 Foundation 노드와 상호 작용하는 방법을 안내드립니다.
 
@@ -38,7 +38,7 @@ Ubuntu Linux 20.04 및 MacOS-11(Big Sur)용 네이티브 바이너리(Native Bin
 
 터미널을 열고 `docker run bosagora/agora --testnet` 명령을 사용합니다.
 
-노드가 시작되고 여러 메시지를 화면에 나타나야 합니다. 약 몇초 동안 네트워크와 동기화를 시작하여 최신 상태의 체인을 다운로드해야 합니다. 
+노드가 시작되고 여러 메시지를 화면에 나타나야 합니다. 약 몇초 동안 네트워크와 동기화를 시작하여 최신 상태의 체인을 다운로드해야 합니다.
 
 ![초기 블록 다운로드시 로그 메시지](./IBD.png)
 
@@ -135,12 +135,10 @@ interfaces:
 ![Running ngrok](ngrok_run.png)
 위 화면에서 빨간색 네모로 표시된, TCP 주소를 복사해야 합니다. 이 주소는 여러분의 설정파일에서 사용됩니다.
 
-**네번째**, 이제 위에서 복사한 TCP 주소를, 설정 파일의 `addresses_to_register` 부분에 아래와 같이 복사해야 합니다.
+**네번째**, 이제 위에서 복사한 TCP 주소를, 설정 파일의 `public_addresses` 부분에 아래와 같이 복사해야 합니다.
 ```
-validator:
-  enabled: true
-  seed: SB3EENDWPUGQZL7KLWGJS2ILMGRBB2MLVLRBUVKDYTO6A4WYLPIQWEE3
-  addresses_to_register:
+node:
+  public_addresses:
     - "agora://2.tcp.ngrok.io:14476"
 ```
 그리고 나서, 이전 섹션에서 설명된 것처럼 검증자를 실행하면 됩니다.

--- a/devel/testnet/README.md
+++ b/devel/testnet/README.md
@@ -115,14 +115,14 @@ to the following:
 validator:
   enabled: true
   seed: SB3EENDWPUGQZL7KLWGJS2ILMGRBB2MLVLRBUVKDYTO6A4WYLPIQWEE3
-  addresses_to_register:
-    - "agora://my-address.example.com:2826"
 ```
 
 Make sure you use the **seed** for the configuration and the **public key** for Faucet.
 
-The address to put in `addresses_to_register` should match the **public address** of your validator.
-This can be an IP address or an hostname. The above example uses port `2826` explicitly,
+Interfaces will be registered to public registry by default. If your validator's
+interface is not directly accessible to public, i.e. behind a reverse proxy,
+`public_addresses` or `register` fields of an interface can be configured.
+This can be an URL address or a hostname. The above example uses port `2826` explicitly,
 but you may elect to change it by using an interface entry, for example:
 ```yaml
 interfaces:
@@ -171,13 +171,11 @@ The following screenshot shows the output of the preceding command:
 You should copy the TCP address provided marked on a red line in the previous screenshot,
 which will be used in your configuration file.
 
-**Fourth**, you should replace the value of the `addresses_to_register` to the copied address
+**Fourth**, you should replace the value of the `public_addresses` to the copied address
 in your configuration file that you have already written.
 ```
-validator:
-  enabled: true
-  seed: SB3EENDWPUGQZL7KLWGJS2ILMGRBB2MLVLRBUVKDYTO6A4WYLPIQWEE3
-  addresses_to_register:
+node:
+  public_addresses:
     - "agora://2.tcp.ngrok.io:14476"
 ```
 And then, you can run your validator as described in the previous sections.

--- a/devel/testnet/config.yaml
+++ b/devel/testnet/config.yaml
@@ -22,8 +22,6 @@ registry:
 # validator:
 #   enabled: true
 #   seed: YOUR_SEED_HERE
-#   addresses_to_register:
-#     - "agora://my-address.example.com"
 
 logging:
   root:

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -66,6 +66,24 @@ node:
   # Address of the name registry
   registry_address: http://127.0.0.1:3003
 
+  # Registering a node to public interface includes three configuration options,
+  # all interfaces are considered as public by default if not configured otherwise;
+  # 1- Default config
+  #    All public interfaces are registered with their `address` values, if the
+  #    address is 0.0.0.0 then public IP address of the host is used
+  # 2- Providing a hostname through `register`
+  #    All public interfaces are registered with `register` hostname
+  # 3- Providing `public_addresses` config
+  #    Interface configuration is ignored and all addresses provided here are
+  #    registered
+
+  # (Optional) Hostname for the node to be registered
+  register: host.test
+  # (Optional) Addresses for interface to be registered, useful when Agora is
+  # configured behind a reverse proxy
+  public_addresses:
+    - https://proxy.host.test/agora
+
 # Each entry in this array is an interface Agora will listen to, allowing to
 # expose the same node on more than one network interface or with different
 # API, such as having one interface using HTTP+JSON and the other TCP+binary.
@@ -75,6 +93,9 @@ interfaces:
     address: 0.0.0.0 # Any node can bind - default value
     # Port on which we bind
     port:    2826    # 0xB0A, default value
+    # A validator node is required to register at least one of its interfaces
+    # to public registry, interfaces can be left out from public registry
+    public: false
   - type: http
     address: 0.0.0.0
     port: 9110
@@ -84,6 +105,9 @@ interfaces:
     port: 9220
     # Enables proxy protocol v1 for the interface, only applicable for TCP
     proxy_proto: true
+  - type: https
+    address: 0.0.0.0
+    port: 2834
 
 # Proxy to be used for outgoing Agora connections
 proxy:
@@ -106,11 +130,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xpvald2ydpxzl9aat978kv78y5g24jxy46mcnl7munf4jyhd0zjrc5x62kn
   seed: SAUHVPR7O7F2QGLDVXG3DQTVHXESE3ZAWHIIGKT35LCHIPLZBZTAFXJA
-  # Network addresses that will be registered with the public key (Validator only)
-  # If left empty, all public network addresses of the node will be registered
-  addresses_to_register:
-    - http://88.88.88.88:8080/api
-    - agora://best.validator.io
   # Whether or not the Validator will enroll automatically at the startup or
   # at the end of Validator cycle
   recurring_enrollment: true

--- a/source/agora/node/Registry.d
+++ b/source/agora/node/Registry.d
@@ -703,7 +703,6 @@ private struct TypedPayload
         switch (this.type)
         {
         case TYPE.CNAME:
-            assert(this.payload.addresses.length == 1);
             // FIXME: Use a proper TTL
 
             /* If it's a CNAME, it has to be to another domain, as we don't

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2315,7 +2315,6 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
         const ValidatorConfig validator = {
             enabled : true,
             key_pair : key_pair,
-            addresses_to_register : [ self_address ],
             recurring_enrollment : test_conf.recurring_enrollment,
             name_registration_interval : 10.seconds,
             preimage_reveal_interval : test_conf.preimage_reveal_interval,

--- a/tests/system/node/2/config.yaml
+++ b/tests/system/node/2/config.yaml
@@ -23,6 +23,7 @@ node:
     seconds : 1200
   realm: "integration.bosagora.io"
   registry_address: http://node-0:1826
+  register: node-2
 
 interfaces:
   - type: http
@@ -66,10 +67,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xzval2a3cdxv28n6slr62wlczslk3juvk7cu05qt3z55ty2rlfqfc6egsh2
   seed: SAQXRDHTWME4GUIVNYCKPN433VJ4BJP2L2T7UWHGSSW47VFC67EQFY3S
-  # Network addresses that will be registered with the public key (Validator only)
-  # If left empty, all public network addresses of the node will be registered
-  addresses_to_register:
-    - "agora://node-2:2735"
   # Block interval is only 5 seconds so we need to check to nominate more often
   nomination_interval:
     seconds: 2

--- a/tests/system/node/3/config.yaml
+++ b/tests/system/node/3/config.yaml
@@ -23,6 +23,7 @@ node:
     seconds : 1200
   realm: "integration.bosagora.io"
   registry_address: http://node-0:1826
+  register: node-3
 
 interfaces:
   - type: http
@@ -66,10 +67,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xzval3ah8z7ewhuzx6mywveyr79f24w49rdypwgurhjkr8z2ke2mycftv9n
   seed: SC3H3ADGT3YGLMDWCLKZ2GILDHDTC4WDE7M3G4URQPWJZZM43TTAM2QG
-  # Network addresses that will be registered with the public key (Validator only)
-  # If left empty, all public network addresses of the node will be registered
-  addresses_to_register:
-    - "agora://node-3:3735"
   # Block interval is only 5 seconds so we need to check to nominate more often
   nomination_interval:
     seconds: 2

--- a/tests/system/node/4/config.yaml
+++ b/tests/system/node/4/config.yaml
@@ -23,6 +23,7 @@ node:
     seconds : 1200
   realm: "integration.bosagora.io"
   registry_address: http://node-0:1826
+  register: node-4
 
 interfaces:
   - type: http
@@ -66,10 +67,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xzval4nvru2ej9m0rptq7hatukkavemryvct4f8smyy3ky9ct5u0s8w6gfy
   seed: SBIJAVYYCSRV5RNO2WVTT25H6VZTEV3YSE7U7WT7UQUNSVBUGB6QNBWG
-  # Network addresses that will be registered with the public key (Validator only)
-  # If left empty, all public network addresses of the node will be registered
-  addresses_to_register:
-    - "agora://node-4:4735"
   # Block interval is only 5 seconds so we need to check to nominate more often
   nomination_interval:
     seconds: 2

--- a/tests/system/node/5/config.yaml
+++ b/tests/system/node/5/config.yaml
@@ -23,6 +23,7 @@ node:
     seconds : 1200
   realm: "integration.bosagora.io"
   registry_address: http://node-0:1826
+  register: node-5
 
 interfaces:
   - type: http
@@ -66,10 +67,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8
   seed: SAZO4WA5SXUN3J6XBXZCFPXJJZ62IQAJYAG2KBVWF2QZKTU2WK3QTNMV
-  # Network addresses that will be registered with the public key (Validator only)
-  # If left empty, all public network addresses of the node will be registered
-  addresses_to_register:
-    - "agora://node-5:5735"
   # Block interval is only 5 seconds so we need to check to nominate more often
   nomination_interval:
     seconds: 2

--- a/tests/system/node/6/config.yaml
+++ b/tests/system/node/6/config.yaml
@@ -23,6 +23,7 @@ node:
     seconds : 1200
   realm: "integration.bosagora.io"
   registry_address: http://node-0:1826
+  register: node-6
 
 interfaces:
   - type: http
@@ -66,10 +67,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xrval6hd8szdektyz69fnqjwqfejhu4rvrpwlahh9rhaazzpvs5g6lh34l5
   seed: SAFIQC7HRZPVPEG47ZHS3OBBCYDREHNC4DEKM3QODM7WKPZPU7VQXCPI
-  # Network addresses that will be registered with the public key (Validator only)
-  # If left empty, all public network addresses of the node will be registered
-  addresses_to_register:
-    - "agora://node-6:6735"
   # Block interval is only 5 seconds so we need to check to nominate more often
   nomination_interval:
     seconds: 2

--- a/tests/system/node/7/config.yaml
+++ b/tests/system/node/7/config.yaml
@@ -23,6 +23,7 @@ node:
     seconds : 1200
   realm: "integration.bosagora.io"
   registry_address: http://node-0:1826
+  register: node-7
 
 interfaces:
   - type: http
@@ -66,10 +67,6 @@ validator:
   # DO NOT USE THOSE VALUES ANYWHERE
   # Public address:  boa1xrval7gwhjz4k9raqukcnv2n4rl4fxt74m2y9eay6l5mqdf4gntnzhhscrh
   seed: SAWI3JZWDDSQR6AX4DRG2OMS26Y6XY4X2WA3FK6D5UW4WTU74GUQXRZP
-  # Network addresses that will be registered with the public key (Validator only)
-  # If left empty, all public network addresses of the node will be registered
-  addresses_to_register:
-    - "agora://node-7:7735"
   # Block interval is only 5 seconds so we need to check to nominate more often
   nomination_interval:
     seconds: 2


### PR DESCRIPTION
Fixes #2320 
Depends on #3239 

After this PR, #3240 can be considered. 

This PR misses Flash configuration intentionally due to current Flash architecture. It ends up with code duplication and unnecessarily doubles memory usage for the same data (i.e. `NetworkManager.addresses_to_register` will be same and required for `Flash`).

There are three options for configuring how a node registers itself to public registry; by default all interfaces are considered as public:

1. Default (no specific configuration from user)
    `node.register` or `node.public_addresses` are not configured by user thus all interfaces are registered. If an interface has
    `0.0.0.0` configured as its `address` than public IP address of the host will be used. In registry, this will result in A record
    for each public interface and associated URI record (including schema and port)
2. `node.register` is configured by user
    Each public interface will be registered with value in the `node.register` as `address` of the interface. This will result in single
    CNAME record and associated URI records for each public interface (including schema and port)
3. `node.public_addresses` is configured by user
    Interfaces are ignored and addresses in this field is registered as it was before in `addresses_to_register` method.
