### PR TITLE
Add missing `public_addresses` field to README

### DIFF
--- a/devel/testnet/README.KR.md
+++ b/devel/testnet/README.KR.md
@@ -83,6 +83,10 @@ docker run -v $(pwd):/agora/ bosagora/agora -c my_config.yaml
 
 위의 작업이 완료되면, 구성 파일을 다음과 같이 변경하면 됩니다.
 ```yaml
+node:
+  public_addresses:
+    - "agora://my-address.example.com:2826"
+
 validator:
   enabled: true
   seed: SB3EENDWPUGQZL7KLWGJS2ILMGRBB2MLVLRBUVKDYTO6A4WYLPIQWEE3

--- a/devel/testnet/README.md
+++ b/devel/testnet/README.md
@@ -112,6 +112,10 @@ will create the stake for you: [Faucet](https://faucet.bosagora.io/).
 Once this is done, all you have to do is to change your configuration file
 to the following:
 ```yaml
+node:
+  public_addresses:
+    - "agora://my-address.example.com:2826"
+
 validator:
   enabled: true
   seed: SB3EENDWPUGQZL7KLWGJS2ILMGRBB2MLVLRBUVKDYTO6A4WYLPIQWEE3


### PR DESCRIPTION
This adds the missing `public_addresses` field to README which is needed to run a validator.