### PR TITLE
Replace assertion with exception for unit test network

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -1445,8 +1445,8 @@ public class TestNetworkManager : NetworkManager
         auto tid = this.registry.locate!TestAPI(address.host);
         if (tid != typeof(tid).init)
             return new RemoteAPI!TestAPI(tid, this.config.node.timeout);
-        assert(0, format("Trying to access node at address '%s' from '%s' without first creating it",
-                         address, this.address));
+        throw (new Exception(
+            format!"Trying to access node at address '%s' from '%s' without first creating it"(address, this.address)));
     }
 
     ///
@@ -1456,8 +1456,8 @@ public class TestNetworkManager : NetworkManager
         auto tid = this.registry.locate!NameRegistryAPI(address.host);
         if (tid != typeof(tid).init)
             return new RemoteAPI!NameRegistryAPI(tid, this.config.node.timeout);
-        assert(0, "Trying to access name registry at address '" ~ address.toString() ~
-               "' without first creating it");
+        throw (new Exception(
+            format!"Trying to access name registry at address '%s' without first creating it"(address)));
     }
 
     /// Returns an instance of a DNSResolver


### PR DESCRIPTION
When `makeClient` or `makeRegistryClient` fails then throw an exception
as the calling code will handle it. This is an attempt to prevent the
`Trying to access ... without first creating it` test failures.