### PR TITLE
Implement DNS seed

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -333,6 +333,11 @@ registry:
   # Note that ports < 1024 are privileged ports and might require root powers
   port: 53
 
+  # DNS query to Realm zone returns randomly picked well distributed Validator nodes
+  # this list updated on timely basis, this field configure period of these updates
+  seed_refresh:
+    minutes: 10
+
   ## The fields below define 3 SOA records, one for each zone required by the network.
   ##
   ## Those can typically be left empty, except for the primary server of the zone.

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -500,6 +500,9 @@ public struct RegistryConfig
     /// The 'flash' zone
     public immutable(ZoneConfig) flash;
 
+    /// Registry seeding refresh interval
+    public Duration seed_refresh = 10.minutes;
+
     /// Validate the semantic of the user-provided configuration
     public void validate () const scope @safe
     {


### PR DESCRIPTION
Fixes #2874 

Adds DNS seed support like Bitcoin seeding. Parameters can be tweaked.

- Adds new config field to Registry
DNS seed update interval
- A or AAAA query will return randomly selected validator nodes
- Maximum of 10 nodes will be returned to seed queries