### PR TITLE
Registry: Prevent registering loopback addresses

### DIFF
--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -309,7 +309,7 @@ public class FullNode : API
 
         this.registry = new NameRegistry(config.node.realm, config.registry,
                                          this.ledger, this.cacheDB, this.taskman,
-                                         this.network);
+                                         this.network, config.node.testing);
         this.network.setRegistry(this.registry);
 
         // Create timers


### PR DESCRIPTION
to reduce the attack surface on nodes' host machines.
Loopback address registry is still allowed when `node.testing` is set
(i.e. Registry and network is in testing mode) to still support local
testing networks.

Fixes #3261 