### PR TITLE
Resend envelopes at exactly half block time

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -620,7 +620,7 @@ extern(D):
             log.info("{}(): Tx set didn't trigger new nomination", __FUNCTION__);
             const Duration halfBlockDuration = this.params.BlockInterval / 2;
             // We are half way through block interval time to externalize
-            if (this.clock.utcTime() > this.ledger.getExpectedBlockTime(this.ledger.height + 1) + halfBlockDuration)
+            if (this.clock.utcTime() >= this.ledger.getExpectedBlockTime(this.ledger.height + 1) + halfBlockDuration)
             {
                 log.info("{}(): Ledger has height #{} expecting #{} as half interval has passed - Resending latest envelopes"
                     , __FUNCTION__, this.ledger.height, this.ledger.expectedHeight(this.clock.utcTime()));


### PR DESCRIPTION
Change to greater than or equals to expected block time plus half block
interval. This is only to enable the unit tests to benefit from the
resend as the time set is exact and does not move forwards. Although it
would be nice to implement the tests to start at expected time and
progress to intervals within the block time span. That is for another
day.