### PR TITLE
DNS: Remove seed configuration

### DIFF
--- a/doc/config.example.yaml
+++ b/doc/config.example.yaml
@@ -229,9 +229,6 @@ network:
   # Supported value: IPv4, IPv6
   - http://192.168.1.42:2828
   - http://192.168.0.44:2828
-dns:
-  # Supported value: FQDN seed
-  - seed.bosagora.io
 
 ################################################################################
 ##                               Logging options                              ##

--- a/source/agora/cli/multi/main.d
+++ b/source/agora/cli/multi/main.d
@@ -91,7 +91,6 @@ private int main (string[] args)
                 node : config.node,
                 validator : config.validator,
                 network : assumeUnique(converted_network),
-                dns_seeds : config.dns_seeds,
                 logging: config.logging,
                 admin: config.admin,
             };

--- a/source/agora/node/Config.d
+++ b/source/agora/node/Config.d
@@ -105,10 +105,6 @@ public struct Config
     /// The list of IPs for use with network discovery
     public @Optional immutable Address[] network;
 
-    /// The list of DNS FQDN seeds for use with network discovery
-    @Name("dns")
-    public @Optional immutable string[] dns_seeds;
-
     /// Logging config
     @Key("name")
     public immutable(LoggerConfig)[] logging = [ {

--- a/source/agora/node/main.d
+++ b/source/agora/node/main.d
@@ -357,7 +357,6 @@ private Nullable!Config makeTestNetConfig (AgoraCLIArgs cmdln)
             admin: config.admin,
             registry: config.registry,
             network: config.network,
-            dns_seeds: config.dns_seeds,
             logging: config.logging,
             event_handlers: config.event_handlers,
         };


### PR DESCRIPTION
Fixes #2256 

Registry answers for seed queries since #3320 and `NetworkManager` adds addresses from node registry for initial peer finding already. This configuration field is not needed anymore.