### PR TITLE
Use ldc-1.28.1 not latest in documentation ci task

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Prepare compiler
         uses: dlang-community/setup-dlang@v1
         with:
-          compiler: ldc-latest
+          compiler: ldc-1.28.1
 
       - name: 'Install dependencies & setup environment'
         run: |


### PR DESCRIPTION
Latest is now ldc-1.29.0 but we are not using this yet.