### PR TITLE
Nominator: Purge externalized SCP slots

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -476,6 +476,7 @@ extern(D):
         }
 
         this.active_timers[] = null;
+        () @trusted { this.scp.purgeSlots(height); }();
     }
 
     /***************************************************************************


### PR DESCRIPTION
SCP holds state for each height and needs them to be
explicitly cleared. This was probably the reason of our
ever growing memory consumption.