### PR TITLE
De-couple TxBuilder from WK.Keys

### DIFF
--- a/source/agora/cli/client/GenTxProcess.d
+++ b/source/agora/cli/client/GenTxProcess.d
@@ -149,7 +149,7 @@ public int genTxProcess (string[] args, ref string[] outputs,
         writefln("%s transactions sent to %s.\nTransactions:",
             op.count, op.address);
         txs.each!(tx => writeln(prettify(tx)));
-        txs = txs.map!(txb => TxBuilder(txb).sign()).array();
+        txs = txs.map!(txb => TxBuilder!(WK.Keys)(txb).sign()).array();
     }
 
     if (op.dump)

--- a/source/agora/consensus/BlockStorage.d
+++ b/source/agora/consensus/BlockStorage.d
@@ -1051,7 +1051,7 @@ private void testStorage (IBlockStorage storage)
     {
         while (--count)
         {
-            txs = last_txs.length ? last_txs.map!(tx => TxBuilder(tx).sign()).array()
+            txs = last_txs.length ? last_txs.map!(tx => TxBuilder!(WK.Keys)(tx).sign()).array()
                 : genesisSpendable().map!(txb => txb.sign()).array();
             last_block = makeNewTestBlock(blocks[$ - 1], txs);
             last_block.updateSignature(

--- a/source/agora/consensus/Ledger.d
+++ b/source/agora/consensus/Ledger.d
@@ -852,7 +852,7 @@ public class ValidatingLedger : NodeLedger
             return last_txs;
         }
 
-        last_txs = last_txs.map!(tx => TxBuilder(tx).sign()).array();
+        last_txs = last_txs.map!(tx => TxBuilder!(WK.Keys)(tx).sign()).array();
         last_txs.each!(tx => assert(this.acceptTransaction(tx) is null));
         this.forceCreateBlock();
         return last_txs;
@@ -1279,7 +1279,7 @@ unittest
 
     // Generate a block with data stored transactions
     txs = txs.enumerate()
-        .map!(en => TxBuilder(en.value)
+        .map!(en => TxBuilder!(WK.Keys)(en.value)
               .deduct(data_fee)
               .payload(data)
               .sign())
@@ -1301,7 +1301,7 @@ unittest
 
     // Generate a block to reuse transactions used for data storage
     txs = txs.enumerate()
-        .map!(en => TxBuilder(en.value)
+        .map!(en => TxBuilder!(WK.Keys)(en.value)
               .refund(WK.Keys[en.index].address)
               .sign())
               .array;
@@ -1326,7 +1326,7 @@ unittest
     Transaction[] genTransactions (Transaction[] txs)
     {
         return txs.enumerate()
-            .map!(en => TxBuilder(en.value).refund(WK.Keys[en.index].address)
+            .map!(en => TxBuilder!(WK.Keys)(en.value).refund(WK.Keys[en.index].address)
                 .sign())
             .array;
     }
@@ -1351,12 +1351,12 @@ unittest
 
     // generate a block with only freezing transactions
     auto new_txs = txs[0 .. 4].enumerate()
-        .map!(en => TxBuilder(en.value).refund(WK.Keys[en.index].address)
+        .map!(en => TxBuilder!(WK.Keys)(en.value).refund(WK.Keys[en.index].address)
             .sign(OutputType.Freeze)).array;
     new_txs ~= txs[4 .. 7].enumerate()
-        .map!(en => TxBuilder(en.value).refund(WK.Keys[en.index].address).sign())
+        .map!(en => TxBuilder!(WK.Keys)(en.value).refund(WK.Keys[en.index].address).sign())
         .array;
-    new_txs ~= TxBuilder(txs[$ - 1]).split(WK.Keys[0].address.repeat(8)).sign();
+    new_txs ~= TxBuilder!(WK.Keys)(txs[$ - 1]).split(WK.Keys[0].address.repeat(8)).sign();
     new_txs.each!(tx => assert(ledger.acceptTransaction(tx) is null));
     ledger.forceCreateBlock();
     assert(ledger.height() == 2);
@@ -1370,7 +1370,7 @@ unittest
     ];
 
     new_txs = iota(new_txs[$ - 1].outputs.length).enumerate
-        .map!(en => TxBuilder(new_txs[$ - 1], cast(uint)en.index)
+        .map!(en => TxBuilder!(WK.Keys)(new_txs[$ - 1], cast(uint)en.index)
             .refund(WK.Keys[en.index].address).sign())
         .array;
     new_txs.each!(tx => assert(ledger.acceptTransaction(tx) is null));
@@ -1667,7 +1667,7 @@ unittest
     ledger.simulatePreimages(Height(params.ValidatorCycle));
 
     auto freeze_tx = GenesisBlock.txs.find!(tx => tx.isFreeze).front();
-    auto melting_tx = TxBuilder(freeze_tx, 0).sign();
+    auto melting_tx = TxBuilder!(WK.Keys)(freeze_tx, 0).sign();
 
     // enrolled stake can't be spent
     assert(ledger.acceptTransaction(melting_tx) !is null);
@@ -1687,7 +1687,7 @@ unittest
     assert(ledger.acceptTransaction(freeze_tx) is null);
     ledger.forceCreateBlock();
 
-    auto melting_tx = TxBuilder(freeze_tx, 0).sign();
+    auto melting_tx = TxBuilder!(WK.Keys)(freeze_tx, 0).sign();
     assert(ledger.acceptTransaction(melting_tx) is null);
 
     ConsensusData data;
@@ -1837,7 +1837,7 @@ unittest
         Height(5), &ledger.peekUTXO, &ledger.getPenaltyDeposit));
     assert(ledger.enrollment_manager.enroll_pool.hasEnrollment(stake, Height(5)));
 
-    auto melting_tx = TxBuilder(GenesisBlock.txs[1], 1).sign();
+    auto melting_tx = TxBuilder!(WK.Keys)(GenesisBlock.txs[1], 1).sign();
     assert(ledger.acceptTransaction(melting_tx) is null);
 
     ledger.forceCreateBlock();

--- a/source/agora/consensus/validation/Block.d
+++ b/source/agora/consensus/validation/Block.d
@@ -637,7 +637,7 @@ unittest
     prev_txs.each!(tx => utxos.put(tx));  // these will be spent
 
     auto prev_block = block;
-    block = block.makeNewTestBlock(prev_txs.map!(tx => TxBuilder(tx).sign()));
+    block = block.makeNewTestBlock(prev_txs.map!(tx => TxBuilder!(WK.Keys)(tx).sign()));
     block.assertValid(engine, prev_block.header.height, prev_block.header.hashFull(),
         findUTXO, Enrollment.MinValidatorCount, checker, findGenesisEnrollments, toDelegate(utGetPenaltyDeposit));
 
@@ -703,7 +703,7 @@ unittest
     // we stopped validation due to a double-spend
     assert(used_set.length == double_spend.length - 1);
 
-    block = GenesisBlock.makeNewTestBlock(prev_txs.map!(tx => TxBuilder(tx).sign()));
+    block = GenesisBlock.makeNewTestBlock(prev_txs.map!(tx => TxBuilder!(WK.Keys)(tx).sign()));
     block.assertValid(engine, GenesisBlock.header.height, GenesisBlock.header.hashFull(),
         findUTXO, Enrollment.MinValidatorCount, checker, findGenesisEnrollments, toDelegate(utGetPenaltyDeposit));
 
@@ -720,7 +720,7 @@ unittest
     const last_root = block.header.merkle_root;
 
     block = GenesisBlock.makeNewTestBlock(prev_txs.enumerate.map!(en =>
-        TxBuilder(en.value).split(WK.Keys.byRange().take(en.index + 1).map!(k => k.address)).sign()));
+        TxBuilder!(WK.Keys)(en.value).split(WK.Keys.byRange().take(en.index + 1).map!(k => k.address)).sign()));
 
     block.assertValid(engine, GenesisBlock.header.height, GenesisBlock.header.hashFull(),
         findUTXO, Enrollment.MinValidatorCount, checker, findGenesisEnrollments, toDelegate(utGetPenaltyDeposit));

--- a/source/agora/test/BanManager.d
+++ b/source/agora/test/BanManager.d
@@ -60,7 +60,7 @@ unittest
 
          foreach (idx; 0 .. count)
          {
-             txes = last_txs.map!(tx => TxBuilder(tx).sign()).array();
+             txes = last_txs.map!(tx => TxBuilder!(WK.Keys)(tx).sign()).array();
              // keep track of last tx's to chain them to
              last_txs = txes[$ - 8 .. $];
              all_txs ~= txes;

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1183,7 +1183,7 @@ public class TestAPIManager
     public Transaction sendTransaction (scope RemoteAPI!TestAPI client)
     {
         auto utxo_pairs = client.getSpendables(1.coins);
-        auto tx = TxBuilder(utxo_pairs[0].utxo.output.address) // refund
+        auto tx = TxBuilder!(WK.Keys)(utxo_pairs[0].utxo.output.address) // refund
             .attach(utxo_pairs.map!(p => tuple(p.utxo.output, p.hash))).sign();
         auto result = client.postTransaction(tx);
         assert(result.status == TransactionResult.status.Accepted);
@@ -1215,7 +1215,7 @@ public class TestAPIManager
         assert(expected.mul(keys.length));
         auto utxo_pairs = first_client.getSpendables(expected);
 
-        return TxBuilder(utxo_pairs[0].utxo.output.address) // refund
+        return TxBuilder!(WK.Keys)(utxo_pairs[0].utxo.output.address) // refund
             .attach(utxo_pairs.map!(p => tuple(p.utxo.output, p.hash)))
             .draw(Amount.MinFreezeAmount, keys) // draw min freeze to enroll for each
             .sign(OutputType.Freeze);

--- a/source/agora/test/Fee.d
+++ b/source/agora/test/Fee.d
@@ -44,7 +44,7 @@ unittest
 
         // create and send tx to all nodes
         network.postAndEnsureTxInPool(
-            TxBuilder(WK.Keys.AAA.address)
+            TxBuilder!(WK.Keys)(WK.Keys.AAA.address)
             .attach(utxo_pairs.map!(p => tuple(p.utxo.output, p.hash)))
             .deduct(1.coins).sign());
 
@@ -188,7 +188,7 @@ unittest
 
         // create and send tx to all nodes
         network.postAndEnsureTxInPool(
-            TxBuilder(WK.Keys.AAA.address)
+            TxBuilder!(WK.Keys)(WK.Keys.AAA.address)
             .attach(utxo_pairs.map!(p => tuple(p.utxo.output, p.hash)))
             .deduct(1.coins).sign());
 

--- a/source/agora/test/Ledger.d
+++ b/source/agora/test/Ledger.d
@@ -104,7 +104,7 @@ unittest
     txs.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
-    txs = txs.map!(tx => TxBuilder(tx).sign()).array();
+    txs = txs.map!(tx => TxBuilder!(WK.Keys)(tx).sign()).array();
     txs.each!(tx => node_1.postTransaction(tx));
     network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
 }
@@ -189,11 +189,11 @@ unittest
 
     network.expectHeightAndPreImg(Height(1), network.blocks[0].header);
 
-    txs = txs.map!(tx => TxBuilder(tx).sign()).array();
+    txs = txs.map!(tx => TxBuilder!(WK.Keys)(tx).sign()).array();
     txs.each!(tx => network.postAndEnsureTxInPool(tx));
     network.expectHeightAndPreImg(Height(2), network.blocks[0].header);
 
-    txs = txs.map!(tx => TxBuilder(tx).sign()).array();
+    txs = txs.map!(tx => TxBuilder!(WK.Keys)(tx).sign()).array();
 
     // create a deep-copy of the first tx
     auto backup_tx = deserializeFull!Transaction(serializeFull(txs[0]));
@@ -256,7 +256,7 @@ unittest
     assert(b1.txs.length == 1);
 
     // Now spend the refund transaction (output index is 0 as it is sorted and lock is same value but ammount is less)
-    auto tx2 = TxBuilder(b1.txs[0], 0).sign();
+    auto tx2 = TxBuilder!(WK.Keys)(b1.txs[0], 0).sign();
     assert(tx2.outputs.length == 1);
 
     network.postAndEnsureTxInPool(tx2); // Make sure it makes it into the block

--- a/source/agora/test/LockHeight.d
+++ b/source/agora/test/LockHeight.d
@@ -40,11 +40,11 @@ unittest
 
     const Height UnlockHeight_2 = Height(2);
     auto unlock_2_txs = txs.map!(
-        tx => TxBuilder(tx).lock(UnlockHeight_2).sign(OutputType.Payment)).array();
+        tx => TxBuilder!(WK.Keys)(tx).lock(UnlockHeight_2).sign(OutputType.Payment)).array();
 
     const Height UnlockHeight_3 = Height(3);
     auto unlock_3_txs = txs.map!(
-        tx => TxBuilder(tx).lock(UnlockHeight_3).sign(OutputType.Payment)).array();
+        tx => TxBuilder!(WK.Keys)(tx).lock(UnlockHeight_3).sign(OutputType.Payment)).array();
 
     assert(unlock_2_txs != unlock_3_txs);
 

--- a/source/agora/test/NetworkManager.d
+++ b/source/agora/test/NetworkManager.d
@@ -78,7 +78,7 @@ unittest
 
             foreach (idx; 1 .. 3)
             {
-                txs = last_tx.map!(tx => TxBuilder(tx).sign()).array();
+                txs = last_tx.map!(tx => TxBuilder!(WK.Keys)(tx).sign()).array();
                 last_tx = txs;
                 block = makeNewTestBlock(last_block, txs);
 
@@ -158,7 +158,7 @@ unittest
     network.expectHeight(iota(GenesisValidators), Height(1));
 
     // create 1 additional block and enough `tx`es
-    auto txs = last_txs.map!(tx => TxBuilder(tx).sign()).array();
+    auto txs = last_txs.map!(tx => TxBuilder!(WK.Keys)(tx).sign()).array();
     // send it to one node
     txs.each!(tx => node_validators[0].postTransaction(tx));
     network.expectHeight(iota(GenesisValidators), Height(2));

--- a/source/agora/test/PostTransactionResult.d
+++ b/source/agora/test/PostTransactionResult.d
@@ -41,7 +41,7 @@ unittest
     auto output_addr = WK.Keys.AA.address;
 
     setHashMagic(0x44); // Sign TX with an incompatible chainID
-    auto tx = TxBuilder(input_txs[0], 0).feeRate(Amount(10_000))
+    auto tx = TxBuilder!(WK.Keys)(input_txs[0], 0).feeRate(Amount(10_000))
             .draw(Amount(100_000), [output_addr])
             .sign();
     auto result = nodes[0].postTransaction(tx);
@@ -49,7 +49,7 @@ unittest
 
     setHashMagic(0); // correct chainID
     // create a transaction with the fee rate of 10000
-    tx = TxBuilder(input_txs[0], 0).feeRate(Amount(10_000))
+    tx = TxBuilder!(WK.Keys)(input_txs[0], 0).feeRate(Amount(10_000))
         .draw(Amount(100_000), [output_addr])
         .sign();
 
@@ -62,7 +62,7 @@ unittest
     assert(result == TransactionResult(TransactionResult.Status.Duplicated));
 
     // post a transaction with no fee, expect `Rejected`
-    tx = TxBuilder(input_txs[0], 1).feeRate(Amount(0))
+    tx = TxBuilder!(WK.Keys)(input_txs[0], 1).feeRate(Amount(0))
         .draw(Amount(100_000), [output_addr])
         .sign();
     result = nodes[0].postTransaction(tx);

--- a/source/agora/test/TransactionReplacement.d
+++ b/source/agora/test/TransactionReplacement.d
@@ -43,7 +43,7 @@ unittest
 
     // create double spend transactions with fees 10000, 10100 .. 13000
     auto txs = [Amount(10000), Amount(10100), Amount(10200), Amount(11000), Amount(13000)]
-        .map!(f => TxBuilder(input_tx, 0).feeRate(f).draw(Amount(100_000), [output_addr])
+        .map!(f => TxBuilder!(WK.Keys)(input_tx, 0).feeRate(f).draw(Amount(100_000), [output_addr])
         .sign()).array();
 
     // send the transaction with 10000 fee to node0

--- a/source/agora/test/UnlockAge.d
+++ b/source/agora/test/UnlockAge.d
@@ -41,7 +41,7 @@ unittest
 
     auto split_up = txs
         .map!(tx => iota(tx.outputs.length)
-            .map!(idx => TxBuilder(tx, cast(uint)idx))).array;
+            .map!(idx => TxBuilder!(WK.Keys)(tx, cast(uint)idx))).array;
 
     // if `unlock_age` is 3 then UTXO at height `1` which unlocks at height `2`
     // will be spendable by this input at height `2 + 3 = 5`.

--- a/source/agora/utils/Test.d
+++ b/source/agora/utils/Test.d
@@ -335,7 +335,7 @@ public auto spendable (const ref Block block) @safe pure nothrow
 {
     return block.txs
         .filter!(tx => tx.isPayment)
-        .map!(tx => iota(tx.outputs.length).map!(idx => TxBuilder(tx, cast(uint)idx)))
+        .map!(tx => iota(tx.outputs.length).map!(idx => TxBuilder!(WK.Keys)(tx, cast(uint)idx)))
         .joiner();
 }
 

--- a/tests/unit/BlockStorageMultiSig.d
+++ b/tests/unit/BlockStorageMultiSig.d
@@ -67,7 +67,7 @@ private void main ()
         storage.saveBlock(block);
         // Prepare transactions for the next block
         txs = txs
-            .map!(tx => TxBuilder(tx).refund(WK.Keys[h + 1].address).sign())
+            .map!(tx => TxBuilder!(WK.Keys)(tx).refund(WK.Keys[h + 1].address).sign())
             .array();
         prev_block = block;
     }

--- a/tests/unit/BlockStorageMultiTx.d
+++ b/tests/unit/BlockStorageMultiTx.d
@@ -54,7 +54,7 @@ private void main ()
         blocks ~= block;
         // Prepare transactions for the next block
         txs = txs
-            .map!(tx => TxBuilder(tx).refund(WK.Keys[block_idx + 1].address).sign())
+            .map!(tx => TxBuilder!(WK.Keys)(tx).refund(WK.Keys[block_idx + 1].address).sign())
             .array();
     }
 


### PR DESCRIPTION
Trying a different approach as the changes in PR https://github.com/bosagora/agora/pull/3256 sometimes causes a segmentation fault when the unit tests run.