### PR TITLE
Config: Make LoggerConfig `additive` flag default true

### DIFF
--- a/source/agora/utils/Log.d
+++ b/source/agora/utils/Log.d
@@ -224,7 +224,7 @@ public struct LoggerConfig
     public @Optional string file;
 
     /// Whether this logger should be additive or not
-    public bool additive;
+    public bool additive = true;
 
     /// Buffer size of the buffer output
     public size_t buffer_size = 16_384;


### PR DESCRIPTION
This is more intuitive and easies the configuration process.

Fixes #3295 

> Perhaps the default should be `additive` so that it behaves as expected.

_Originally posted by @hewison-chris in https://github.com/bosagora/agora/issues/3295#issuecomment-1099822597_