### PR TITLE
Add `additive` field to the TestNet configuration

### DIFF
--- a/devel/testnet/config.yaml
+++ b/devel/testnet/config.yaml
@@ -32,3 +32,4 @@ logging:
     console: true
     propagate: true
     file: log/root.log
+    additive: true

--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -245,6 +245,9 @@ logging:
     #
     # Values: Trace, Info, Warn, Error, Fatal, None (default)
     level: Info
+    # Whether to propagate that level to the children
+    # Default to `true` as this is the expected behavior for most users
+    propagate: true
     # Whether or not to log output to the console
     console: true
     # Output file to write the logging output to
@@ -254,6 +257,8 @@ logging:
     # Intermediate directories will be created as needed.
     # This setting is optional, as no file would be written to if empty / not supplied.
     file: log/root.log
+    # Whether this logger should be additive or not
+    additive: true
 
   # Nested logger configuration
   # Order does not matter as long as there is no duplication


### PR DESCRIPTION
There was no log message while running a validator on TestNet. It was because the `additive` field was missing in the `logging` config of a configuration file. 