### PR TITLE
TxBuilder: Remove hard dependency to WellKnown keys

### DIFF
--- a/source/agora/utils/PrettyPrinter.d
+++ b/source/agora/utils/PrettyPrinter.d
@@ -586,6 +586,7 @@ Outputs (1): boa1xzgenes5...gm67(59,499,999.9,920,9)<Payment>
     // need reproducible unlocks for test (signing generates unique nonces)
     import agora.script.Lock;
     import agora.utils.Test;
+    import agora.utils.TxBuilder;
     static Unlock unlocker (in Transaction, in OutputRef) @safe nothrow
     {
         return Unlock.init;

--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -42,7 +42,7 @@ import agora.crypto.Key;
 import agora.crypto.Schnorr;
 import agora.script.Lock;
 import agora.serialization.Serializer;
-public import agora.utils.TxBuilder;
+import agora.utils.TxBuilder;
 public import agora.utils.Utility : retryFor;
 
 import std.algorithm;
@@ -313,6 +313,24 @@ unittest
     // check we can fetch preimages from previous cycle
     assert(WK.PreImages.at(Height(1), only_node2) == preimages_height_1);
 }
+
+// Uses a random nonce when signing (non-determenistic signature),
+// and defaults to LockType.Key
+private Unlock WKUnlocker (in Transaction tx, in OutputRef out_ref)
+    @safe nothrow
+{
+    import agora.script.Signature : getChallenge;
+
+    auto ownerKP = WK.Keys[out_ref.output.address];
+    assert(ownerKP !is KeyPair.init,
+           "Address not found in Well-Known keypairs: "
+           ~ out_ref.output.address.toString());
+
+    return genKeyUnlock(ownerKP.sign(tx.getChallenge()));
+}
+
+///
+public alias TxBuilder = StaticTransactionBuilder!WKUnlocker;
 
 /***************************************************************************
 


### PR DESCRIPTION
The last step missing to allow the TxBuilder to be truly independent
from the Well-Known keys, yet offer a similar API.