### PR TITLE
Prevent headers which are signed by slashed validators

### DIFF
--- a/source/agora/consensus/protocol/Nominator.d
+++ b/source/agora/consensus/protocol/Nominator.d
@@ -1089,7 +1089,8 @@ extern(D):
         {
             if (header.validators[idx]) // in the header already
                 validator_mask[idx] = true;
-            else if (val.utxo() in block_sigs) // We have the missing signature
+            else if (val.utxo() in block_sigs
+                && header.preimages[idx] != Hash.init) // We have the missing signature and it is not slashed
             {
                 validator_mask[idx] = true;
                 const sig = block_sigs[val.utxo()];

--- a/source/agora/consensus/state/Ledger.d
+++ b/source/agora/consensus/state/Ledger.d
@@ -891,11 +891,18 @@ public class Ledger
             }
 
             const pi = header.preimages[idx];
-            // TODO: Currently we consider that validators slashed at this height
-            // can sign the block (e.g. they have a space in the bit field),
-            // however without their pre-image they can't sign the block.
-            if (pi is Hash.init)
-                continue;
+            if (pi is Hash.init)    // This is a validator that did not reveal preimage before block reached consensus
+            {
+                if (!header.validators[idx])
+                    continue; // This is a slashed validator so can not sign
+                else
+                {
+                    // We can not accept this header including a signature for a slashed validator
+                    log.error("Block#{}: Header is not consistent. The signature at index {} is included for slashed validator {}",
+                        header.height, idx, validator.address);
+                    return "Block: Signature included for slashed validator";
+                }
+            }
 
             sum_K = sum_K + K;
             sum_s = sum_s + Scalar(pi);


### PR DESCRIPTION
Fixes #3296. 
First commit ensures that we would not accept a header in this situation (as we receive it from other nodes).
The second commit  prevents the situation where these headers are generated. 
