### PR TITLE
Issue3224: `scp fatal` in `combineCandidates`

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1537,7 +1537,7 @@ extern(D):
                 {
                     consensus_data: data,
                     hash: data.hashFull(),
-                    total_rate = total_rate,
+                    total_rate: total_rate,
                 };
                 candidate_holders ~= candidate_holder;
             }


### PR DESCRIPTION
This will prevent the fatal SCP error and log an error with details.
Although most likely this is showing that there is a bug that needs to be fixed as `combineCandidates` should only be called with nominated tx sets the node has.