### PR TITLE
Trivial: Use `createTimer` for Client gossip timer

### DIFF
--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -188,8 +188,7 @@ public class NetworkClient
         this.exception = new Exception(
             format("Request failure after %s attempts", max_retries));
         // Create and stop timer immediately
-        this.gossip_timer = this.taskman.setTimer(GossipDelay, &this.gossipTask, Periodic.No);
-        this.gossip_timer.stop();
+        this.gossip_timer = this.taskman.createTimer(&this.gossipTask);
     }
 
     /// Shut down the gossiping timer


### PR DESCRIPTION
It is immediately stopped after setting, `createTimer` is more suitable
for those conditions.