### PR TITLE
dub.json: Allow LDC v1.29 and above

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -34,7 +34,7 @@
         "dub": "~>1.25",
 	"dmd": "no",
 	"gdc": "no",
-	"ldc": "~>1.28.1"
+	"ldc": ">=1.28.1"
     },
 
     "configurations": [


### PR DESCRIPTION
Using '~>1.28.1' means '>=1.28.1' && '<1.29.0',
which is not what we want.