### PR TITLE
Add new validator to whitelist

### DIFF
--- a/source/agora/network/Manager.d
+++ b/source/agora/network/Manager.d
@@ -366,6 +366,7 @@ public class NetworkManager
                 log.info("Found new Validator: {} (UTXO: {}, key: {})",
                          client.addresses(), utxo, key);
                 client.setIdentity(utxo, key);
+                this.whitelist(utxo);
             }
             else
                 log.info("Found new FullNode: {}", client.addresses());


### PR DESCRIPTION
In the case of the genesis validators, there is no address registered right after
nodes start from scratch, which means the genesis validators might be banned
although there have been the `whitelist` calls for the validators in the middle
of accepting the Genesis block. So we should add the UTXOs to the `whitelist`
when the handshaking has been completed.

Fixes #3177 