### PR TITLE
TestConf: Use registry to discover test network

### DIFF
--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2263,6 +2263,8 @@ public APIManager makeTestNetwork (APIManager : TestAPIManager = TestAPIManager)
     {
         InterfaceConfig conf =
         {
+            // See `addNewNode`, set to tcp since `agora://` is used in NodePair
+            type: InterfaceConfig.Type.tcp,
             address : address,
         };
 

--- a/source/agora/test/Base.d
+++ b/source/agora/test/Base.d
@@ -2105,7 +2105,7 @@ public struct TestConf
     public size_t outsider_validators = 0;
 
     /// whether to set up the peers in the config
-    public bool configure_network = true;
+    public bool configure_network = false;
 
     /***************************************************************************
 
@@ -2155,6 +2155,7 @@ public struct TestConf
         retry_delay: 300.msecs,
         timeout: 300.msecs,
         max_retries: 10,
+        network_discovery_interval: 1.seconds,
 
         // Always set to true, cannot be overriden, but also set here for clarity
         testing: true,

--- a/source/agora/test/GossipProtocol.d
+++ b/source/agora/test/GossipProtocol.d
@@ -58,7 +58,10 @@ unittest
 unittest
 {
     // node #7 is the fullnode
-    TestConf conf = { full_nodes : 1 };
+
+    // A Validator can only initiate connection, thus gossip TXs, to a FullNode
+    // when FullNode address is expilicitly configured.
+    TestConf conf = { full_nodes : 1, configure_network : true };
     auto network = makeTestNetwork!TestAPIManager(conf);
     network.start();
     scope(exit) network.shutdown();


### PR DESCRIPTION
also reduce the discover interval.

Fixes #3033