### PR TITLE
Stop TCP interfaces and RPC connections on shutdown

### DIFF
--- a/source/agora/api/FullNode.d
+++ b/source/agora/api/FullNode.d
@@ -24,6 +24,7 @@ import agora.consensus.data.PreImageInfo;
 import agora.consensus.data.Transaction;
 import agora.consensus.data.ValidatorInfo;
 import agora.crypto.Key;
+import agora.network.RPC : noRPCRoute;
 
 import vibe.data.serialization;
 import vibe.http.common;
@@ -429,4 +430,9 @@ public interface API
     ***************************************************************************/
 
     public WrappedConsensusParams getConsensusParams ();
+
+    /// Shutdown the node and its connections to other peers
+    @noRPCRoute
+    @noRoute
+    public void shutdown ();
 }

--- a/source/agora/network/Client.d
+++ b/source/agora/network/Client.d
@@ -195,6 +195,13 @@ public class NetworkClient
     public void shutdown () @safe nothrow
     {
         this.gossip_timer.stop();
+        foreach (conn; this.connections)
+        {
+            try
+                conn.api.shutdown();
+            catch (Exception ex)
+                log.dbg("Connection ({}) failed to close, continuing: {}", conn.address, ex);
+        }
     }
 
     /// For gossiping we don't want to block the calling fiber, so we use
@@ -654,6 +661,7 @@ public class NetworkClient
                 {
                     try
                     {
+                        conn.api.shutdown();
                         this.connections = this.connections.remove!(c => c == conn);
                         this.connections_version++;
                         log.warn("Removing banned address {} while performing {}, addresses left: {}",

--- a/source/agora/network/VibeManager.d
+++ b/source/agora/network/VibeManager.d
@@ -59,6 +59,21 @@ shared static this ()
 /// And implementation of `agora.network.Manager : NetworkManager` using Vibe.d
 public final class VibeNetworkManager : NetworkManager
 {
+    /// A stub class for overriding `shutdown` for the REST client
+    private class ValidatorRestClient : RestInterfaceClient!(agora.api.Validator.API)
+    {
+        this (RestInterfaceSettings settings)
+        {
+            super(settings);
+        }
+
+        public override void shutdown ()
+        {
+            // REST client doesn't need a shutdown
+            return;
+        }
+    }
+
     /// Construct an instance of this object
     public this (in Config config, ManagedDatabase cache, ITaskManager taskman,
                  Clock clock, agora.api.FullNode.API owner_node, Ledger ledger)
@@ -83,8 +98,7 @@ public final class VibeNetworkManager : NetworkManager
                 timeout, timeout, timeout);
 
         if (url.schema.startsWith("http"))
-            return new RestInterfaceClient!(agora.api.Validator.API)(
-                this.makeRestInterfaceSettings(url));
+            return new ValidatorRestClient(this.makeRestInterfaceSettings(url));
 
         assert(0, "Unknown agora schema: " ~ url.toString());
     }

--- a/source/agora/node/FullNode.d
+++ b/source/agora/node/FullNode.d
@@ -708,7 +708,7 @@ public class FullNode : API
 
     ***************************************************************************/
 
-    public void shutdown () @safe
+    public override void shutdown () @safe
     {
         this.is_shutting_down = true;
         log.info("Shutting down..");

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -230,7 +230,26 @@ private SigHandlerT getSignalHandler () @safe pure nothrow @nogc
             }
             catch (Exception exc)
             {
-                printf("Exception thrown while stopping an HTTP listener: %.*s\n",
+                printf("Exception thrown while stopping a HTTP listener: %.*s\n",
+                       cast(int) exc.msg.length, exc.msg.ptr);
+                debug {
+                    scope (failure) assert(0);
+                    writeln("========================================");
+                    writeln("Full stack trace: ", exc);
+                }
+            }
+        }
+
+        foreach (ref l; listeners.tcp)
+        {
+            try
+            {
+                l.stopListening();
+                l = typeof(l).init;
+            }
+            catch (Exception exc)
+            {
+                printf("Exception thrown while stopping a TCP listener: %.*s\n",
                        cast(int) exc.msg.length, exc.msg.ptr);
                 debug {
                     scope (failure) assert(0);


### PR DESCRIPTION
Towards a better shutdown procedure

This will reduce the number of eventcore leaks during shutdown, only DNS UDP connection will be remaining as leaking.

Part of #3158 

depends on #3311 and https://github.com/bosagora/localrest/pull/6