### PR TITLE
Fix #3265 : Add ctor for AAAA type to RDATA

### DIFF
--- a/source/agora/common/DNS.d
+++ b/source/agora/common/DNS.d
@@ -721,6 +721,12 @@ public struct ResourceRecord
         }
 
         /// Ditto
+        public this (inout(ubyte)[16] val) inout @safe pure nothrow @nogc
+        {
+            this.aaaa = val;
+        }
+
+        /// Ditto
         public this (inout(Domain) val) inout @safe pure nothrow @nogc
         {
             this.name = val;


### PR DESCRIPTION
AAAA field is separated from plain binary