### PR TITLE
AgoraLayout: Change colors to be more gradual

### DIFF
--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -478,36 +478,27 @@ public class AgoraLayout : Appender.Layout
     /// Returns: A colorized version of a LogLevel
     protected static string coloredName (LogLevel lvl)
     {
-        switch (lvl)
+        final switch (lvl)
         {
-            // White on Cyan
-        case LogLevel.Debug:
-            return "\u001b[46mDebug\u001b[0m";
-            // Cyan
-        case LogLevel.Trace:
-            return "\u001b[36mTrace\u001b[0m";
-            // Blue
-        case LogLevel.Verbose:
-            return "\u001b[34mVerbose\u001b[0m";
-            // Green
-        case LogLevel.Info:
+        case LogLevel.Debug:   // Magenta
+            return "\u001b[35mDebug\u001b[0m";
+        case LogLevel.Trace:   // Blue
+            return "\u001b[34mTrace\u001b[0m";
+        case LogLevel.Verbose: // Cyan
+            return "\u001b[36mVerbose\u001b[0m";
+        case LogLevel.Info:    // Green
             return "\u001b[32mInfo\u001b[0m";
-            // Yellow
-        case LogLevel.Warn:
+        case LogLevel.Warn:    // Yellow
             return "\u001b[33mWarn\u001b[0m";
-            // Magenta
-        case LogLevel.Error:
-            return "\u001b[35mError\u001b[0m";
-            // Red
-        case LogLevel.Fatal:
+        case LogLevel.Error:   // Red
+            return "\u001b[31mError\u001b[0m";
+        case LogLevel.Fatal:   // Red
             return "\u001b[31mFatal\u001b[0m";
 
-            // The following two should never be printed,
-            // so use white on red and make them noticeable
+        // The following two should never be printed,
+        // so use white on red and make them noticeable
         case LogLevel.None:
             return "\u001b[41mNone\u001b[0m";
-        default:
-            return "\u001b[41mUnknown\u001b[0m";
         }
     }
 }


### PR DESCRIPTION
```
Use a 'final switch' to ensure all cases are handled;
Make Fatal and Error red, freeing up magenta;
Make Debug magenta, and switch colors for trace (formerly Cyan)
and verbose (formerly Blue) so that the color scheme follows
the same order as the natural spectrum of visible light.
```

Piggybacking on this little test code:
```diff
Δ source/agora/utils/Log.d
       host: null,
    };

-    const before = GC.stats();
-    layout.format(event, dg);
-    const after = GC.stats();
-    assert(result == "2018-04-30 00:42:42,420 \u001b[33mWarn\u001b[0m [Barney] - Have you met Ted?");
-    assert(before == after);
+    // const before = GC.stats();
+    // layout.format(event, dg);
+    // const after = GC.stats();
+    // assert(result == "2018-04-30 00:42:42,420 \u001b[33mWarn\u001b[0m [Barney] - Have you met Ted?");
+    // assert(before == after);
+
+    import std.stdio;
+
+    for (size_t i; i < LogLevel.None; ++i)
+    {
+        result.length = 0;
+        assumeSafeAppend(result);
+        event.level = cast(LogLevel) i;
+        layout.format(event, dg);
+        writeln(result);
+    }
}
```

We had this before:
<img width="608" alt="Screen Shot 2022-03-24 at 13 16 23" src="https://user-images.githubusercontent.com/2180215/159841086-d1163199-05f8-4284-8ad5-c5138026a1ce.png">

After this PR we'll have this:
<img width="613" alt="Screen Shot 2022-03-24 at 13 16 07" src="https://user-images.githubusercontent.com/2180215/159841118-c5007802-b073-45e2-95a2-c8afafcca984.png">

If anyone has preference on another color scheme let me know. I was mostly bothered by `Debug` being hard to read on a regular terminal.