### PR TITLE
Metrics: Change scrape_duration to milliseconds only

### DIFF
--- a/source/agora/stats/CollectorRegistry.d
+++ b/source/agora/stats/CollectorRegistry.d
@@ -96,7 +96,7 @@ public class CollectorRegistry
         }
 
         return this.collector.getCollection() ~
-            format("scrape_duration \"%s\"", MonoTime.currTime - start);
+            format("scrape_duration_ms %s", (MonoTime.currTime - start).total!"msecs");
     }
 }
 


### PR DESCRIPTION
```
The default encoding appends a string, which Prometheus doesn't like,
and that kills the whole stats. Using a millisecond resolution is good enough.
```

Tested live