### PR TITLE
Trivial: Improve node startup sequence

### DIFF
--- a/source/agora/node/Runner.d
+++ b/source/agora/node/Runner.d
@@ -76,7 +76,7 @@ package __gshared int exitCode;
 
 *******************************************************************************/
 
-public Listeners runNode (Config config)
+public void runNode (Config config, ref Listeners result)
 {
     foreach (const ref settings; config.logging)
     {
@@ -90,7 +90,6 @@ public Listeners runNode (Config config)
 
     mkdirRecurse(config.node.data_dir);
 
-    Listeners result;
     const bool hasHTTPInterface = config.interfaces.any!(
         i => i.type.among(InterfaceConfig.Type.http, InterfaceConfig.Type.https));
     URLRouter router;
@@ -228,8 +227,6 @@ public Listeners runNode (Config config)
             result.tcp ~= listenRPC!(agora.api.FullNode.API)(result.node, interface_.address, interface_.port, interface_.proxy_proto,
                 config.node.timeout, &result.node.getNetworkManager().discoverFromClient, isBannedDg);
     }
-
-    return result;
 }
 
 /*******************************************************************************

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -173,7 +173,7 @@ private int main (string[] args)
     runTask(
         () nothrow {
             try
-                listeners = runNode(config);
+                runNode(config, listeners);
             catch (Exception exc)
             {
                 try


### PR DESCRIPTION
Even it is a small time window a node can be requested to terminate
while it is in node initialization (`runNode`). Returning as a bulk
prevents already started parts to be shutdown during node termination.